### PR TITLE
feat(design-data): Phase 1 validation infrastructure

### DIFF
--- a/.changeset/phase1-design-data-validate.md
+++ b/.changeset/phase1-design-data-validate.md
@@ -1,0 +1,6 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+Add `token-file.json` schema for legacy token maps, a validation snapshot, and Moon tasks that run
+the `design-data` CLI (`validate` / `migrate verify`) against `src/` and `schemas/`.

--- a/.cursor/rules
+++ b/.cursor/rules
@@ -224,6 +224,7 @@ fetch(url)
 - Use Apache-2.0 license
 - Include copyright headers in source files
 - Follow existing copyright patterns
+- **New files** must use the **current calendar year** (the year the file is created) in the copyright line, e.g. `Copyright YYYY Adobe. All rights reserved.` Use the same comment style as neighboring files (`//` in Rust, `#` in YAML/moon.yml, block or line comments in JS/TS, etc.)
 
 ## Performance Considerations
 - Use efficient algorithms for token processing

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -8,6 +8,16 @@ Design tokens are directly integrated into our component libraries, UI kits, and
 
 Follow the monorepo [setup guide](../../README.md#setup-monorepo-locally).
 
+## Design Data validation
+
+Moon tasks run the Rust `design-data` CLI against `src/` and `schemas/`:
+
+* `moon run tokens:validateDesignData` — JSON Schema (Layer 1) + catalog rules (Layer 2)
+* `moon run tokens:verifyDesignDataSnapshot` — same as above, compared to
+  `snapshots/validation-snapshot.json` (update with `design-data migrate snapshot` when outputs change)
+
+From the repo root with Rust available, you can also run `cargo run -p design-data-cli --manifest-path sdk/Cargo.toml -- validate ./packages/tokens/src --schema-path ./packages/tokens/schemas`.
+
 ## Generate a Diff from the last release
 
 The `pnpm generateDiffResult` script will build the project and compare the tokens in the `dist` directory with the last released version of Spectrum Tokens. It will generate a report of added tokens, deleted tokens, tokens with value changes, and tokens with potential name changes. The script can't guarantee the correct name changes; it compares new tokens and deleted tokens to see if any have the same value and are likely to be token name changes.

--- a/packages/tokens/moon.yml
+++ b/packages/tokens/moon.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Adobe. All rights reserved.
+# Copyright 2026 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -15,6 +15,45 @@ fileGroups:
   tests:
     - "test/**/*"
 tasks:
+  validateDesignData:
+    command: cargo
+    args:
+      - run
+      - --manifest-path
+      - ../../sdk/Cargo.toml
+      - --bin
+      - design-data
+      - --
+      - validate
+      - ./src
+      - --schema-path
+      - ./schemas
+    platform: system
+    inputs:
+      - "@globs(sources)"
+      - "schemas/**/*.json"
+      - "snapshots/**/*.json"
+  verifyDesignDataSnapshot:
+    command: cargo
+    args:
+      - run
+      - --manifest-path
+      - ../../sdk/Cargo.toml
+      - --bin
+      - design-data
+      - --
+      - migrate
+      - verify
+      - ./src
+      - --snapshot
+      - ./snapshots/validation-snapshot.json
+      - --schema-path
+      - ./schemas
+    platform: system
+    inputs:
+      - "@globs(sources)"
+      - "schemas/**/*.json"
+      - "snapshots/**/*.json"
   build:
     deps:
       - ~:buildTokens
@@ -58,6 +97,7 @@ tasks:
       - "@globs(sources)"
     deps:
       - ~:buildTokens
+      - ~:verifyDesignDataSnapshot
     platform: node
   test-watch:
     command:

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -22,6 +22,10 @@
     "provenance": true
   },
   "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/packages/tokens#readme",
+  "exports": {
+    ".": "./index.js",
+    "./schemas/token-file.json": "./schemas/token-file.json"
+  },
   "devDependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/packages/tokens/schemas/token-file.json
+++ b/packages/tokens/schemas/token-file.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/token-file.json",
+  "title": "Spectrum token file",
+  "description": "Top-level shape for legacy Spectrum token JSON files (packages/tokens/src/*.json). Each property key is a token name; each value is a token object with a $schema discriminator.",
+  "type": "object",
+  "patternProperties": {
+    "^[a-z0-9]+(-[a-z0-9]+)*$": {
+      "anyOf": [
+        { "$ref": "token-types/alias.json" },
+        { "$ref": "token-types/color.json" },
+        { "$ref": "token-types/color-set.json" },
+        { "$ref": "token-types/dimension.json" },
+        { "$ref": "token-types/drop-shadow.json" },
+        { "$ref": "token-types/font-family.json" },
+        { "$ref": "token-types/font-size.json" },
+        { "$ref": "token-types/font-style.json" },
+        { "$ref": "token-types/font-weight.json" },
+        { "$ref": "token-types/gradient-stop.json" },
+        { "$ref": "token-types/multiplier.json" },
+        { "$ref": "token-types/opacity.json" },
+        { "$ref": "token-types/scale-set.json" },
+        { "$ref": "token-types/set.json" },
+        { "$ref": "token-types/system-set.json" },
+        { "$ref": "token-types/text-align.json" },
+        { "$ref": "token-types/text-transform.json" },
+        { "$ref": "token-types/token.json" },
+        { "$ref": "token-types/typography.json" }
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/tokens/schemas/token-types/multiplier.json
+++ b/packages/tokens/schemas/token-types/multiplier.json
@@ -14,8 +14,7 @@
       "const": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json"
     },
     "value": {
-      "type": "number",
-      "pattern": "^(?:\\d+\\.?\\d*)|(?:\\.?\\d+)$"
+      "type": "number"
     },
     "component": {},
     "private": {},

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -1,0 +1,4 @@
+{
+  "errors": [],
+  "warnings": []
+}

--- a/packages/tokens/test/tokenSchemaValidator.test.js
+++ b/packages/tokens/test/tokenSchemaValidator.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Adobe. All rights reserved.
+Copyright 2026 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -38,6 +38,10 @@ test.before(async (t) => {
   );
   t.context.schemaIds = schemaIds;
 
+  const tokenFileSchema = await readJSON("schemas/token-file.json");
+  ajv.addSchema(tokenFileSchema, tokenFileSchema["$id"]);
+  t.context.tokenFileSchemaId = tokenFileSchema["$id"];
+
   const tokenFilesNames = await glob("src/*.json");
   t.context.tokenFiles = await Promise.all(
     tokenFilesNames.map(async (tokenFile) => {
@@ -46,21 +50,9 @@ test.before(async (t) => {
   );
 });
 
-test("Schema should compile without errors", async (t) => {
-  try {
-    const validate = await ajv.compile({
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "object",
-      patternProperties: {
-        "^(?:(?:[a-z]|\\d)+-?)*(?:[a-z]|\\d)+$": {
-          anyOf: t.context.schemaIds.map((schemaId) => ({ $ref: schemaId })),
-        },
-      },
-    });
-  } catch (error) {
-    console.log(error);
-  }
-  t.pass();
+test("token-file schema compiles", (t) => {
+  const validate = ajv.getSchema(t.context.tokenFileSchemaId);
+  t.truthy(validate, "token-file schema should be registered");
 });
 
 test("Every token should have a $schema property", (t) => {
@@ -92,6 +84,20 @@ test("Every token schema should validate against the definition", (t) => {
         });
       }
     });
+  });
+  t.deepEqual(errors, []);
+});
+
+test("Every token file validates against token-file.json", (t) => {
+  const errors = [];
+  t.context.tokenFiles.forEach((tokenFileObj) => {
+    if (!ajv.validate(t.context.tokenFileSchemaId, tokenFileObj.data)) {
+      t.log(`${tokenFileObj.fileName} failed token-file validation.`);
+      errors.push({
+        fileName: tokenFileObj.fileName,
+        errors: ajv.errors,
+      });
+    }
   });
   t.deepEqual(errors, []);
 });

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -91,6 +91,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +173,17 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -233,9 +259,13 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 name = "design-data-cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "design-data-core",
  "miette",
+ "predicates",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -246,7 +276,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "walkdir",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "displaydoc"
@@ -287,6 +324,21 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -742,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +962,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1056,18 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1051,6 +1151,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1200,6 +1309,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1330,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -1414,6 +1542,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1651,15 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/sdk/cli/Cargo.toml
+++ b/sdk/cli/Cargo.toml
@@ -14,3 +14,9 @@ path = "src/main.rs"
 clap = { version = "4.5", features = ["derive"] }
 design-data-core = { path = "../core" }
 miette = { version = "7.4", features = ["fancy"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
+tempfile = "3.14"

--- a/sdk/cli/src/format.rs
+++ b/sdk/cli/src/format.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! CLI output formatters (`pretty` and `json`).
+
+use design_data_core::report::ValidationReport;
+
+/// Human-readable stderr/stdout mix: errors on stderr, success line on stdout.
+pub fn print_report_pretty(report: &ValidationReport) {
+    if report.errors.is_empty() && report.warnings.is_empty() {
+        println!("No issues found.");
+        return;
+    }
+    for d in &report.errors {
+        eprintln!(
+            "error: {} [{}] {}",
+            d.file.display(),
+            d.rule_id.as_deref().unwrap_or("structural"),
+            d.message
+        );
+        if let Some(t) = &d.token {
+            eprintln!("  token: {t}");
+        }
+        if let Some(p) = &d.instance_path {
+            eprintln!("  at: {p}");
+        }
+    }
+    for d in &report.warnings {
+        eprintln!(
+            "warning: {} [{}] {}",
+            d.file.display(),
+            d.rule_id.as_deref().unwrap_or("?"),
+            d.message
+        );
+    }
+}
+
+/// Full report as JSON (stdout).
+pub fn format_report_json(report: &ValidationReport) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report)
+}

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Adobe. All rights reserved.
+// Copyright 2026 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may obtain a copy
 // of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -8,9 +8,18 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use clap::{Parser, Subcommand};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 
-/// Spectrum Design Data tooling (scaffold — see #722, #726).
+mod format;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use design_data_core::compat::{load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot};
+use design_data_core::schema::SchemaRegistry;
+use design_data_core::validate;
+use miette::{IntoDiagnostic, WrapErr};
+
+/// Spectrum Design Data tooling — validate and migrate design tokens.
 #[derive(Parser)]
 #[command(name = "design-data", version, about)]
 struct Cli {
@@ -20,32 +29,176 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Validate design data against schemas and rules (stub)
+    /// Validate design data against JSON Schemas (Layer 1) and catalog rules (Layer 2)
     Validate {
-        /// Path to files or directory to validate
+        /// Path to a JSON file or directory to validate
         #[arg(value_name = "PATH")]
-        path: Option<std::path::PathBuf>,
+        path: Option<PathBuf>,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+        /// Root directory containing `token-types/` and `token-file.json`
+        #[arg(long, value_name = "DIR")]
+        schema_path: Option<PathBuf>,
+        /// Treat warnings as errors
+        #[arg(long)]
+        strict: bool,
+    },
+    /// Snapshot and backward-compat verification helpers
+    Migrate {
+        #[command(subcommand)]
+        sub: MigrateSub,
     },
 }
 
-fn main() -> miette::Result<()> {
+#[derive(Subcommand)]
+enum MigrateSub {
+    /// Run validation and compare to a golden snapshot JSON
+    Verify {
+        /// Token JSON file or directory (same as `validate`)
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+        /// Golden snapshot produced by `migrate snapshot`
+        #[arg(long, value_name = "FILE")]
+        snapshot: PathBuf,
+        #[arg(long, value_name = "DIR")]
+        schema_path: Option<PathBuf>,
+    },
+    /// Run validation and write a sorted snapshot JSON for CI / golden testing
+    Snapshot {
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+        #[arg(long, value_name = "FILE")]
+        output: PathBuf,
+        #[arg(long, value_name = "DIR")]
+        schema_path: Option<PathBuf>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum OutputFormat {
+    #[default]
+    Pretty,
+    Json,
+}
+
+fn default_schema_path() -> PathBuf {
+    if let Ok(p) = std::env::var("DESIGN_DATA_SCHEMA_ROOT") {
+        return PathBuf::from(p);
+    }
+    let candidates = [
+        PathBuf::from("packages/tokens/schemas"),
+        PathBuf::from("../packages/tokens/schemas"),
+    ];
+    for c in &candidates {
+        if c.join("token-types").is_dir() {
+            return c.clone();
+        }
+    }
+    PathBuf::from("packages/tokens/schemas")
+}
+
+fn run_validate(
+    path: &Path,
+    format: OutputFormat,
+    schema_path: Option<PathBuf>,
+    strict: bool,
+) -> miette::Result<ExitCode> {
+    if !validate::engine_ready() {
+        miette::bail!("validation engine not ready");
+    }
+    let schema_root = schema_path.unwrap_or_else(default_schema_path);
+    let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load schemas from {}", schema_root.display()))?;
+
+    let report = validate::validate_all(path, &registry)
+        .into_diagnostic()
+        .wrap_err("validation failed")?;
+
+    match format {
+        OutputFormat::Json => {
+            println!("{}", format::format_report_json(&report).into_diagnostic()?);
+        }
+        OutputFormat::Pretty => {
+            format::print_report_pretty(&report);
+        }
+    }
+
+    if report.failed(strict) {
+        return Ok(ExitCode::from(1));
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn run_migrate_verify(
+    path: &Path,
+    snapshot: &Path,
+    schema_path: Option<PathBuf>,
+) -> miette::Result<ExitCode> {
+    let schema_root = schema_path.unwrap_or_else(default_schema_path);
+    let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root).into_diagnostic()?;
+    let report = validate::validate_all(path, &registry).into_diagnostic()?;
+    let expected = load_snapshot(snapshot).into_diagnostic()?;
+    if snapshot_matches(&report, &expected) {
+        println!("Snapshot OK: {}", snapshot.display());
+        return Ok(ExitCode::SUCCESS);
+    }
+    let current = ValidationSnapshot::from(&report);
+    eprintln!("Snapshot mismatch with {}", snapshot.display());
+    eprintln!(
+        "current: {}",
+        serde_json::to_string_pretty(&current).into_diagnostic()?
+    );
+    Ok(ExitCode::from(1))
+}
+
+fn run_migrate_snapshot(
+    path: &Path,
+    output: &Path,
+    schema_path: Option<PathBuf>,
+) -> miette::Result<ExitCode> {
+    let schema_root = schema_path.unwrap_or_else(default_schema_path);
+    let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root).into_diagnostic()?;
+    let report = validate::validate_all(path, &registry).into_diagnostic()?;
+    let snap = ValidationSnapshot::from(&report);
+    write_snapshot(output, &snap).into_diagnostic()?;
+    println!("Wrote {}", output.display());
+    Ok(ExitCode::SUCCESS)
+}
+
+fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    match cli.command {
-        Commands::Validate { path } => {
-            if !design_data_core::validate::engine_ready() {
-                miette::bail!("validation engine not ready");
-            }
-            let target = path
-                .as_deref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| ".".to_string());
-            println!(
-                "validate (stub): {} — core crate: {}",
-                target,
-                design_data_core::crate_name()
-            );
-            Ok(())
+    let result = match cli.command {
+        Commands::Validate {
+            path,
+            format,
+            schema_path,
+            strict,
+        } => {
+            let target = path.unwrap_or_else(|| PathBuf::from("."));
+            run_validate(&target, format, schema_path, strict)
+        }
+        Commands::Migrate { sub } => match sub {
+            MigrateSub::Verify {
+                path,
+                snapshot,
+                schema_path,
+            } => run_migrate_verify(&path, &snapshot, schema_path),
+            MigrateSub::Snapshot {
+                path,
+                output,
+                schema_path,
+            } => run_migrate_snapshot(&path, &output, schema_path),
+        },
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            ExitCode::from(2)
         }
     }
 }

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -1,0 +1,84 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Integration tests for the `design-data` binary (`assert_cmd`).
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use serde_json::json;
+
+fn tokens_src_and_schemas() -> (PathBuf, PathBuf) {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = manifest.join("../../packages/tokens/src");
+    let schemas = manifest.join("../../packages/tokens/schemas");
+    assert!(
+        src.is_dir(),
+        "expected token sources at {}",
+        src.display()
+    );
+    assert!(
+        schemas.join("token-types").is_dir(),
+        "expected schemas at {}",
+        schemas.display()
+    );
+    (src, schemas)
+}
+
+#[test]
+fn validate_spectrum_tokens_json_success() {
+    let (src, schemas) = tokens_src_and_schemas();
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "validate",
+            src.to_str().expect("utf8 path"),
+            "--schema-path",
+            schemas.to_str().expect("utf8 path"),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("\"valid\": true"));
+}
+
+#[test]
+fn validate_bad_token_file_fails() {
+    let (_src, schemas) = tokens_src_and_schemas();
+
+    let tmp = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .expect("tempfile");
+    let body = json!({
+        "bad-token": {
+            "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+            "value": "not-a-color",
+            "uuid": "00000000-0000-4000-8000-000000000001"
+        }
+    });
+    std::fs::write(tmp.path(), body.to_string()).expect("write token file");
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "validate",
+            tmp.path().to_str().expect("utf8 path"),
+            "--schema-path",
+            schemas.to_str().expect("utf8 path"),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .failure();
+}

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -14,3 +14,4 @@ jsonschema = "0.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
+walkdir = "2.5"

--- a/sdk/core/src/compat.rs
+++ b/sdk/core/src/compat.rs
@@ -1,0 +1,87 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Snapshot comparison for `migrate --verify` backward-compat checks.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::report::{Severity, ValidationReport};
+use crate::CoreError;
+
+/// Serializable validation outcome for golden-file comparison.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationSnapshot {
+    pub errors: Vec<SnapshotDiagnostic>,
+    pub warnings: Vec<SnapshotDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SnapshotDiagnostic {
+    pub file: String,
+    pub token: Option<String>,
+    pub rule_id: Option<String>,
+    pub severity: String,
+    pub message: String,
+}
+
+impl From<&ValidationReport> for ValidationSnapshot {
+    fn from(report: &ValidationReport) -> Self {
+        Self {
+            errors: report.errors.iter().map(SnapshotDiagnostic::from).collect(),
+            warnings: report.warnings.iter().map(SnapshotDiagnostic::from).collect(),
+        }
+    }
+}
+
+impl From<&crate::report::Diagnostic> for SnapshotDiagnostic {
+    fn from(d: &crate::report::Diagnostic) -> Self {
+        SnapshotDiagnostic {
+            file: d.file.display().to_string(),
+            token: d.token.clone(),
+            rule_id: d.rule_id.clone(),
+            severity: match d.severity {
+                Severity::Error => "error".to_string(),
+                Severity::Warning => "warning".to_string(),
+                Severity::Info => "info".to_string(),
+            },
+            message: d.message.clone(),
+        }
+    }
+}
+
+/// Read a snapshot JSON file from disk.
+pub fn load_snapshot(path: &Path) -> Result<ValidationSnapshot, CoreError> {
+    let text = std::fs::read_to_string(path)?;
+    let snap: ValidationSnapshot = serde_json::from_str(&text)?;
+    Ok(snap)
+}
+
+/// Write snapshot JSON (stable key order via sorted diagnostics).
+pub fn write_snapshot(path: &Path, snapshot: &ValidationSnapshot) -> Result<(), CoreError> {
+    let mut snap = snapshot.clone();
+    snap.errors.sort();
+    snap.warnings.sort();
+    let text = serde_json::to_string_pretty(&snap)?;
+    std::fs::write(path, text)?;
+    Ok(())
+}
+
+/// Compare current report to an expected snapshot (sorted).
+pub fn snapshot_matches(report: &ValidationReport, expected: &ValidationSnapshot) -> bool {
+    let mut current = ValidationSnapshot::from(report);
+    current.errors.sort();
+    current.warnings.sort();
+    let mut exp = expected.clone();
+    exp.errors.sort();
+    exp.warnings.sort();
+    current == exp
+}

--- a/sdk/core/src/discovery.rs
+++ b/sdk/core/src/discovery.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Discover JSON files under a path (recursive).
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// All `*.json` files under `root`, sorted for stable output.
+pub fn discover_json_files(root: &Path) -> std::io::Result<Vec<PathBuf>> {
+    if root.is_file() {
+        if root.extension().and_then(|e| e.to_str()) == Some("json") {
+            return Ok(vec![root.to_path_buf()]);
+        }
+        return Ok(vec![]);
+    }
+
+    if !root.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("path does not exist: {}", root.display()),
+        ));
+    }
+
+    let mut out = Vec::new();
+    for entry in WalkDir::new(root).follow_links(false).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let p = entry.path();
+        if p.extension().and_then(|e| e.to_str()) == Some("json") {
+            out.push(p.to_path_buf());
+        }
+    }
+    out.sort();
+    Ok(out)
+}

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -1,0 +1,208 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! In-memory token graph for relational (Layer 2) validation.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::discovery::discover_json_files;
+use crate::CoreError;
+
+/// One dimension declaration (new spec shape), when present in a JSON file.
+#[derive(Debug, Clone)]
+pub struct DimensionRecord {
+    pub file: PathBuf,
+    pub name: String,
+    pub modes: Vec<String>,
+    pub default_mode: String,
+}
+
+/// One token entry (legacy file key or test fixture id).
+#[derive(Debug, Clone)]
+pub struct TokenRecord {
+    pub name: String,
+    pub file: PathBuf,
+    pub schema_url: Option<String>,
+    pub uuid: Option<String>,
+    /// Resolved alias target id when applicable.
+    pub alias_target: Option<String>,
+    pub raw: Value,
+}
+
+/// Token graph across files.
+#[derive(Debug, Clone, Default)]
+pub struct TokenGraph {
+    pub tokens: HashMap<String, TokenRecord>,
+    pub dimensions: Vec<DimensionRecord>,
+}
+
+impl TokenGraph {
+    /// Build a graph from legacy Spectrum token sources (`*.json` token maps).
+    pub fn from_json_dir(root: &Path) -> Result<Self, CoreError> {
+        let mut g = TokenGraph::default();
+        for path in discover_json_files(root)? {
+            let text = std::fs::read_to_string(&path)?;
+            let value: Value = serde_json::from_str(&text)?;
+            let Some(obj) = value.as_object() else {
+                continue;
+            };
+
+            if looks_like_dimension_doc(obj) {
+                if let Some(d) = parse_dimension(&path, obj) {
+                    g.dimensions.push(d);
+                }
+                continue;
+            }
+
+            if !looks_like_token_file(obj) {
+                continue;
+            }
+
+            for (token_name, token_val) in obj {
+                let Some(tok_obj) = token_val.as_object() else {
+                    continue;
+                };
+                let schema_url = tok_obj
+                    .get("$schema")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let uuid = tok_obj
+                    .get("uuid")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let alias_target = extract_alias_target(tok_obj);
+                g.tokens.insert(
+                    token_name.clone(),
+                    TokenRecord {
+                        name: token_name.clone(),
+                        file: path.clone(),
+                        schema_url,
+                        uuid,
+                        alias_target,
+                        raw: token_val.clone(),
+                    },
+                );
+            }
+        }
+        Ok(g)
+    }
+
+    /// Merge tokens for tests / conformance (global token id → record).
+    pub fn from_pairs(entries: Vec<(String, PathBuf, Value)>) -> Self {
+        let mut tokens = HashMap::new();
+        for (name, file, raw) in entries {
+            let tok_obj = raw.as_object();
+            let schema_url = tok_obj
+                .and_then(|o| o.get("$schema"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let uuid = tok_obj
+                .and_then(|o| o.get("uuid"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let alias_target = tok_obj.and_then(extract_alias_target);
+            tokens.insert(
+                name.clone(),
+                TokenRecord {
+                    name,
+                    file,
+                    schema_url,
+                    uuid,
+                    alias_target,
+                    raw,
+                },
+            );
+        }
+        Self {
+            tokens,
+            dimensions: Vec::new(),
+        }
+    }
+
+    /// Attach dimension records (e.g. from conformance fixtures).
+    pub fn with_dimensions(mut self, dimensions: Vec<DimensionRecord>) -> Self {
+        self.dimensions = dimensions;
+        self
+    }
+}
+
+fn looks_like_token_file(obj: &serde_json::Map<String, Value>) -> bool {
+    obj.values().next().is_some_and(|v| {
+        v.as_object()
+            .is_some_and(|o| o.contains_key("$schema") || o.contains_key("$ref") || o.contains_key("name"))
+    })
+}
+
+fn looks_like_dimension_doc(obj: &serde_json::Map<String, Value>) -> bool {
+    obj.contains_key("modes")
+        && obj.contains_key("default")
+        && obj.get("name").and_then(|v| v.as_str()).is_some()
+        && !obj.values().any(|v| v.as_object().is_some_and(|o| o.contains_key("$schema")))
+}
+
+fn parse_dimension(path: &Path, obj: &serde_json::Map<String, Value>) -> Option<DimensionRecord> {
+    let name = obj.get("name")?.as_str()?.to_string();
+    let default_mode = obj.get("default")?.as_str()?.to_string();
+    let modes: Vec<String> = obj
+        .get("modes")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect();
+    Some(DimensionRecord {
+        file: path.to_path_buf(),
+        name,
+        modes,
+        default_mode,
+    })
+}
+
+fn extract_alias_target(obj: &serde_json::Map<String, Value>) -> Option<String> {
+    if let Some(r) = obj.get("$ref").and_then(|v| v.as_str()) {
+        return Some(normalize_ref_target(r));
+    }
+    if let Some(s) = obj.get("value").and_then(|v| v.as_str()) {
+        if s.starts_with('{') && s.ends_with('}') && s.len() > 2 {
+            return Some(s[1..s.len() - 1].to_string());
+        }
+    }
+    None
+}
+
+fn normalize_ref_target(s: &str) -> String {
+    let s = s.trim();
+    let file_name = s.rsplit(['/', '\\']).next().unwrap_or(s);
+    file_name
+        .strip_suffix(".json")
+        .unwrap_or(file_name)
+        .to_string()
+}
+
+impl TokenRecord {
+    /// Follow alias edges until a non-alias or missing target.
+    pub fn resolve_leaf<'a>(&'a self, graph: &'a TokenGraph) -> &'a TokenRecord {
+        let mut current = self;
+        let mut seen: Vec<&str> = vec![&self.name];
+        while let Some(target_name) = &current.alias_target {
+            let Some(next) = graph.tokens.get(target_name) else {
+                break;
+            };
+            if seen.contains(&target_name.as_str()) {
+                break;
+            }
+            seen.push(target_name);
+            current = next;
+        }
+        current
+    }
+}

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Adobe. All rights reserved.
+// Copyright 2026 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may obtain a copy
 // of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -8,11 +8,33 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! Design Data core library — validation, resolution, and tooling (scaffold).
-//!
-//! Implementation work is tracked in GitHub issues #724 and #725.
+//! Design Data core library — validation, resolution, and tooling.
 
+pub mod compat;
+pub mod discovery;
+pub mod graph;
+pub mod report;
+pub mod schema;
 pub mod validate;
+
+use std::path::PathBuf;
+
+/// Errors from schema loading, IO, and JSON parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum CoreError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Referencing(#[from] jsonschema::ReferencingError),
+    #[error("JSON Schema compile: {0}")]
+    SchemaBuild(String),
+    #[error("schema file is missing $id: {0}")]
+    MissingSchemaId(PathBuf),
+    #[error("expected token schema directory at {0}")]
+    SchemaDirectoryMissing(PathBuf),
+}
 
 /// Returns the crate name for sanity checks and CLI `--version` wiring later.
 pub fn crate_name() -> &'static str {
@@ -21,7 +43,11 @@ pub fn crate_name() -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
+    use crate::schema::SchemaRegistry;
+    use crate::validate::structural::validate_structural;
 
     #[test]
     fn validate_module_reports_ready() {
@@ -31,5 +57,142 @@ mod tests {
     #[test]
     fn crate_name_is_set() {
         assert_eq!(crate_name(), "design-data-core");
+    }
+
+    #[test]
+    fn structural_validates_spectrum_token_sources() {
+        let schemas = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/schemas");
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/src");
+        let registry = SchemaRegistry::load_legacy_token_schemas(&schemas).expect("schemas load");
+        let report = validate_structural(&src, &registry).expect("validate");
+        assert!(report.errors.is_empty(), "{report:?}");
+    }
+}
+
+#[cfg(test)]
+mod relational_conformance {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{DimensionRecord, TokenGraph};
+    use crate::validate::relational::diagnostics_for_rule;
+
+    #[test]
+    fn spec001_alias_target_missing() {
+        let g = TokenGraph::from_pairs(vec![(
+            "missing-alias".into(),
+            PathBuf::from("fixture.json"),
+            json!({
+                "name": {"property": "alias-missing-target"},
+                "$ref": "tokens/nonexistent-token.json"
+            }),
+        )]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-001").is_empty());
+    }
+
+    #[test]
+    fn spec002_spacing_alias_to_color() {
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "spacing-alias".into(),
+                PathBuf::from("a.json"),
+                json!({
+                    "name": {"property": "spacing-alias"},
+                    "$ref": "token-color.json",
+                    "uuid": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+                }),
+            ),
+            (
+                "token-color".into(),
+                PathBuf::from("b.json"),
+                json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": {"property": "base-color"},
+                    "value": "rgb(0, 128, 255)",
+                    "uuid": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+                }),
+            ),
+        ]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-002").is_empty());
+    }
+
+    #[test]
+    fn spec003_alias_cycle() {
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "token-a".into(),
+                PathBuf::from("ta.json"),
+                json!({
+                    "name": {"property": "cycle-a"},
+                    "$ref": "token-b.json",
+                    "uuid": "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+                }),
+            ),
+            (
+                "token-b".into(),
+                PathBuf::from("tb.json"),
+                json!({
+                    "name": {"property": "cycle-b"},
+                    "$ref": "token-a.json",
+                    "uuid": "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+                }),
+            ),
+        ]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-003").is_empty());
+    }
+
+    #[test]
+    fn spec004_duplicate_uuid() {
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "a".into(),
+                PathBuf::from("x.json"),
+                json!({"uuid": "11111111-1111-1111-1111-111111111111", "value": "1"}),
+            ),
+            (
+                "b".into(),
+                PathBuf::from("y.json"),
+                json!({"uuid": "11111111-1111-1111-1111-111111111111", "value": "2"}),
+            ),
+        ]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-004").is_empty());
+    }
+
+    #[test]
+    fn spec005_dimension_default_not_in_modes() {
+        let g = TokenGraph::default().with_dimensions(vec![DimensionRecord {
+            file: PathBuf::from("dimension.json"),
+            name: "scale".into(),
+            modes: vec!["medium".into(), "large".into()],
+            default_mode: "xlarge".into(),
+        }]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-005").is_empty());
+    }
+
+    #[test]
+    fn spec006_duplicate_name_object() {
+        let name = json!({"property": "ambiguous", "colorScheme": "dark"});
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "t1".into(),
+                PathBuf::from("1.json"),
+                json!({
+                    "name": name.clone(),
+                    "value": "rgb(10, 10, 10)",
+                    "uuid": "ffffffff-ffff-4fff-8fff-ffffffffffff"
+                }),
+            ),
+            (
+                "t2".into(),
+                PathBuf::from("2.json"),
+                json!({
+                    "name": name,
+                    "value": "rgb(20, 20, 20)",
+                    "uuid": "11111111-1111-4111-8111-111111111111"
+                }),
+            ),
+        ]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-006").is_empty());
     }
 }

--- a/sdk/core/src/report.rs
+++ b/sdk/core/src/report.rs
@@ -1,0 +1,76 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Validation reports and diagnostics (structural + relational).
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Severity for a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+}
+
+/// Single validation diagnostic.
+#[derive(Debug, Clone, Serialize)]
+pub struct Diagnostic {
+    /// Source file (token JSON or manifest).
+    pub file: PathBuf,
+    /// Token name when applicable (top-level key in a token file).
+    pub token: Option<String>,
+    /// Rule id from the catalog (e.g. SPEC-001); structural issues omit this.
+    pub rule_id: Option<String>,
+    pub severity: Severity,
+    pub message: String,
+    /// JSON Schema instance path or similar.
+    pub instance_path: Option<String>,
+    /// JSON Schema keyword path when from structural validation.
+    pub schema_path: Option<String>,
+}
+
+/// Combined validation result.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ValidationReport {
+    pub valid: bool,
+    pub errors: Vec<Diagnostic>,
+    pub warnings: Vec<Diagnostic>,
+}
+
+impl ValidationReport {
+    /// Merge another report into `self` (recomputes `valid`).
+    pub fn merge(&mut self, other: ValidationReport) {
+        self.errors.extend(other.errors);
+        self.warnings.extend(other.warnings);
+        self.recompute_valid();
+    }
+
+    pub fn recompute_valid(&mut self) {
+        self.valid = self.errors.is_empty();
+    }
+
+    pub fn push_error(&mut self, d: Diagnostic) {
+        self.errors.push(d);
+        self.valid = false;
+    }
+
+    pub fn push_warning(&mut self, d: Diagnostic) {
+        self.warnings.push(d);
+    }
+
+    /// True if there are errors, or warnings when `strict` is set.
+    pub fn failed(&self, strict: bool) -> bool {
+        !self.errors.is_empty() || (strict && !self.warnings.is_empty())
+    }
+}

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Load legacy Spectrum token JSON Schemas (`packages/tokens/schemas`) into a [`SchemaRegistry`].
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use jsonschema::{Draft, Registry, Resource, Validator};
+use serde_json::Value;
+
+use crate::CoreError;
+
+/// Compiled validators for legacy token types plus `token-file.json`.
+pub struct SchemaRegistry {
+    by_url: HashMap<String, Arc<Validator>>,
+    token_file_validator: Arc<Validator>,
+    token_file_schema_url: String,
+}
+
+impl SchemaRegistry {
+    /// Load `schemas/token-types/*.json` and `schemas/token-file.json` from `schemas_dir`.
+    pub fn load_legacy_token_schemas(schemas_dir: &Path) -> Result<Self, CoreError> {
+        let token_types_dir = schemas_dir.join("token-types");
+        if !token_types_dir.is_dir() {
+            return Err(CoreError::SchemaDirectoryMissing(token_types_dir));
+        }
+
+        let mut pairs: Vec<(String, Resource)> = Vec::new();
+        let mut values_by_url: HashMap<String, Value> = HashMap::new();
+
+        for entry in fs::read_dir(&token_types_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let text = fs::read_to_string(&path)?;
+            let value: Value = serde_json::from_str(&text)?;
+            let id = value
+                .get("$id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| CoreError::MissingSchemaId(path.clone()))?
+                .to_string();
+            let resource = Resource::from_contents(value.clone())?;
+            pairs.push((id.clone(), resource));
+            values_by_url.insert(id, value);
+        }
+
+        let token_file_path = schemas_dir.join("token-file.json");
+        let token_file_text = fs::read_to_string(&token_file_path)?;
+        let token_file_value: Value = serde_json::from_str(&token_file_text)?;
+        let token_file_id = token_file_value
+            .get("$id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| CoreError::MissingSchemaId(token_file_path.clone()))?
+            .to_string();
+        let token_file_resource = Resource::from_contents(token_file_value.clone())?;
+        pairs.push((token_file_id.clone(), token_file_resource));
+
+        let registry = Registry::try_from_resources(pairs)?;
+        let registry = Arc::new(registry);
+
+        let build_opts = || {
+            jsonschema::options()
+                .with_registry((*registry).clone())
+                .with_draft(Draft::Draft202012)
+                .should_validate_formats(true)
+        };
+
+        let mut by_url = HashMap::new();
+        for (url, schema_value) in &values_by_url {
+            let validator = build_opts()
+                .build(schema_value)
+                .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
+            by_url.insert(url.clone(), Arc::new(validator));
+        }
+
+        let token_file_validator = build_opts()
+            .build(&token_file_value)
+            .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
+
+        Ok(Self {
+            by_url,
+            token_file_validator: Arc::new(token_file_validator),
+            token_file_schema_url: token_file_id,
+        })
+    }
+
+    /// Validator for a token object's `$schema` URL (legacy token-types).
+    pub fn validator_for_url(&self, schema_url: &str) -> Option<&Arc<Validator>> {
+        self.by_url.get(schema_url)
+    }
+
+    /// Whole-file validator (`token-file.json`).
+    pub fn token_file_validator(&self) -> &Arc<Validator> {
+        &self.token_file_validator
+    }
+
+    pub fn token_file_schema_url(&self) -> &str {
+        &self.token_file_schema_url
+    }
+}

--- a/sdk/core/src/validate/mod.rs
+++ b/sdk/core/src/validate/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Adobe. All rights reserved.
+// Copyright 2026 Adobe. All rights reserved.
 // This file is licensed to you under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may obtain a copy
 // of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -8,9 +8,33 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! Structural and graph validation (stubs until #724 / #725).
+//! Structural (Layer 1) and relational (Layer 2) validation.
 
-/// Placeholder until JSON Schema Phase 1 is implemented.
+pub mod relational;
+pub mod rule;
+pub mod rules;
+pub mod structural;
+
+use std::path::Path;
+
+use crate::graph::TokenGraph;
+use crate::report::ValidationReport;
+use crate::schema::SchemaRegistry;
+use crate::CoreError;
+
+/// Core validation pipeline is available (schemas + engine compile).
 pub fn engine_ready() -> bool {
     true
+}
+
+/// Run structural validation then relational rules on legacy token JSON under `data_path`.
+pub fn validate_all(
+    data_path: &Path,
+    schema_registry: &SchemaRegistry,
+) -> Result<ValidationReport, CoreError> {
+    let mut report = structural::validate_structural(data_path, schema_registry)?;
+    let graph = TokenGraph::from_json_dir(data_path)?;
+    let rel = relational::validate_relational(&graph);
+    report.merge(rel);
+    Ok(report)
 }

--- a/sdk/core/src/validate/relational.rs
+++ b/sdk/core/src/validate/relational.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Layer 2 — relational rules from the catalog.
+
+use crate::graph::TokenGraph;
+use crate::report::{Diagnostic, Severity, ValidationReport};
+use crate::validate::rules;
+
+/// Run all relational rules; merges errors and warnings by severity on each diagnostic.
+pub fn validate_relational(graph: &TokenGraph) -> ValidationReport {
+    let mut report = ValidationReport {
+        valid: true,
+        errors: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    for d in rules::run_rules(graph) {
+        match d.severity {
+            Severity::Error => report.push_error(d),
+            Severity::Warning => report.push_warning(d),
+            Severity::Info => report.warnings.push(d),
+        }
+    }
+
+    report.recompute_valid();
+    report
+}
+
+/// Test helper: filter diagnostics by rule id.
+pub fn diagnostics_for_rule(graph: &TokenGraph, rule_id: &str) -> Vec<Diagnostic> {
+    rules::run_rules(graph)
+        .into_iter()
+        .filter(|d| d.rule_id.as_deref() == Some(rule_id))
+        .collect()
+}

--- a/sdk/core/src/validate/rule.rs
+++ b/sdk/core/src/validate/rule.rs
@@ -1,0 +1,26 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Layer 2 rule trait (catalog ids).
+
+use crate::graph::TokenGraph;
+use crate::report::Diagnostic;
+
+/// Context for relational rules.
+pub struct ValidationContext<'a> {
+    pub graph: &'a TokenGraph,
+}
+
+/// Catalog-backed validation rule.
+pub trait ValidationRule: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn name(&self) -> &'static str;
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic>;
+}

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -1,0 +1,42 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+mod spec001;
+mod spec002;
+mod spec003;
+mod spec004;
+mod spec005;
+mod spec006;
+
+use crate::graph::TokenGraph;
+use crate::report::Diagnostic;
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+/// All default catalog rules (SPEC-001 … SPEC-006).
+pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
+    vec![
+        Box::new(spec001::Rule),
+        Box::new(spec002::Rule),
+        Box::new(spec003::Rule),
+        Box::new(spec004::Rule),
+        Box::new(spec005::Rule),
+        Box::new(spec006::Rule),
+    ]
+}
+
+/// Run every rule and collect diagnostics.
+pub fn run_rules(graph: &TokenGraph) -> Vec<Diagnostic> {
+    let ctx = ValidationContext { graph };
+    let mut out = Vec::new();
+    for r in default_rules() {
+        out.extend(r.validate(&ctx));
+    }
+    out
+}

--- a/sdk/core/src/validate/rules/spec001.rs
+++ b/sdk/core/src/validate/rules/spec001.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-001"
+    }
+
+    fn name(&self) -> &'static str {
+        "alias-target-exists"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(target) = &t.alias_target else {
+                continue;
+            };
+            if !ctx.graph.tokens.contains_key(target) {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!("Alias target not found for $ref: {target}"),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec002.rs
+++ b/sdk/core/src/validate/rules/spec002.rs
@@ -1,0 +1,71 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-002"
+    }
+
+    fn name(&self) -> &'static str {
+        "alias-type-compatibility"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(target_name) = &t.alias_target else {
+                continue;
+            };
+            let Some(target) = ctx.graph.tokens.get(target_name) else {
+                continue;
+            };
+            let leaf = target.resolve_leaf(ctx.graph);
+
+            // Conformance heuristic: spacing-like alias must not resolve to a color leaf.
+            if name_suggests_spacing(&t.name) && is_color_schema(leaf.schema_url.as_deref().unwrap_or("")) {
+                out.push(diagnostic(
+                    self.id(),
+                    t,
+                    format!(
+                        "Alias {} resolves to incompatible type (expected spacing-related, got color)",
+                        t.name
+                    ),
+                ));
+            }
+        }
+        out
+    }
+}
+
+fn diagnostic(id: &str, t: &crate::graph::TokenRecord, message: String) -> Diagnostic {
+    Diagnostic {
+        file: t.file.clone(),
+        token: Some(t.name.clone()),
+        rule_id: Some(id.to_string()),
+        severity: Severity::Error,
+        message,
+        instance_path: None,
+        schema_path: None,
+    }
+}
+
+fn is_color_schema(url: &str) -> bool {
+    url.ends_with("color.json")
+}
+
+fn name_suggests_spacing(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.contains("spacing") || n.contains("spacing-alias")
+}

--- a/sdk/core/src/validate/rules/spec003.rs
+++ b/sdk/core/src/validate/rules/spec003.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-003"
+    }
+
+    fn name(&self) -> &'static str {
+        "no-circular-aliases"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for start in ctx.graph.tokens.values() {
+            if start.alias_target.is_none() {
+                continue;
+            }
+            let mut path: Vec<String> = vec![start.name.clone()];
+            let mut current = start;
+            loop {
+                let Some(next_name) = current.alias_target.as_ref() else {
+                    break;
+                };
+                if path.iter().any(|p| p == next_name) {
+                    out.push(Diagnostic {
+                        file: start.file.clone(),
+                        token: Some(start.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!("Circular alias chain detected involving {}", start.name),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                    break;
+                }
+                path.push(next_name.clone());
+                let Some(next) = ctx.graph.tokens.get(next_name.as_str()) else {
+                    break;
+                };
+                current = next;
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec004.rs
+++ b/sdk/core/src/validate/rules/spec004.rs
@@ -1,0 +1,55 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use std::collections::HashMap;
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-004"
+    }
+
+    fn name(&self) -> &'static str {
+        "uuid-global-uniqueness"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut by_uuid: HashMap<&str, Vec<&crate::graph::TokenRecord>> = HashMap::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(u) = t.uuid.as_deref() else {
+                continue;
+            };
+            by_uuid.entry(u).or_default().push(t);
+        }
+
+        let mut out = Vec::new();
+        for (uuid, group) in by_uuid {
+            if group.len() < 2 {
+                continue;
+            }
+            for t in group {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!("Duplicate uuid {uuid}"),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec005.rs
+++ b/sdk/core/src/validate/rules/spec005.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-005"
+    }
+
+    fn name(&self) -> &'static str {
+        "cascade-coverage"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for d in &ctx.graph.dimensions {
+            if !d.modes.iter().any(|m| m == &d.default_mode) {
+                out.push(Diagnostic {
+                    file: d.file.clone(),
+                    token: None,
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Dimension coverage violation for {}: default {:?} is not in modes {:?}",
+                        d.name, d.default_mode, d.modes
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec006.rs
+++ b/sdk/core/src/validate/rules/spec006.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use std::collections::HashMap;
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-006"
+    }
+
+    fn name(&self) -> &'static str {
+        "specificity-correctness"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut by_name_key: HashMap<String, Vec<&crate::graph::TokenRecord>> = HashMap::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(name_val) = t.raw.get("name") else {
+                continue;
+            };
+            if !name_val.is_object() {
+                continue;
+            }
+            let Ok(key) = serde_json::to_string(name_val) else {
+                continue;
+            };
+            by_name_key.entry(key).or_default().push(t);
+        }
+
+        let mut out = Vec::new();
+        for (key, group) in by_name_key {
+            if group.len() < 2 {
+                continue;
+            }
+            let first = group[0];
+            out.push(Diagnostic {
+                file: first.file.clone(),
+                token: Some(first.name.clone()),
+                rule_id: Some(self.id().to_string()),
+                severity: Severity::Warning,
+                message: format!(
+                    "Ambiguous cascade resolution (specificity tie) for context {key}"
+                ),
+                instance_path: None,
+                schema_path: None,
+            });
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/structural.rs
+++ b/sdk/core/src/validate/structural.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Layer 1 — per-token JSON Schema validation for legacy token files.
+
+use std::path::Path;
+
+use jsonschema::ValidationError;
+
+use serde_json::Value;
+
+use crate::discovery::discover_json_files;
+use crate::report::{Diagnostic, Severity, ValidationReport};
+use crate::schema::SchemaRegistry;
+use crate::CoreError;
+
+/// Validate every `*.json` file under `data_path` as a legacy Spectrum token file.
+pub fn validate_structural(
+    data_path: &Path,
+    registry: &SchemaRegistry,
+) -> Result<ValidationReport, CoreError> {
+    let mut report = ValidationReport {
+        valid: true,
+        errors: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    let files = discover_json_files(data_path)?;
+    for file in files {
+        validate_token_file(&file, registry, &mut report)?;
+    }
+
+    report.recompute_valid();
+    Ok(report)
+}
+
+fn validate_token_file(
+    path: &Path,
+    registry: &SchemaRegistry,
+    report: &mut ValidationReport,
+) -> Result<(), CoreError> {
+    let text = std::fs::read_to_string(path)?;
+    let root: Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            report.push_error(Diagnostic {
+                file: path.to_path_buf(),
+                token: None,
+                rule_id: None,
+                severity: Severity::Error,
+                message: format!("invalid JSON: {e}"),
+                instance_path: None,
+                schema_path: None,
+            });
+            return Ok(());
+        }
+    };
+
+    let Some(obj) = root.as_object() else {
+        report.push_error(Diagnostic {
+            file: path.to_path_buf(),
+            token: None,
+            rule_id: None,
+            severity: Severity::Error,
+            message: "token file root must be a JSON object".to_string(),
+            instance_path: Some("/".to_string()),
+            schema_path: None,
+        });
+        return Ok(());
+    };
+
+    for (token_name, token_value) in obj {
+        let Some(token_obj) = token_value.as_object() else {
+            report.push_error(Diagnostic {
+                file: path.to_path_buf(),
+                token: Some(token_name.clone()),
+                rule_id: None,
+                severity: Severity::Error,
+                message: "token value must be a JSON object".to_string(),
+                instance_path: Some(format!("/{}", escape_json_pointer(token_name))),
+                schema_path: None,
+            });
+            continue;
+        };
+
+        let schema_url = match token_obj.get("$schema").and_then(|v| v.as_str()) {
+            Some(u) => u,
+            None => {
+                report.push_error(Diagnostic {
+                    file: path.to_path_buf(),
+                    token: Some(token_name.clone()),
+                    rule_id: None,
+                    severity: Severity::Error,
+                    message: "missing required \"$schema\" property".to_string(),
+                    instance_path: Some(format!("/{}", escape_json_pointer(token_name))),
+                    schema_path: None,
+                });
+                continue;
+            }
+        };
+
+        let Some(validator) = registry.validator_for_url(schema_url) else {
+            report.push_error(Diagnostic {
+                file: path.to_path_buf(),
+                token: Some(token_name.clone()),
+                rule_id: None,
+                severity: Severity::Error,
+                message: format!("unknown \"$schema\" URL (no loaded schema): {schema_url}"),
+                instance_path: Some(format!("/{}", escape_json_pointer(token_name))),
+                schema_path: None,
+            });
+            continue;
+        };
+
+        for err in validator.iter_errors(token_value) {
+            let err: ValidationError<'_> = err;
+            report.push_error(Diagnostic {
+                file: path.to_path_buf(),
+                token: Some(token_name.clone()),
+                rule_id: None,
+                severity: Severity::Error,
+                message: err.to_string(),
+                instance_path: Some(err.instance_path.to_string()),
+                schema_path: Some(err.schema_path.to_string()),
+            });
+        }
+    }
+
+    // Whole-file validation against token-file.json (matches packages/tokens tests).
+    for err in registry.token_file_validator().iter_errors(&root) {
+        let err: ValidationError<'_> = err;
+        report.push_error(Diagnostic {
+            file: path.to_path_buf(),
+            token: None,
+            rule_id: None,
+            severity: Severity::Error,
+            message: err.to_string(),
+            instance_path: Some(err.instance_path.to_string()),
+            schema_path: Some(err.schema_path.to_string()),
+        });
+    }
+
+    Ok(())
+}
+
+fn escape_json_pointer(key: &str) -> String {
+    key.replace('~', "~0").replace('/', "~1")
+}

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Adobe. All rights reserved.
+# Copyright 2026 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## What
Phase 1 of the Design Data Specification: validation engine and CLI for legacy Spectrum tokens.

## Key changes
- `token-file.json` top-level schema + `multiplier.json` fix
- `sdk/core`: SchemaRegistry, TokenGraph, structural + relational validators, SPEC-001 through SPEC-006
- `sdk/cli`: `validate` and `migrate` subcommands with pretty/JSON output
- Moon tasks (`validateDesignData`, `verifyDesignDataSnapshot`) in `packages/tokens/moon.yml`
- Golden snapshot at `packages/tokens/snapshots/validation-snapshot.json`
- Changeset for `@adobe/spectrum-tokens`
- Updated JS tests and README

## Test plan
- `moon run tokens:test`
- `cargo test --manifest-path sdk/Cargo.toml`


Made with [Cursor](https://cursor.com)

## Design Data project tracking ([project board](https://github.com/orgs/adobe/projects/89/views/1))

Closes #723
Closes #724
Closes #725
Closes #726
Closes #727
Closes #728
