### PR TITLE
feat(design-data): SPEC-007 name-roundtrip rule and naming exceptions

### DIFF
--- a/.changeset/naming-exceptions-spec007.md
+++ b/.changeset/naming-exceptions-spec007.md
@@ -1,0 +1,9 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+Add naming-exceptions.json and SPEC-007 (name-roundtrip) validation
+rule. Tracks 194 legacy token names that cannot be deterministically
+generated from a structured name object (167 state-position, 27
+compound-state). This infrastructure supports the migration path from
+legacy flat kebab-case names to structured name objects.

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -55,3 +55,12 @@ rules:
     message: "Ambiguous cascade resolution (specificity tie) for context {context}"
     spec_ref: spec/cascade.md#semantic-specificity
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-007
+    name: name-roundtrip
+    severity: warning
+    category: naming-consistency
+    assert: Every legacy token name MUST be reproducible from a structured name object via deterministic generation rules, unless listed in naming-exceptions.json.
+    message: "Token '{token}' does not roundtrip through name-object generation rules"
+    spec_ref: spec/token-format.md#name-object
+    introduced_in: "1.0.0-draft"

--- a/packages/tokens/moon.yml
+++ b/packages/tokens/moon.yml
@@ -28,11 +28,14 @@ tasks:
       - ./src
       - --schema-path
       - ./schemas
+      - --exceptions-path
+      - ./naming-exceptions.json
     platform: system
     inputs:
       - "@globs(sources)"
       - "schemas/**/*.json"
       - "snapshots/**/*.json"
+      - "naming-exceptions.json"
   verifyDesignDataSnapshot:
     command: cargo
     args:
@@ -49,11 +52,14 @@ tasks:
       - ./snapshots/validation-snapshot.json
       - --schema-path
       - ./schemas
+      - --exceptions-path
+      - ./naming-exceptions.json
     platform: system
     inputs:
       - "@globs(sources)"
       - "schemas/**/*.json"
       - "snapshots/**/*.json"
+      - "naming-exceptions.json"
   build:
     deps:
       - ~:buildTokens

--- a/packages/tokens/naming-exceptions.json
+++ b/packages/tokens/naming-exceptions.json
@@ -1,0 +1,1170 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/naming-exceptions.json",
+  "description": "Legacy token names that cannot be deterministically generated from a structured name object. Each entry tracks a known inconsistency for future remediation.",
+  "exceptions": [
+    {
+      "token": "drop-shadow-emphasized-default-color",
+      "file": "color-aliases.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-color",
+      "file": "color-aliases.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-key-color",
+      "file": "color-aliases.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-color-default",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-color-down",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-color-emphasized",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-color-hover",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-color-key-focus",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "table-selected-row-background-color-non-emphasized",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "table-selected-row-background-opacity-hover",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "table-selected-row-background-opacity-non-emphasized",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "table-selected-row-background-opacity-non-emphasized-hover",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "tree-view-selected-row-background-color-emphasized",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "tree-view-selected-row-background-default",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "tree-view-selected-row-background-hover",
+      "file": "color-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-opacity-emphasized",
+      "file": "layout-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-opacity-emphasized-down",
+      "file": "layout-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-opacity-emphasized-hover",
+      "file": "layout-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "stack-item-selected-background-opacity-emphasized-key-focus",
+      "file": "layout-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "tree-view-selected-row-background-opacity-emphasized",
+      "file": "layout-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "tree-view-selected-row-background-opacity-emphasized-hover",
+      "file": "layout-component.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-blur",
+      "file": "layout.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-x",
+      "file": "layout.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-y",
+      "file": "layout.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-blur",
+      "file": "layout.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-x",
+      "file": "layout.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-y",
+      "file": "layout.json",
+      "category": "compound-state",
+      "reason": "Does not roundtrip through canonical generation rules (category: compound-state)"
+    },
+    {
+      "token": "disabled-background-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-border-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-content-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-static-black-background-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-static-black-border-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-static-black-content-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-static-white-background-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-static-white-border-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "disabled-static-white-content-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "drop-shadow-emphasized-key-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "focus-indicator-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "static-black-focus-indicator-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "static-white-focus-indicator-color",
+      "file": "color-aliases.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "select-box-selected-border-color",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "swatch-disabled-icon-border-color",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "swatch-disabled-icon-border-opacity",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "table-row-down-opacity",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "table-row-hover-color",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "table-row-hover-opacity",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "table-selected-row-background-color",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "table-selected-row-background-opacity",
+      "file": "color-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "icon-color-disabled-primary",
+      "file": "icons.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "icon-color-emphasized-background",
+      "file": "icons.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "accordion-focus-indicator-gap",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-default-width-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-default-width-extra-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-default-width-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-default-width-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-default-width-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-edge-to-content-default-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-edge-to-content-default-extra-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-edge-to-content-default-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-edge-to-content-default-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "card-edge-to-content-default-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-default-width-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-default-width-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-default-width-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-default-width-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-edge-to-content-not-selected-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-edge-to-content-not-selected-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-edge-to-content-not-selected-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-edge-to-content-not-selected-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-top-to-selected-icon-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-top-to-selected-icon-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-top-to-selected-icon-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "menu-item-top-to-selected-icon-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "meter-default-width",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "slider-handle-border-width-down-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "slider-handle-border-width-down-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "slider-handle-border-width-down-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "slider-handle-border-width-down-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-height-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-height-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-height-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-height-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-width-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-width-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-width-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "steplist-step-default-width-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "switch-handle-selected-size-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "switch-handle-selected-size-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "switch-handle-selected-size-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "switch-handle-selected-size-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tab-item-focus-indicator-gap-extra-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tab-item-focus-indicator-gap-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tab-item-focus-indicator-gap-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tab-item-focus-indicator-gap-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tag-field-default-width-large",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tag-field-default-width-medium",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "tag-field-default-width-small",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-cjk-emphasized-font-style",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-cjk-emphasized-font-weight",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-cjk-strong-emphasized-font-style",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-cjk-strong-emphasized-font-weight",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-sans-serif-emphasized-font-style",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-sans-serif-emphasized-font-weight",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-sans-serif-strong-emphasized-font-style",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-sans-serif-strong-emphasized-font-weight",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-serif-emphasized-font-style",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-serif-emphasized-font-weight",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-serif-strong-emphasized-font-style",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "title-serif-strong-emphasized-font-weight",
+      "file": "layout-component.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "focus-indicator-gap",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "focus-indicator-thickness",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "side-focus-indicator",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-cjk-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-cjk-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-cjk-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-cjk-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-sans-serif-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-sans-serif-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-sans-serif-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-sans-serif-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-serif-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-serif-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-serif-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "body-serif-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-cjk-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-cjk-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-cjk-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-cjk-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "code-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "default-font-family",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "default-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-light-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-light-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-light-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-light-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-cjk-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-light-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-light-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-light-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-light-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-sans-serif-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-light-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-light-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-light-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-light-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "detail-serif-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-heavy-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-heavy-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-heavy-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-heavy-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-light-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-light-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-light-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-light-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-cjk-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-heavy-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-heavy-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-heavy-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-heavy-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-light-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-light-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-light-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-light-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-sans-serif-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-heavy-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-heavy-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-heavy-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-heavy-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-light-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-light-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-light-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-light-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-strong-emphasized-font-style",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "heading-serif-strong-emphasized-font-weight",
+      "file": "typography.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    }
+  ]
+}

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -1,4 +1,1363 @@
 {
   "errors": [],
-  "warnings": []
+  "warnings": [
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-background-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-background-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-border-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-border-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-content-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-content-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-static-black-background-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-static-black-background-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-static-black-border-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-static-black-border-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-static-black-content-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-static-black-content-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-static-white-background-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-static-white-background-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-static-white-border-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-static-white-border-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "disabled-static-white-content-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'disabled-static-white-content-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "drop-shadow-emphasized-default-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-default-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "drop-shadow-emphasized-hover-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-hover-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "drop-shadow-emphasized-hover-key-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-hover-key-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "drop-shadow-emphasized-key-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-key-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "focus-indicator-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'focus-indicator-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "static-black-focus-indicator-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'static-black-focus-indicator-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-aliases.json",
+      "token": "static-white-focus-indicator-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'static-white-focus-indicator-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "select-box-selected-border-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'select-box-selected-border-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "stack-item-selected-background-color-default",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-color-default' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "stack-item-selected-background-color-down",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-color-down' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "stack-item-selected-background-color-emphasized",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-color-emphasized' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "stack-item-selected-background-color-hover",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-color-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "stack-item-selected-background-color-key-focus",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-color-key-focus' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "swatch-disabled-icon-border-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'swatch-disabled-icon-border-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "swatch-disabled-icon-border-opacity",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'swatch-disabled-icon-border-opacity' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-row-down-opacity",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-row-down-opacity' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-row-hover-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-row-hover-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-row-hover-opacity",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-row-hover-opacity' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-selected-row-background-color",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-selected-row-background-color' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-selected-row-background-color-non-emphasized",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-selected-row-background-color-non-emphasized' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-selected-row-background-opacity",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-selected-row-background-opacity' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-selected-row-background-opacity-hover",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-selected-row-background-opacity-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-selected-row-background-opacity-non-emphasized",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-selected-row-background-opacity-non-emphasized' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "table-selected-row-background-opacity-non-emphasized-hover",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'table-selected-row-background-opacity-non-emphasized-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "tree-view-selected-row-background-color-emphasized",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tree-view-selected-row-background-color-emphasized' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "tree-view-selected-row-background-default",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tree-view-selected-row-background-default' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-component.json",
+      "token": "tree-view-selected-row-background-hover",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tree-view-selected-row-background-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/icons.json",
+      "token": "icon-color-disabled-primary",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'icon-color-disabled-primary' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/icons.json",
+      "token": "icon-color-emphasized-background",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'icon-color-emphasized-background' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "accordion-focus-indicator-gap",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'accordion-focus-indicator-gap' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-default-width-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-default-width-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-default-width-extra-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-default-width-extra-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-default-width-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-default-width-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-default-width-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-default-width-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-default-width-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-default-width-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-edge-to-content-default-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-edge-to-content-default-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-edge-to-content-default-extra-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-edge-to-content-default-extra-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-edge-to-content-default-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-edge-to-content-default-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-edge-to-content-default-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-edge-to-content-default-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "card-edge-to-content-default-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'card-edge-to-content-default-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "field-default-width-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-default-width-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "field-default-width-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-default-width-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "field-default-width-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-default-width-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "field-default-width-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-default-width-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-edge-to-content-not-selected-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-edge-to-content-not-selected-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-edge-to-content-not-selected-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-edge-to-content-not-selected-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-edge-to-content-not-selected-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-edge-to-content-not-selected-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-edge-to-content-not-selected-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-edge-to-content-not-selected-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-top-to-selected-icon-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-top-to-selected-icon-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-top-to-selected-icon-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-top-to-selected-icon-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-top-to-selected-icon-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-top-to-selected-icon-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "menu-item-top-to-selected-icon-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'menu-item-top-to-selected-icon-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "meter-default-width",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'meter-default-width' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "slider-handle-border-width-down-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'slider-handle-border-width-down-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "slider-handle-border-width-down-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'slider-handle-border-width-down-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "slider-handle-border-width-down-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'slider-handle-border-width-down-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "slider-handle-border-width-down-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'slider-handle-border-width-down-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "stack-item-selected-background-opacity-emphasized",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-opacity-emphasized' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "stack-item-selected-background-opacity-emphasized-down",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-opacity-emphasized-down' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "stack-item-selected-background-opacity-emphasized-hover",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-opacity-emphasized-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "stack-item-selected-background-opacity-emphasized-key-focus",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'stack-item-selected-background-opacity-emphasized-key-focus' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-height-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-height-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-height-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-height-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-height-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-height-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-height-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-height-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-width-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-width-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-width-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-width-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-width-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-width-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "steplist-step-default-width-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'steplist-step-default-width-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "switch-handle-selected-size-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'switch-handle-selected-size-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "switch-handle-selected-size-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'switch-handle-selected-size-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "switch-handle-selected-size-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'switch-handle-selected-size-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "switch-handle-selected-size-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'switch-handle-selected-size-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-focus-indicator-gap-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-focus-indicator-gap-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-focus-indicator-gap-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-focus-indicator-gap-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-focus-indicator-gap-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-focus-indicator-gap-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-focus-indicator-gap-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-focus-indicator-gap-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tag-field-default-width-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tag-field-default-width-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tag-field-default-width-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tag-field-default-width-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tag-field-default-width-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tag-field-default-width-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-cjk-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-cjk-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-cjk-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-cjk-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-cjk-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-cjk-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-cjk-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-cjk-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-sans-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-sans-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-sans-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-sans-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-sans-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-sans-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-sans-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-sans-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "title-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'title-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tree-view-selected-row-background-opacity-emphasized",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tree-view-selected-row-background-opacity-emphasized' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tree-view-selected-row-background-opacity-emphasized-hover",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tree-view-selected-row-background-opacity-emphasized-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "drop-shadow-emphasized-default-blur",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-default-blur' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "drop-shadow-emphasized-default-x",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-default-x' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "drop-shadow-emphasized-default-y",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-default-y' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "drop-shadow-emphasized-hover-blur",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-hover-blur' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "drop-shadow-emphasized-hover-x",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-hover-x' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "drop-shadow-emphasized-hover-y",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'drop-shadow-emphasized-hover-y' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "focus-indicator-gap",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'focus-indicator-gap' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "focus-indicator-thickness",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'focus-indicator-thickness' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "side-focus-indicator",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'side-focus-indicator' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-cjk-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-cjk-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-cjk-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-cjk-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-cjk-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-cjk-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-cjk-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-cjk-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-sans-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-sans-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-sans-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-sans-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-sans-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-sans-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-sans-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-sans-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "body-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'body-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-cjk-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-cjk-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-cjk-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-cjk-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-cjk-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-cjk-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-cjk-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-cjk-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "code-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'code-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "default-font-family",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'default-font-family' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "default-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'default-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-light-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-light-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-light-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-light-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-light-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-light-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-light-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-light-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-cjk-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-cjk-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-light-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-light-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-light-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-light-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-light-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-light-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-light-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-light-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-sans-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-sans-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-light-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-light-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-light-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-light-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-light-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-light-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-light-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-light-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "detail-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'detail-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-heavy-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-heavy-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-heavy-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-heavy-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-heavy-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-heavy-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-heavy-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-heavy-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-light-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-light-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-light-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-light-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-light-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-light-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-light-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-light-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-cjk-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-cjk-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-heavy-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-heavy-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-heavy-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-heavy-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-heavy-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-heavy-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-heavy-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-heavy-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-light-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-light-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-light-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-light-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-light-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-light-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-light-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-light-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-sans-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-sans-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-heavy-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-heavy-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-heavy-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-heavy-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-heavy-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-heavy-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-heavy-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-heavy-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-light-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-light-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-light-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-light-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-light-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-light-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-light-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-light-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-strong-emphasized-font-style",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-strong-emphasized-font-style' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/typography.json",
+      "token": "heading-serif-strong-emphasized-font-weight",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'heading-serif-strong-emphasized-font-weight' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    }
+  ]
 }

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -13,8 +13,11 @@ use std::process::ExitCode;
 
 mod format;
 
+use std::collections::HashSet;
+
 use clap::{Parser, Subcommand, ValueEnum};
 use design_data_core::compat::{load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot};
+use design_data_core::naming::NamingExceptionsFile;
 use design_data_core::schema::SchemaRegistry;
 use design_data_core::validate;
 use miette::{IntoDiagnostic, WrapErr};
@@ -40,6 +43,9 @@ enum Commands {
         /// Root directory containing `token-types/` and `token-file.json`
         #[arg(long, value_name = "DIR")]
         schema_path: Option<PathBuf>,
+        /// Path to naming-exceptions.json allowlist for SPEC-007
+        #[arg(long, value_name = "FILE")]
+        exceptions_path: Option<PathBuf>,
         /// Treat warnings as errors
         #[arg(long)]
         strict: bool,
@@ -63,6 +69,8 @@ enum MigrateSub {
         snapshot: PathBuf,
         #[arg(long, value_name = "DIR")]
         schema_path: Option<PathBuf>,
+        #[arg(long, value_name = "FILE")]
+        exceptions_path: Option<PathBuf>,
     },
     /// Run validation and write a sorted snapshot JSON for CI / golden testing
     Snapshot {
@@ -72,6 +80,8 @@ enum MigrateSub {
         output: PathBuf,
         #[arg(long, value_name = "DIR")]
         schema_path: Option<PathBuf>,
+        #[arg(long, value_name = "FILE")]
+        exceptions_path: Option<PathBuf>,
     },
 }
 
@@ -80,6 +90,27 @@ enum OutputFormat {
     #[default]
     Pretty,
     Json,
+}
+
+fn load_exceptions(path: Option<&Path>) -> miette::Result<HashSet<String>> {
+    let Some(p) = path else {
+        return Ok(default_exceptions_path()
+            .and_then(|p| NamingExceptionsFile::load(&p).ok())
+            .map(|f| f.token_set())
+            .unwrap_or_default());
+    };
+    let file = NamingExceptionsFile::load(p)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load exceptions from {}", p.display()))?;
+    Ok(file.token_set())
+}
+
+fn default_exceptions_path() -> Option<PathBuf> {
+    let candidates = [
+        PathBuf::from("packages/tokens/naming-exceptions.json"),
+        PathBuf::from("../packages/tokens/naming-exceptions.json"),
+    ];
+    candidates.into_iter().find(|c| c.is_file())
 }
 
 fn default_schema_path() -> PathBuf {
@@ -102,6 +133,7 @@ fn run_validate(
     path: &Path,
     format: OutputFormat,
     schema_path: Option<PathBuf>,
+    exceptions_path: Option<PathBuf>,
     strict: bool,
 ) -> miette::Result<ExitCode> {
     if !validate::engine_ready() {
@@ -111,8 +143,9 @@ fn run_validate(
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load schemas from {}", schema_root.display()))?;
+    let exceptions = load_exceptions(exceptions_path.as_deref())?;
 
-    let report = validate::validate_all(path, &registry)
+    let report = validate::validate_all_with_exceptions(path, &registry, &exceptions)
         .into_diagnostic()
         .wrap_err("validation failed")?;
 
@@ -135,10 +168,13 @@ fn run_migrate_verify(
     path: &Path,
     snapshot: &Path,
     schema_path: Option<PathBuf>,
+    exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
     let schema_root = schema_path.unwrap_or_else(default_schema_path);
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root).into_diagnostic()?;
-    let report = validate::validate_all(path, &registry).into_diagnostic()?;
+    let exceptions = load_exceptions(exceptions_path.as_deref())?;
+    let report =
+        validate::validate_all_with_exceptions(path, &registry, &exceptions).into_diagnostic()?;
     let expected = load_snapshot(snapshot).into_diagnostic()?;
     if snapshot_matches(&report, &expected) {
         println!("Snapshot OK: {}", snapshot.display());
@@ -157,10 +193,13 @@ fn run_migrate_snapshot(
     path: &Path,
     output: &Path,
     schema_path: Option<PathBuf>,
+    exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
     let schema_root = schema_path.unwrap_or_else(default_schema_path);
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root).into_diagnostic()?;
-    let report = validate::validate_all(path, &registry).into_diagnostic()?;
+    let exceptions = load_exceptions(exceptions_path.as_deref())?;
+    let report =
+        validate::validate_all_with_exceptions(path, &registry, &exceptions).into_diagnostic()?;
     let snap = ValidationSnapshot::from(&report);
     write_snapshot(output, &snap).into_diagnostic()?;
     println!("Wrote {}", output.display());
@@ -175,22 +214,25 @@ fn main() -> ExitCode {
             path,
             format,
             schema_path,
+            exceptions_path,
             strict,
         } => {
             let target = path.unwrap_or_else(|| PathBuf::from("."));
-            run_validate(&target, format, schema_path, strict)
+            run_validate(&target, format, schema_path, exceptions_path, strict)
         }
         Commands::Migrate { sub } => match sub {
             MigrateSub::Verify {
                 path,
                 snapshot,
                 schema_path,
-            } => run_migrate_verify(&path, &snapshot, schema_path),
+                exceptions_path,
+            } => run_migrate_verify(&path, &snapshot, schema_path, exceptions_path),
             MigrateSub::Snapshot {
                 path,
                 output,
                 schema_path,
-            } => run_migrate_snapshot(&path, &output, schema_path),
+                exceptions_path,
+            } => run_migrate_snapshot(&path, &output, schema_path, exceptions_path),
         },
     };
 

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod compat;
 pub mod discovery;
 pub mod graph;
+pub mod naming;
 pub mod report;
 pub mod schema;
 pub mod validate;

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Legacy name generation and parsing for the name-object ↔ kebab-case roundtrip.
+//!
+//! The **canonical generation order** for a legacy token name is:
+//!
+//! ```text
+//! {component}-{property}-{state}
+//! ```
+//!
+//! Where `component` and `state` are optional. Foundation tokens (no component)
+//! produce just `{property}` or `{property}-{state}`.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+
+/// Well-known interactive / semantic state words that may appear as the
+/// trailing segment(s) of a legacy token name.
+static STATE_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "default",
+        "hover",
+        "down",
+        "focus",
+        "selected",
+        "disabled",
+        "key-focus",
+        "emphasized",
+        "error",
+        "invalid",
+        "active",
+        "open",
+        "closed",
+        "indeterminate",
+        "keyboard-focus",
+    ]
+    .into_iter()
+    .collect()
+});
+
+/// Structured identity extracted from (or mapped to) a legacy kebab-case key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NameObject {
+    pub property: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+/// Generate the canonical legacy name from a [`NameObject`].
+///
+/// Rules:
+/// 1. If `component` is present, emit `{component}-{property}`.
+/// 2. If `state` is present, append `-{state}`.
+pub fn generate_legacy_name(obj: &NameObject) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if let Some(c) = &obj.component {
+        parts.push(c);
+    }
+    parts.push(&obj.property);
+    if let Some(s) = &obj.state {
+        parts.push(s);
+    }
+    parts.join("-")
+}
+
+/// Attempt to decompose a legacy key into a [`NameObject`].
+///
+/// `component_hint` comes from the legacy JSON body's `"component"` field when
+/// present and is trusted for stripping the prefix.
+///
+/// After stripping the component prefix the remainder is split: if the **last**
+/// hyphen-segment is a known state word it becomes `state`; everything else
+/// becomes `property`.
+pub fn parse_legacy_name(key: &str, component_hint: Option<&str>) -> NameObject {
+    let remainder = match component_hint {
+        Some(c) if key.starts_with(c) && key.get(c.len()..c.len() + 1) == Some("-") => {
+            &key[c.len() + 1..]
+        }
+        _ => key,
+    };
+
+    let (property, state) = split_trailing_state(remainder);
+
+    NameObject {
+        property: property.to_string(),
+        component: component_hint.map(str::to_string),
+        state: state.map(str::to_string),
+    }
+}
+
+/// Split a remainder string into `(property, Option<state>)` by checking
+/// whether the last hyphen-delimited segment is a known state word.
+///
+/// Compound states like `key-focus` are two raw segments that form a single
+/// state token; we try the two-segment suffix first.
+fn split_trailing_state(s: &str) -> (&str, Option<&str>) {
+    // Try two-segment compound states first (e.g., "key-focus", "keyboard-focus").
+    if let Some(pos) = s.rmatch_indices('-').nth(1) {
+        let candidate = &s[pos.0 + 1..];
+        if STATE_WORDS.contains(candidate) {
+            let prop = &s[..pos.0];
+            if !prop.is_empty() {
+                return (prop, Some(candidate));
+            }
+        }
+    }
+
+    // Try single-segment state.
+    if let Some(pos) = s.rfind('-') {
+        let candidate = &s[pos + 1..];
+        if STATE_WORDS.contains(candidate) {
+            let prop = &s[..pos];
+            if !prop.is_empty() {
+                return (prop, Some(candidate));
+            }
+        }
+    }
+
+    (s, None)
+}
+
+/// An entry in the naming-exceptions.json allowlist.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamingException {
+    pub token: String,
+    pub file: String,
+    pub category: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested: Option<String>,
+}
+
+/// Top-level shape of the exceptions file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamingExceptionsFile {
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    pub schema: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub exceptions: Vec<NamingException>,
+}
+
+impl NamingExceptionsFile {
+    pub fn load(path: &Path) -> Result<Self, crate::CoreError> {
+        let text = std::fs::read_to_string(path)?;
+        let file: Self = serde_json::from_str(&text)?;
+        Ok(file)
+    }
+
+    pub fn token_set(&self) -> HashSet<String> {
+        self.exceptions.iter().map(|e| e.token.clone()).collect()
+    }
+}
+
+/// Check whether `key` roundtrips through parse → generate **and** that no
+/// state word is embedded inside the `property` portion (which would indicate
+/// the legacy name has state in a non-canonical position).
+pub fn roundtrips(key: &str, component_hint: Option<&str>) -> bool {
+    let obj = parse_legacy_name(key, component_hint);
+    if generate_legacy_name(&obj) != key {
+        return false;
+    }
+    !has_embedded_state(&obj.property)
+}
+
+/// Returns `true` when the property string contains a known state word as a
+/// hyphen-delimited segment in a non-trailing position, indicating the
+/// legacy name encoded state before property.
+fn has_embedded_state(property: &str) -> bool {
+    let segments: Vec<&str> = property.split('-').collect();
+    if segments.len() <= 1 {
+        return false;
+    }
+    // Check every segment except the last (the last is already handled by
+    // split_trailing_state during parse).
+    for (i, seg) in segments.iter().enumerate() {
+        if i == segments.len() - 1 {
+            continue;
+        }
+        if STATE_WORDS.contains(seg) {
+            return true;
+        }
+        // Two-segment compounds: check "{seg}-{next}".
+        if i + 1 < segments.len() - 1 {
+            let compound = format!("{}-{}", seg, segments[i + 1]);
+            if STATE_WORDS.contains(compound.as_str()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_component_property() {
+        let obj = parse_legacy_name("checkbox-control-size", Some("checkbox"));
+        assert_eq!(obj.component.as_deref(), Some("checkbox"));
+        assert_eq!(obj.property, "control-size");
+        assert_eq!(obj.state, None);
+        assert!(roundtrips("checkbox-control-size", Some("checkbox")));
+    }
+
+    #[test]
+    fn component_property_state() {
+        let obj = parse_legacy_name("menu-item-background-color-hover", Some("menu-item"));
+        assert_eq!(obj.component.as_deref(), Some("menu-item"));
+        assert_eq!(obj.property, "background-color");
+        assert_eq!(obj.state.as_deref(), Some("hover"));
+        assert!(roundtrips(
+            "menu-item-background-color-hover",
+            Some("menu-item")
+        ));
+    }
+
+    #[test]
+    fn foundation_no_component() {
+        let obj = parse_legacy_name("corner-radius-100", None);
+        assert_eq!(obj.component, None);
+        assert_eq!(obj.property, "corner-radius-100");
+        assert_eq!(obj.state, None);
+        assert!(roundtrips("corner-radius-100", None));
+    }
+
+    #[test]
+    fn compound_state_key_focus() {
+        let obj = parse_legacy_name(
+            "menu-item-background-color-keyboard-focus",
+            Some("menu-item"),
+        );
+        assert_eq!(obj.state.as_deref(), Some("keyboard-focus"));
+        assert_eq!(obj.property, "background-color");
+        assert!(roundtrips(
+            "menu-item-background-color-keyboard-focus",
+            Some("menu-item")
+        ));
+    }
+
+    #[test]
+    fn state_first_does_not_roundtrip() {
+        // "swatch-disabled-icon-border-color" has "disabled" before property.
+        // parse_legacy_name will treat trailing "color" as property (not a state),
+        // so the generated name won't match.
+        assert!(!roundtrips(
+            "swatch-disabled-icon-border-color",
+            Some("swatch")
+        ));
+    }
+
+    #[test]
+    fn non_decomposable() {
+        let obj = parse_legacy_name("white", None);
+        assert_eq!(obj.property, "white");
+        assert_eq!(obj.state, None);
+        assert!(roundtrips("white", None));
+    }
+
+    #[test]
+    fn foundation_with_trailing_state() {
+        let obj = parse_legacy_name("accent-background-color-default", None);
+        assert_eq!(obj.property, "accent-background-color");
+        assert_eq!(obj.state.as_deref(), Some("default"));
+        assert!(roundtrips("accent-background-color-default", None));
+    }
+}

--- a/sdk/core/src/validate/mod.rs
+++ b/sdk/core/src/validate/mod.rs
@@ -15,6 +15,7 @@ pub mod rule;
 pub mod rules;
 pub mod structural;
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use crate::graph::TokenGraph;
@@ -32,9 +33,18 @@ pub fn validate_all(
     data_path: &Path,
     schema_registry: &SchemaRegistry,
 ) -> Result<ValidationReport, CoreError> {
+    validate_all_with_exceptions(data_path, schema_registry, &HashSet::new())
+}
+
+/// Run structural + relational validation with a naming-exceptions allowlist.
+pub fn validate_all_with_exceptions(
+    data_path: &Path,
+    schema_registry: &SchemaRegistry,
+    naming_exceptions: &HashSet<String>,
+) -> Result<ValidationReport, CoreError> {
     let mut report = structural::validate_structural(data_path, schema_registry)?;
     let graph = TokenGraph::from_json_dir(data_path)?;
-    let rel = relational::validate_relational(&graph);
+    let rel = relational::validate_relational(&graph, naming_exceptions);
     report.merge(rel);
     Ok(report)
 }

--- a/sdk/core/src/validate/relational.rs
+++ b/sdk/core/src/validate/relational.rs
@@ -10,19 +10,24 @@
 
 //! Layer 2 — relational rules from the catalog.
 
+use std::collections::HashSet;
+
 use crate::graph::TokenGraph;
 use crate::report::{Diagnostic, Severity, ValidationReport};
 use crate::validate::rules;
 
 /// Run all relational rules; merges errors and warnings by severity on each diagnostic.
-pub fn validate_relational(graph: &TokenGraph) -> ValidationReport {
+pub fn validate_relational(
+    graph: &TokenGraph,
+    naming_exceptions: &HashSet<String>,
+) -> ValidationReport {
     let mut report = ValidationReport {
         valid: true,
         errors: Vec::new(),
         warnings: Vec::new(),
     };
 
-    for d in rules::run_rules(graph) {
+    for d in rules::run_rules(graph, naming_exceptions) {
         match d.severity {
             Severity::Error => report.push_error(d),
             Severity::Warning => report.push_warning(d),
@@ -36,7 +41,8 @@ pub fn validate_relational(graph: &TokenGraph) -> ValidationReport {
 
 /// Test helper: filter diagnostics by rule id.
 pub fn diagnostics_for_rule(graph: &TokenGraph, rule_id: &str) -> Vec<Diagnostic> {
-    rules::run_rules(graph)
+    let empty = HashSet::new();
+    rules::run_rules(graph, &empty)
         .into_iter()
         .filter(|d| d.rule_id.as_deref() == Some(rule_id))
         .collect()

--- a/sdk/core/src/validate/rule.rs
+++ b/sdk/core/src/validate/rule.rs
@@ -10,12 +10,17 @@
 
 //! Layer 2 rule trait (catalog ids).
 
+use std::collections::HashSet;
+
 use crate::graph::TokenGraph;
 use crate::report::Diagnostic;
 
 /// Context for relational rules.
 pub struct ValidationContext<'a> {
     pub graph: &'a TokenGraph,
+    /// Token names listed in the naming-exceptions allowlist.
+    /// Empty when no exceptions file is loaded.
+    pub naming_exceptions: &'a HashSet<String>,
 }
 
 /// Catalog-backed validation rule.

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -14,12 +14,15 @@ mod spec003;
 mod spec004;
 mod spec005;
 mod spec006;
+mod spec007;
+
+use std::collections::HashSet;
 
 use crate::graph::TokenGraph;
 use crate::report::Diagnostic;
 use crate::validate::rule::{ValidationContext, ValidationRule};
 
-/// All default catalog rules (SPEC-001 … SPEC-006).
+/// All default catalog rules (SPEC-001 … SPEC-007).
 pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
     vec![
         Box::new(spec001::Rule),
@@ -28,12 +31,16 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec004::Rule),
         Box::new(spec005::Rule),
         Box::new(spec006::Rule),
+        Box::new(spec007::Rule),
     ]
 }
 
 /// Run every rule and collect diagnostics.
-pub fn run_rules(graph: &TokenGraph) -> Vec<Diagnostic> {
-    let ctx = ValidationContext { graph };
+pub fn run_rules(graph: &TokenGraph, naming_exceptions: &HashSet<String>) -> Vec<Diagnostic> {
+    let ctx = ValidationContext {
+        graph,
+        naming_exceptions,
+    };
     let mut out = Vec::new();
     for r in default_rules() {
         out.extend(r.validate(&ctx));

--- a/sdk/core/src/validate/rules/spec007.rs
+++ b/sdk/core/src/validate/rules/spec007.rs
@@ -1,0 +1,69 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::naming;
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-007"
+    }
+
+    fn name(&self) -> &'static str {
+        "name-roundtrip"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let component_hint = t
+                .raw
+                .as_object()
+                .and_then(|o| o.get("component"))
+                .and_then(|v| v.as_str());
+
+            if naming::roundtrips(&t.name, component_hint) {
+                continue;
+            }
+
+            if ctx.naming_exceptions.contains(&t.name) {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Info,
+                    message: format!(
+                        "Known naming exception: '{}' does not match canonical generation rules (tracked in naming-exceptions.json)",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            } else {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "Token '{}' does not roundtrip through name-object generation rules and is not in the exceptions allowlist",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}


### PR DESCRIPTION
## What
- **SPEC-007** validation rule: name roundtrip (structured name ↔ legacy token name) with an allowlist for known legacy exceptions.
- **`naming-exceptions.json`**: tracks **194** legacy token names that cannot be deterministically generated from a structured name object.

## Key changes
- `sdk/core/src/naming.rs` — name parsing/generation, roundtrip checks, `NamingExceptionsFile`
- `sdk/core/src/validate/rules/spec007.rs` — SPEC-007 rule (Info for allowlisted, Warning for untracked non-roundtrips)
- `packages/tokens/naming-exceptions.json` — exception data
- `sdk/cli/src/main.rs` — `--exceptions-path`; auto-discover `naming-exceptions.json`; migrate subcommands updated
- `packages/tokens/moon.yml` — validate/verify tasks pass exceptions path; inputs updated
- `packages/design-data-spec/rules/rules.yaml` — SPEC-007 catalog entry
- `packages/tokens/snapshots/validation-snapshot.json` — regenerated golden snapshot
- `.changeset/naming-exceptions-spec007.md` — patch bump for `@adobe/spectrum-tokens`

## Exception breakdown
- **167** `state-position`
- **27** `compound-state`

## Test plan
- `cargo test` (sdk)
- `moon run tokens:test`

Made with [Cursor](https://cursor.com)

## Design Data project tracking ([project board](https://github.com/orgs/adobe/projects/89/views/1))

Extends relational validation from #740; also closes #725.
