### PR TITLE
fix(tokens): restore dist exports and run design-data via sdk:build

### DIFF
--- a/.changeset/restore-dist-exports.md
+++ b/.changeset/restore-dist-exports.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+fix(tokens): restore ./dist/* subpath export for backward compatibility

--- a/packages/tokens/moon.yml
+++ b/packages/tokens/moon.yml
@@ -16,14 +16,8 @@ fileGroups:
     - "test/**/*"
 tasks:
   validateDesignData:
-    command: cargo
+    command: ../../sdk/target/debug/design-data
     args:
-      - run
-      - --manifest-path
-      - ../../sdk/Cargo.toml
-      - --bin
-      - design-data
-      - --
       - validate
       - ./src
       - --schema-path
@@ -31,20 +25,16 @@ tasks:
       - --exceptions-path
       - ./naming-exceptions.json
     platform: system
+    deps:
+      - sdk:build
     inputs:
       - "@globs(sources)"
       - "schemas/**/*.json"
       - "snapshots/**/*.json"
       - "naming-exceptions.json"
   verifyDesignDataSnapshot:
-    command: cargo
+    command: ../../sdk/target/debug/design-data
     args:
-      - run
-      - --manifest-path
-      - ../../sdk/Cargo.toml
-      - --bin
-      - design-data
-      - --
       - migrate
       - verify
       - ./src
@@ -55,6 +45,8 @@ tasks:
       - --exceptions-path
       - ./naming-exceptions.json
     platform: system
+    deps:
+      - sdk:build
     inputs:
       - "@globs(sources)"
       - "schemas/**/*.json"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/packages/tokens#readme",
   "exports": {
     ".": "./index.js",
-    "./schemas/token-file.json": "./schemas/token-file.json"
+    "./schemas/token-file.json": "./schemas/token-file.json",
+    "./dist/*": "./dist/*"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/packages/tokens/test/packageExports.test.js
+++ b/packages/tokens/test/packageExports.test.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import { access, readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const packageJsonPath = fileURLToPath(
+  new URL("../package.json", import.meta.url),
+);
+const pkgDir = path.dirname(packageJsonPath);
+
+/**
+ * Resolve a subpath like ./dist/json/variables.json against the
+ * "./dist/*" -> "./dist/*" export pattern (Node replaces * with the suffix).
+ */
+function resolveDistStarSubpath(request) {
+  if (!request.startsWith("./dist/")) {
+    return null;
+  }
+  const suffix = request.slice("./dist/".length);
+  return `./dist/${suffix}`;
+}
+
+test("package.json exports preserve backward-compatible entry points", async (t) => {
+  const pkg = JSON.parse(await readFile(packageJsonPath, { encoding: "utf8" }));
+  const { exports } = pkg;
+
+  t.truthy(exports, "exports field must be defined");
+  t.is(exports["."], "./index.js", "main entry export");
+  t.is(
+    exports["./schemas/token-file.json"],
+    "./schemas/token-file.json",
+    "token-file schema export",
+  );
+  t.is(
+    exports["./dist/*"],
+    "./dist/*",
+    "dist wildcard export required for @adobe/spectrum-tokens/dist/json/variables.json",
+  );
+});
+
+test("dist/json/variables.json maps through ./dist/* export and exists after build", async (t) => {
+  const pkg = JSON.parse(await readFile(packageJsonPath, { encoding: "utf8" }));
+  const { exports } = pkg;
+
+  t.is(exports["./dist/*"], "./dist/*");
+
+  const consumerSubpath = "./dist/json/variables.json";
+  const resolvedTarget = resolveDistStarSubpath(consumerSubpath);
+  t.is(
+    resolvedTarget,
+    "./dist/json/variables.json",
+    "subpath should map to dist/json/variables.json under ./dist/* pattern",
+  );
+
+  const absolutePath = path.join(pkgDir, "dist/json/variables.json");
+  await t.notThrowsAsync(
+    async () => access(absolutePath),
+    "dist/json/variables.json must exist (buildTokens runs before test)",
+  );
+});


### PR DESCRIPTION
## Summary

- **Backward compatibility:** Add `"./dist/*": "./dist/*"` to `@adobe/spectrum-tokens` `exports` so consumers can keep importing paths like `@adobe/spectrum-tokens/dist/json/variables.json` (reported by React Spectrum).
- **Regression tests:** New AVA tests in `packages/tokens/test/packageExports.test.js` assert the exports map and that `dist/json/variables.json` exists after build.
- **Moon / Rust:** Replace `cargo run --manifest-path ../../sdk/Cargo.toml` in `validateDesignData` and `verifyDesignDataSnapshot` with the pre-built `design-data` binary and `deps: [sdk:build]`, so Moon no longer runs `cargo generate-lockfile` from `packages/tokens/` (fixes `moon run tokens:test` in that scenario) and avoids redundant recompilation per validation task.

## Test plan

- [x] `moon run tokens:test`

## Related

Aligns with cross-project Rust orchestration described in #722 / #728.

Made with [Cursor](https://cursor.com)