### PR TITLE
fix(mcp): align with MCP spec for strict clients (closes #705)

### DIFF
--- a/.changeset/fix-mcp-spec-compatibility.md
+++ b/.changeset/fix-mcp-spec-compatibility.md
@@ -1,0 +1,11 @@
+---
+"@adobe/spectrum-design-data-mcp": patch
+"@adobe/s2-docs-mcp": patch
+---
+
+Fix MCP spec compliance for strict clients like Kiro and Claude
+
+- Remove invalid `required: true` from individual property definitions in tool `inputSchema` objects (JSON Schema requires `required` as a string array on the parent object, not a boolean on properties)
+- Upgrade `@modelcontextprotocol/sdk` from `^0.5.0` to `^1.27.1`
+- Return tool execution errors as results with `isError: true` instead of throwing (per MCP spec)
+- Read server version dynamically from `package.json` instead of hardcoding

--- a/.changeset/fix-mcp-spec-compatibility.md
+++ b/.changeset/fix-mcp-spec-compatibility.md
@@ -5,7 +5,9 @@
 
 Fix MCP spec compliance for strict clients like Kiro and Claude
 
-- Remove invalid `required: true` from individual property definitions in tool `inputSchema` objects (JSON Schema requires `required` as a string array on the parent object, not a boolean on properties)
+- Remove invalid `required: true` from individual property definitions
+  in tool `inputSchema` objects (JSON Schema requires `required` as a
+  string array on the parent object, not a boolean on properties)
 - Upgrade `@modelcontextprotocol/sdk` from `^0.5.0` to `^1.27.1`
 - Return tool execution errors as results with `isError: true` instead of throwing (per MCP spec)
 - Read server version dynamically from `package.json` instead of hardcoding

--- a/.cursor/skills/enhance-sync-pr/SKILL.md
+++ b/.cursor/skills/enhance-sync-pr/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: enhance-sync-pr
+description: >-
+  Enhances auto-generated spectrum-design-data PRs from spectrum-tokens-studio-data sync
+  (branch tokens-sync/patch-spectrum2-from-main, author mrcjhicks). Diagnoses CI failures,
+  suggests fixes, creates changesets with token-changeset-generator, updates PR title/body,
+  and attributes the original Tokens Studio implementer. Use when fixing sync PRs, PRs from
+  tokens-sync, enhance-sync-pr workflow gaps, or missing changesets on studio syncs.
+---
+
+# Enhance sync PR (Tokens Studio → spectrum-design-data)
+
+## When this applies
+
+* PR opened by `mrcjhicks` from `tokens-sync/patch-spectrum2-from-main` (or similar sync branch).
+* Body links to `github.com/adobe/spectrum-tokens-studio-data/actions/runs/…`.
+* CI red after sync (validation, snapshot, component props, wireframe, etc.).
+* Changeset missing; title still `feat: updates from spectrum-tokens-studio-data` or duplicated `feat: Feat:`.
+
+## Repo and tools
+
+* **Monorepo root:** workspace root (`spectrum-design-data`).
+* **Changeset generator:** [`tools/token-changeset-generator`](../../../tools/token-changeset-generator) — fetches source PR motivation, runs `tdiff`, infers semver bump.
+* **Automation:** [`.github/workflows/enhance-sync-pr.yml`](../../../.github/workflows/enhance-sync-pr.yml) and [`.github/actions/extract-source-pr-info`](../../../.github/actions/extract-source-pr-info).
+
+## 1. Resolve source PR
+
+From the design-data PR body, take the **spectrum-tokens-studio-data** Actions run URL or the **Tokens Studio PR** link.
+
+```bash
+gh pr view <N> --repo adobe/spectrum-design-data --json body,title,headRefName,url
+```
+
+If only the run URL exists, resolve merged PR from that run (same logic as `extract-source-pr-info`).
+
+Record:
+
+* Source PR URL (e.g. `https://github.com/adobe/spectrum-tokens-studio-data/pull/297`)
+* Source author (`user.login` from that PR) for attribution
+
+```bash
+gh api repos/adobe/spectrum-tokens-studio-data/pulls/<num> --jq '{title, author: .user.login, body}'
+```
+
+## 2. Diagnose CI (suggest fixes; user approves edits)
+
+Check out the PR branch with full history (`fetch-depth: 0`) so `tdiff` can compare to `main`.
+
+Run in order:
+
+```bash
+moon run tokens:validateDesignData
+moon run tokens:verifyDesignDataSnapshot
+cd packages/tokens && pnpm ava
+```
+
+Or full graph: `moon ci` (same as GitHub Actions).
+
+### Failure map (what to suggest)
+
+| Symptom                                        | Likely cause                                                                                                | Suggestion                                                                                                                                                                                                                                                                                                                                                                                              |       |                 |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------- |
+| `checkComponentProps` lists token names        | Missing or wrong `component` on entries in `color-component.json`, `layout-component.json`, or `icons.json` | Set `component` to match token name prefix (see [`packages/tokens/test/checkComponentProps.js`](../../../packages/tokens/test/checkComponentProps.js)).                                                                                                                                                                                                                                                 |       |                 |
+| Schema / `color-set` errors                    | `sets` missing `light`, `dark`, or **`wireframe`**                                                          | Align with [`schemas/token-types/color-set.json`](../../../packages/tokens/schemas/token-types/color-set.json).                                                                                                                                                                                                                                                                                         |       |                 |
+| `verifyDesignDataSnapshot` / snapshot mismatch | Validation report changed vs golden file                                                                    | Paths in the snapshot are relative to `packages/tokens/`. After `moon run sdk:build`, run **`migrate snapshot` from `packages/tokens/`** so paths match `moon run tokens:verifyDesignDataSnapshot`: `cd packages/tokens && ../../sdk/target/debug/design-data migrate snapshot ./src --output ./snapshots/validation-snapshot.json --schema-path ./schemas --exceptions-path ./naming-exceptions.json`. |       |                 |
+| Token file / `$schema` / `uuid`                | Invalid token shape                                                                                         | Fix per [`token-file.json`](../../../packages/tokens/schemas/token-file.json) and failing AVA tests.                                                                                                                                                                                                                                                                                                    |       |                 |
+| Alias / renamed / manifest                     | Broken refs or manifest drift                                                                               | Fix aliases; run `moon run tokens:buildManifest`.                                                                                                                                                                                                                                                                                                                                                       |       |                 |
+| Changeset lint on PR                           | Bad frontmatter                                                                                             | Valid `---` / \`"[**@adobe/spectrum-tokens**](https://github.com/adobe/spectrum-tokens)": patch                                                                                                                                                                                                                                                                                                         | minor | major\` / body. |
+
+Re-run targeted tasks after each fix until green.
+
+## 3. PR title and body
+
+* **Title:** One conventional prefix. Strip a leading `feat:` / `Feat:` (and similar) from the **source** title, then use `feat: <clean title>` (avoid `feat: Feat: …`).
+* **Body template:**
+
+```markdown
+## Token updates from Spectrum Tokens Studio Data
+
+**Original implementer:** @<github-login>
+
+**Source PR:** [#<n> <title>](<url>)
+
+**Automated sync via:** [GitHub Actions run](<run-url>)
+
+### Source description
+
+<paste or summarize source PR body / motivation>
+
+---
+
+<keep existing automated footer if present>
+```
+
+Use `gh pr edit <N> --repo adobe/spectrum-design-data --title "..." --body-file body.md`.
+
+## 4. Changeset + git attribution
+
+Generate changeset (requires `GITHUB_TOKEN` for API rate limits):
+
+```bash
+cd tools/token-changeset-generator && pnpm install --frozen-lockfile
+GITHUB_TOKEN=... node src/cli.js generate \
+  --tokens-studio-pr 'https://github.com/adobe/spectrum-tokens-studio-data/pull/<num>' \
+  --spectrum-tokens-pr 'https://github.com/adobe/spectrum-design-data/pull/<N>' \
+  --source-author '<login>'
+```
+
+Bump type is inferred from diff (e.g. deletions → major, additions → minor).
+
+Commit using the **source implementer’s** git identity so changelog “Thanks @…” matches design work:
+
+```bash
+git config user.email '<email>'
+git config user.name '<display name>'
+git add .changeset/*.md
+git commit -m "chore: add changeset for <short summary>" -m "Co-authored-by: <name> <email>"
+```
+
+If the commit author is already the implementer, `Co-authored-by` is optional but harmless.
+
+## 5. Verify
+
+```bash
+moon run tokens:validateDesignData
+moon run tokens:verifyDesignDataSnapshot
+cd packages/tokens && pnpm ava
+pnpm changeset-lint check .changeset/*.md
+```
+
+Push the branch; confirm CI and changeset-bot on the PR.
+
+## Reference: prior manual PRs
+
+Well-formed examples: merged sync PRs with `token-changeset-generator`-style changesets and enriched bodies (e.g. [#615](https://github.com/adobe/spectrum-design-data/issues/615), [#593](https://github.com/adobe/spectrum-design-data/issues/593)). Early PRs used hand-written “Design motivation” + “Token diff” in the changeset body — the generator now standardizes that shape.

--- a/docs/markdown/pages/ai.md
+++ b/docs/markdown/pages/ai.md
@@ -17,9 +17,9 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 
 **npm:** `@adobe/spectrum-design-data-mcp`
 
-**Token tools:** `query-tokens`, `find-tokens-by-use-case`, `get-component-tokens`, `get-design-recommendations`, `get-token-categories`, `get-token-details`
+**Token tools:** `query-tokens`, `query-tokens-by-value`, `get-token-details`, `get-component-tokens`
 
-**Schema tools:** `query-component-schemas`, `get-component-schema`, `list-components`, `validate-component-props`, `get-type-schemas`
+**Schema tools:** `list-components`, `get-component-schema`, `validate-component-props`, `search-components-by-feature`
 
 **Cursor config (single server):**
 
@@ -28,7 +28,7 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
   "mcpServers": {
     "spectrum-design-data": {
       "command": "npx",
-      "args": ["@adobe/spectrum-design-data-mcp"]
+      "args": ["-y", "@adobe/spectrum-design-data-mcp"]
     }
   }
 }
@@ -49,7 +49,7 @@ Spectrum 2 component documentation and design guidelines. Use when the AI needs 
   "mcpServers": {
     "s2-docs": {
       "command": "npx",
-      "args": ["@adobe/s2-docs-mcp"]
+      "args": ["-y", "@adobe/s2-docs-mcp"]
     }
   }
 }
@@ -66,11 +66,11 @@ Add both servers to `.cursor/mcp.json` so the AI can use tokens, schemas, and S2
   "mcpServers": {
     "spectrum-design-data": {
       "command": "npx",
-      "args": ["@adobe/spectrum-design-data-mcp"]
+      "args": ["-y", "@adobe/spectrum-design-data-mcp"]
     },
     "s2-docs": {
       "command": "npx",
-      "args": ["@adobe/s2-docs-mcp"]
+      "args": ["-y", "@adobe/s2-docs-mcp"]
     }
   }
 }

--- a/docs/site/src/pages/ai.md
+++ b/docs/site/src/pages/ai.md
@@ -16,9 +16,9 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 
 **npm:** `@adobe/spectrum-design-data-mcp`
 
-**Token tools:** `query-tokens`, `find-tokens-by-use-case`, `get-component-tokens`, `get-design-recommendations`, `get-token-categories`, `get-token-details`
+**Token tools:** `query-tokens`, `query-tokens-by-value`, `get-token-details`, `get-component-tokens`
 
-**Schema tools:** `query-component-schemas`, `get-component-schema`, `list-components`, `validate-component-props`, `get-type-schemas`
+**Schema tools:** `list-components`, `get-component-schema`, `validate-component-props`, `search-components-by-feature`
 
 **Cursor config (single server):**
 
@@ -27,7 +27,7 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
   "mcpServers": {
     "spectrum-design-data": {
       "command": "npx",
-      "args": ["@adobe/spectrum-design-data-mcp"]
+      "args": ["-y", "@adobe/spectrum-design-data-mcp"]
     }
   }
 }
@@ -48,7 +48,7 @@ Spectrum 2 component documentation and design guidelines. Use when the AI needs 
   "mcpServers": {
     "s2-docs": {
       "command": "npx",
-      "args": ["@adobe/s2-docs-mcp"]
+      "args": ["-y", "@adobe/s2-docs-mcp"]
     }
   }
 }
@@ -65,11 +65,11 @@ Add both servers to `.cursor/mcp.json` so the AI can use tokens, schemas, and S2
   "mcpServers": {
     "spectrum-design-data": {
       "command": "npx",
-      "args": ["@adobe/spectrum-design-data-mcp"]
+      "args": ["-y", "@adobe/spectrum-design-data-mcp"]
     },
     "s2-docs": {
       "command": "npx",
-      "args": ["@adobe/s2-docs-mcp"]
+      "args": ["-y", "@adobe/s2-docs-mcp"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
 
+  packages/design-data-spec: {}
+
   packages/design-system-registry:
     devDependencies:
       "@adobe/spectrum-component-api-schemas":
@@ -575,8 +577,8 @@ importers:
   tools/s2-docs-mcp:
     dependencies:
       "@modelcontextprotocol/sdk":
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^1.27.1
+        version: 1.27.1(zod@3.25.76)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -599,8 +601,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tokens
       "@modelcontextprotocol/sdk":
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^1.27.1
+        version: 1.27.1(zod@3.25.76)
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -1730,16 +1732,23 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
-  "@modelcontextprotocol/sdk@0.5.0":
-    resolution:
-      {
-        integrity: sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==,
-      }
-
   "@modelcontextprotocol/sdk@1.26.0":
     resolution:
       {
         integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      "@cfworker/json-schema": ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      "@cfworker/json-schema":
+        optional: true
+
+  "@modelcontextprotocol/sdk@1.27.1":
+    resolution:
+      {
+        integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -10166,12 +10175,6 @@ snapshots:
       - encoding
       - supports-color
 
-  "@modelcontextprotocol/sdk@0.5.0":
-    dependencies:
-      content-type: 1.0.5
-      raw-body: 3.0.0
-      zod: 3.25.76
-
   "@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)":
     dependencies:
       "@hono/node-server": 1.19.9(hono@4.11.9)
@@ -10189,6 +10192,28 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)":
+    dependencies:
+      "@hono/node-server": 1.19.9(hono@4.11.9)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.11.9
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:

--- a/tools/s2-docs-mcp/package.json
+++ b/tools/s2-docs-mcp/package.json
@@ -31,7 +31,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^13.1.0"
   },
   "engines": {

--- a/tools/s2-docs-mcp/src/index.js
+++ b/tools/s2-docs-mcp/src/index.js
@@ -10,6 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -19,6 +23,11 @@ import {
 
 import { createDocsTools } from "./tools/docs.js";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, "../package.json"), "utf8"),
+);
+
 /**
  * Create and configure the S2 Docs MCP server
  * @returns {Server} Configured MCP server instance
@@ -27,7 +36,7 @@ export function createMCPServer() {
   const server = new Server(
     {
       name: "s2-docs",
-      version: "1.0.0",
+      version: packageJson.version,
     },
     {
       capabilities: {
@@ -73,7 +82,16 @@ export function createMCPServer() {
         ],
       };
     } catch (error) {
-      throw new Error(`Tool execution failed: ${error.message}`);
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Tool execution failed: ${message}`,
+          },
+        ],
+        isError: true,
+      };
     }
   });
 

--- a/tools/spectrum-design-data-mcp/README.md
+++ b/tools/spectrum-design-data-mcp/README.md
@@ -32,7 +32,7 @@ Or clone and run locally:
 
 ```bash
 git clone https://github.com/adobe/spectrum-design-data.git
-cd spectrum-tokens/tools/spectrum-design-data-mcp
+cd spectrum-design-data/tools/spectrum-design-data-mcp
 pnpm install
 ```
 
@@ -105,7 +105,7 @@ Add to your MCP configuration (e.g., `.cursor/mcp.json` for Cursor IDE):
     "spectrum-design-data": {
       "command": "node",
       "args": [
-        "./path/to/spectrum-tokens/tools/spectrum-design-data-mcp/src/index.js"
+        "./path/to/spectrum-design-data/tools/spectrum-design-data-mcp/src/index.js"
       ]
     }
   }
@@ -234,7 +234,7 @@ npm audit
 
 ```bash
 git clone https://github.com/adobe/spectrum-design-data.git
-cd spectrum-tokens
+cd spectrum-design-data
 pnpm install
 cd tools/spectrum-design-data-mcp
 ```

--- a/tools/spectrum-design-data-mcp/package.json
+++ b/tools/spectrum-design-data-mcp/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@adobe/spectrum-tokens": "workspace:*",
     "@adobe/spectrum-component-api-schemas": "workspace:*",
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "commander": "^13.1.0"
   },
   "devDependencies": {

--- a/tools/spectrum-design-data-mcp/src/index.js
+++ b/tools/spectrum-design-data-mcp/src/index.js
@@ -10,6 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -20,6 +24,11 @@ import {
 import { createTokenTools } from "./tools/tokens.js";
 import { createSchemaTools } from "./tools/schemas.js";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, "../package.json"), "utf8"),
+);
+
 /**
  * Create and configure the Spectrum Design Data MCP server
  * @returns {Server} Configured MCP server instance
@@ -28,7 +37,7 @@ export function createMCPServer() {
   const server = new Server(
     {
       name: "spectrum-design-data",
-      version: "0.1.0",
+      version: packageJson.version,
     },
     {
       capabilities: {
@@ -71,7 +80,16 @@ export function createMCPServer() {
         ],
       };
     } catch (error) {
-      throw new Error(`Tool execution failed: ${error.message}`);
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Tool execution failed: ${message}`,
+          },
+        ],
+        isError: true,
+      };
     }
   });
 

--- a/tools/spectrum-design-data-mcp/src/tools/schemas.js
+++ b/tools/spectrum-design-data-mcp/src/tools/schemas.js
@@ -27,7 +27,6 @@ export function createSchemaTools() {
           component: {
             type: "string",
             description: "Component name",
-            required: true,
           },
         },
         required: ["component"],
@@ -89,12 +88,10 @@ export function createSchemaTools() {
           component: {
             type: "string",
             description: "Component name",
-            required: true,
           },
           props: {
             type: "object",
             description: "Props to validate",
-            required: true,
           },
         },
         required: ["component", "props"],
@@ -132,7 +129,6 @@ export function createSchemaTools() {
           feature: {
             type: "string",
             description: "Property name substring",
-            required: true,
           },
         },
         required: ["feature"],

--- a/tools/spectrum-design-data-mcp/src/tools/tokens.js
+++ b/tools/spectrum-design-data-mcp/src/tools/tokens.js
@@ -152,7 +152,6 @@ export function createTokenTools() {
           tokenPath: {
             type: "string",
             description: "Token path/name",
-            required: true,
           },
           category: { type: "string", description: "Category to search in" },
         },


### PR DESCRIPTION
## Summary

Fixes [#705](https://github.com/adobe/spectrum-design-data/issues/705) -- the `@adobe/spectrum-design-data-mcp` and `@adobe/s2-docs-mcp` servers were incompatible with strict MCP clients like Kiro and Claude due to several spec violations.

### Changes

- **Invalid JSON Schema `required: true` on properties** -- Removed `required: true` from individual property definitions in tool `inputSchema` objects. JSON Schema requires `required` as a string array on the parent object, not a boolean on properties. The correct top-level `required: [...]` arrays were already present, making the property-level booleans both invalid and redundant. This was the primary cause of the reported errors.
- **Outdated SDK** -- Upgraded `@modelcontextprotocol/sdk` from `^0.5.0` to `^1.27.1` in both MCP packages.
- **Error handling** -- Tool execution errors now return results with `isError: true` instead of throwing, per the [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling).
- **Server version** -- Both servers now read `version` dynamically from `package.json` instead of hardcoding a stale value.
- **Cursor skills** -- Added `.cursor/skills/enhance-sync-pr/` to version control.

### Affected packages

- `@adobe/spectrum-design-data-mcp` (patch)
- `@adobe/s2-docs-mcp` (patch)

## Test plan

- [x] `moon run spectrum-design-data-mcp:test` -- 18 tests passed
- [x] Manual verification that both `createMCPServer()` functions load correctly with SDK 1.x
- [x] Verify CI passes
- [ ] Confirm MCP server works in Claude / Kiro after publishing

Made with [Cursor](https://cursor.com)