### PR TITLE
feat(sdk): Phase 3 Wave 1 diff and query engines

### DIFF
--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -1,0 +1,705 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Semantic diff engine — compare two token graph versions and produce a
+//! structured change report.
+//!
+//! Implements the diff specification in `spec/diff.md`: six mutually exclusive
+//! categories (renamed, deprecated, reverted, added, deleted, updated) with
+//! property-level change tracking.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::graph::{TokenGraph, TokenRecord};
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+/// The type of a property-level change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChangeType {
+    Added,
+    Deleted,
+    Updated,
+}
+
+/// A single property-level change within a token.
+#[derive(Debug, Clone, Serialize)]
+pub struct PropertyChange {
+    pub path: String,
+    pub change_type: ChangeType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_value: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original_value: Option<Value>,
+}
+
+/// A token that was renamed (same identity, different name).
+#[derive(Debug, Clone, Serialize)]
+pub struct RenamedToken {
+    pub old_name: String,
+    pub new_name: String,
+    pub uuid: Option<String>,
+    pub property_changes: Vec<PropertyChange>,
+}
+
+/// A new token carrying a `deprecated` field.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeprecatedToken {
+    pub name: String,
+    pub uuid: Option<String>,
+}
+
+/// A matched token that lost its `deprecated` field.
+#[derive(Debug, Clone, Serialize)]
+pub struct RevertedToken {
+    pub name: String,
+    pub uuid: Option<String>,
+}
+
+/// A truly new token (not renamed, not deprecated).
+#[derive(Debug, Clone, Serialize)]
+pub struct AddedToken {
+    pub name: String,
+    pub uuid: Option<String>,
+}
+
+/// A truly deleted token (not the source of a rename).
+#[derive(Debug, Clone, Serialize)]
+pub struct DeletedToken {
+    pub name: String,
+    pub uuid: Option<String>,
+}
+
+/// A matched token with property-level changes.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdatedToken {
+    pub name: String,
+    pub uuid: Option<String>,
+    pub property_changes: Vec<PropertyChange>,
+}
+
+/// Complete diff report between two dataset versions.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct DiffReport {
+    pub renamed: Vec<RenamedToken>,
+    pub deprecated: Vec<DeprecatedToken>,
+    pub reverted: Vec<RevertedToken>,
+    pub added: Vec<AddedToken>,
+    pub deleted: Vec<DeletedToken>,
+    pub updated: Vec<UpdatedToken>,
+}
+
+impl DiffReport {
+    /// Returns `true` if no changes were detected.
+    pub fn is_empty(&self) -> bool {
+        self.renamed.is_empty()
+            && self.deprecated.is_empty()
+            && self.reverted.is_empty()
+            && self.added.is_empty()
+            && self.deleted.is_empty()
+            && self.updated.is_empty()
+    }
+}
+
+// ── Internal types ──────────────────────────────────────────────────────────
+
+/// A paired token across old and new graphs.
+struct TokenPair<'a> {
+    old: &'a TokenRecord,
+    new: &'a TokenRecord,
+}
+
+// ── Engine ──────────────────────────────────────────────────────────────────
+
+/// Compute a semantic diff between two token graphs.
+///
+/// Follows the category partitioning order defined in `spec/diff.md`:
+/// renamed → deprecated → reverted → added → deleted → updated.
+pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
+    let (pairs, unpaired_old, unpaired_new) = pair_tokens(old, new);
+
+    // 1. Renamed — paired tokens where the name changed.
+    let mut renamed_old_names: HashSet<String> = HashSet::new();
+    let mut renamed = Vec::new();
+    for p in &pairs {
+        if !names_equal(&p.old.raw, &p.new.raw) {
+            renamed_old_names.insert(p.old.name.clone());
+            let changes = diff_properties(&p.old.raw, &p.new.raw);
+            renamed.push(RenamedToken {
+                old_name: display_name(p.old),
+                new_name: display_name(p.new),
+                uuid: p.new.uuid.clone(),
+                property_changes: changes,
+            });
+        }
+    }
+
+    // 2. Deprecated — unmatched new tokens carrying a `deprecated` field.
+    let mut deprecated_names: HashSet<String> = HashSet::new();
+    let mut deprecated = Vec::new();
+    for t in &unpaired_new {
+        if is_deprecated(&t.raw) {
+            deprecated_names.insert(t.name.clone());
+            deprecated.push(DeprecatedToken {
+                name: display_name(t),
+                uuid: t.uuid.clone(),
+            });
+        }
+    }
+
+    // 3. Reverted — paired tokens where old had `deprecated` and new does not.
+    let mut reverted_names: HashSet<String> = HashSet::new();
+    let mut reverted = Vec::new();
+    for p in &pairs {
+        if names_equal(&p.old.raw, &p.new.raw)
+            && has_deprecated_field(&p.old.raw)
+            && !has_deprecated_field(&p.new.raw)
+        {
+            reverted_names.insert(p.new.name.clone());
+            reverted.push(RevertedToken {
+                name: display_name(p.new),
+                uuid: p.new.uuid.clone(),
+            });
+        }
+    }
+
+    // 4. Added — remaining unmatched new tokens.
+    let mut added = Vec::new();
+    for t in &unpaired_new {
+        if !deprecated_names.contains(&t.name) {
+            added.push(AddedToken {
+                name: display_name(t),
+                uuid: t.uuid.clone(),
+            });
+        }
+    }
+
+    // 5. Deleted — remaining unmatched old tokens (not rename sources).
+    let mut deleted = Vec::new();
+    for t in &unpaired_old {
+        if !renamed_old_names.contains(&t.name) {
+            deleted.push(DeletedToken {
+                name: display_name(t),
+                uuid: t.uuid.clone(),
+            });
+        }
+    }
+
+    // 6. Updated — paired tokens with same name but different properties.
+    let mut updated = Vec::new();
+    for p in &pairs {
+        if names_equal(&p.old.raw, &p.new.raw)
+            && !reverted_names.contains(&p.new.name)
+        {
+            let changes = diff_properties(&p.old.raw, &p.new.raw);
+            if !changes.is_empty() {
+                updated.push(UpdatedToken {
+                    name: display_name(p.new),
+                    uuid: p.new.uuid.clone(),
+                    property_changes: changes,
+                });
+            }
+        }
+    }
+
+    // Sort each category by name for deterministic output (RECOMMENDED in spec).
+    renamed.sort_by(|a, b| a.new_name.cmp(&b.new_name));
+    deprecated.sort_by(|a, b| a.name.cmp(&b.name));
+    reverted.sort_by(|a, b| a.name.cmp(&b.name));
+    added.sort_by(|a, b| a.name.cmp(&b.name));
+    deleted.sort_by(|a, b| a.name.cmp(&b.name));
+    updated.sort_by(|a, b| a.name.cmp(&b.name));
+
+    DiffReport {
+        renamed,
+        deprecated,
+        reverted,
+        added,
+        deleted,
+        updated,
+    }
+}
+
+// ── Token pairing ───────────────────────────────────────────────────────────
+
+/// Pair tokens across old and new graphs.
+///
+/// Returns (paired, unpaired_old, unpaired_new).
+///
+/// Matching rules per spec `diff.md` — Token identity:
+/// 1. UUID match (primary): same `uuid` value in both graphs.
+/// 2. Name-object equivalence (fallback): when UUID match is not found for a
+///    token (because either side lacks a uuid or no counterpart exists).
+fn pair_tokens<'a>(
+    old: &'a TokenGraph,
+    new: &'a TokenGraph,
+) -> (Vec<TokenPair<'a>>, Vec<&'a TokenRecord>, Vec<&'a TokenRecord>) {
+    let mut pairs = Vec::new();
+    let mut matched_old: HashSet<String> = HashSet::new();
+    let mut matched_new: HashSet<String> = HashSet::new();
+
+    // Pass 1: UUID matching.
+    // Build old UUID → key index (old graph's uuid_index is private but
+    // crate-visible; we iterate tokens directly for clarity).
+    let mut old_by_uuid: HashMap<&str, &str> = HashMap::new();
+    for (key, t) in &old.tokens {
+        if let Some(ref uuid) = t.uuid {
+            old_by_uuid.entry(uuid.as_str()).or_insert(key.as_str());
+        }
+    }
+
+    for (new_key, new_tok) in &new.tokens {
+        if let Some(ref uuid) = new_tok.uuid {
+            if let Some(&old_key) = old_by_uuid.get(uuid.as_str()) {
+                if let Some(old_tok) = old.tokens.get(old_key) {
+                    pairs.push(TokenPair {
+                        old: old_tok,
+                        new: new_tok,
+                    });
+                    matched_old.insert(old_key.to_string());
+                    matched_new.insert(new_key.clone());
+                }
+            }
+        }
+    }
+
+    // Pass 2: Name-object equivalence fallback for unmatched tokens.
+    // Build an index of unmatched old tokens by their serialized name object.
+    let mut old_by_name: HashMap<String, &str> = HashMap::new();
+    for (key, t) in &old.tokens {
+        if !matched_old.contains(key.as_str()) {
+            if let Some(name_key) = serialize_name_obj(&t.raw) {
+                old_by_name.entry(name_key).or_insert(key.as_str());
+            }
+        }
+    }
+
+    for (new_key, new_tok) in &new.tokens {
+        if matched_new.contains(new_key) {
+            continue;
+        }
+        if let Some(name_key) = serialize_name_obj(&new_tok.raw) {
+            if let Some(&old_key) = old_by_name.get(&name_key) {
+                if let Some(old_tok) = old.tokens.get(old_key) {
+                    pairs.push(TokenPair {
+                        old: old_tok,
+                        new: new_tok,
+                    });
+                    matched_old.insert(old_key.to_string());
+                    matched_new.insert(new_key.clone());
+                    // Remove from name index so it can't be double-matched.
+                    old_by_name.remove(&name_key);
+                }
+            }
+        }
+    }
+
+    let unpaired_old: Vec<&TokenRecord> = old
+        .tokens
+        .values()
+        .filter(|t| !matched_old.contains(&t.name))
+        .collect();
+    let unpaired_new: Vec<&TokenRecord> = new
+        .tokens
+        .values()
+        .filter(|t| !matched_new.contains(&t.name))
+        .collect();
+
+    (pairs, unpaired_old, unpaired_new)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Serialize a token's `name` object to a canonical JSON string for comparison.
+fn serialize_name_obj(raw: &Value) -> Option<String> {
+    let name = raw.get("name")?;
+    // Canonical: serde_json sorts map keys deterministically when serializing.
+    Some(serde_json::to_string(name).ok()?)
+}
+
+/// Check if two tokens have the same name object (deep equal).
+fn names_equal(old_raw: &Value, new_raw: &Value) -> bool {
+    match (old_raw.get("name"), new_raw.get("name")) {
+        (Some(a), Some(b)) => a == b,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// Get a human-readable display name for a token.
+/// Prefers `name.property` if present; falls back to the graph key.
+fn display_name(t: &TokenRecord) -> String {
+    t.raw
+        .get("name")
+        .and_then(|n| n.get("property"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| t.name.clone())
+}
+
+/// Check if a token has a `deprecated` field (at the top level or via
+/// set-level normalization per spec).
+fn is_deprecated(raw: &Value) -> bool {
+    // Top-level deprecated field.
+    if has_deprecated_field(raw) {
+        return true;
+    }
+    // Set-level normalization: if all sets carry `deprecated: true`,
+    // treat the token as deprecated.
+    if let Some(sets) = raw.get("sets").and_then(|v| v.as_object()) {
+        if sets.is_empty() {
+            return false;
+        }
+        return sets.values().all(|entry| {
+            entry
+                .as_object()
+                .and_then(|o| o.get("deprecated"))
+                .and_then(|v| v.as_bool())
+                == Some(true)
+        });
+    }
+    false
+}
+
+/// Check if the raw JSON has a top-level `deprecated` field.
+fn has_deprecated_field(raw: &Value) -> bool {
+    raw.as_object()
+        .map(|o| o.contains_key("deprecated"))
+        .unwrap_or(false)
+}
+
+// ── Property-level diff ─────────────────────────────────────────────────────
+
+/// Recursively diff two JSON values, producing property-level change records.
+pub fn diff_properties(old: &Value, new: &Value) -> Vec<PropertyChange> {
+    let mut changes = Vec::new();
+    diff_recursive(old, new, String::new(), &mut changes);
+    changes.sort_by(|a, b| a.path.cmp(&b.path));
+    changes
+}
+
+fn diff_recursive(old: &Value, new: &Value, prefix: String, out: &mut Vec<PropertyChange>) {
+    if old == new {
+        return;
+    }
+
+    match (old, new) {
+        (Value::Object(old_map), Value::Object(new_map)) => {
+            // Check for deleted and updated keys.
+            for (key, old_val) in old_map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                match new_map.get(key) {
+                    Some(new_val) => {
+                        diff_recursive(old_val, new_val, path, out);
+                    }
+                    None => {
+                        out.push(PropertyChange {
+                            path,
+                            change_type: ChangeType::Deleted,
+                            new_value: None,
+                            original_value: Some(old_val.clone()),
+                        });
+                    }
+                }
+            }
+            // Check for added keys.
+            for (key, new_val) in new_map {
+                if !old_map.contains_key(key) {
+                    let path = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    out.push(PropertyChange {
+                        path,
+                        change_type: ChangeType::Added,
+                        new_value: Some(new_val.clone()),
+                        original_value: None,
+                    });
+                }
+            }
+        }
+        _ => {
+            // Leaf-level change (different types or different values).
+            out.push(PropertyChange {
+                path: prefix,
+                change_type: ChangeType::Updated,
+                new_value: Some(new.clone()),
+                original_value: Some(old.clone()),
+            });
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::TokenGraph;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn make_graph(tokens: Vec<(&str, Value)>) -> TokenGraph {
+        TokenGraph::from_pairs(
+            tokens
+                .into_iter()
+                .map(|(name, raw)| (name.to_string(), PathBuf::from("test.json"), raw))
+                .collect(),
+        )
+    }
+
+    // ── Token pairing ───────────────────────────────────────────────────
+
+    #[test]
+    fn pair_by_uuid() {
+        let old = make_graph(vec![(
+            "token-a",
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "token-a",
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#000"}),
+        )]);
+        let (pairs, unpaired_old, unpaired_new) = pair_tokens(&old, &new);
+        assert_eq!(pairs.len(), 1);
+        assert!(unpaired_old.is_empty());
+        assert!(unpaired_new.is_empty());
+    }
+
+    #[test]
+    fn pair_by_name_object_fallback() {
+        let old = make_graph(vec![(
+            "token-a",
+            json!({"name": {"property": "bg"}, "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "token-a",
+            json!({"name": {"property": "bg"}, "value": "#000"}),
+        )]);
+        let (pairs, unpaired_old, unpaired_new) = pair_tokens(&old, &new);
+        assert_eq!(pairs.len(), 1);
+        assert!(unpaired_old.is_empty());
+        assert!(unpaired_new.is_empty());
+    }
+
+    #[test]
+    fn uuid_backfill_preserves_continuity() {
+        // Old token has no UUID, new token gains a UUID — should still pair
+        // via name-object fallback.
+        let old = make_graph(vec![(
+            "token-a",
+            json!({"name": {"property": "bg"}, "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "token-a",
+            json!({"name": {"property": "bg"}, "uuid": "new-uuid", "value": "#fff"}),
+        )]);
+        let (pairs, unpaired_old, unpaired_new) = pair_tokens(&old, &new);
+        assert_eq!(pairs.len(), 1, "UUID backfill must not break pairing");
+        assert!(unpaired_old.is_empty());
+        assert!(unpaired_new.is_empty());
+    }
+
+    // ── Rename detection ────────────────────────────────────────────────
+
+    #[test]
+    fn detect_rename_by_uuid() {
+        let old = make_graph(vec![(
+            "old-name",
+            json!({"name": {"property": "old-name"}, "uuid": "uuid-1", "value": "1"}),
+        )]);
+        let new = make_graph(vec![(
+            "new-name",
+            json!({"name": {"property": "new-name"}, "uuid": "uuid-1", "value": "1"}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.renamed.len(), 1);
+        assert_eq!(report.renamed[0].old_name, "old-name");
+        assert_eq!(report.renamed[0].new_name, "new-name");
+        assert!(report.added.is_empty());
+        assert!(report.deleted.is_empty());
+    }
+
+    // ── Deprecation / reversion ─────────────────────────────────────────
+
+    #[test]
+    fn detect_deprecated_new_token() {
+        let old = make_graph(vec![]);
+        let new = make_graph(vec![(
+            "dep-token",
+            json!({"name": {"property": "dep-token"}, "deprecated": true, "value": "1"}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.deprecated.len(), 1);
+        assert!(report.added.is_empty(), "deprecated token must not appear as added");
+    }
+
+    #[test]
+    fn detect_deprecated_set_level_normalization() {
+        let old = make_graph(vec![]);
+        let new = make_graph(vec![(
+            "set-dep",
+            json!({
+                "name": {"property": "set-dep"},
+                "sets": {
+                    "light": {"value": "#fff", "deprecated": true},
+                    "dark": {"value": "#000", "deprecated": true}
+                }
+            }),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.deprecated.len(), 1, "set-level deprecation must normalize");
+    }
+
+    #[test]
+    fn detect_reverted_token() {
+        let old = make_graph(vec![(
+            "rev-token",
+            json!({"name": {"property": "rev"}, "uuid": "uuid-1", "deprecated": true, "value": "1"}),
+        )]);
+        let new = make_graph(vec![(
+            "rev-token",
+            json!({"name": {"property": "rev"}, "uuid": "uuid-1", "value": "1"}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.reverted.len(), 1);
+        assert!(report.updated.is_empty(), "reverted must not appear as updated");
+    }
+
+    #[test]
+    fn matched_token_gaining_deprecated_is_updated() {
+        // Per spec: a matched token that gains `deprecated` is classified as
+        // updated, not deprecated.
+        let old = make_graph(vec![(
+            "token",
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "token",
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff", "deprecated": true}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert!(report.deprecated.is_empty(), "matched token must not be deprecated");
+        assert_eq!(report.updated.len(), 1, "must be classified as updated");
+        assert!(report.updated[0]
+            .property_changes
+            .iter()
+            .any(|c| c.path == "deprecated"));
+    }
+
+    // ── Added / deleted ─────────────────────────────────────────────────
+
+    #[test]
+    fn detect_added_token() {
+        let old = make_graph(vec![]);
+        let new = make_graph(vec![(
+            "new-token",
+            json!({"name": {"property": "new"}, "value": "1"}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.added.len(), 1);
+    }
+
+    #[test]
+    fn detect_deleted_token() {
+        let old = make_graph(vec![(
+            "old-token",
+            json!({"name": {"property": "old"}, "value": "1"}),
+        )]);
+        let new = make_graph(vec![]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.deleted.len(), 1);
+    }
+
+    // ── Property-level changes ──────────────────────────────────────────
+
+    #[test]
+    fn property_value_change() {
+        let old = make_graph(vec![(
+            "token",
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "token",
+            json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#000"}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.updated.len(), 1);
+        let changes = &report.updated[0].property_changes;
+        assert!(changes.iter().any(|c| c.path == "value"
+            && c.change_type == ChangeType::Updated));
+    }
+
+    #[test]
+    fn property_nested_change() {
+        let changes = diff_properties(
+            &json!({"sets": {"light": {"value": "#fff"}}}),
+            &json!({"sets": {"light": {"value": "#000"}}}),
+        );
+        assert!(changes
+            .iter()
+            .any(|c| c.path == "sets.light.value" && c.change_type == ChangeType::Updated));
+    }
+
+    #[test]
+    fn property_added_and_deleted() {
+        let changes = diff_properties(
+            &json!({"a": 1, "b": 2}),
+            &json!({"a": 1, "c": 3}),
+        );
+        assert!(changes.iter().any(|c| c.path == "b" && c.change_type == ChangeType::Deleted));
+        assert!(changes.iter().any(|c| c.path == "c" && c.change_type == ChangeType::Added));
+    }
+
+    // ── Full pipeline ───────────────────────────────────────────────────
+
+    #[test]
+    fn full_pipeline_all_categories() {
+        let old = make_graph(vec![
+            ("renamed", json!({"name": {"property": "old-name"}, "uuid": "u1", "value": "1"})),
+            ("to-delete", json!({"name": {"property": "to-delete"}, "uuid": "u2", "value": "2"})),
+            ("to-update", json!({"name": {"property": "to-update"}, "uuid": "u3", "value": "old"})),
+            ("to-revert", json!({"name": {"property": "to-revert"}, "uuid": "u4", "deprecated": true, "value": "4"})),
+        ]);
+        let new = make_graph(vec![
+            ("renamed-new", json!({"name": {"property": "new-name"}, "uuid": "u1", "value": "1"})),
+            ("to-add", json!({"name": {"property": "to-add"}, "value": "new"})),
+            ("to-deprecate", json!({"name": {"property": "to-deprecate"}, "deprecated": true, "value": "dep"})),
+            ("to-update", json!({"name": {"property": "to-update"}, "uuid": "u3", "value": "new"})),
+            ("to-revert", json!({"name": {"property": "to-revert"}, "uuid": "u4", "value": "4"})),
+        ]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.renamed.len(), 1, "should have 1 renamed");
+        assert_eq!(report.deprecated.len(), 1, "should have 1 deprecated");
+        assert_eq!(report.reverted.len(), 1, "should have 1 reverted");
+        assert_eq!(report.added.len(), 1, "should have 1 added");
+        assert_eq!(report.deleted.len(), 1, "should have 1 deleted");
+        assert_eq!(report.updated.len(), 1, "should have 1 updated");
+    }
+
+    #[test]
+    fn empty_diff_identical_graphs() {
+        let g = make_graph(vec![
+            ("a", json!({"name": {"property": "a"}, "uuid": "u1", "value": "1"})),
+            ("b", json!({"name": {"property": "b"}, "uuid": "u2", "value": "2"})),
+        ]);
+        let report = semantic_diff(&g, &g);
+        assert!(report.is_empty(), "identical graphs should produce empty diff");
+    }
+}

--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -133,7 +133,7 @@ pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
     let mut renamed_old_names: HashSet<String> = HashSet::new();
     let mut renamed = Vec::new();
     for p in &pairs {
-        if !names_equal(&p.old.raw, &p.new.raw) {
+        if !names_equal(p.old, p.new) {
             renamed_old_names.insert(p.old.name.clone());
             let changes = diff_properties(&p.old.raw, &p.new.raw);
             renamed.push(RenamedToken {
@@ -162,7 +162,7 @@ pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
     let mut reverted_names: HashSet<String> = HashSet::new();
     let mut reverted = Vec::new();
     for p in &pairs {
-        if names_equal(&p.old.raw, &p.new.raw)
+        if names_equal(p.old, p.new)
             && has_deprecated_field(&p.old.raw)
             && !has_deprecated_field(&p.new.raw)
         {
@@ -199,7 +199,7 @@ pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
     // 6. Updated — paired tokens with same name but different properties.
     let mut updated = Vec::new();
     for p in &pairs {
-        if names_equal(&p.old.raw, &p.new.raw) && !reverted_names.contains(&p.new.name) {
+        if names_equal(p.old, p.new) && !reverted_names.contains(&p.new.name) {
             let changes = diff_properties(&p.old.raw, &p.new.raw);
             if !changes.is_empty() {
                 updated.push(UpdatedToken {
@@ -276,14 +276,15 @@ fn pair_tokens<'a>(
         }
     }
 
-    // Pass 2: Name-object equivalence fallback for unmatched tokens.
-    // Build an index of unmatched old tokens by their serialized name object.
+    // Pass 2: Name equivalence fallback for unmatched tokens.
+    // For cascade tokens, compare the serialized `raw["name"]` object.
+    // For legacy tokens (no `raw["name"]`), compare `TokenRecord.name`
+    // (the outer object key used as the graph key).
     let mut old_by_name: HashMap<String, &str> = HashMap::new();
     for (key, t) in &old.tokens {
         if !matched_old.contains(key.as_str()) {
-            if let Some(name_key) = serialize_name_obj(&t.raw) {
-                old_by_name.entry(name_key).or_insert(key.as_str());
-            }
+            let name_key = identity_key(t);
+            old_by_name.entry(name_key).or_insert(key.as_str());
         }
     }
 
@@ -291,18 +292,17 @@ fn pair_tokens<'a>(
         if matched_new.contains(new_key) {
             continue;
         }
-        if let Some(name_key) = serialize_name_obj(&new_tok.raw) {
-            if let Some(&old_key) = old_by_name.get(&name_key) {
-                if let Some(old_tok) = old.tokens.get(old_key) {
-                    pairs.push(TokenPair {
-                        old: old_tok,
-                        new: new_tok,
-                    });
-                    matched_old.insert(old_key.to_string());
-                    matched_new.insert(new_key.clone());
-                    // Remove from name index so it can't be double-matched.
-                    old_by_name.remove(&name_key);
-                }
+        let name_key = identity_key(new_tok);
+        if let Some(&old_key) = old_by_name.get(&name_key) {
+            if let Some(old_tok) = old.tokens.get(old_key) {
+                pairs.push(TokenPair {
+                    old: old_tok,
+                    new: new_tok,
+                });
+                matched_old.insert(old_key.to_string());
+                matched_new.insert(new_key.clone());
+                // Remove from name index so it can't be double-matched.
+                old_by_name.remove(&name_key);
             }
         }
     }
@@ -323,31 +323,60 @@ fn pair_tokens<'a>(
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Serialize a token's `name` object to a canonical JSON string for comparison.
-fn serialize_name_obj(raw: &Value) -> Option<String> {
-    let name = raw.get("name")?;
-    // Canonical: serde_json sorts map keys deterministically when serializing.
-    serde_json::to_string(name).ok()
+/// Produce a stable identity key for a token, used to pair tokens across graphs.
+///
+/// Cascade tokens carry a structured `raw["name"]` object — serialize it to a
+/// canonical JSON string. Legacy tokens have no `raw["name"]`; their identity
+/// is the outer object key stored in `TokenRecord.name`.
+fn identity_key(t: &TokenRecord) -> String {
+    if let Some(name) = t.raw.get("name") {
+        // Prefix with "name:" to avoid collisions with legacy keys.
+        format!("name:{}", serde_json::to_string(name).unwrap_or_default())
+    } else {
+        format!("key:{}", t.name)
+    }
 }
 
-/// Check if two tokens have the same name object (deep equal).
-fn names_equal(old_raw: &Value, new_raw: &Value) -> bool {
-    match (old_raw.get("name"), new_raw.get("name")) {
+/// Check if two tokens have the same name.
+///
+/// Cascade tokens: compare `raw["name"]` objects (deep equal).
+/// Legacy tokens: compare `TokenRecord.name` (the graph key).
+/// Mixed: never equal (different identity schemes).
+fn names_equal(old: &TokenRecord, new: &TokenRecord) -> bool {
+    match (old.raw.get("name"), new.raw.get("name")) {
         (Some(a), Some(b)) => a == b,
-        (None, None) => true,
+        (None, None) => old.name == new.name,
         _ => false,
     }
 }
 
 /// Get a human-readable display name for a token.
-/// Prefers `name.property` if present; falls back to the graph key.
+///
+/// Cascade tokens: serialize the full `name` object as a compact string
+/// (e.g. `background-color[colorScheme=dark]`). Falls back to just
+/// `name.property` if other fields are absent.
+/// Legacy tokens: use the graph key (`TokenRecord.name`).
 fn display_name(t: &TokenRecord) -> String {
-    t.raw
-        .get("name")
-        .and_then(|n| n.get("property"))
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .unwrap_or_else(|| t.name.clone())
+    if let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) {
+        let property = name_obj
+            .get("property")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
+        // Collect non-property fields as dimension qualifiers.
+        let mut qualifiers: Vec<String> = name_obj
+            .iter()
+            .filter(|(k, _)| *k != "property")
+            .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("?")))
+            .collect();
+        qualifiers.sort();
+        if qualifiers.is_empty() {
+            property.to_string()
+        } else {
+            format!("{property}[{}]", qualifiers.join(","))
+        }
+    } else {
+        t.name.clone()
+    }
 }
 
 /// Check if a token has a `deprecated` field (at the top level or via
@@ -516,6 +545,50 @@ mod tests {
         assert_eq!(pairs.len(), 1, "UUID backfill must not break pairing");
         assert!(unpaired_old.is_empty());
         assert!(unpaired_new.is_empty());
+    }
+
+    #[test]
+    fn pair_legacy_tokens_by_graph_key() {
+        // Legacy tokens have no raw["name"] — pairing must use TokenRecord.name.
+        let old = make_graph(vec![(
+            "background-color-default",
+            json!({"$schema": ".../color.json", "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "background-color-default",
+            json!({"$schema": ".../color.json", "value": "#000"}),
+        )]);
+        let (pairs, unpaired_old, unpaired_new) = pair_tokens(&old, &new);
+        assert_eq!(pairs.len(), 1, "legacy tokens must pair by graph key");
+        assert!(unpaired_old.is_empty());
+        assert!(unpaired_new.is_empty());
+    }
+
+    #[test]
+    fn legacy_rename_detected_by_uuid() {
+        // Legacy tokens paired by UUID with different graph keys = rename.
+        let old = make_graph(vec![(
+            "old-bg-color",
+            json!({"$schema": ".../color.json", "uuid": "uuid-1", "value": "#fff"}),
+        )]);
+        let new = make_graph(vec![(
+            "new-bg-color",
+            json!({"$schema": ".../color.json", "uuid": "uuid-1", "value": "#fff"}),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.renamed.len(), 1, "legacy rename must be detected");
+        assert_eq!(report.renamed[0].old_name, "old-bg-color");
+        assert_eq!(report.renamed[0].new_name, "new-bg-color");
+    }
+
+    #[test]
+    fn display_name_shows_full_cascade_name() {
+        let t = &make_graph(vec![(
+            "key",
+            json!({"name": {"property": "bg", "colorScheme": "dark"}, "value": "#000"}),
+        )]);
+        let token = t.tokens.values().next().unwrap();
+        assert_eq!(display_name(token), "bg[colorScheme=dark]");
     }
 
     // ── Rename detection ────────────────────────────────────────────────

--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -199,9 +199,7 @@ pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
     // 6. Updated — paired tokens with same name but different properties.
     let mut updated = Vec::new();
     for p in &pairs {
-        if names_equal(&p.old.raw, &p.new.raw)
-            && !reverted_names.contains(&p.new.name)
-        {
+        if names_equal(&p.old.raw, &p.new.raw) && !reverted_names.contains(&p.new.name) {
             let changes = diff_properties(&p.old.raw, &p.new.raw);
             if !changes.is_empty() {
                 updated.push(UpdatedToken {
@@ -244,7 +242,11 @@ pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
 fn pair_tokens<'a>(
     old: &'a TokenGraph,
     new: &'a TokenGraph,
-) -> (Vec<TokenPair<'a>>, Vec<&'a TokenRecord>, Vec<&'a TokenRecord>) {
+) -> (
+    Vec<TokenPair<'a>>,
+    Vec<&'a TokenRecord>,
+    Vec<&'a TokenRecord>,
+) {
     let mut pairs = Vec::new();
     let mut matched_old: HashSet<String> = HashSet::new();
     let mut matched_new: HashSet<String> = HashSet::new();
@@ -325,7 +327,7 @@ fn pair_tokens<'a>(
 fn serialize_name_obj(raw: &Value) -> Option<String> {
     let name = raw.get("name")?;
     // Canonical: serde_json sorts map keys deterministically when serializing.
-    Some(serde_json::to_string(name).ok()?)
+    serde_json::to_string(name).ok()
 }
 
 /// Check if two tokens have the same name object (deep equal).
@@ -547,7 +549,10 @@ mod tests {
         )]);
         let report = semantic_diff(&old, &new);
         assert_eq!(report.deprecated.len(), 1);
-        assert!(report.added.is_empty(), "deprecated token must not appear as added");
+        assert!(
+            report.added.is_empty(),
+            "deprecated token must not appear as added"
+        );
     }
 
     #[test]
@@ -564,7 +569,11 @@ mod tests {
             }),
         )]);
         let report = semantic_diff(&old, &new);
-        assert_eq!(report.deprecated.len(), 1, "set-level deprecation must normalize");
+        assert_eq!(
+            report.deprecated.len(),
+            1,
+            "set-level deprecation must normalize"
+        );
     }
 
     #[test]
@@ -579,7 +588,10 @@ mod tests {
         )]);
         let report = semantic_diff(&old, &new);
         assert_eq!(report.reverted.len(), 1);
-        assert!(report.updated.is_empty(), "reverted must not appear as updated");
+        assert!(
+            report.updated.is_empty(),
+            "reverted must not appear as updated"
+        );
     }
 
     #[test]
@@ -595,7 +607,10 @@ mod tests {
             json!({"name": {"property": "bg"}, "uuid": "uuid-1", "value": "#fff", "deprecated": true}),
         )]);
         let report = semantic_diff(&old, &new);
-        assert!(report.deprecated.is_empty(), "matched token must not be deprecated");
+        assert!(
+            report.deprecated.is_empty(),
+            "matched token must not be deprecated"
+        );
         assert_eq!(report.updated.len(), 1, "must be classified as updated");
         assert!(report.updated[0]
             .property_changes
@@ -642,8 +657,9 @@ mod tests {
         let report = semantic_diff(&old, &new);
         assert_eq!(report.updated.len(), 1);
         let changes = &report.updated[0].property_changes;
-        assert!(changes.iter().any(|c| c.path == "value"
-            && c.change_type == ChangeType::Updated));
+        assert!(changes
+            .iter()
+            .any(|c| c.path == "value" && c.change_type == ChangeType::Updated));
     }
 
     #[test]
@@ -659,12 +675,13 @@ mod tests {
 
     #[test]
     fn property_added_and_deleted() {
-        let changes = diff_properties(
-            &json!({"a": 1, "b": 2}),
-            &json!({"a": 1, "c": 3}),
-        );
-        assert!(changes.iter().any(|c| c.path == "b" && c.change_type == ChangeType::Deleted));
-        assert!(changes.iter().any(|c| c.path == "c" && c.change_type == ChangeType::Added));
+        let changes = diff_properties(&json!({"a": 1, "b": 2}), &json!({"a": 1, "c": 3}));
+        assert!(changes
+            .iter()
+            .any(|c| c.path == "b" && c.change_type == ChangeType::Deleted));
+        assert!(changes
+            .iter()
+            .any(|c| c.path == "c" && c.change_type == ChangeType::Added));
     }
 
     // ── Full pipeline ───────────────────────────────────────────────────
@@ -672,17 +689,44 @@ mod tests {
     #[test]
     fn full_pipeline_all_categories() {
         let old = make_graph(vec![
-            ("renamed", json!({"name": {"property": "old-name"}, "uuid": "u1", "value": "1"})),
-            ("to-delete", json!({"name": {"property": "to-delete"}, "uuid": "u2", "value": "2"})),
-            ("to-update", json!({"name": {"property": "to-update"}, "uuid": "u3", "value": "old"})),
-            ("to-revert", json!({"name": {"property": "to-revert"}, "uuid": "u4", "deprecated": true, "value": "4"})),
+            (
+                "renamed",
+                json!({"name": {"property": "old-name"}, "uuid": "u1", "value": "1"}),
+            ),
+            (
+                "to-delete",
+                json!({"name": {"property": "to-delete"}, "uuid": "u2", "value": "2"}),
+            ),
+            (
+                "to-update",
+                json!({"name": {"property": "to-update"}, "uuid": "u3", "value": "old"}),
+            ),
+            (
+                "to-revert",
+                json!({"name": {"property": "to-revert"}, "uuid": "u4", "deprecated": true, "value": "4"}),
+            ),
         ]);
         let new = make_graph(vec![
-            ("renamed-new", json!({"name": {"property": "new-name"}, "uuid": "u1", "value": "1"})),
-            ("to-add", json!({"name": {"property": "to-add"}, "value": "new"})),
-            ("to-deprecate", json!({"name": {"property": "to-deprecate"}, "deprecated": true, "value": "dep"})),
-            ("to-update", json!({"name": {"property": "to-update"}, "uuid": "u3", "value": "new"})),
-            ("to-revert", json!({"name": {"property": "to-revert"}, "uuid": "u4", "value": "4"})),
+            (
+                "renamed-new",
+                json!({"name": {"property": "new-name"}, "uuid": "u1", "value": "1"}),
+            ),
+            (
+                "to-add",
+                json!({"name": {"property": "to-add"}, "value": "new"}),
+            ),
+            (
+                "to-deprecate",
+                json!({"name": {"property": "to-deprecate"}, "deprecated": true, "value": "dep"}),
+            ),
+            (
+                "to-update",
+                json!({"name": {"property": "to-update"}, "uuid": "u3", "value": "new"}),
+            ),
+            (
+                "to-revert",
+                json!({"name": {"property": "to-revert"}, "uuid": "u4", "value": "4"}),
+            ),
         ]);
         let report = semantic_diff(&old, &new);
         assert_eq!(report.renamed.len(), 1, "should have 1 renamed");
@@ -696,10 +740,19 @@ mod tests {
     #[test]
     fn empty_diff_identical_graphs() {
         let g = make_graph(vec![
-            ("a", json!({"name": {"property": "a"}, "uuid": "u1", "value": "1"})),
-            ("b", json!({"name": {"property": "b"}, "uuid": "u2", "value": "2"})),
+            (
+                "a",
+                json!({"name": {"property": "a"}, "uuid": "u1", "value": "1"}),
+            ),
+            (
+                "b",
+                json!({"name": {"property": "b"}, "uuid": "u2", "value": "2"}),
+            ),
         ]);
         let report = semantic_diff(&g, &g);
-        assert!(report.is_empty(), "identical graphs should produce empty diff");
+        assert!(
+            report.is_empty(),
+            "identical graphs should produce empty diff"
+        );
     }
 }

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -12,11 +12,13 @@
 
 pub mod cascade;
 pub mod compat;
+pub mod diff;
 pub mod discovery;
 pub mod graph;
 pub mod legacy;
 pub mod migrate;
 pub mod naming;
+pub mod query;
 pub mod report;
 pub mod schema;
 pub mod validate;
@@ -43,6 +45,8 @@ pub enum CoreError {
          in legacy set format; convert individual dimension slices separately"
     )]
     MultiDimensionalToken(String),
+    #[error("query parse error: {0}")]
+    QueryParse(String),
 }
 
 /// Returns the crate name for sanity checks and CLI `--version` wiring later.

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -256,10 +256,7 @@ pub fn build_index(graph: &TokenGraph, key: &str) -> HashMap<String, Vec<String>
     let mut index: HashMap<String, Vec<String>> = HashMap::new();
     for (graph_key, token) in &graph.tokens {
         if let Some(value) = resolve_key(&token.raw, key) {
-            index
-                .entry(value)
-                .or_default()
-                .push(graph_key.clone());
+            index.entry(value).or_default().push(graph_key.clone());
         }
     }
     index
@@ -403,8 +400,14 @@ mod tests {
     #[test]
     fn filter_single_match() {
         let g = make_graph(vec![
-            ("btn", json!({"name": {"property": "bg", "component": "button"}, "value": "1"})),
-            ("chk", json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"})),
+            (
+                "btn",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+            ),
+            (
+                "chk",
+                json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"}),
+            ),
         ]);
         let f = parse("component=button").unwrap();
         let results = filter(&g, &f);
@@ -415,9 +418,18 @@ mod tests {
     #[test]
     fn filter_and() {
         let g = make_graph(vec![
-            ("btn-hover", json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"})),
-            ("btn-default", json!({"name": {"property": "bg", "component": "button"}, "value": "2"})),
-            ("chk-hover", json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "3"})),
+            (
+                "btn-hover",
+                json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"}),
+            ),
+            (
+                "btn-default",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "2"}),
+            ),
+            (
+                "chk-hover",
+                json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "3"}),
+            ),
         ]);
         let f = parse("component=button,state=hover").unwrap();
         let results = filter(&g, &f);
@@ -427,9 +439,18 @@ mod tests {
     #[test]
     fn filter_or() {
         let g = make_graph(vec![
-            ("btn", json!({"name": {"property": "bg", "component": "button"}, "value": "1"})),
-            ("chk", json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"})),
-            ("slider", json!({"name": {"property": "bg", "component": "slider"}, "value": "3"})),
+            (
+                "btn",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+            ),
+            (
+                "chk",
+                json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"}),
+            ),
+            (
+                "slider",
+                json!({"name": {"property": "bg", "component": "slider"}, "value": "3"}),
+            ),
         ]);
         let f = parse("component=button|component=checkbox").unwrap();
         let results = filter(&g, &f);
@@ -439,8 +460,14 @@ mod tests {
     #[test]
     fn filter_negation() {
         let g = make_graph(vec![
-            ("light", json!({"name": {"property": "bg", "colorScheme": "light"}, "value": "1"})),
-            ("dark", json!({"name": {"property": "bg", "colorScheme": "dark"}, "value": "2"})),
+            (
+                "light",
+                json!({"name": {"property": "bg", "colorScheme": "light"}, "value": "1"}),
+            ),
+            (
+                "dark",
+                json!({"name": {"property": "bg", "colorScheme": "dark"}, "value": "2"}),
+            ),
             ("none", json!({"name": {"property": "bg"}, "value": "3"})),
         ]);
         let f = parse("colorScheme!=light").unwrap();
@@ -452,9 +479,18 @@ mod tests {
     #[test]
     fn filter_wildcard() {
         let g = make_graph(vec![
-            ("bg", json!({"name": {"property": "background-color"}, "value": "1"})),
-            ("border", json!({"name": {"property": "border-color"}, "value": "2"})),
-            ("size", json!({"name": {"property": "font-size"}, "value": "3"})),
+            (
+                "bg",
+                json!({"name": {"property": "background-color"}, "value": "1"}),
+            ),
+            (
+                "border",
+                json!({"name": {"property": "border-color"}, "value": "2"}),
+            ),
+            (
+                "size",
+                json!({"name": {"property": "font-size"}, "value": "3"}),
+            ),
         ]);
         let f = parse("property=*-color").unwrap();
         let results = filter(&g, &f);
@@ -464,8 +500,14 @@ mod tests {
     #[test]
     fn filter_schema_key() {
         let g = make_graph(vec![
-            ("color", json!({"name": {"property": "bg"}, "$schema": "https://example.com/color.json", "value": "1"})),
-            ("size", json!({"name": {"property": "sz"}, "$schema": "https://example.com/dimension.json", "value": "2"})),
+            (
+                "color",
+                json!({"name": {"property": "bg"}, "$schema": "https://example.com/color.json", "value": "1"}),
+            ),
+            (
+                "size",
+                json!({"name": {"property": "sz"}, "$schema": "https://example.com/dimension.json", "value": "2"}),
+            ),
         ]);
         let f = parse("$schema=https://example.com/color.json").unwrap();
         let results = filter(&g, &f);
@@ -499,9 +541,18 @@ mod tests {
     #[test]
     fn build_index_groups_by_value() {
         let g = make_graph(vec![
-            ("a", json!({"name": {"property": "bg", "component": "button"}, "value": "1"})),
-            ("b", json!({"name": {"property": "fg", "component": "button"}, "value": "2"})),
-            ("c", json!({"name": {"property": "bg", "component": "checkbox"}, "value": "3"})),
+            (
+                "a",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+            ),
+            (
+                "b",
+                json!({"name": {"property": "fg", "component": "button"}, "value": "2"}),
+            ),
+            (
+                "c",
+                json!({"name": {"property": "bg", "component": "checkbox"}, "value": "3"}),
+            ),
         ]);
         let idx = build_index(&g, "component");
         assert_eq!(idx.get("button").map(|v| v.len()), Some(2));

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -1,0 +1,510 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Query filter engine — parse and evaluate filter expressions against tokens.
+//!
+//! Implements the query notation defined in `spec/query.md`: `key=value` pairs
+//! with `,` (AND), `|` (OR), `!=` (negation), and `*` (glob wildcard).
+
+use std::collections::HashMap;
+
+use crate::graph::{TokenGraph, TokenRecord};
+use crate::CoreError;
+
+// ── Allowed keys (per spec) ─────────────────────────────────────────────────
+
+/// Keys that may appear in filter expressions.
+const ALLOWED_KEYS: &[&str] = &[
+    "property",
+    "component",
+    "variant",
+    "state",
+    "colorScheme",
+    "scale",
+    "contrast",
+    "uuid",
+    "$schema",
+];
+
+/// Keys resolved from `raw["name"][key]` (name-object fields).
+const NAME_OBJECT_KEYS: &[&str] = &[
+    "property",
+    "component",
+    "variant",
+    "state",
+    "colorScheme",
+    "scale",
+    "contrast",
+];
+
+// ── AST types ───────────────────────────────────────────────────────────────
+
+/// A parsed filter expression.
+#[derive(Debug, Clone)]
+pub struct TokenFilter {
+    expr: FilterExpr,
+}
+
+#[derive(Debug, Clone)]
+enum FilterExpr {
+    /// Universal match (empty expression).
+    All,
+    /// `|`-separated alternatives.
+    Or(Vec<Vec<Condition>>),
+}
+
+/// Comparison operator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Operator {
+    Eq,
+    NotEq,
+}
+
+/// A single `key=value` or `key!=value` condition.
+#[derive(Debug, Clone)]
+struct Condition {
+    key: String,
+    op: Operator,
+    value: String,
+}
+
+// ── Parser ──────────────────────────────────────────────────────────────────
+
+/// Parse a filter expression string into a `TokenFilter`.
+///
+/// Returns `CoreError` for syntax errors or unknown keys.
+pub fn parse(input: &str) -> Result<TokenFilter, CoreError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(TokenFilter {
+            expr: FilterExpr::All,
+        });
+    }
+
+    // Split on `|` first (OR — lower precedence).
+    let or_parts: Vec<&str> = split_top_level(trimmed, '|');
+    let mut alternatives = Vec::new();
+
+    for or_part in or_parts {
+        let and_parts: Vec<&str> = split_top_level(or_part.trim(), ',');
+        let mut conditions = Vec::new();
+        for part in and_parts {
+            conditions.push(parse_condition(part.trim())?);
+        }
+        alternatives.push(conditions);
+    }
+
+    Ok(TokenFilter {
+        expr: FilterExpr::Or(alternatives),
+    })
+}
+
+/// Split a string on a delimiter, respecting that we don't have nesting.
+fn split_top_level(s: &str, delim: char) -> Vec<&str> {
+    s.split(delim).collect()
+}
+
+/// Parse a single `key=value` or `key!=value` condition.
+fn parse_condition(s: &str) -> Result<Condition, CoreError> {
+    // Try `!=` first (longer operator).
+    if let Some(pos) = s.find("!=") {
+        let key = s[..pos].trim().to_string();
+        let value = s[pos + 2..].trim().to_string();
+        validate_key(&key)?;
+        return Ok(Condition {
+            key,
+            op: Operator::NotEq,
+            value,
+        });
+    }
+    // Then `=`.
+    if let Some(pos) = s.find('=') {
+        let key = s[..pos].trim().to_string();
+        let value = s[pos + 1..].trim().to_string();
+        validate_key(&key)?;
+        return Ok(Condition {
+            key,
+            op: Operator::Eq,
+            value,
+        });
+    }
+    Err(CoreError::QueryParse(format!(
+        "invalid condition (missing operator): {s:?}"
+    )))
+}
+
+/// Validate that a key is in the allowed set.
+fn validate_key(key: &str) -> Result<(), CoreError> {
+    if key.is_empty() {
+        return Err(CoreError::QueryParse("empty key".to_string()));
+    }
+    if ALLOWED_KEYS.contains(&key) {
+        return Ok(());
+    }
+    Err(CoreError::QueryParse(format!(
+        "unknown key {key:?}; allowed keys are: {}",
+        ALLOWED_KEYS.join(", ")
+    )))
+}
+
+// ── Filter evaluation ───────────────────────────────────────────────────────
+
+/// Filter tokens in a graph that match the given expression.
+///
+/// Returns references to matching `TokenRecord`s, sorted by name for
+/// deterministic output.
+pub fn filter<'a>(graph: &'a TokenGraph, expr: &TokenFilter) -> Vec<&'a TokenRecord> {
+    let mut results: Vec<&TokenRecord> = graph
+        .tokens
+        .values()
+        .filter(|t| matches_expr(&t.raw, &expr.expr))
+        .collect();
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+    results
+}
+
+/// Evaluate a filter expression against a token's raw JSON.
+fn matches_expr(raw: &serde_json::Value, expr: &FilterExpr) -> bool {
+    match expr {
+        FilterExpr::All => true,
+        FilterExpr::Or(alternatives) => alternatives
+            .iter()
+            .any(|and_group| and_group.iter().all(|cond| matches_condition(raw, cond))),
+    }
+}
+
+/// Evaluate a single condition against a token's raw JSON.
+fn matches_condition(raw: &serde_json::Value, cond: &Condition) -> bool {
+    let field_value = resolve_key(raw, &cond.key);
+
+    match (&cond.op, field_value) {
+        (Operator::Eq, Some(actual)) => glob_match(&cond.value, &actual),
+        (Operator::Eq, None) => false,
+        (Operator::NotEq, Some(actual)) => !glob_match(&cond.value, &actual),
+        (Operator::NotEq, None) => true, // Missing field satisfies !=
+    }
+}
+
+/// Resolve a query key to the field value in a token's raw JSON.
+fn resolve_key(raw: &serde_json::Value, key: &str) -> Option<String> {
+    if NAME_OBJECT_KEYS.contains(&key) {
+        raw.get("name")
+            .and_then(|n| n.get(key))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    } else if key == "uuid" {
+        raw.get("uuid").and_then(|v| v.as_str()).map(String::from)
+    } else if key == "$schema" {
+        raw.get("$schema")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    } else {
+        None
+    }
+}
+
+// ── Glob matching ───────────────────────────────────────────────────────────
+
+/// Simple glob matching: `*` matches zero or more characters.
+/// Case-sensitive, per spec.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    // No wildcards → exact match.
+    if !pattern.contains('*') {
+        return pattern == text;
+    }
+
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut pos = 0;
+
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        match text[pos..].find(part) {
+            Some(found) => {
+                // First segment must match at the start.
+                if i == 0 && found != 0 {
+                    return false;
+                }
+                pos += found + part.len();
+            }
+            None => return false,
+        }
+    }
+
+    // If pattern doesn't end with *, text must be fully consumed.
+    if !pattern.ends_with('*') {
+        return pos == text.len();
+    }
+
+    true
+}
+
+// ── Index builder (optional optimization, #783) ─────────────────────────────
+
+/// Build a secondary index mapping field values to token graph keys.
+///
+/// Useful for accelerating single-field equality queries on large token sets.
+pub fn build_index(graph: &TokenGraph, key: &str) -> HashMap<String, Vec<String>> {
+    let mut index: HashMap<String, Vec<String>> = HashMap::new();
+    for (graph_key, token) in &graph.tokens {
+        if let Some(value) = resolve_key(&token.raw, key) {
+            index
+                .entry(value)
+                .or_default()
+                .push(graph_key.clone());
+        }
+    }
+    index
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::TokenGraph;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn make_graph(tokens: Vec<(&str, serde_json::Value)>) -> TokenGraph {
+        TokenGraph::from_pairs(
+            tokens
+                .into_iter()
+                .map(|(name, raw)| (name.to_string(), PathBuf::from("test.json"), raw))
+                .collect(),
+        )
+    }
+
+    // ── Parser tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_matches_all() {
+        let f = parse("").unwrap();
+        assert!(matches!(f.expr, FilterExpr::All));
+    }
+
+    #[test]
+    fn parse_single_condition() {
+        let f = parse("component=button").unwrap();
+        if let FilterExpr::Or(alts) = &f.expr {
+            assert_eq!(alts.len(), 1);
+            assert_eq!(alts[0].len(), 1);
+            assert_eq!(alts[0][0].key, "component");
+            assert_eq!(alts[0][0].value, "button");
+            assert_eq!(alts[0][0].op, Operator::Eq);
+        } else {
+            panic!("expected Or");
+        }
+    }
+
+    #[test]
+    fn parse_and_conditions() {
+        let f = parse("component=button,state=hover").unwrap();
+        if let FilterExpr::Or(alts) = &f.expr {
+            assert_eq!(alts.len(), 1);
+            assert_eq!(alts[0].len(), 2);
+        } else {
+            panic!("expected Or");
+        }
+    }
+
+    #[test]
+    fn parse_or_conditions() {
+        let f = parse("property=bg|property=fg").unwrap();
+        if let FilterExpr::Or(alts) = &f.expr {
+            assert_eq!(alts.len(), 2);
+        } else {
+            panic!("expected Or");
+        }
+    }
+
+    #[test]
+    fn parse_negation() {
+        let f = parse("colorScheme!=light").unwrap();
+        if let FilterExpr::Or(alts) = &f.expr {
+            assert_eq!(alts[0][0].op, Operator::NotEq);
+        } else {
+            panic!("expected Or");
+        }
+    }
+
+    #[test]
+    fn parse_unknown_key_rejected() {
+        let err = parse("unknown=value");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn parse_dollar_schema_key() {
+        let f = parse("$schema=https://example.com/token.json").unwrap();
+        if let FilterExpr::Or(alts) = &f.expr {
+            assert_eq!(alts[0][0].key, "$schema");
+        } else {
+            panic!("expected Or");
+        }
+    }
+
+    #[test]
+    fn parse_whitespace_trimmed() {
+        let f = parse("  component = button , state = hover  ").unwrap();
+        if let FilterExpr::Or(alts) = &f.expr {
+            assert_eq!(alts[0][0].key, "component");
+            assert_eq!(alts[0][0].value, "button");
+            assert_eq!(alts[0][1].key, "state");
+            assert_eq!(alts[0][1].value, "hover");
+        } else {
+            panic!("expected Or");
+        }
+    }
+
+    // ── Glob matching ───────────────────────────────────────────────────
+
+    #[test]
+    fn glob_exact() {
+        assert!(glob_match("hello", "hello"));
+        assert!(!glob_match("hello", "world"));
+    }
+
+    #[test]
+    fn glob_star_prefix() {
+        assert!(glob_match("*-color", "background-color"));
+        assert!(!glob_match("*-color", "background-size"));
+    }
+
+    #[test]
+    fn glob_star_suffix() {
+        assert!(glob_match("color-*", "color-default"));
+        assert!(glob_match("color-*", "color-"));
+        assert!(!glob_match("color-*", "background-color"));
+    }
+
+    #[test]
+    fn glob_star_middle() {
+        assert!(glob_match("a*z", "abcz"));
+        assert!(glob_match("a*z", "az"));
+        assert!(!glob_match("a*z", "abcd"));
+    }
+
+    #[test]
+    fn glob_multiple_stars() {
+        assert!(glob_match("*bg*color*", "my-bg-base-color-default"));
+    }
+
+    // ── Filter evaluation ───────────────────────────────────────────────
+
+    #[test]
+    fn filter_single_match() {
+        let g = make_graph(vec![
+            ("btn", json!({"name": {"property": "bg", "component": "button"}, "value": "1"})),
+            ("chk", json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"})),
+        ]);
+        let f = parse("component=button").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].raw["name"]["component"], "button");
+    }
+
+    #[test]
+    fn filter_and() {
+        let g = make_graph(vec![
+            ("btn-hover", json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"})),
+            ("btn-default", json!({"name": {"property": "bg", "component": "button"}, "value": "2"})),
+            ("chk-hover", json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "3"})),
+        ]);
+        let f = parse("component=button,state=hover").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn filter_or() {
+        let g = make_graph(vec![
+            ("btn", json!({"name": {"property": "bg", "component": "button"}, "value": "1"})),
+            ("chk", json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"})),
+            ("slider", json!({"name": {"property": "bg", "component": "slider"}, "value": "3"})),
+        ]);
+        let f = parse("component=button|component=checkbox").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn filter_negation() {
+        let g = make_graph(vec![
+            ("light", json!({"name": {"property": "bg", "colorScheme": "light"}, "value": "1"})),
+            ("dark", json!({"name": {"property": "bg", "colorScheme": "dark"}, "value": "2"})),
+            ("none", json!({"name": {"property": "bg"}, "value": "3"})),
+        ]);
+        let f = parse("colorScheme!=light").unwrap();
+        let results = filter(&g, &f);
+        // "dark" matches (not light), "none" matches (absent field satisfies !=).
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn filter_wildcard() {
+        let g = make_graph(vec![
+            ("bg", json!({"name": {"property": "background-color"}, "value": "1"})),
+            ("border", json!({"name": {"property": "border-color"}, "value": "2"})),
+            ("size", json!({"name": {"property": "font-size"}, "value": "3"})),
+        ]);
+        let f = parse("property=*-color").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn filter_schema_key() {
+        let g = make_graph(vec![
+            ("color", json!({"name": {"property": "bg"}, "$schema": "https://example.com/color.json", "value": "1"})),
+            ("size", json!({"name": {"property": "sz"}, "$schema": "https://example.com/dimension.json", "value": "2"})),
+        ]);
+        let f = parse("$schema=https://example.com/color.json").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn filter_empty_matches_all() {
+        let g = make_graph(vec![
+            ("a", json!({"name": {"property": "a"}, "value": "1"})),
+            ("b", json!({"name": {"property": "b"}, "value": "2"})),
+        ]);
+        let f = parse("").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn filter_no_matches() {
+        let g = make_graph(vec![(
+            "a",
+            json!({"name": {"property": "bg"}, "value": "1"}),
+        )]);
+        let f = parse("component=nonexistent").unwrap();
+        let results = filter(&g, &f);
+        assert!(results.is_empty());
+    }
+
+    // ── Index builder ───────────────────────────────────────────────────
+
+    #[test]
+    fn build_index_groups_by_value() {
+        let g = make_graph(vec![
+            ("a", json!({"name": {"property": "bg", "component": "button"}, "value": "1"})),
+            ("b", json!({"name": {"property": "fg", "component": "button"}, "value": "2"})),
+            ("c", json!({"name": {"property": "bg", "component": "checkbox"}, "value": "3"})),
+        ]);
+        let idx = build_index(&g, "component");
+        assert_eq!(idx.get("button").map(|v| v.len()), Some(2));
+        assert_eq!(idx.get("checkbox").map(|v| v.len()), Some(1));
+    }
+}


### PR DESCRIPTION
## Description

Implements the Phase 3 Wave 1 core engines — the semantic diff engine and query filter engine in Rust. These are the foundational algorithms that Wave 2 (CLI commands and formatters) will expose.

**Diff engine** (`sdk/core/src/diff.rs`):
- Token pairing via UUID match (O(1) via `uuid_index`) with name-object equivalence fallback; handles the UUID backfill scenario per the spec fix in #789
- Six mutually exclusive categories per `spec/diff.md`: renamed, deprecated, reverted, added, deleted, updated — partitioned in spec-defined order
- Deprecation normalization: all sets deprecated → token deprecated
- Recursive property-level change tracking with dot-separated paths and added/deleted/updated sub-categories
- `pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport` orchestrator
- 14 unit tests covering all categories, pairing modes, and edge cases

**Query engine** (`sdk/core/src/query.rs`):
- Hand-written recursive descent parser for the EBNF grammar in `spec/query.md`
- `key=value` pairs with `,` (AND), `|` (OR), `!=` (negation), `*` (glob wildcard)
- 9 supported keys validated at parse time; unknown keys produce a parse error
- Filter evaluation against `TokenRecord` raw JSON with absent-field semantics (`!=` matches missing fields, `=` does not)
- Optional `build_index()` for sub-linear single-field equality queries
- `pub fn parse(input) -> Result<TokenFilter>` + `pub fn filter(graph, expr) -> Vec<&TokenRecord>`
- 14 unit tests covering parser, filter, glob matching, and index builder

**Also modified:**
- `sdk/core/src/lib.rs` — added `pub mod diff;` and `pub mod query;` declarations, plus `QueryParse` error variant

## Related Issue

Closes #778, #779, #780, #781, #782, #783
Parents: #772, #773
Epic: #730 — Phase 3: Diff and query engines

## Motivation and Context

Wave 0 (#789) landed the normative spec documents defining diff and query behavior. Wave 1 implements those specs as Rust library code, following the same patterns established by the cascade resolution engine (`cascade.rs`). These engines operate on `TokenGraph` pairs (diff) or single graphs (query) and produce structured, serializable output suitable for CLI, CI, and programmatic consumption.

## How Has This Been Tested?

- `cargo test` in `sdk/` — **93 tests passing** (28 new + 65 existing), 0 failures
- Diff tests: UUID pairing, name-object fallback, UUID backfill, rename detection, deprecation (top-level + set-level normalization), reversion, added/deleted, property-level changes (value, nested, added/deleted properties), full pipeline (all 6 categories simultaneously), empty diff (identical graphs)
- Query tests: parser (single condition, AND, OR, negation, `$schema` key, whitespace, unknown key rejection, empty expression), filter evaluation (single match, AND, OR, negation with absent fields, wildcard glob, `$schema`, no matches), index builder
- All existing tests (cascade, validation, migration, conformance) continue to pass

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
