### PR TITLE
feat(cli): Phase 3 Wave 2 diff and query CLI commands with formatters

### DIFF
--- a/sdk/cli/src/format.rs
+++ b/sdk/cli/src/format.rs
@@ -8,8 +8,9 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! CLI output formatters (`pretty` and `json`).
+//! CLI output formatters (`pretty`, `json`, and `markdown`).
 
+use design_data_core::diff::{ChangeType, DiffReport, PropertyChange};
 use design_data_core::report::ValidationReport;
 
 /// Human-readable stderr/stdout mix: errors on stderr, success line on stdout.
@@ -45,4 +46,268 @@ pub fn print_report_pretty(report: &ValidationReport) {
 /// Full report as JSON (stdout).
 pub fn format_report_json(report: &ValidationReport) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(report)
+}
+
+// ── Diff formatters ─────────────────────────────────────────────────────────
+
+/// Whether ANSI colors should be used.
+fn use_color() -> bool {
+    std::env::var("NO_COLOR").is_err()
+}
+
+/// ANSI color helpers — return empty strings when NO_COLOR is set.
+fn color(code: &str) -> &str {
+    if use_color() {
+        code
+    } else {
+        ""
+    }
+}
+
+const RESET: &str = "\x1b[0m";
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+const MAGENTA: &str = "\x1b[35m";
+
+/// Human-readable diff report on stdout with ANSI colors.
+pub fn print_diff_pretty(report: &DiffReport) {
+    if report.is_empty() {
+        println!("No changes.");
+        return;
+    }
+
+    // Summary line.
+    let mut parts = Vec::new();
+    if !report.renamed.is_empty() {
+        parts.push(format!("{} renamed", report.renamed.len()));
+    }
+    if !report.deprecated.is_empty() {
+        parts.push(format!("{} deprecated", report.deprecated.len()));
+    }
+    if !report.reverted.is_empty() {
+        parts.push(format!("{} reverted", report.reverted.len()));
+    }
+    if !report.added.is_empty() {
+        parts.push(format!("{} added", report.added.len()));
+    }
+    if !report.deleted.is_empty() {
+        parts.push(format!("{} deleted", report.deleted.len()));
+    }
+    if !report.updated.is_empty() {
+        parts.push(format!("{} updated", report.updated.len()));
+    }
+    println!("{}\n", parts.join(", "));
+
+    // Renamed.
+    for t in &report.renamed {
+        println!(
+            "  {c}renamed{r}  {} → {}",
+            t.old_name,
+            t.new_name,
+            c = color(CYAN),
+            r = color(RESET),
+        );
+        print_property_changes_pretty(&t.property_changes);
+    }
+
+    // Deprecated.
+    for t in &report.deprecated {
+        println!(
+            "  {c}deprecated{r}  {}",
+            t.name,
+            c = color(MAGENTA),
+            r = color(RESET),
+        );
+    }
+
+    // Reverted.
+    for t in &report.reverted {
+        println!(
+            "  {c}reverted{r}  {}",
+            t.name,
+            c = color(MAGENTA),
+            r = color(RESET),
+        );
+    }
+
+    // Added.
+    for t in &report.added {
+        println!(
+            "  {c}added{r}  {}",
+            t.name,
+            c = color(GREEN),
+            r = color(RESET),
+        );
+    }
+
+    // Deleted.
+    for t in &report.deleted {
+        println!(
+            "  {c}deleted{r}  {}",
+            t.name,
+            c = color(RED),
+            r = color(RESET),
+        );
+    }
+
+    // Updated.
+    for t in &report.updated {
+        println!(
+            "  {c}updated{r}  {}",
+            t.name,
+            c = color(YELLOW),
+            r = color(RESET),
+        );
+        print_property_changes_pretty(&t.property_changes);
+    }
+}
+
+fn print_property_changes_pretty(changes: &[PropertyChange]) {
+    for c in changes {
+        match c.change_type {
+            ChangeType::Added => {
+                println!(
+                    "    {g}+{r} {}: {}",
+                    c.path,
+                    fmt_value(&c.new_value),
+                    g = color(GREEN),
+                    r = color(RESET),
+                );
+            }
+            ChangeType::Deleted => {
+                println!(
+                    "    {rd}-{r} {}: {}",
+                    c.path,
+                    fmt_value(&c.original_value),
+                    rd = color(RED),
+                    r = color(RESET),
+                );
+            }
+            ChangeType::Updated => {
+                println!(
+                    "    {y}~{r} {}: {} → {}",
+                    c.path,
+                    fmt_value(&c.original_value),
+                    fmt_value(&c.new_value),
+                    y = color(YELLOW),
+                    r = color(RESET),
+                );
+            }
+        }
+    }
+}
+
+fn fmt_value(v: &Option<serde_json::Value>) -> String {
+    match v {
+        Some(val) => {
+            if let Some(s) = val.as_str() {
+                s.to_string()
+            } else {
+                val.to_string()
+            }
+        }
+        None => "-".to_string(),
+    }
+}
+
+/// Markdown-formatted diff report for changelogs.
+pub fn format_diff_markdown(report: &DiffReport) -> String {
+    let mut out = String::new();
+
+    if report.is_empty() {
+        out.push_str("No changes.\n");
+        return out;
+    }
+
+    // Summary.
+    let total = report.renamed.len()
+        + report.deprecated.len()
+        + report.reverted.len()
+        + report.added.len()
+        + report.deleted.len()
+        + report.updated.len();
+    out.push_str(&format!("**{total} token(s) changed.**\n\n"));
+
+    if !report.renamed.is_empty() {
+        out.push_str(&format!("## Renamed ({})\n\n", report.renamed.len()));
+        for t in &report.renamed {
+            out.push_str(&format!("- `{}` → `{}`\n", t.old_name, t.new_name));
+            format_property_changes_md(&t.property_changes, &mut out);
+        }
+        out.push('\n');
+    }
+
+    if !report.deprecated.is_empty() {
+        out.push_str(&format!("## Deprecated ({})\n\n", report.deprecated.len()));
+        for t in &report.deprecated {
+            out.push_str(&format!("- `{}`\n", t.name));
+        }
+        out.push('\n');
+    }
+
+    if !report.reverted.is_empty() {
+        out.push_str(&format!("## Reverted ({})\n\n", report.reverted.len()));
+        for t in &report.reverted {
+            out.push_str(&format!("- `{}`\n", t.name));
+        }
+        out.push('\n');
+    }
+
+    if !report.added.is_empty() {
+        out.push_str(&format!("## Added ({})\n\n", report.added.len()));
+        for t in &report.added {
+            out.push_str(&format!("- `{}`\n", t.name));
+        }
+        out.push('\n');
+    }
+
+    if !report.deleted.is_empty() {
+        out.push_str(&format!("## Deleted ({})\n\n", report.deleted.len()));
+        for t in &report.deleted {
+            out.push_str(&format!("- `{}`\n", t.name));
+        }
+        out.push('\n');
+    }
+
+    if !report.updated.is_empty() {
+        out.push_str(&format!("## Updated ({})\n\n", report.updated.len()));
+        for t in &report.updated {
+            out.push_str(&format!("- `{}`\n", t.name));
+            format_property_changes_md(&t.property_changes, &mut out);
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+fn format_property_changes_md(changes: &[PropertyChange], out: &mut String) {
+    for c in changes {
+        match c.change_type {
+            ChangeType::Added => {
+                out.push_str(&format!(
+                    "  - **+** `{}`: {}\n",
+                    c.path,
+                    fmt_value(&c.new_value),
+                ));
+            }
+            ChangeType::Deleted => {
+                out.push_str(&format!(
+                    "  - **-** `{}`: {}\n",
+                    c.path,
+                    fmt_value(&c.original_value),
+                ));
+            }
+            ChangeType::Updated => {
+                out.push_str(&format!(
+                    "  - **~** `{}`: {} → {}\n",
+                    c.path,
+                    fmt_value(&c.original_value),
+                    fmt_value(&c.new_value),
+                ));
+            }
+        }
+    }
 }

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -20,10 +20,12 @@ use design_data_core::cascade::{resolve, ResolutionContext};
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
+use design_data_core::diff;
 use design_data_core::graph::TokenGraph;
 use design_data_core::legacy;
 use design_data_core::migrate;
 use design_data_core::naming::NamingExceptionsFile;
+use design_data_core::query;
 use design_data_core::schema::SchemaRegistry;
 use design_data_core::validate;
 use miette::{IntoDiagnostic, WrapErr};
@@ -83,6 +85,36 @@ enum Commands {
         #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
         format: OutputFormat,
     },
+    /// Compare two token datasets and report changes
+    Diff {
+        /// Directory containing the old/before token dataset
+        #[arg(value_name = "OLD")]
+        old: PathBuf,
+        /// Directory containing the new/after token dataset
+        #[arg(value_name = "NEW")]
+        new: PathBuf,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+        /// Filter to scope diff to matching tokens (query notation)
+        #[arg(long, value_name = "EXPR")]
+        filter: Option<String>,
+    },
+    /// Filter and list tokens matching a query expression
+    Query {
+        /// Path to token dataset directory
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Filter expression (e.g. "component=button,state=hover")
+        #[arg(long, value_name = "EXPR")]
+        filter: String,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+        /// Output only the match count
+        #[arg(long)]
+        count: bool,
+    },
     /// Snapshot and backward-compat verification helpers
     Migrate {
         #[command(subcommand)]
@@ -141,6 +173,7 @@ enum OutputFormat {
     #[default]
     Pretty,
     Json,
+    Markdown,
 }
 
 fn load_exceptions(path: Option<&Path>) -> miette::Result<HashSet<String>> {
@@ -277,7 +310,7 @@ fn run_resolve(
                         serde_json::to_string_pretty(&winner.raw).into_diagnostic()?
                     );
                 }
-                OutputFormat::Pretty => {
+                OutputFormat::Pretty | OutputFormat::Markdown => {
                     println!("Property:  {property}");
                     if let Some(val) = winner.raw.get("value") {
                         println!("Value:     {val}");
@@ -324,7 +357,7 @@ fn run_validate(
         OutputFormat::Json => {
             println!("{}", format::format_report_json(&report).into_diagnostic()?);
         }
-        OutputFormat::Pretty => {
+        OutputFormat::Pretty | OutputFormat::Markdown => {
             format::print_report_pretty(&report);
         }
     }
@@ -417,6 +450,132 @@ fn run_migrate_snapshot(
     Ok(ExitCode::SUCCESS)
 }
 
+fn run_diff(
+    old_path: &Path,
+    new_path: &Path,
+    format: OutputFormat,
+    filter_expr: Option<&str>,
+) -> miette::Result<ExitCode> {
+    let old_graph = TokenGraph::from_json_dir(old_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load old tokens from {}", old_path.display()))?;
+    let new_graph = TokenGraph::from_json_dir(new_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load new tokens from {}", new_path.display()))?;
+
+    // Optionally filter both graphs to matching tokens before diffing.
+    let (old_filtered, new_filtered) = if let Some(expr_str) = filter_expr {
+        let expr = query::parse(expr_str)
+            .into_diagnostic()
+            .wrap_err("failed to parse --filter expression")?;
+        let old_matched = query::filter(&old_graph, &expr);
+        let new_matched = query::filter(&new_graph, &expr);
+        (
+            TokenGraph::from_pairs(
+                old_matched
+                    .iter()
+                    .map(|t| (t.name.clone(), t.file.clone(), t.raw.clone()))
+                    .collect(),
+            ),
+            TokenGraph::from_pairs(
+                new_matched
+                    .iter()
+                    .map(|t| (t.name.clone(), t.file.clone(), t.raw.clone()))
+                    .collect(),
+            ),
+        )
+    } else {
+        (old_graph, new_graph)
+    };
+
+    let report = diff::semantic_diff(&old_filtered, &new_filtered);
+
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report).into_diagnostic()?
+            );
+        }
+        OutputFormat::Markdown => {
+            print!("{}", format::format_diff_markdown(&report));
+        }
+        OutputFormat::Pretty => {
+            format::print_diff_pretty(&report);
+        }
+    }
+
+    if report.is_empty() {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        Ok(ExitCode::from(1))
+    }
+}
+
+fn run_query(
+    path: &Path,
+    filter_expr: &str,
+    format: OutputFormat,
+    count_only: bool,
+) -> miette::Result<ExitCode> {
+    let graph = TokenGraph::from_json_dir(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+
+    let expr = query::parse(filter_expr)
+        .into_diagnostic()
+        .wrap_err("failed to parse filter expression")?;
+
+    let results = query::filter(&graph, &expr);
+
+    if count_only {
+        println!("{}", results.len());
+        return if results.is_empty() {
+            Ok(ExitCode::from(1))
+        } else {
+            Ok(ExitCode::SUCCESS)
+        };
+    }
+
+    match format {
+        OutputFormat::Json => {
+            let raw_values: Vec<&serde_json::Value> = results.iter().map(|t| &t.raw).collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&raw_values).into_diagnostic()?
+            );
+        }
+        OutputFormat::Pretty | OutputFormat::Markdown => {
+            if results.is_empty() {
+                println!("No matching tokens.");
+            } else {
+                println!("{} token(s) matched:\n", results.len());
+                for t in &results {
+                    let name = t
+                        .raw
+                        .get("name")
+                        .and_then(|n| n.get("property"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&t.name);
+                    let uuid = t.uuid.as_deref().unwrap_or("-");
+                    let schema = t.raw.get("$schema").and_then(|v| v.as_str()).unwrap_or("-");
+                    println!("  {name}");
+                    println!("    UUID:    {uuid}");
+                    println!("    Schema:  {schema}");
+                    println!("    File:    {}", t.file.display());
+                    println!();
+                }
+            }
+        }
+    }
+
+    if results.is_empty() {
+        Ok(ExitCode::from(1))
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -458,6 +617,21 @@ fn main() -> ExitCode {
                 contrast,
                 format,
             )
+        }
+        Commands::Diff {
+            old,
+            new,
+            format,
+            filter,
+        } => run_diff(&old, &new, format, filter.as_deref()),
+        Commands::Query {
+            path,
+            filter,
+            format,
+            count,
+        } => {
+            let target = path.unwrap_or_else(|| PathBuf::from("."));
+            run_query(&target, &filter, format, count)
         }
         Commands::Migrate { sub } => match sub {
             MigrateSub::Verify {

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -21,6 +21,7 @@ use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
 use design_data_core::diff;
+use design_data_core::diff::display_name;
 use design_data_core::graph::TokenGraph;
 use design_data_core::legacy;
 use design_data_core::migrate;
@@ -94,8 +95,8 @@ enum Commands {
         #[arg(value_name = "NEW")]
         new: PathBuf,
         /// Output format
-        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
-        format: OutputFormat,
+        #[arg(long, value_enum, default_value_t = DiffFormat::Pretty)]
+        format: DiffFormat,
         /// Filter to scope diff to matching tokens (query notation)
         #[arg(long, value_name = "EXPR")]
         filter: Option<String>,
@@ -170,6 +171,14 @@ enum MigrateSub {
 
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
 enum OutputFormat {
+    #[default]
+    Pretty,
+    Json,
+}
+
+/// Output format for the `diff` command (superset of `OutputFormat` — adds `markdown`).
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum DiffFormat {
     #[default]
     Pretty,
     Json,
@@ -310,7 +319,7 @@ fn run_resolve(
                         serde_json::to_string_pretty(&winner.raw).into_diagnostic()?
                     );
                 }
-                OutputFormat::Pretty | OutputFormat::Markdown => {
+                OutputFormat::Pretty => {
                     println!("Property:  {property}");
                     if let Some(val) = winner.raw.get("value") {
                         println!("Value:     {val}");
@@ -357,7 +366,7 @@ fn run_validate(
         OutputFormat::Json => {
             println!("{}", format::format_report_json(&report).into_diagnostic()?);
         }
-        OutputFormat::Pretty | OutputFormat::Markdown => {
+        OutputFormat::Pretty => {
             format::print_report_pretty(&report);
         }
     }
@@ -453,7 +462,7 @@ fn run_migrate_snapshot(
 fn run_diff(
     old_path: &Path,
     new_path: &Path,
-    format: OutputFormat,
+    format: DiffFormat,
     filter_expr: Option<&str>,
 ) -> miette::Result<ExitCode> {
     let old_graph = TokenGraph::from_json_dir(old_path)
@@ -491,16 +500,16 @@ fn run_diff(
     let report = diff::semantic_diff(&old_filtered, &new_filtered);
 
     match format {
-        OutputFormat::Json => {
+        DiffFormat::Json => {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&report).into_diagnostic()?
             );
         }
-        OutputFormat::Markdown => {
+        DiffFormat::Markdown => {
             print!("{}", format::format_diff_markdown(&report));
         }
-        OutputFormat::Pretty => {
+        DiffFormat::Pretty => {
             format::print_diff_pretty(&report);
         }
     }
@@ -545,18 +554,13 @@ fn run_query(
                 serde_json::to_string_pretty(&raw_values).into_diagnostic()?
             );
         }
-        OutputFormat::Pretty | OutputFormat::Markdown => {
+        OutputFormat::Pretty => {
             if results.is_empty() {
                 println!("No matching tokens.");
             } else {
                 println!("{} token(s) matched:\n", results.len());
                 for t in &results {
-                    let name = t
-                        .raw
-                        .get("name")
-                        .and_then(|n| n.get("property"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(&t.name);
+                    let name = display_name(t);
                     let uuid = t.uuid.as_deref().unwrap_or("-");
                     let schema = t.raw.get("$schema").and_then(|v| v.as_str()).unwrap_or("-");
                     println!("  {name}");

--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -356,7 +356,7 @@ fn names_equal(old: &TokenRecord, new: &TokenRecord) -> bool {
 /// (e.g. `background-color[colorScheme=dark]`). Falls back to just
 /// `name.property` if other fields are absent.
 /// Legacy tokens: use the graph key (`TokenRecord.name`).
-fn display_name(t: &TokenRecord) -> String {
+pub fn display_name(t: &TokenRecord) -> String {
     if let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) {
         let property = name_obj
             .get("property")


### PR DESCRIPTION
## Description

Adds `diff` and `query` CLI subcommands to `design-data`, along with output formatters for pretty (terminal), JSON, and Markdown output.

**`design-data diff <old> <new>`** — Semantic diff between two token datasets:
- `--format pretty` (default): ANSI-colored terminal output with summary counts, per-category sections, and property-level change details. Respects `NO_COLOR` env var.
- `--format json`: Serialized `DiffReport` matching the backward-compatible JS tools output structure.
- `--format markdown`: Changelog-ready sections with H2 headings per category.
- `--filter "..."`: Scope the diff to tokens matching a query expression.
- Exit code: 0 = no changes, 1 = changes detected.

**`design-data query <path> --filter "..."`** — Filter and list tokens:
- `--format pretty` (default): Token list with name, UUID, schema, file.
- `--format json`: Array of raw token JSON objects.
- `--count`: Output only the match count.
- Exit code: 0 = matches found, 1 = no matches.

**Output formatters** (`format.rs`):
- `print_diff_pretty()` — ANSI colors: green=added, red=deleted, yellow=updated, cyan=renamed, magenta=deprecated/reverted. Property changes shown with `+`/`-`/`~` prefixes.
- `format_diff_markdown()` — H2 sections per category, backtick-wrapped token names, nested bullet property changes.
- JSON handled directly via `serde_json::to_string_pretty(&report)` since `DiffReport` derives `Serialize`.

Also adds `Markdown` variant to the `OutputFormat` enum (falls through to Pretty for validate/resolve where not applicable).

## Related Issue

Closes #784, #785, #786, #787
Parents: #774, #775
Epic: #730 — Phase 3: Diff and query engines

## Motivation and Context

Wave 1 (#790) delivered the core diff and query engines as library code. Wave 2 exposes them through the CLI, making them usable for developers, CI pipelines, and changelog generation.

## How Has This Been Tested?

- `cargo clippy -- -D warnings` — clean
- `cargo test` — **96 tests passing**, 0 failures (all existing tests unaffected)
- `cargo build` — compiles cleanly
- New `OutputFormat::Markdown` variant handled in all existing format match arms (falls through to Pretty for validate/resolve)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
