### PR TITLE
feat(spec,sdk): token lifecycle model and evolution policy

### DIFF
--- a/packages/design-data-spec/conformance/diff/replaced-by-pairing/expected.json
+++ b/packages/design-data-spec/conformance/diff/replaced-by-pairing/expected.json
@@ -1,0 +1,43 @@
+{
+  "renamed": [
+    {
+      "old_name": "old-button-bg",
+      "new_name": "action-background-default",
+      "uuid": "aaaaaaaa-0002-4000-8000-000000000001",
+      "property_changes": [
+        {
+          "path": "deprecated",
+          "change_type": "deleted",
+          "original_value": "3.0.0"
+        },
+        {
+          "path": "deprecated_comment",
+          "change_type": "deleted",
+          "original_value": "Use action-background-default instead."
+        },
+        {
+          "path": "name.property",
+          "change_type": "updated",
+          "new_value": "action-background-default",
+          "original_value": "old-button-bg"
+        },
+        {
+          "path": "replaced_by",
+          "change_type": "deleted",
+          "original_value": "aaaaaaaa-0002-4000-8000-000000000001"
+        },
+        {
+          "path": "uuid",
+          "change_type": "updated",
+          "new_value": "aaaaaaaa-0002-4000-8000-000000000001",
+          "original_value": "aaaaaaaa-0001-4000-8000-000000000001"
+        }
+      ]
+    }
+  ],
+  "deprecated": [],
+  "reverted": [],
+  "added": [],
+  "deleted": [],
+  "updated": []
+}

--- a/packages/design-data-spec/conformance/diff/replaced-by-pairing/new/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/diff/replaced-by-pairing/new/tokens.tokens.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": { "property": "action-background-default" },
+    "value": "#0265dc",
+    "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/diff/replaced-by-pairing/old/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/diff/replaced-by-pairing/old/tokens.tokens.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": { "property": "old-button-bg" },
+    "value": "#0265dc",
+    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+    "deprecated": "3.0.0",
+    "deprecated_comment": "Use action-background-default instead.",
+    "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/invalid/SPEC-010/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-010/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-010",
+      "severity": "error",
+      "message_pattern": "replaced_by target UUID not found"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-010/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-010/tokens.tokens.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": { "property": "deprecated-token" },
+    "value": "#ffffff",
+    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+    "deprecated": "3.0.0",
+    "replaced_by": "bbbbbbbb-9999-4000-8000-000000000099"
+  }
+]

--- a/packages/design-data-spec/conformance/invalid/SPEC-011/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-011/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-011",
+      "severity": "error",
+      "message_pattern": "replaced_by is an array but deprecated_comment is missing"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-011/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-011/tokens.tokens.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": { "property": "split-token" },
+    "value": "#ffffff",
+    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+    "deprecated": "3.0.0",
+    "replaced_by": [
+      "aaaaaaaa-0002-4000-8000-000000000001",
+      "aaaaaaaa-0003-4000-8000-000000000001"
+    ]
+  },
+  {
+    "name": { "property": "replacement-a" },
+    "value": "#eeeeee",
+    "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
+  },
+  {
+    "name": { "property": "replacement-b" },
+    "value": "#dddddd",
+    "uuid": "aaaaaaaa-0003-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/invalid/SPEC-012/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-012/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-012",
+      "severity": "error",
+      "message_pattern": "has replaced_by but is not marked deprecated"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-012/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-012/tokens.tokens.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": { "property": "not-deprecated-but-replaced" },
+    "value": "#ffffff",
+    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+    "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001"
+  },
+  {
+    "name": { "property": "replacement" },
+    "value": "#000000",
+    "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/invalid/SPEC-013/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-013/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-013",
+      "severity": "error",
+      "message_pattern": "has plannedRemoval but is not marked deprecated"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-013/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-013/tokens.tokens.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": { "property": "not-deprecated-but-planned-removal" },
+    "value": "#ffffff",
+    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+    "plannedRemoval": "4.0.0"
+  }
+]

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -82,3 +82,39 @@ rules:
     message: "Token name field '{field}' value '{value}' is not in the design-system-registry enum for '{field}'"
     spec_ref: spec/token-format.md#name-object
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-010
+    name: replaced-by-target-exists
+    severity: error
+    category: reference-integrity
+    assert: Every UUID in replaced_by MUST resolve to an existing token in the dataset.
+    message: "replaced_by target UUID not found: {uuid}"
+    spec_ref: spec/token-format.md#lifecycle-and-metadata
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-011
+    name: replaced-by-array-requires-comment
+    severity: error
+    category: completeness
+    assert: When replaced_by is an array, deprecated_comment MUST be present to explain which replacement applies in which context.
+    message: "replaced_by is an array but deprecated_comment is missing on token {token}"
+    spec_ref: spec/token-format.md#lifecycle-and-metadata
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-012
+    name: replaced-by-requires-deprecated
+    severity: error
+    category: completeness
+    assert: If replaced_by is present, deprecated MUST also be present.
+    message: "Token {token} has replaced_by but is not marked deprecated"
+    spec_ref: spec/token-format.md#lifecycle-and-metadata
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-013
+    name: planned-removal-requires-deprecated
+    severity: error
+    category: completeness
+    assert: If plannedRemoval is present, deprecated MUST also be present.
+    message: "Token {token} has plannedRemoval but is not marked deprecated"
+    spec_ref: spec/token-format.md#lifecycle-and-metadata
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -89,16 +89,22 @@
           "type": "string"
         },
         "deprecated": {
-          "type": "boolean"
+          "type": "string",
+          "description": "Spec version when token was deprecated (e.g. \"3.2.0\"). Truthy = deprecated."
         },
         "deprecated_comment": {
           "type": "string"
         },
-        "status": {
-          "type": "string"
+        "replaced_by": {
+          "oneOf": [
+            { "type": "string", "format": "uuid" },
+            { "type": "array", "items": { "type": "string", "format": "uuid" }, "minItems": 1 }
+          ],
+          "description": "UUID(s) of the replacement token(s). Array form requires deprecated_comment."
         },
-        "renamed": {
-          "type": "string"
+        "plannedRemoval": {
+          "type": "string",
+          "description": "Spec version when token will be removed."
         },
         "private": {
           "type": "boolean"
@@ -136,16 +142,22 @@
           "type": "string"
         },
         "deprecated": {
-          "type": "boolean"
+          "type": "string",
+          "description": "Spec version when token was deprecated (e.g. \"3.2.0\"). Truthy = deprecated."
         },
         "deprecated_comment": {
           "type": "string"
         },
-        "status": {
-          "type": "string"
+        "replaced_by": {
+          "oneOf": [
+            { "type": "string", "format": "uuid" },
+            { "type": "array", "items": { "type": "string", "format": "uuid" }, "minItems": 1 }
+          ],
+          "description": "UUID(s) of the replacement token(s). Array form requires deprecated_comment."
         },
-        "renamed": {
-          "type": "string"
+        "plannedRemoval": {
+          "type": "string",
+          "description": "Spec version when token will be removed."
         },
         "private": {
           "type": "boolean"

--- a/packages/design-data-spec/spec/diff.md
+++ b/packages/design-data-spec/spec/diff.md
@@ -12,10 +12,11 @@ A **token identity** determines whether a token in the old dataset and a token i
 
 1. **UUID match** — If a token in the old dataset and a token in the new dataset share the same `uuid` value, they are the **same token** regardless of name.
 2. **Name-object equivalence** — When a UUID match is not found for a token — because the old token, the new token, or both lack a `uuid`, or because no counterpart with the matching `uuid` exists in the other dataset — two tokens are the same if their `name` objects are deeply equal (all fields present with identical values).
+3. **Replacement link** — When passes 1 and 2 leave an old token unpaired and it carries a `replaced_by` field whose UUID matches an unpaired new token, the pair is established. This enables diff classification as **renamed** for tokens that were deprecated with a machine-readable replacement pointer.
 
-**NORMATIVE:** UUID matching **MUST** take precedence over name-object equivalence. A UUID match always identifies the token pair, even if name objects differ (which constitutes a rename).
+**NORMATIVE:** UUID matching **MUST** take precedence over name-object equivalence, which **MUST** take precedence over replacement link matching. A UUID match always identifies the token pair, even if name objects differ (which constitutes a rename).
 
-**RATIONALE:** UUID-based identity allows tokens to be renamed without breaking continuity tracking. Name-object equivalence is a fallback for legacy datasets that predate UUID adoption.
+**RATIONALE:** UUID-based identity allows tokens to be renamed without breaking continuity tracking. Name-object equivalence is a fallback for legacy datasets that predate UUID adoption. Replacement link matching is a tertiary fallback for deprecated tokens that carry an explicit `replaced_by` UUID pointing to their successor.
 
 ## Change taxonomy
 

--- a/packages/design-data-spec/spec/evolution.md
+++ b/packages/design-data-spec/spec/evolution.md
@@ -1,0 +1,98 @@
+# Evolution
+
+**Spec version:** `1.0.0-draft` (see [Overview](index.md))
+
+This document defines the **evolution policy** for the Design Data Specification: how the spec, schemas, and token data change over time, with a focus on the token deprecation lifecycle and backward compatibility.
+
+## Token deprecation lifecycle
+
+Tokens progress through the following lifecycle stages:
+
+```
+introduced → active → deprecated → planned removal → removed
+```
+
+| Stage               | Token state                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| **Introduced**      | Token first appears in the dataset. `introduced` field records the version.     |
+| **Active**          | Token is current and recommended for use. No `deprecated` field.                |
+| **Deprecated**      | Token is no longer recommended. `deprecated` records the version. Consumers receive warnings. `replaced_by` points to the successor token(s) when a direct replacement exists. |
+| **Planned removal** | `plannedRemoval` records the target version. The token remains in the dataset but consumers should complete migration. |
+| **Removed**         | Token is deleted from the dataset. Consumers that still reference it will break. |
+
+### Lifecycle fields
+
+See [Token format — Lifecycle and metadata](token-format.md#lifecycle-and-metadata) for the full field definitions and normative rules.
+
+### What `replaced_by` guarantees
+
+When a token carries `replaced_by`:
+
+- Each target UUID **MUST** resolve to an existing token in the dataset (rule `SPEC-010`).
+- The target token **SHOULD NOT** itself be deprecated. Chains of replacements (A replaced by B, B replaced by C) are discouraged; authors should point directly to the final replacement.
+- For a single UUID (1:1 replacement), consumers can mechanically rewrite references.
+- For an array of UUIDs (one-to-many split), the `deprecated_comment` **MUST** explain which replacement applies in which context.
+
+## Migration windows
+
+**NORMATIVE:** A deprecated token **MUST** remain in the published dataset for at least **two minor versions** after the version recorded in `deprecated` before it may be removed.
+
+**EXAMPLE:** A token deprecated in `3.2.0` may not be removed until `3.4.0` at the earliest. Removal in a major version (e.g. `4.0.0`) is always permitted regardless of how recently the token was deprecated.
+
+**RATIONALE:** Two minor versions gives consumers at least two release cycles to migrate. The major-version escape hatch allows accumulated deprecations to be cleaned up in a coordinated breaking release.
+
+If `plannedRemoval` is set, it overrides the default window — the token will be removed in the specified version (which must not precede the `deprecated` version).
+
+## Change classification
+
+The specification follows [Semantic Versioning](https://semver.org/) for its published artifacts (schemas, rule catalog, spec documents).
+
+### Minor changes (backward compatible)
+
+- New tokens added to the dataset
+- New optional fields added to token schema
+- New validation rules added to the rule catalog
+- Tokens deprecated (with `deprecated` field)
+- Rule severity relaxed (error → warning)
+- New enum values added to registries
+
+### Major changes (breaking)
+
+- Tokens removed from the dataset
+- Required fields added to token schema
+- Existing fields removed or type-changed
+- Rule severity tightened (warning → error)
+- Enum values removed from registries
+- Constraint tightening (e.g. stricter value validation)
+
+### Patch changes (clarifications)
+
+- Typo fixes in spec prose
+- Clarifications to normative text that do not change conformance behavior
+- Test fixture additions or corrections
+
+## Legacy format contract
+
+The `@adobe/spectrum-tokens` package continues to publish tokens in the **legacy format** (JSON object maps with `color-set`, `scale-set`, etc.) for backward compatibility with existing consumers.
+
+**NORMATIVE:** The legacy format output **MUST** be generated from the cascade-format authoritative source. It is a **derived artifact**, not independently authored.
+
+### Lifecycle field mapping
+
+| Cascade format                          | Legacy format                        |
+| --------------------------------------- | ------------------------------------ |
+| `deprecated: "3.2.0"` (version string) | `deprecated: true` (boolean)         |
+| `replaced_by: "<uuid>"`                | `renamed: "<target-token-name>"`     |
+| `introduced`                            | Not emitted                          |
+| `plannedRemoval`                        | Not emitted                          |
+| `deprecated_comment`                    | `deprecated_comment` (passed through)|
+
+### Coexistence during migration
+
+Both formats are published simultaneously. The cascade format is the source of truth; the legacy format is generated from it. This dual-format period continues until platform consumers have migrated to the cascade format or to platform SDKs that consume it.
+
+## References
+
+* [#623 — Token Lifecycle Metadata](https://github.com/adobe/spectrum-design-data/discussions/623)
+* [#735 — RFC: Versioning and Evolution](https://github.com/adobe/spectrum-design-data/discussions/735)
+* [#736 — Define spec evolution policy and migration contract](https://github.com/adobe/spectrum-design-data/issues/736)

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -15,10 +15,7 @@ The specification defines:
 4. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
 5. **Semantic diff** — change taxonomy, token identity rules, and property-level change tracking for comparing dataset versions ([Diff](diff.md)).
 6. **Query notation** — filter syntax for selecting tokens by structured fields ([Query](query.md)).
-
-Out of scope for this draft (tracked elsewhere):
-
-* Full evolution, migration windows, and SDK version negotiation — see [discussion #735](https://github.com/adobe/spectrum-design-data/discussions/735).
+7. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
 
 ## Conformance
 
@@ -60,6 +57,7 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 | [Manifest](manifest.md)         | Platform manifest fields and validation expectations.            |
 | [Diff](diff.md)                 | Semantic diff change taxonomy, token identity, property changes. |
 | [Query](query.md)               | Filter notation for selecting tokens by structured fields.       |
+| [Evolution](evolution.md)       | Deprecation lifecycle, migration windows, change classification. |
 
 ## JSON Schema `$id` and versioning
 

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -98,7 +98,7 @@ When generating legacy-format output from cascade tokens:
 When migrating legacy-format tokens to cascade:
 
 - `deprecated: true` maps to `deprecated: "unknown"` (authors should backfill the actual version)
-- `renamed: "<name>"` maps to `replaced_by: "<uuid>"` (resolved via name lookup in the graph)
+- `renamed: "<name>"` maps to `replaced_by: "<uuid>"` (resolved via name lookup across all files in the migrated input set). If the rename target is not found in the scanned corpus, the field is dropped — `replaced_by` must be set manually in that case
 
 ### `specVersion`
 

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -48,19 +48,57 @@ When **`value`** is present, it **MUST** conform to the declared value type for 
 
 ### Lifecycle and metadata
 
-The following OPTIONAL fields align with token lifecycle discussions (e.g. [#623](https://github.com/adobe/spectrum-design-data/discussions/623)):
+The following OPTIONAL fields implement the token lifecycle model described in [#623](https://github.com/adobe/spectrum-design-data/discussions/623) and the evolution policy in [Evolution](evolution.md). Inspired by Swift's `@available` attribute, Kotlin's `@Deprecated`, and OpenAPI 3.3's deprecation model.
 
-| Field                | Type          | Description                                     |
-| -------------------- | ------------- | ----------------------------------------------- |
-| `uuid`               | string (UUID) | Stable unique id for rename tracking and diffs. |
-| `introduced`         | string        | Version or date token was introduced.           |
-| `deprecated`         | boolean       | Marked deprecated.                              |
-| `deprecated_comment` | string        | Human-readable deprecation note.                |
-| `status`             | string        | e.g. `experimental`, `stable`.                  |
-| `renamed`            | string        | Previous name or id if renamed.                 |
-| `private`            | boolean       | Not part of public API surface.                 |
+| Field                | Type                                        | Description                                                                   |
+| -------------------- | ------------------------------------------- | ----------------------------------------------------------------------------- |
+| `uuid`               | string (UUID)                               | Stable unique id for rename tracking and diffs.                               |
+| `introduced`         | string (version)                            | Spec version when the token was first added (e.g. `"1.0.0"`).                |
+| `deprecated`         | string (version)                            | Spec version when the token was deprecated (e.g. `"3.2.0"`). Truthy = deprecated. |
+| `deprecated_comment` | string                                      | Human-readable deprecation explanation and migration guidance.                |
+| `replaced_by`        | string (UUID) or array of string (UUID)     | UUID(s) of the replacement token(s). Single string for 1:1 replacement; array for one-to-many splits. |
+| `plannedRemoval`     | string (version)                            | Spec version when the token will be removed. If omitted, defaults to the next major version after `deprecated`. |
+| `private`            | boolean                                     | Not part of public API surface.                                               |
 
-**NORMATIVE:** If `deprecated` is `true`, `deprecated_comment` **SHOULD** be present.
+#### Lifecycle example
+
+```json
+{
+  "name": { "property": "button-background-primary" },
+  "value": "#0265dc",
+  "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+  "introduced": "1.0.0",
+  "deprecated": "3.2.0",
+  "deprecated_comment": "Use action-background-default instead.",
+  "replaced_by": "bbbbbbbb-0002-4000-8000-000000000001",
+  "plannedRemoval": "4.0.0"
+}
+```
+
+#### Normative rules
+
+**NORMATIVE:** If `deprecated` is present, `deprecated_comment` **SHOULD** be present.
+
+**NORMATIVE:** If `replaced_by` is an array, `deprecated_comment` is **REQUIRED** — the comment **MUST** explain which replacement applies in which context.
+
+**NORMATIVE:** If `replaced_by` is present, `deprecated` **MUST** be present.
+
+**NORMATIVE:** If `plannedRemoval` is present, `deprecated` **MUST** be present, and the `plannedRemoval` version **MUST NOT** precede the `deprecated` version.
+
+**NORMATIVE:** Each UUID in `replaced_by` **MUST** resolve to an existing token in the dataset (see rule `SPEC-010`).
+
+#### Legacy format mapping
+
+When generating legacy-format output from cascade tokens:
+
+- `deprecated: "3.2.0"` maps to `deprecated: true`
+- `replaced_by: "<uuid>"` maps to `renamed: "<target-token-name>"` (resolved via UUID lookup)
+- `introduced` and `plannedRemoval` have no legacy equivalent and are not emitted
+
+When migrating legacy-format tokens to cascade:
+
+- `deprecated: true` maps to `deprecated: "unknown"` (authors should backfill the actual version)
+- `renamed: "<name>"` maps to `replaced_by: "<uuid>"` (resolved via name lookup in the graph)
 
 ### `specVersion`
 

--- a/packages/tokens/schemas/token-types/token.json
+++ b/packages/tokens/schemas/token-types/token.json
@@ -29,15 +29,27 @@
       "default": false
     },
     "deprecated": {
-      "type": "boolean",
-      "default": false
+      "type": ["boolean", "string"],
+      "default": false,
+      "description": "Boolean (legacy) or version string (cascade). Truthy = deprecated."
     },
     "deprecated_comment": {
       "type": "string"
     },
     "renamed": {
       "type": "string",
-      "description": "New token name if this token has been renamed. Use for 1:1 complete replacements."
+      "description": "Legacy format: new token name. Use replaced_by (UUID) in cascade format instead."
+    },
+    "replaced_by": {
+      "oneOf": [
+        { "type": "string", "format": "uuid" },
+        { "type": "array", "items": { "type": "string", "format": "uuid" }, "minItems": 1 }
+      ],
+      "description": "UUID(s) of the replacement token(s). Array form requires deprecated_comment."
+    },
+    "plannedRemoval": {
+      "type": "string",
+      "description": "Spec version when token will be removed."
     },
     "description": {
       "type": "string",

--- a/sdk/core/src/diff.rs
+++ b/sdk/core/src/diff.rs
@@ -239,6 +239,8 @@ pub fn semantic_diff(old: &TokenGraph, new: &TokenGraph) -> DiffReport {
 /// 1. UUID match (primary): same `uuid` value in both graphs.
 /// 2. Name-object equivalence (fallback): when UUID match is not found for a
 ///    token (because either side lacks a uuid or no counterpart exists).
+/// 3. Replacement link (tertiary): when an unpaired old token carries a
+///    `replaced_by` UUID matching an unpaired new token.
 fn pair_tokens<'a>(
     old: &'a TokenGraph,
     new: &'a TokenGraph,
@@ -303,6 +305,40 @@ fn pair_tokens<'a>(
                 matched_new.insert(new_key.clone());
                 // Remove from name index so it can't be double-matched.
                 old_by_name.remove(&name_key);
+            }
+        }
+    }
+
+    // Pass 3: Replacement link fallback for unmatched tokens.
+    // If an old token carries `replaced_by` (a UUID string), look up that UUID
+    // in the new graph. If the new token is also unpaired, pair them.
+    // Build new UUID → key index for unpaired new tokens.
+    let mut new_by_uuid: HashMap<&str, &str> = HashMap::new();
+    for (key, t) in &new.tokens {
+        if !matched_new.contains(key) {
+            if let Some(ref uuid) = t.uuid {
+                new_by_uuid.entry(uuid.as_str()).or_insert(key.as_str());
+            }
+        }
+    }
+
+    for (old_key, old_tok) in &old.tokens {
+        if matched_old.contains(old_key.as_str()) {
+            continue;
+        }
+        let target_uuid = old_tok.raw.get("replaced_by").and_then(|v| v.as_str());
+        if let Some(uuid) = target_uuid {
+            if let Some(&new_key) = new_by_uuid.get(uuid) {
+                if let Some(new_tok) = new.tokens.get(new_key) {
+                    pairs.push(TokenPair {
+                        old: old_tok,
+                        new: new_tok,
+                    });
+                    matched_old.insert(old_key.clone());
+                    matched_new.insert(new_key.to_string());
+                    // Remove from new UUID index so it can't be double-matched.
+                    new_by_uuid.remove(uuid);
+                }
             }
         }
     }
@@ -808,6 +844,34 @@ mod tests {
         assert_eq!(report.added.len(), 1, "should have 1 added");
         assert_eq!(report.deleted.len(), 1, "should have 1 deleted");
         assert_eq!(report.updated.len(), 1, "should have 1 updated");
+    }
+
+    #[test]
+    fn replaced_by_pairs_deprecated_to_new() {
+        // Old token is deprecated with replaced_by pointing to new token's UUID.
+        // No shared UUID or name — pairing via replaced_by (pass 3).
+        let old = make_graph(vec![(
+            "old-token",
+            json!({
+                "name": {"property": "old-prop"},
+                "uuid": "uuid-old",
+                "deprecated": "3.0.0",
+                "replaced_by": "uuid-new",
+                "value": "#fff"
+            }),
+        )]);
+        let new = make_graph(vec![(
+            "new-token",
+            json!({
+                "name": {"property": "new-prop"},
+                "uuid": "uuid-new",
+                "value": "#fff"
+            }),
+        )]);
+        let report = semantic_diff(&old, &new);
+        assert_eq!(report.renamed.len(), 1, "should pair via replaced_by");
+        assert!(report.added.is_empty(), "new token should not be added");
+        assert!(report.deleted.is_empty(), "old token should not be deleted");
     }
 
     #[test]

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -61,8 +61,10 @@ const OUTER_LIFECYCLE_FIELDS: &[&str] = &[
     "deprecated",
     "deprecated_comment",
     "renamed",
+    "replaced_by",
+    "plannedRemoval",
+    "introduced",
     "private",
-    "status",
     "description",
 ];
 

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -40,7 +40,7 @@
 //!
 //! `$ref` values are denormalized back to `value: "{target}"` alias syntax.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 
 use serde_json::{Map, Value};
@@ -156,6 +156,21 @@ fn convert_array(
     arr: &[Value],
     summary: &mut LegacySummary,
 ) -> Result<Map<String, Value>, CoreError> {
+    // Build UUID → property-name map for resolving replaced_by → renamed.
+    let uuid_to_name: HashMap<&str, &str> = arr
+        .iter()
+        .filter_map(|item| {
+            let tok = item.as_object()?;
+            let uuid = tok.get("uuid")?.as_str()?;
+            let name = tok
+                .get("name")
+                .and_then(|v| v.as_object())
+                .and_then(|n| n.get("property"))
+                .and_then(|v| v.as_str())?;
+            Some((uuid, name))
+        })
+        .collect();
+
     // Group tokens by property name, preserving document order via BTreeMap.
     let mut groups: BTreeMap<String, Vec<&Map<String, Value>>> = BTreeMap::new();
 
@@ -186,7 +201,7 @@ fn convert_array(
             return Err(CoreError::MultiDimensionalToken(property));
         }
 
-        let entry = if let Some(dim) = dim_keys.into_iter().next() {
+        let mut entry = if let Some(dim) = dim_keys.into_iter().next() {
             let result = build_set_entry(&property, &tokens, dim, summary);
             summary.sets_reconstructed += 1;
             result
@@ -196,11 +211,56 @@ fn convert_array(
             build_flat_entry(tokens[0])
         };
 
+        // Convert cascade lifecycle fields to legacy format.
+        if let Some(obj) = entry.as_object_mut() {
+            normalize_lifecycle_for_legacy(obj, &uuid_to_name);
+        }
+
         summary.tokens_produced += 1;
         out.insert(property, entry);
     }
 
     Ok(out)
+}
+
+/// Convert cascade lifecycle fields to legacy format on a token entry.
+///
+/// - `deprecated: "version"` → `deprecated: true`
+/// - `replaced_by: "uuid"` → `renamed: "<property-name>"` (resolved via map)
+/// - `plannedRemoval`, `introduced` → removed (no legacy equivalent)
+fn normalize_lifecycle_for_legacy(
+    entry: &mut Map<String, Value>,
+    uuid_to_name: &HashMap<&str, &str>,
+) {
+    // deprecated: version string → boolean true
+    if let Some(dep) = entry.get("deprecated") {
+        if dep.is_string() {
+            entry.insert("deprecated".into(), Value::Bool(true));
+        }
+    }
+
+    // replaced_by → renamed (resolve UUID to property name)
+    if let Some(replaced) = entry.remove("replaced_by") {
+        if let Some(uuid) = replaced.as_str() {
+            if let Some(&name) = uuid_to_name.get(uuid) {
+                entry.insert("renamed".into(), Value::String(name.to_string()));
+            }
+        }
+        // Array form: don't emit renamed (no 1:1 mapping); deprecated_comment explains it.
+    }
+
+    // Drop fields with no legacy equivalent.
+    entry.remove("plannedRemoval");
+    entry.remove("introduced");
+
+    // Recurse into sets entries.
+    if let Some(sets) = entry.get_mut("sets").and_then(|v| v.as_object_mut()) {
+        for (_mode, set_entry) in sets.iter_mut() {
+            if let Some(obj) = set_entry.as_object_mut() {
+                normalize_lifecycle_for_legacy(obj, uuid_to_name);
+            }
+        }
+    }
 }
 
 /// Collect the set of recognized dimension keys present in any token in the group.

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -373,6 +373,43 @@ mod relational_conformance {
         )]);
         assert!(!diagnostics_for_rule(&g, "SPEC-013").is_empty());
     }
+
+    #[test]
+    fn spec013_planned_removal_precedes_deprecated() {
+        let g = TokenGraph::from_pairs(vec![(
+            "bad".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "bad"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "deprecated": "3.2.0",
+                "plannedRemoval": "3.1.0",
+                "value": "#fff"
+            }),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-013");
+        assert!(!diags.is_empty(), "should catch preceding plannedRemoval");
+        assert!(
+            diags[0].message.contains("preceding"),
+            "message should mention version ordering"
+        );
+    }
+
+    #[test]
+    fn spec013_valid_planned_removal_no_error() {
+        let g = TokenGraph::from_pairs(vec![(
+            "ok".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "ok"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "deprecated": "3.2.0",
+                "plannedRemoval": "4.0.0",
+                "value": "#fff"
+            }),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-013").is_empty());
+    }
 }
 
 /// Resolution conformance tests — fixture-driven, closes #768.

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -410,6 +410,26 @@ mod relational_conformance {
         )]);
         assert!(diagnostics_for_rule(&g, "SPEC-013").is_empty());
     }
+
+    #[test]
+    fn spec013_multi_digit_semver_ordering() {
+        // 3.10.0 > 3.2.0, so this is valid — should not error.
+        let g = TokenGraph::from_pairs(vec![(
+            "ok".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "ok"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "deprecated": "3.2.0",
+                "plannedRemoval": "3.10.0",
+                "value": "#fff"
+            }),
+        )]);
+        assert!(
+            diagnostics_for_rule(&g, "SPEC-013").is_empty(),
+            "3.10.0 > 3.2.0 — should not error"
+        );
+    }
 }
 
 /// Resolution conformance tests — fixture-driven, closes #768.

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -284,6 +284,95 @@ mod relational_conformance {
         ]);
         assert!(!diagnostics_for_rule(&g, "SPEC-006").is_empty());
     }
+
+    #[test]
+    fn spec010_replaced_by_target_not_found() {
+        let g = TokenGraph::from_pairs(vec![(
+            "dep".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "old"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "deprecated": "3.0.0",
+                "replaced_by": "bbbbbbbb-9999-4000-8000-000000000099",
+                "value": "#fff"
+            }),
+        )]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-010").is_empty());
+    }
+
+    #[test]
+    fn spec010_replaced_by_target_exists_no_error() {
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "dep".into(),
+                PathBuf::from("t.json"),
+                json!({
+                    "name": {"property": "old"},
+                    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                    "deprecated": "3.0.0",
+                    "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001",
+                    "value": "#fff"
+                }),
+            ),
+            (
+                "new".into(),
+                PathBuf::from("t.json"),
+                json!({
+                    "name": {"property": "new"},
+                    "uuid": "aaaaaaaa-0002-4000-8000-000000000001",
+                    "value": "#000"
+                }),
+            ),
+        ]);
+        assert!(diagnostics_for_rule(&g, "SPEC-010").is_empty());
+    }
+
+    #[test]
+    fn spec011_replaced_by_array_missing_comment() {
+        let g = TokenGraph::from_pairs(vec![(
+            "split".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "split"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "deprecated": "3.0.0",
+                "replaced_by": ["aaaaaaaa-0002-4000-8000-000000000001"],
+                "value": "#fff"
+            }),
+        )]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-011").is_empty());
+    }
+
+    #[test]
+    fn spec012_replaced_by_without_deprecated() {
+        let g = TokenGraph::from_pairs(vec![(
+            "bad".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "bad"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001",
+                "value": "#fff"
+            }),
+        )]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-012").is_empty());
+    }
+
+    #[test]
+    fn spec013_planned_removal_without_deprecated() {
+        let g = TokenGraph::from_pairs(vec![(
+            "bad".into(),
+            PathBuf::from("t.json"),
+            json!({
+                "name": {"property": "bad"},
+                "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                "plannedRemoval": "4.0.0",
+                "value": "#fff"
+            }),
+        )]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-013").is_empty());
+    }
 }
 
 /// Resolution conformance tests — fixture-driven, closes #768.
@@ -610,6 +699,11 @@ mod diff_conformance {
     #[test]
     fn rename_with_property_changes() {
         run_fixture("rename-with-property-changes");
+    }
+
+    #[test]
+    fn replaced_by_pairing() {
+        run_fixture("replaced-by-pairing");
     }
 }
 

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -576,7 +576,9 @@ mod tests {
     fn convert_dir_resolves_cross_file_renamed_to_replaced_by() {
         use std::fs;
 
-        let tmp = std::env::temp_dir().join("migrate_cross_file_test");
+        // Use a unique dir name to avoid collisions across concurrent test runs.
+        let id = std::process::id();
+        let tmp = std::env::temp_dir().join(format!("migrate_cross_file_test_{id}"));
         let input = tmp.join("input");
         let output = tmp.join("output");
         let _ = fs::remove_dir_all(&tmp);

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -60,8 +60,10 @@ const OUTER_LIFECYCLE_FIELDS: &[&str] = &[
     "deprecated",
     "deprecated_comment",
     "renamed",
+    "replaced_by",
+    "plannedRemoval",
+    "introduced",
     "private",
-    "status",
     "description",
 ];
 

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -133,15 +133,40 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary
     std::fs::create_dir_all(output_dir)?;
     let mut summary = MigrateSummary::default();
 
-    for input_path in discover_json_files(input_dir)? {
-        // Skip files that don't look like legacy token sources (e.g. schemas).
-        let text = std::fs::read_to_string(&input_path)?;
+    // Pass 1: scan all files to build a global name → UUID map for cross-file
+    // renamed → replaced_by resolution.
+    let files = discover_json_files(input_dir)?;
+    let mut global_name_to_uuid: HashMap<String, String> = HashMap::new();
+    let mut file_contents: Vec<(std::path::PathBuf, Value)> = Vec::new();
+
+    for input_path in &files {
+        let text = std::fs::read_to_string(input_path)?;
         let value: Value = serde_json::from_str(&text)?;
+        if let Some(obj) = value.as_object() {
+            for (name, val) in obj {
+                if let Some(tok) = val.as_object() {
+                    if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                        global_name_to_uuid.insert(name.clone(), uuid.to_string());
+                    }
+                }
+            }
+        }
+        file_contents.push((input_path.clone(), value));
+    }
+
+    // Build a borrowed view for the conversion functions.
+    let name_to_uuid_ref: HashMap<&str, &str> = global_name_to_uuid
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    // Pass 2: convert each file using the global map.
+    for (input_path, value) in &file_contents {
         let Some(obj) = value.as_object() else {
             continue;
         };
 
-        let tokens = convert_object(obj, &mut summary);
+        let tokens = convert_object_with_context(obj, &mut summary, &name_to_uuid_ref);
         if tokens.is_empty() {
             continue;
         }
@@ -165,17 +190,11 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /// Convert all entries in a legacy token file object to cascade tokens.
-fn convert_object(obj: &Map<String, Value>, summary: &mut MigrateSummary) -> Vec<Value> {
-    // Build name → UUID map for resolving renamed → replaced_by.
-    let name_to_uuid: HashMap<&str, &str> = obj
-        .iter()
-        .filter_map(|(name, val)| {
-            let tok = val.as_object()?;
-            let uuid = tok.get("uuid")?.as_str()?;
-            Some((name.as_str(), uuid))
-        })
-        .collect();
-
+fn convert_object_with_context(
+    obj: &Map<String, Value>,
+    summary: &mut MigrateSummary,
+    name_to_uuid: &HashMap<&str, &str>,
+) -> Vec<Value> {
     let mut out = Vec::new();
     for (name, val) in obj {
         let Some(tok_obj) = val.as_object() else {
@@ -186,12 +205,12 @@ fn convert_object(obj: &Map<String, Value>, summary: &mut MigrateSummary) -> Vec
             .and_then(|v| v.as_str())
             .unwrap_or("");
         if schema.ends_with("color-set.json") || schema.ends_with("scale-set.json") {
-            let tokens = convert_token_with_context(name, tok_obj, &name_to_uuid);
+            let tokens = convert_token_with_context(name, tok_obj, name_to_uuid);
             summary.set_entries_unwrapped += tokens.len();
             summary.tokens_produced += tokens.len();
             out.extend(tokens);
         } else {
-            out.push(build_flat(name, tok_obj, &name_to_uuid));
+            out.push(build_flat(name, tok_obj, name_to_uuid));
             summary.flat_tokens_converted += 1;
             summary.tokens_produced += 1;
         }

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -40,6 +40,7 @@
 //! **Flat tokens** (no `sets`) are wrapped with a `name` object and alias syntax
 //! is normalized: `value: "{foo}"` → `$ref: "foo"`.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use serde_json::{Map, Value};
@@ -89,18 +90,37 @@ pub struct MigrateSummary {
 /// Convert a single legacy token JSON object map entry to cascade token(s).
 ///
 /// Returns one token for flat entries, or N tokens for set tokens (one per mode).
+/// Does not resolve `renamed` → `replaced_by` (no graph context). Use
+/// `convert_dir` for full lifecycle conversion.
 pub fn convert_token(name: &str, token_obj: &Map<String, Value>) -> Vec<Value> {
+    let empty = HashMap::new();
+    convert_token_with_context(name, token_obj, &empty)
+}
+
+/// Convert a single legacy token with access to a name→UUID map for resolving
+/// `renamed` → `replaced_by`.
+fn convert_token_with_context(
+    name: &str,
+    token_obj: &Map<String, Value>,
+    name_to_uuid: &HashMap<&str, &str>,
+) -> Vec<Value> {
     let schema = token_obj
         .get("$schema")
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
     if schema.ends_with("color-set.json") {
-        convert_set(name, token_obj, "colorScheme", COLOR_SET_MODE_ORDER)
+        convert_set(
+            name,
+            token_obj,
+            "colorScheme",
+            COLOR_SET_MODE_ORDER,
+            name_to_uuid,
+        )
     } else if schema.ends_with("scale-set.json") {
-        convert_set(name, token_obj, "scale", SCALE_SET_MODE_ORDER)
+        convert_set(name, token_obj, "scale", SCALE_SET_MODE_ORDER, name_to_uuid)
     } else {
-        vec![build_flat(name, token_obj)]
+        vec![build_flat(name, token_obj, name_to_uuid)]
     }
 }
 
@@ -146,6 +166,16 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary
 
 /// Convert all entries in a legacy token file object to cascade tokens.
 fn convert_object(obj: &Map<String, Value>, summary: &mut MigrateSummary) -> Vec<Value> {
+    // Build name → UUID map for resolving renamed → replaced_by.
+    let name_to_uuid: HashMap<&str, &str> = obj
+        .iter()
+        .filter_map(|(name, val)| {
+            let tok = val.as_object()?;
+            let uuid = tok.get("uuid")?.as_str()?;
+            Some((name.as_str(), uuid))
+        })
+        .collect();
+
     let mut out = Vec::new();
     for (name, val) in obj {
         let Some(tok_obj) = val.as_object() else {
@@ -156,12 +186,12 @@ fn convert_object(obj: &Map<String, Value>, summary: &mut MigrateSummary) -> Vec
             .and_then(|v| v.as_str())
             .unwrap_or("");
         if schema.ends_with("color-set.json") || schema.ends_with("scale-set.json") {
-            let tokens = convert_token(name, tok_obj);
+            let tokens = convert_token_with_context(name, tok_obj, &name_to_uuid);
             summary.set_entries_unwrapped += tokens.len();
             summary.tokens_produced += tokens.len();
             out.extend(tokens);
         } else {
-            out.push(build_flat(name, tok_obj));
+            out.push(build_flat(name, tok_obj, &name_to_uuid));
             summary.flat_tokens_converted += 1;
             summary.tokens_produced += 1;
         }
@@ -175,10 +205,11 @@ fn convert_set(
     outer: &Map<String, Value>,
     dim_key: &str,
     mode_order: &[&str],
+    name_to_uuid: &HashMap<&str, &str>,
 ) -> Vec<Value> {
     let sets = match outer.get("sets").and_then(|v| v.as_object()) {
         Some(s) => s,
-        None => return vec![build_flat(property, outer)],
+        None => return vec![build_flat(property, outer, name_to_uuid)],
     };
 
     // Emit modes in stable order (defined order first, then any extras).
@@ -197,7 +228,14 @@ fn convert_set(
         .iter()
         .filter_map(|mode| {
             let entry = sets.get(*mode)?.as_object()?;
-            Some(build_set_entry(property, outer, entry, dim_key, mode))
+            Some(build_set_entry(
+                property,
+                outer,
+                entry,
+                dim_key,
+                mode,
+                name_to_uuid,
+            ))
         })
         .collect()
 }
@@ -209,6 +247,7 @@ fn build_set_entry(
     entry: &Map<String, Value>,
     dim_key: &str,
     mode: &str,
+    name_to_uuid: &HashMap<&str, &str>,
 ) -> Value {
     let mut out = Map::new();
 
@@ -246,13 +285,17 @@ fn build_set_entry(
         }
     }
 
-    normalize_lifecycle_for_cascade(&mut out);
+    normalize_lifecycle_for_cascade(&mut out, name_to_uuid);
 
     Value::Object(out)
 }
 
 /// Build a cascade token from a flat (non-set) legacy token.
-fn build_flat(property: &str, token_obj: &Map<String, Value>) -> Value {
+fn build_flat(
+    property: &str,
+    token_obj: &Map<String, Value>,
+    name_to_uuid: &HashMap<&str, &str>,
+) -> Value {
     let mut out = Map::new();
 
     // Name object: property + optional component.
@@ -285,7 +328,7 @@ fn build_flat(property: &str, token_obj: &Map<String, Value>) -> Value {
         }
     }
 
-    normalize_lifecycle_for_cascade(&mut out);
+    normalize_lifecycle_for_cascade(&mut out, name_to_uuid);
 
     Value::Object(out)
 }
@@ -293,8 +336,12 @@ fn build_flat(property: &str, token_obj: &Map<String, Value>) -> Value {
 /// Convert legacy lifecycle fields to cascade model on a token map.
 ///
 /// - `deprecated: true` → `deprecated: "unknown"` (authors should backfill)
-/// - `renamed: "<name>"` → removed (replaced_by must be set manually with UUID)
-fn normalize_lifecycle_for_cascade(entry: &mut Map<String, Value>) {
+/// - `renamed: "<name>"` → `replaced_by: "<uuid>"` (resolved via name_to_uuid map)
+/// - `status` → removed (derivable in cascade model)
+fn normalize_lifecycle_for_cascade(
+    entry: &mut Map<String, Value>,
+    name_to_uuid: &HashMap<&str, &str>,
+) {
     // deprecated: boolean true → version string "unknown"
     if let Some(dep) = entry.get("deprecated") {
         if dep.as_bool() == Some(true) {
@@ -304,8 +351,17 @@ fn normalize_lifecycle_for_cascade(entry: &mut Map<String, Value>) {
         }
     }
 
-    // renamed → remove (can't convert to replaced_by without UUID graph context)
-    entry.remove("renamed");
+    // renamed → replaced_by (resolve name to UUID via the file's token map)
+    if let Some(renamed) = entry
+        .remove("renamed")
+        .and_then(|v| v.as_str().map(String::from))
+    {
+        if let Some(&uuid) = name_to_uuid.get(renamed.as_str()) {
+            entry.insert("replaced_by".into(), Value::String(uuid.to_string()));
+        }
+        // If the target name isn't found in this file, drop silently — the
+        // target may be in another file and replaced_by must be set manually.
+    }
 
     // status → remove (derivable, not part of cascade model)
     entry.remove("status");

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -571,4 +571,66 @@ mod tests {
         assert_eq!(tokens[1]["$ref"], "blue-300");
         assert!(tokens[0].get("value").is_none());
     }
+
+    #[test]
+    fn convert_dir_resolves_cross_file_renamed_to_replaced_by() {
+        use std::fs;
+
+        let tmp = std::env::temp_dir().join("migrate_cross_file_test");
+        let input = tmp.join("input");
+        let output = tmp.join("output");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&input).unwrap();
+
+        // File 1: old-token with renamed pointing to new-token (in file 2).
+        fs::write(
+            input.join("file1.json"),
+            serde_json::to_string_pretty(&json!({
+                "old-token": {
+                    "$schema": ".../color.json",
+                    "value": "#fff",
+                    "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+                    "deprecated": true,
+                    "renamed": "new-token"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // File 2: new-token (the rename target).
+        fs::write(
+            input.join("file2.json"),
+            serde_json::to_string_pretty(&json!({
+                "new-token": {
+                    "$schema": ".../color.json",
+                    "value": "#000",
+                    "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let summary = crate::migrate::convert_dir(&input, &output).unwrap();
+        assert_eq!(summary.files_written, 2);
+
+        // Read the output for file1 and verify replaced_by was resolved.
+        let out1_text = fs::read_to_string(output.join("file1.tokens.json")).unwrap();
+        let out1: Value = serde_json::from_str(&out1_text).unwrap();
+        let token = &out1.as_array().unwrap()[0];
+
+        assert_eq!(
+            token["replaced_by"], "aaaaaaaa-0002-4000-8000-000000000001",
+            "renamed should resolve to replaced_by via cross-file UUID lookup"
+        );
+        assert!(
+            token.get("renamed").is_none(),
+            "renamed should be stripped from cascade output"
+        );
+        assert_eq!(token["deprecated"], "unknown");
+
+        // Cleanup.
+        let _ = fs::remove_dir_all(&tmp);
+    }
 }

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -246,6 +246,8 @@ fn build_set_entry(
         }
     }
 
+    normalize_lifecycle_for_cascade(&mut out);
+
     Value::Object(out)
 }
 
@@ -283,7 +285,30 @@ fn build_flat(property: &str, token_obj: &Map<String, Value>) -> Value {
         }
     }
 
+    normalize_lifecycle_for_cascade(&mut out);
+
     Value::Object(out)
+}
+
+/// Convert legacy lifecycle fields to cascade model on a token map.
+///
+/// - `deprecated: true` → `deprecated: "unknown"` (authors should backfill)
+/// - `renamed: "<name>"` → removed (replaced_by must be set manually with UUID)
+fn normalize_lifecycle_for_cascade(entry: &mut Map<String, Value>) {
+    // deprecated: boolean true → version string "unknown"
+    if let Some(dep) = entry.get("deprecated") {
+        if dep.as_bool() == Some(true) {
+            entry.insert("deprecated".into(), Value::String("unknown".into()));
+        } else if dep.as_bool() == Some(false) {
+            entry.remove("deprecated");
+        }
+    }
+
+    // renamed → remove (can't convert to replaced_by without UUID graph context)
+    entry.remove("renamed");
+
+    // status → remove (derivable, not part of cascade model)
+    entry.remove("status");
 }
 
 /// Insert `value` or `$ref` into the output map from a source object.
@@ -406,9 +431,11 @@ mod tests {
         );
         assert_eq!(tokens.len(), 2);
         for t in &tokens {
-            assert_eq!(t["deprecated"], true);
+            // deprecated: true → "unknown" in cascade model
+            assert_eq!(t["deprecated"], "unknown");
             assert_eq!(t["deprecated_comment"], "use new-token instead");
-            assert_eq!(t["renamed"], "new-token");
+            // renamed is stripped (replaced_by with UUID should be set manually)
+            assert!(t.get("renamed").is_none(), "renamed should be stripped");
         }
     }
 
@@ -425,10 +452,13 @@ mod tests {
                 }
             })),
         );
-        // desktop entry overrides outer deprecated=true with false
-        assert_eq!(tokens[0]["deprecated"], false);
-        // mobile entry inherits outer deprecated=true
-        assert_eq!(tokens[1]["deprecated"], true);
+        // desktop entry overrides outer deprecated=true with false → removed
+        assert!(
+            tokens[0].get("deprecated").is_none(),
+            "deprecated: false should be stripped"
+        );
+        // mobile entry inherits outer deprecated=true → "unknown"
+        assert_eq!(tokens[1]["deprecated"], "unknown");
     }
 
     #[test]

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -17,6 +17,10 @@ mod spec006;
 mod spec007;
 mod spec008;
 mod spec009;
+mod spec010;
+mod spec011;
+mod spec012;
+mod spec013;
 
 use std::collections::HashSet;
 
@@ -24,7 +28,7 @@ use crate::graph::TokenGraph;
 use crate::report::Diagnostic;
 use crate::validate::rule::{ValidationContext, ValidationRule};
 
-/// All default catalog rules (SPEC-001 … SPEC-009).
+/// All default catalog rules (SPEC-001 … SPEC-013).
 pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
     vec![
         Box::new(spec001::Rule),
@@ -36,6 +40,10 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec007::Rule),
         Box::new(spec008::Rule),
         Box::new(spec009::Rule),
+        Box::new(spec010::Rule),
+        Box::new(spec011::Rule),
+        Box::new(spec012::Rule),
+        Box::new(spec013::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec010.rs
+++ b/sdk/core/src/validate/rules/spec010.rs
@@ -1,0 +1,61 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-010"
+    }
+
+    fn name(&self) -> &'static str {
+        "replaced-by-target-exists"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(replaced_by) = t.raw.get("replaced_by") else {
+                continue;
+            };
+
+            let uuids: Vec<&str> = if let Some(s) = replaced_by.as_str() {
+                vec![s]
+            } else if let Some(arr) = replaced_by.as_array() {
+                arr.iter().filter_map(|v| v.as_str()).collect()
+            } else {
+                continue;
+            };
+
+            for uuid in uuids {
+                let exists = ctx
+                    .graph
+                    .tokens
+                    .values()
+                    .any(|other| other.uuid.as_deref() == Some(uuid));
+                if !exists {
+                    out.push(Diagnostic {
+                        file: t.file.clone(),
+                        token: Some(t.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!("replaced_by target UUID not found: {uuid}"),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec011.rs
+++ b/sdk/core/src/validate/rules/spec011.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-011"
+    }
+
+    fn name(&self) -> &'static str {
+        "replaced-by-array-requires-comment"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(replaced_by) = t.raw.get("replaced_by") else {
+                continue;
+            };
+            if !replaced_by.is_array() {
+                continue;
+            }
+            let has_comment = t
+                .raw
+                .get("deprecated_comment")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty());
+            if !has_comment {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "replaced_by is an array but deprecated_comment is missing on token {}",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec012.rs
+++ b/sdk/core/src/validate/rules/spec012.rs
@@ -1,0 +1,53 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-012"
+    }
+
+    fn name(&self) -> &'static str {
+        "replaced-by-requires-deprecated"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            if t.raw.get("replaced_by").is_none() {
+                continue;
+            }
+            let has_deprecated = t
+                .raw
+                .as_object()
+                .map(|o| o.contains_key("deprecated"))
+                .unwrap_or(false);
+            if !has_deprecated {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token {} has replaced_by but is not marked deprecated",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec013.rs
+++ b/sdk/core/src/validate/rules/spec013.rs
@@ -1,0 +1,53 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-013"
+    }
+
+    fn name(&self) -> &'static str {
+        "planned-removal-requires-deprecated"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            if t.raw.get("plannedRemoval").is_none() {
+                continue;
+            }
+            let has_deprecated = t
+                .raw
+                .as_object()
+                .map(|o| o.contains_key("deprecated"))
+                .unwrap_or(false);
+            if !has_deprecated {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token {} has plannedRemoval but is not marked deprecated",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}

--- a/sdk/core/src/validate/rules/spec013.rs
+++ b/sdk/core/src/validate/rules/spec013.rs
@@ -25,15 +25,12 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
         for t in ctx.graph.tokens.values() {
-            if t.raw.get("plannedRemoval").is_none() {
+            let Some(planned) = t.raw.get("plannedRemoval").and_then(|v| v.as_str()) else {
                 continue;
-            }
-            let has_deprecated = t
-                .raw
-                .as_object()
-                .map(|o| o.contains_key("deprecated"))
-                .unwrap_or(false);
-            if !has_deprecated {
+            };
+            let deprecated_str = t.raw.get("deprecated").and_then(|v| v.as_str());
+
+            if deprecated_str.is_none() {
                 out.push(Diagnostic {
                     file: t.file.clone(),
                     token: Some(t.name.clone()),
@@ -46,6 +43,26 @@ impl ValidationRule for Rule {
                     instance_path: None,
                     schema_path: None,
                 });
+                continue;
+            }
+
+            // Check that plannedRemoval does not precede deprecated (lexicographic
+            // comparison works for SemVer strings like "3.2.0" < "4.0.0").
+            if let Some(dep) = deprecated_str {
+                if planned < dep {
+                    out.push(Diagnostic {
+                        file: t.file.clone(),
+                        token: Some(t.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!(
+                            "Token {} has plannedRemoval ({planned}) preceding deprecated ({dep})",
+                            t.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
             }
         }
         out

--- a/sdk/core/src/validate/rules/spec013.rs
+++ b/sdk/core/src/validate/rules/spec013.rs
@@ -46,10 +46,10 @@ impl ValidationRule for Rule {
                 continue;
             }
 
-            // Check that plannedRemoval does not precede deprecated (lexicographic
-            // comparison works for SemVer strings like "3.2.0" < "4.0.0").
+            // Check that plannedRemoval does not precede deprecated using
+            // numeric segment comparison (handles "3.10.0" > "3.2.0" correctly).
             if let Some(dep) = deprecated_str {
-                if planned < dep {
+                if semver_precedes(planned, dep) {
                     out.push(Diagnostic {
                         file: t.file.clone(),
                         token: Some(t.name.clone()),
@@ -66,5 +66,43 @@ impl ValidationRule for Rule {
             }
         }
         out
+    }
+}
+
+/// Returns true if version `a` precedes version `b` using numeric segment
+/// comparison (e.g. "3.2.0" < "3.10.0"). Falls back to lexicographic
+/// comparison if segments aren't numeric.
+fn semver_precedes(a: &str, b: &str) -> bool {
+    let parse = |s: &str| -> Vec<u64> {
+        s.split('.')
+            .map(|seg| seg.parse::<u64>().unwrap_or(u64::MAX))
+            .collect()
+    };
+    let va = parse(a);
+    let vb = parse(b);
+    va < vb
+}
+
+#[cfg(test)]
+mod tests {
+    use super::semver_precedes;
+
+    #[test]
+    fn basic_ordering() {
+        assert!(semver_precedes("3.1.0", "3.2.0"));
+        assert!(!semver_precedes("3.2.0", "3.1.0"));
+        assert!(!semver_precedes("3.2.0", "3.2.0"));
+    }
+
+    #[test]
+    fn multi_digit_segments() {
+        assert!(semver_precedes("3.2.0", "3.10.0"));
+        assert!(!semver_precedes("3.10.0", "3.2.0"));
+    }
+
+    #[test]
+    fn major_version_difference() {
+        assert!(semver_precedes("3.9.9", "4.0.0"));
+        assert!(!semver_precedes("4.0.0", "3.9.9"));
     }
 }


### PR DESCRIPTION
## Description

Introduces a richer token lifecycle model inspired by Swift's `@available`, Kotlin's `@Deprecated`, and OpenAPI 3.3's deprecation object. Replaces the minimal `deprecated: boolean` + `renamed: string` with version-tagged fields and UUID-based replacement pointers.

### New lifecycle fields (cascade format)

| Field | Type | Description |
|-------|------|-------------|
| `deprecated` | string (version) | Spec version when deprecated (was boolean) |
| `replaced_by` | UUID or UUID[] | Machine-actionable replacement pointer (replaces `renamed`) |
| `plannedRemoval` | string (version) | Target removal version (optional) |
| `introduced` | string (version) | When token was first added (optional) |

### New spec document

- `spec/evolution.md` — deprecation lifecycle, migration windows (2 minor versions minimum), change classification (minor vs major), legacy format contract

### New validation rules

- **SPEC-010**: `replaced_by` target UUID(s) must exist in dataset
- **SPEC-011**: `replaced_by` array requires `deprecated_comment`
- **SPEC-012**: `replaced_by` requires `deprecated`
- **SPEC-013**: `plannedRemoval` requires `deprecated`

### Diff engine enhancement

- Pass 3 in `pair_tokens()`: when a deprecated old token carries `replaced_by` pointing to an unpaired new token's UUID, they are paired — enabling `renamed` classification for tokens with explicit replacement pointers

### Legacy format compatibility

- `deprecated: "3.2.0"` → `deprecated: true` in legacy output
- `replaced_by: "<uuid>"` → `renamed: "<name>"` in legacy output (resolved via UUID lookup)
- Package schema accepts both boolean and string `deprecated` for dual-format support

## Related Issue

Closes #736
References discussions #623, #735

## Motivation and Context

Token deprecation is actively used (756+ deprecated tokens from layout consolidation in #753) with spacing token work coming next. The previous `renamed` field was a name string — disconnected from the diff engine and ambiguous in cascade format where identity is UUID-based. This gives the toolchain a machine-actionable lifecycle model.

## How Has This Been Tested?

- `cd sdk && cargo test` — 125 tests pass (7 new: 1 diff unit, 1 diff conformance, 5 rule validation)
- `cd sdk && cargo clippy -- -D warnings` — clean
- Conformance fixtures for all 4 new rules and `replaced_by` diff pairing

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Breaking: `deprecated` changes from boolean to version string in cascade format. Legacy format output unchanged.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
