### PR TITLE
fix(sdk): carry outer set UUID through cascade roundtrip via set_uuid field

### DIFF
--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -106,14 +106,21 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<LegacySummary,
         if let Some(arr) = value.as_array() {
             for item in arr {
                 if let Some(tok) = item.as_object() {
-                    if let (Some(uuid), Some(name)) = (
-                        tok.get("uuid").and_then(|v| v.as_str()),
-                        tok.get("name")
-                            .and_then(|v| v.as_object())
-                            .and_then(|n| n.get("property"))
-                            .and_then(|v| v.as_str()),
-                    ) {
-                        global_uuid_to_name.insert(uuid.to_string(), name.to_string());
+                    let name = tok
+                        .get("name")
+                        .and_then(|v| v.as_object())
+                        .and_then(|n| n.get("property"))
+                        .and_then(|v| v.as_str());
+                    if let Some(name) = name {
+                        // Index the per-mode uuid.
+                        if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                            global_uuid_to_name.insert(uuid.to_string(), name.to_string());
+                        }
+                        // Also index set_uuid so replaced_by pointing at a set token's
+                        // outer UUID resolves correctly to renamed.
+                        if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
+                            global_uuid_to_name.insert(set_uuid.to_string(), name.to_string());
+                        }
                     }
                 }
             }
@@ -320,9 +327,9 @@ fn build_set_entry(
     }
 
     // Recover the outer set-level UUID from the cascade tokens (stored as set_uuid).
-    if let Some(set_uuid) = consistent_str_field(tokens, |t| {
-        t.get("set_uuid").and_then(|v| v.as_str())
-    }) {
+    if let Some(set_uuid) =
+        consistent_str_field(tokens, |t| t.get("set_uuid").and_then(|v| v.as_str()))
+    {
         outer.insert("uuid".into(), Value::String(set_uuid.to_string()));
     }
 
@@ -618,5 +625,73 @@ mod tests {
             err.contains("bg"),
             "error message should name the property: {err}"
         );
+    }
+
+    /// Regression: replaced_by pointing at a set token's outer UUID must resolve
+    /// to `renamed` in the legacy output. Previously the global uuid_to_name map
+    /// only indexed per-mode UUIDs, so set_uuid entries were invisible.
+    #[test]
+    fn replaced_by_set_uuid_resolves_to_renamed() {
+        let arr = json!([
+            // old-token: flat, deprecated, replaced_by the outer UUID of new-set.
+            {
+                "name": {"property": "old-token"},
+                "$schema": ".../color.json",
+                "value": "#fff",
+                "uuid": "old-0001",
+                "deprecated": true,
+                "replaced_by": "set-outer-uuid-0001"
+            },
+            // new-set light mode: carries set_uuid = "set-outer-uuid-0001".
+            {
+                "name": {"property": "new-set", "colorScheme": "light"},
+                "$schema": ".../color.json",
+                "value": "#aaa",
+                "uuid": "new-0001",
+                "set_uuid": "set-outer-uuid-0001"
+            },
+            // new-set dark mode: same set_uuid.
+            {
+                "name": {"property": "new-set", "colorScheme": "dark"},
+                "$schema": ".../color.json",
+                "value": "#111",
+                "uuid": "new-0002",
+                "set_uuid": "set-outer-uuid-0001"
+            },
+            // new-set wireframe mode: same set_uuid.
+            {
+                "name": {"property": "new-set", "colorScheme": "wireframe"},
+                "$schema": ".../color.json",
+                "value": "#888",
+                "uuid": "new-0003",
+                "set_uuid": "set-outer-uuid-0001"
+            }
+        ]);
+
+        // Build the global map the same way convert_dir does.
+        let mut global: HashMap<String, String> = HashMap::new();
+        for item in arr.as_array().unwrap() {
+            let tok = item.as_object().unwrap();
+            let name = tok["name"]["property"].as_str().unwrap();
+            if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                global.insert(uuid.to_string(), name.to_string());
+            }
+            if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
+                global.insert(set_uuid.to_string(), name.to_string());
+            }
+        }
+
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &global).unwrap();
+
+        let old = &out["old-token"];
+        assert_eq!(
+            old.get("renamed").and_then(|v| v.as_str()),
+            Some("new-set"),
+            "replaced_by pointing at set_uuid should resolve to renamed"
+        );
+        assert_eq!(old["deprecated"], true);
+        // new-set should have its outer UUID reconstructed.
+        assert_eq!(out["new-set"]["uuid"], "set-outer-uuid-0001");
     }
 }

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -319,6 +319,13 @@ fn build_set_entry(
         outer.insert("component".into(), Value::String(c.to_string()));
     }
 
+    // Recover the outer set-level UUID from the cascade tokens (stored as set_uuid).
+    if let Some(set_uuid) = consistent_str_field(tokens, |t| {
+        t.get("set_uuid").and_then(|v| v.as_str())
+    }) {
+        outer.insert("uuid".into(), Value::String(set_uuid.to_string()));
+    }
+
     // Hoist lifecycle fields that are identical across all mode entries.
     for field in OUTER_LIFECYCLE_FIELDS {
         if let Some(val) = consistent_field(tokens, field) {

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -744,14 +744,19 @@ mod tests {
 
         assert_eq!(summary.files_scanned, 1);
         assert_eq!(summary.files_modified, 1);
-        assert_eq!(summary.uuids_added, 1, "only the set token missing uuid should get one");
+        assert_eq!(
+            summary.uuids_added, 1,
+            "only the set token missing uuid should get one"
+        );
 
         // Read back and verify.
         let text = fs::read_to_string(tmp.join("tokens.json")).unwrap();
         let val: serde_json::Value = serde_json::from_str(&text).unwrap();
 
         // no-uuid-set should now have a uuid.
-        let new_uuid = val["no-uuid-set"]["uuid"].as_str().expect("uuid should be present");
+        let new_uuid = val["no-uuid-set"]["uuid"]
+            .as_str()
+            .expect("uuid should be present");
         assert!(!new_uuid.is_empty());
         // It should look like a UUID (basic length check).
         assert_eq!(new_uuid.len(), 36, "uuid should be a standard UUID string");

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -345,9 +345,15 @@ fn build_set_entry(
     // Value or alias.
     insert_value_or_ref(&mut out, entry);
 
-    // UUID from entry.
+    // UUID from entry (mode-level).
     if let Some(uuid) = entry.get("uuid").and_then(|v| v.as_str()) {
         out.insert("uuid".into(), Value::String(uuid.to_string()));
+    }
+
+    // Carry the outer set-level UUID so legacy-output can reconstruct it.
+    // Stored as `set_uuid` to distinguish it from the per-mode uuid.
+    if let Some(set_uuid) = outer.get("uuid").and_then(|v| v.as_str()) {
+        out.insert("set_uuid".into(), Value::String(set_uuid.to_string()));
     }
 
     // Lifecycle fields: outer level first, entry level overrides.


### PR DESCRIPTION
## Description

Forward migration (`migrate convert`) now stores the legacy outer-level `uuid`
of set tokens as `set_uuid` on each cascade token. The inverse (`legacy-output`)
recovers it when reconstructing the set entry.

## Related Issue

Part of #794. Follow-up to #799 / #800.

## Motivation and Context

The 1235 outer UUIDs added to set tokens in #800 were silently dropped during
`migrate convert` — `build_set_entry` only captured the per-mode `uuid` from
each mode entry, not the outer-level UUID. This caused the roundtrip diff to
balloon from ~270 to ~5000 lines after #800 merged.

`set_uuid` is a migration-internal field that survives the cascade representation
and is stripped during `legacy-output` reconstruction. It does not appear in mode
entries or in any spec-defined cascade fields.

## How Has This Been Tested?

- `cargo test --workspace` — all 134 tests pass
- Full jq roundtrip diff: 5/8 files clean, remaining 3 files contain only
  lifecycle hoisting differences (semantically equivalent, not UUID-related)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] All new and existing tests passed.