### PR TITLE
feat(sdk,tokens): roundtrip-verify command and CI task (#794)

### DIFF
--- a/packages/tokens/moon.yml
+++ b/packages/tokens/moon.yml
@@ -83,6 +83,17 @@ tasks:
       - dist
     local: true
     platform: system
+  verifyLegacyRoundtrip:
+    command: ../../sdk/target/debug/design-data
+    args:
+      - migrate
+      - roundtrip-verify
+      - ./src
+    platform: system
+    deps:
+      - sdk:build
+    inputs:
+      - "@globs(sources)"
   test:
     command:
       - pnpm
@@ -96,6 +107,7 @@ tasks:
     deps:
       - ~:buildTokens
       - ~:verifyDesignDataSnapshot
+      - ~:verifyLegacyRoundtrip
     platform: node
   test-watch:
     command:

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -173,6 +173,12 @@ enum MigrateSub {
         #[arg(value_name = "DIR")]
         dir: PathBuf,
     },
+    /// Verify that the legacy → cascade → legacy roundtrip is clean
+    RoundtripVerify {
+        /// Legacy source directory to roundtrip (e.g. packages/tokens/src)
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -439,6 +445,25 @@ fn run_migrate_add_uuids(dir: &Path) -> miette::Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
+fn run_migrate_roundtrip_verify(path: &Path) -> miette::Result<ExitCode> {
+    let diffs = legacy::roundtrip_verify(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("roundtrip-verify failed: {}", path.display()))?;
+    if diffs.is_empty() {
+        println!("Roundtrip OK: {}", path.display());
+        return Ok(ExitCode::SUCCESS);
+    }
+    for d in &diffs {
+        if d.token.is_empty() {
+            eprintln!("  {}: {}", d.file, d.detail);
+        } else {
+            eprintln!("  {}/{}: {}", d.file, d.token, d.detail);
+        }
+    }
+    eprintln!("{} difference(s) found", diffs.len());
+    Ok(ExitCode::from(1))
+}
+
 fn run_migrate_convert(input: &Path, output: &Path) -> miette::Result<ExitCode> {
     let summary = migrate::convert_dir(input, output)
         .into_diagnostic()
@@ -672,6 +697,7 @@ fn main() -> ExitCode {
                 run_migrate_legacy_output(&input, &output)
             }
             MigrateSub::AddUuids { dir } => run_migrate_add_uuids(&dir),
+            MigrateSub::RoundtripVerify { path } => run_migrate_roundtrip_verify(&path),
         },
     };
 

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -171,6 +171,251 @@ pub fn convert_token(token: &Map<String, Value>) -> Option<(String, Value)> {
     Some((property, entry))
 }
 
+// ── Roundtrip verification ────────────────────────────────────────────────────
+
+/// A semantic difference found between a generated legacy file and its reference.
+#[derive(Debug, PartialEq)]
+pub struct VerifyDifference {
+    /// Name of the file being compared (stem only, e.g. `"layout"`).
+    pub file: String,
+    /// The token property name where the difference was found.
+    pub token: String,
+    /// Human-readable description of the difference.
+    pub detail: String,
+}
+
+/// Run a full legacy → cascade → legacy roundtrip on `legacy_src` and compare
+/// the output semantically against the original source.
+///
+/// Lifecycle hoisting (e.g. `deprecated` moving from mode entries to the outer
+/// token level) is treated as equivalent — the comparison normalises both sides
+/// before diffing so these structural-but-not-semantic changes do not produce
+/// false positives.
+///
+/// Returns a list of meaningful differences. An empty `Vec` means the roundtrip
+/// is clean. Returns `Err` only on I/O or parse failures.
+pub fn roundtrip_verify(legacy_src: &Path) -> Result<Vec<VerifyDifference>, CoreError> {
+    let cascade_tmp = tempfile::tempdir()?;
+    let legacy_tmp = tempfile::tempdir()?;
+    crate::migrate::convert_dir(legacy_src, cascade_tmp.path())?;
+    convert_dir(cascade_tmp.path(), legacy_tmp.path())?;
+    verify_against_reference(legacy_tmp.path(), legacy_src)
+}
+
+/// Compare a directory of generated legacy files against a reference directory.
+///
+/// For each `.json` file in `reference_dir`, finds the matching file in
+/// `output_dir` and compares token entries semantically. Lifecycle fields
+/// (`deprecated`, `deprecated_comment`, `renamed`) are normalised — a field
+/// present only at the outer level in one side and only in all mode entries in
+/// the other is treated as equivalent.
+pub fn verify_against_reference(
+    output_dir: &Path,
+    reference_dir: &Path,
+) -> Result<Vec<VerifyDifference>, CoreError> {
+    let mut diffs = Vec::new();
+
+    for ref_path in discover_json_files(reference_dir)? {
+        let stem = ref_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let out_path = output_dir.join(format!("{stem}.json"));
+        if !out_path.exists() {
+            diffs.push(VerifyDifference {
+                file: stem.clone(),
+                token: String::new(),
+                detail: format!("file {stem}.json missing from output"),
+            });
+            continue;
+        }
+
+        let ref_text = std::fs::read_to_string(&ref_path)?;
+        let out_text = std::fs::read_to_string(&out_path)?;
+        let ref_obj: Map<String, Value> = serde_json::from_str::<Value>(&ref_text)
+            .ok()
+            .and_then(|v| v.as_object().cloned())
+            .unwrap_or_default();
+        let out_obj: Map<String, Value> = serde_json::from_str::<Value>(&out_text)
+            .ok()
+            .and_then(|v| v.as_object().cloned())
+            .unwrap_or_default();
+
+        // Tokens present in reference but missing from output.
+        for key in ref_obj.keys() {
+            if !out_obj.contains_key(key.as_str()) {
+                diffs.push(VerifyDifference {
+                    file: stem.clone(),
+                    token: key.clone(),
+                    detail: "token missing from output".into(),
+                });
+            }
+        }
+
+        // Tokens present in output but not in reference.
+        for key in out_obj.keys() {
+            if !ref_obj.contains_key(key.as_str()) {
+                diffs.push(VerifyDifference {
+                    file: stem.clone(),
+                    token: key.clone(),
+                    detail: "extra token in output not present in reference".into(),
+                });
+            }
+        }
+
+        // Semantic comparison of tokens present in both.
+        for (key, ref_entry) in &ref_obj {
+            let Some(out_entry) = out_obj.get(key) else {
+                continue; // already reported above
+            };
+            let entry_diffs =
+                compare_token_entries(key, ref_entry, out_entry);
+            for detail in entry_diffs {
+                diffs.push(VerifyDifference {
+                    file: stem.clone(),
+                    token: key.clone(),
+                    detail,
+                });
+            }
+        }
+    }
+
+    Ok(diffs)
+}
+
+/// Compare two legacy token entries semantically.
+/// Returns a list of difference descriptions (empty = equivalent).
+///
+/// Lifecycle hoisting is normalised: fields that appear only at the outer level
+/// on one side but consistently in all mode entries on the other are treated as
+/// equivalent.
+fn compare_token_entries(name: &str, reference: &Value, output: &Value) -> Vec<String> {
+    let _ = name;
+    let mut diffs = Vec::new();
+
+    let (Some(ref_obj), Some(out_obj)) = (reference.as_object(), output.as_object()) else {
+        if reference != output {
+            diffs.push(format!("value mismatch: {reference:?} vs {out_obj:?}", out_obj = output));
+        }
+        return diffs;
+    };
+
+    // Compare $schema.
+    if ref_obj.get("$schema") != out_obj.get("$schema") {
+        diffs.push(format!(
+            "$schema mismatch: {:?} vs {:?}",
+            ref_obj.get("$schema"),
+            out_obj.get("$schema")
+        ));
+    }
+
+    // Compare uuid (outer set-level).
+    if ref_obj.get("uuid") != out_obj.get("uuid") {
+        diffs.push(format!(
+            "uuid mismatch: {:?} vs {:?}",
+            ref_obj.get("uuid"),
+            out_obj.get("uuid")
+        ));
+    }
+
+    // Compare component.
+    if ref_obj.get("component") != out_obj.get("component") {
+        diffs.push(format!(
+            "component mismatch: {:?} vs {:?}",
+            ref_obj.get("component"),
+            out_obj.get("component")
+        ));
+    }
+
+    // Compare value/alias for flat tokens.
+    if ref_obj.get("value") != out_obj.get("value") {
+        diffs.push(format!(
+            "value mismatch: {:?} vs {:?}",
+            ref_obj.get("value"),
+            out_obj.get("value")
+        ));
+    }
+
+    // Normalise and compare lifecycle fields, tolerating hoisting differences.
+    // "Effective" value = outer field if present, else the consistent value
+    // across all mode entries (if any).
+    const LIFECYCLE: &[&str] = &["deprecated", "deprecated_comment", "renamed"];
+    for field in LIFECYCLE {
+        let ref_eff = effective_lifecycle_value(ref_obj, field);
+        let out_eff = effective_lifecycle_value(out_obj, field);
+        if ref_eff != out_eff {
+            diffs.push(format!(
+                "{field} mismatch: {ref_eff:?} vs {out_eff:?}"
+            ));
+        }
+    }
+
+    // Compare sets structure (modes, values, uuids).
+    match (ref_obj.get("sets"), out_obj.get("sets")) {
+        (Some(ref_sets), Some(out_sets)) => {
+            let ref_sets = ref_sets.as_object();
+            let out_sets = out_sets.as_object();
+            if let (Some(ref_sets), Some(out_sets)) = (ref_sets, out_sets) {
+                for mode in ref_sets.keys() {
+                    let Some(out_mode) = out_sets.get(mode.as_str()) else {
+                        diffs.push(format!("sets.{mode} missing from output"));
+                        continue;
+                    };
+                    let ref_mode = &ref_sets[mode];
+                    // Compare value within the mode.
+                    if ref_mode.get("value") != out_mode.get("value") {
+                        diffs.push(format!(
+                            "sets.{mode}.value mismatch: {:?} vs {:?}",
+                            ref_mode.get("value"),
+                            out_mode.get("value")
+                        ));
+                    }
+                    // Compare per-mode uuid.
+                    if ref_mode.get("uuid") != out_mode.get("uuid") {
+                        diffs.push(format!(
+                            "sets.{mode}.uuid mismatch: {:?} vs {:?}",
+                            ref_mode.get("uuid"),
+                            out_mode.get("uuid")
+                        ));
+                    }
+                }
+                for mode in out_sets.keys() {
+                    if !ref_sets.contains_key(mode.as_str()) {
+                        diffs.push(format!("sets.{mode} extra in output"));
+                    }
+                }
+            }
+        }
+        (None, None) => {}
+        (Some(_), None) => diffs.push("sets present in reference but missing from output".into()),
+        (None, Some(_)) => diffs.push("sets present in output but missing from reference".into()),
+    }
+
+    diffs
+}
+
+/// Return the "effective" value of a lifecycle field for a token entry,
+/// normalising hoisting: if the field is absent at the outer level but
+/// present consistently across all mode entries, that consistent value is
+/// returned.
+fn effective_lifecycle_value<'a>(entry: &'a Map<String, Value>, field: &str) -> Option<&'a Value> {
+    // Outer level wins if present.
+    if let Some(v) = entry.get(field) {
+        return Some(v);
+    }
+    // Fall back to consistent value across all mode entries.
+    let sets = entry.get("sets")?.as_object()?;
+    let mut iter = sets.values().filter_map(|v| v.as_object()?.get(field));
+    let first = iter.next()?;
+    if iter.all(|v| v == first) {
+        Some(first)
+    } else {
+        None
+    }
+}
+
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /// Convert a cascade array to a legacy object map.
@@ -693,5 +938,25 @@ mod tests {
         assert_eq!(old["deprecated"], true);
         // new-set should have its outer UUID reconstructed.
         assert_eq!(out["new-set"]["uuid"], "set-outer-uuid-0001");
+    }
+
+    /// Integration test: full roundtrip against the real Spectrum token sources.
+    /// Skipped automatically when the packages/tokens/src directory is absent
+    /// (e.g. in a sparse checkout).
+    #[test]
+    fn full_roundtrip_clean_against_spectrum_token_sources() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/tokens/src");
+        if !src.exists() {
+            return;
+        }
+        let diffs = crate::legacy::roundtrip_verify(&src)
+            .expect("roundtrip_verify should not error");
+        assert!(
+            diffs.is_empty(),
+            "legacy roundtrip has {} difference(s):\n{:#?}",
+            diffs.len(),
+            diffs
+        );
     }
 }

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -234,14 +234,18 @@ pub fn verify_against_reference(
 
         let ref_text = std::fs::read_to_string(&ref_path)?;
         let out_text = std::fs::read_to_string(&out_path)?;
-        let ref_obj: Map<String, Value> = serde_json::from_str::<Value>(&ref_text)
-            .ok()
-            .and_then(|v| v.as_object().cloned())
-            .unwrap_or_default();
-        let out_obj: Map<String, Value> = serde_json::from_str::<Value>(&out_text)
-            .ok()
-            .and_then(|v| v.as_object().cloned())
-            .unwrap_or_default();
+        let ref_obj: Map<String, Value> =
+            serde_json::from_str::<Value>(&ref_text)
+                .map_err(|e| CoreError::ParseError(format!("{stem}.json (reference): {e}")))?
+                .as_object()
+                .cloned()
+                .ok_or_else(|| CoreError::ParseError(format!("{stem}.json (reference): not an object")))?;
+        let out_obj: Map<String, Value> =
+            serde_json::from_str::<Value>(&out_text)
+                .map_err(|e| CoreError::ParseError(format!("{stem}.json (output): {e}")))?
+                .as_object()
+                .cloned()
+                .ok_or_else(|| CoreError::ParseError(format!("{stem}.json (output): not an object")))?;
 
         // Tokens present in reference but missing from output.
         for key in ref_obj.keys() {
@@ -341,7 +345,7 @@ fn compare_token_entries(name: &str, reference: &Value, output: &Value) -> Vec<S
     // Normalise and compare lifecycle fields, tolerating hoisting differences.
     // "Effective" value = outer field if present, else the consistent value
     // across all mode entries (if any).
-    const LIFECYCLE: &[&str] = &["deprecated", "deprecated_comment", "renamed"];
+    const LIFECYCLE: &[&str] = &["deprecated", "deprecated_comment", "renamed", "private", "description"];
     for field in LIFECYCLE {
         let ref_eff = effective_lifecycle_value(ref_obj, field);
         let out_eff = effective_lifecycle_value(out_obj, field);
@@ -352,7 +356,7 @@ fn compare_token_entries(name: &str, reference: &Value, output: &Value) -> Vec<S
         }
     }
 
-    // Compare sets structure (modes, values, uuids).
+    // Compare sets structure (modes and all per-mode fields).
     match (ref_obj.get("sets"), out_obj.get("sets")) {
         (Some(ref_sets), Some(out_sets)) => {
             let ref_sets = ref_sets.as_object();
@@ -364,20 +368,33 @@ fn compare_token_entries(name: &str, reference: &Value, output: &Value) -> Vec<S
                         continue;
                     };
                     let ref_mode = &ref_sets[mode];
-                    // Compare value within the mode.
-                    if ref_mode.get("value") != out_mode.get("value") {
-                        diffs.push(format!(
-                            "sets.{mode}.value mismatch: {:?} vs {:?}",
-                            ref_mode.get("value"),
-                            out_mode.get("value")
-                        ));
+                    // Fields compared directly (not subject to hoisting).
+                    for field in &["value", "uuid", "$schema"] {
+                        if ref_mode.get(*field) != out_mode.get(*field) {
+                            diffs.push(format!(
+                                "sets.{mode}.{field} mismatch: {:?} vs {:?}",
+                                ref_mode.get(*field),
+                                out_mode.get(*field)
+                            ));
+                        }
                     }
-                    // Compare per-mode uuid.
-                    if ref_mode.get("uuid") != out_mode.get("uuid") {
+                    // Per-mode lifecycle fields — normalised for hoisting.
+                    // A field present in a reference mode but absent in the output mode is
+                    // acceptable if the output token's outer level carries the same value
+                    // (hoisting occurred during conversion). This mirrors the outer-level
+                    // effective_lifecycle_value normalisation.
+                    for field in LIFECYCLE {
+                        let ref_val = ref_mode.as_object().and_then(|m| m.get(*field));
+                        let out_val = out_mode.as_object().and_then(|m| m.get(*field));
+                        if ref_val == out_val {
+                            continue;
+                        }
+                        // Allow hoisting: ref has field in mode, output hoisted it to outer.
+                        if out_val.is_none() && out_obj.get(*field) == ref_val {
+                            continue;
+                        }
                         diffs.push(format!(
-                            "sets.{mode}.uuid mismatch: {:?} vs {:?}",
-                            ref_mode.get("uuid"),
-                            out_mode.get("uuid")
+                            "sets.{mode}.{field} mismatch: {ref_val:?} vs {out_val:?}"
                         ));
                     }
                 }

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -47,6 +47,8 @@ pub enum CoreError {
     MultiDimensionalToken(String),
     #[error("query parse error: {0}")]
     QueryParse(String),
+    #[error("parse error: {0}")]
+    ParseError(String),
 }
 
 /// Returns the crate name for sanity checks and CLI `--version` wiring later.


### PR DESCRIPTION
## Description

Adds `design-data migrate roundtrip-verify <dir>` — a single command that runs
the full legacy → cascade → legacy pipeline and semantically compares the output
against the original source. Lifecycle hoisting (deprecated/renamed moving from
mode entries to outer level) is accepted as an equivalent structural variation.

Also wires the check into `moon ci` via a new `tokens:verifyLegacyRoundtrip`
task that runs as part of the `test` dependency chain.

## Related Issue

Closes #794 (steps 4–6). Depends on #799/#800/#802.

## How Has This Been Tested?

- `cargo test --workspace` — 136 tests pass, including new integration test
  `full_roundtrip_clean_against_spectrum_token_sources`
- `moon run tokens:verifyLegacyRoundtrip` — exits 0, `Roundtrip OK: ./src`
- `design-data migrate roundtrip-verify packages/tokens/src` — clean output

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.