### PR TITLE
feat(sdk): Figma Variables export — figma read + export commands (#795)

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -210,10 +210,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -262,6 +278,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "design-data-cli"
 version = "0.1.0"
 dependencies = [
@@ -272,6 +314,7 @@ dependencies = [
  "predicates",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -279,10 +322,12 @@ name = "design-data-core"
 version = "0.1.0"
 dependencies = [
  "jsonschema",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
  "uuid",
  "walkdir",
 ]
@@ -314,6 +359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,7 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -345,6 +399,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -367,10 +427,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -442,14 +523,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -470,6 +566,25 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -541,6 +656,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -550,6 +666,39 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -570,9 +719,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -810,6 +961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,7 +1025,24 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -972,6 +1152,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,12 +1249,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1083,6 +1322,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1396,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1183,23 +1506,34 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1207,6 +1541,21 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1214,6 +1563,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1225,7 +1580,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1250,10 +1640,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1317,6 +1739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,7 +1763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1349,6 +1777,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -1403,6 +1837,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +1867,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1422,7 +1877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1472,16 +1927,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1585,6 +2101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,6 +2151,12 @@ dependencies = [
  "uuid",
  "vsimd",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1798,12 +2326,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1813,6 +2360,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2414,135 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1978,6 +2701,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/sdk/cli/Cargo.toml
+++ b/sdk/cli/Cargo.toml
@@ -11,8 +11,9 @@ name = "design-data"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
-design-data-core = { path = "../core" }
+clap = { version = "4.5", features = ["derive", "env"] }
+design-data-core = { path = "../core", features = ["figma"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 miette = { version = "7.4", features = ["fancy"] }
 serde_json = "1.0"
 

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -17,12 +17,12 @@ use std::collections::HashSet;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use design_data_core::cascade::{resolve, ResolutionContext};
-use design_data_core::figma;
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
 use design_data_core::diff;
 use design_data_core::diff::display_name;
+use design_data_core::figma;
 use design_data_core::graph::TokenGraph;
 use design_data_core::legacy;
 use design_data_core::migrate;
@@ -681,12 +681,12 @@ fn run_figma_export(
 
     // 3. Output or post.
     if dry_run {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&body).into_diagnostic()?
-        );
+        println!("{}", serde_json::to_string_pretty(&body).into_diagnostic()?);
     } else {
-        eprintln!("Posting {} variables to Figma...", summary.variables_created);
+        eprintln!(
+            "Posting {} variables to Figma...",
+            summary.variables_created
+        );
         let post_response = rt
             .block_on(client.post_variables(file_key, &body))
             .map_err(|e| miette::miette!("{e}"))?;
@@ -702,10 +702,7 @@ fn run_figma_export(
         summary.variables_created, summary.mode_values_set
     );
     if !summary.skipped_composite.is_empty() {
-        eprintln!(
-            "  Skipped (composite): {}",
-            summary.skipped_composite.len()
-        );
+        eprintln!("  Skipped (composite): {}", summary.skipped_composite.len());
     }
     if !summary.skipped_alias_unresolved.is_empty() {
         eprintln!(
@@ -719,15 +716,18 @@ fn run_figma_export(
             summary.skipped_unknown_schema.len()
         );
     }
+    if !summary.skipped_unparseable_value.is_empty() {
+        eprintln!(
+            "  Skipped (unparseable value): {} — {:?}",
+            summary.skipped_unparseable_value.len(),
+            summary.skipped_unparseable_value,
+        );
+    }
 
     Ok(ExitCode::SUCCESS)
 }
 
-fn run_figma_read(
-    file_key: &str,
-    token: &str,
-    format: OutputFormat,
-) -> miette::Result<ExitCode> {
+fn run_figma_read(file_key: &str, token: &str, format: OutputFormat) -> miette::Result<ExitCode> {
     let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
     let client = figma::api::FigmaClient::new(token.to_string());
 

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use design_data_core::cascade::{resolve, ResolutionContext};
+use design_data_core::figma;
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
@@ -121,6 +122,11 @@ enum Commands {
         #[command(subcommand)]
         sub: MigrateSub,
     },
+    /// Interact with Figma Variables REST API
+    Figma {
+        #[command(subcommand)]
+        sub: FigmaSub,
+    },
 }
 
 #[derive(Subcommand)]
@@ -178,6 +184,37 @@ enum MigrateSub {
         /// Legacy source directory to roundtrip (e.g. packages/tokens/src)
         #[arg(value_name = "PATH")]
         path: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
+enum FigmaSub {
+    /// Read existing variables from a Figma file
+    Read {
+        /// Figma file key (from the URL: figma.com/design/<file_key>/...)
+        #[arg(long)]
+        file_key: String,
+        /// Figma personal access token (or set FIGMA_TOKEN env var)
+        #[arg(long, env = "FIGMA_TOKEN")]
+        token: String,
+        /// Output format (pretty or json)
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+    },
+    /// Export legacy tokens as Figma Variables
+    Export {
+        /// Path to legacy token source directory
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+        /// Figma file key to target
+        #[arg(long)]
+        file_key: String,
+        /// Figma personal access token (or set FIGMA_TOKEN env var)
+        #[arg(long, env = "FIGMA_TOKEN")]
+        token: String,
+        /// Generate payload without calling the API
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -622,6 +659,135 @@ fn run_query(
     }
 }
 
+fn run_figma_export(
+    path: &Path,
+    file_key: &str,
+    token: &str,
+    dry_run: bool,
+) -> miette::Result<ExitCode> {
+    let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
+    let client = figma::api::FigmaClient::new(token.to_string());
+
+    // 1. GET existing variables to obtain collection/mode IDs.
+    eprintln!("Fetching existing variables from Figma...");
+    let response = rt
+        .block_on(client.get_local_variables(file_key))
+        .map_err(|e| miette::miette!("{e}"))?;
+
+    // 2. Build the export payload.
+    eprintln!("Building export payload from {}...", path.display());
+    let (body, summary) = figma::mapping::build_export_payload(path, &response.meta)
+        .map_err(|e| miette::miette!("{e}"))?;
+
+    // 3. Output or post.
+    if dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).into_diagnostic()?
+        );
+    } else {
+        eprintln!("Posting {} variables to Figma...", summary.variables_created);
+        let post_response = rt
+            .block_on(client.post_variables(file_key, &body))
+            .map_err(|e| miette::miette!("{e}"))?;
+        eprintln!(
+            "Done. {} ID mappings returned.",
+            post_response.meta.temp_id_to_real_id.len()
+        );
+    }
+
+    // 4. Print summary to stderr.
+    eprintln!(
+        "\nSummary: {} variables, {} mode values",
+        summary.variables_created, summary.mode_values_set
+    );
+    if !summary.skipped_composite.is_empty() {
+        eprintln!(
+            "  Skipped (composite): {}",
+            summary.skipped_composite.len()
+        );
+    }
+    if !summary.skipped_alias_unresolved.is_empty() {
+        eprintln!(
+            "  Skipped (unresolved alias): {}",
+            summary.skipped_alias_unresolved.len()
+        );
+    }
+    if !summary.skipped_unknown_schema.is_empty() {
+        eprintln!(
+            "  Skipped (unknown schema): {}",
+            summary.skipped_unknown_schema.len()
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn run_figma_read(
+    file_key: &str,
+    token: &str,
+    format: OutputFormat,
+) -> miette::Result<ExitCode> {
+    let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
+    let client = figma::api::FigmaClient::new(token.to_string());
+
+    let response = rt
+        .block_on(client.get_local_variables(file_key))
+        .map_err(|e| miette::miette!("{e}"))?;
+
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&response.meta).into_diagnostic()?
+            );
+        }
+        OutputFormat::Pretty => {
+            let meta = &response.meta;
+            println!(
+                "{} collection(s), {} variable(s)\n",
+                meta.variable_collections.len(),
+                meta.variables.len()
+            );
+
+            // Sort collections by name for stable output.
+            let mut collections: Vec<_> = meta.variable_collections.values().collect();
+            collections.sort_by(|a, b| a.name.cmp(&b.name));
+
+            for col in &collections {
+                let mode_names: Vec<&str> = col.modes.iter().map(|m| m.name.as_str()).collect();
+                println!(
+                    "Collection: \"{}\" ({} mode(s): {})",
+                    col.name,
+                    col.modes.len(),
+                    mode_names.join(", ")
+                );
+
+                // Collect variables belonging to this collection.
+                let mut vars: Vec<&figma::types::FigmaVariable> = meta
+                    .variables
+                    .values()
+                    .filter(|v| v.variable_collection_id == col.id && !v.remote)
+                    .collect();
+                vars.sort_by(|a, b| a.name.cmp(&b.name));
+
+                println!("  Variables: {}", vars.len());
+
+                // Show first 5 samples.
+                for v in vars.iter().take(5) {
+                    println!("  Sample: {} [{}]", v.name, v.resolved_type);
+                }
+                if vars.len() > 5 {
+                    println!("  ... and {} more", vars.len() - 5);
+                }
+                println!();
+            }
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -698,6 +864,19 @@ fn main() -> ExitCode {
             }
             MigrateSub::AddUuids { dir } => run_migrate_add_uuids(&dir),
             MigrateSub::RoundtripVerify { path } => run_migrate_roundtrip_verify(&path),
+        },
+        Commands::Figma { sub } => match sub {
+            FigmaSub::Read {
+                file_key,
+                token,
+                format,
+            } => run_figma_read(&file_key, &token, format),
+            FigmaSub::Export {
+                path,
+                file_key,
+                token,
+                dry_run,
+            } => run_figma_export(&path, &file_key, &token, dry_run),
         },
     };
 

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -17,5 +17,11 @@ tempfile = "3.14"
 thiserror = "2.0"
 uuid = { version = "1.11", features = ["v4"] }
 walkdir = "2.5"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
+
+[features]
+default = []
+figma = ["dep:reqwest", "dep:tokio"]
 
 [dev-dependencies]

--- a/sdk/core/src/figma/api.rs
+++ b/sdk/core/src/figma/api.rs
@@ -1,0 +1,87 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Figma Variables REST API HTTP client.
+
+use super::types::{GetVariablesResponse, PostVariablesBody, PostVariablesResponse};
+use super::FigmaError;
+
+const BASE_URL: &str = "https://api.figma.com";
+
+/// Minimal async client for the Figma Variables REST API.
+pub struct FigmaClient {
+    token: String,
+    client: reqwest::Client,
+}
+
+impl FigmaClient {
+    pub fn new(token: String) -> Self {
+        Self {
+            token,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Fetch all local variables from a Figma file.
+    ///
+    /// `GET /v1/files/:file_key/variables/local`
+    pub async fn get_local_variables(
+        &self,
+        file_key: &str,
+    ) -> Result<GetVariablesResponse, FigmaError> {
+        let url = format!("{BASE_URL}/v1/files/{file_key}/variables/local");
+        let resp = self
+            .client
+            .get(&url)
+            .header("X-Figma-Token", &self.token)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(FigmaError::Api {
+                status,
+                message: body,
+            });
+        }
+
+        Ok(resp.json().await?)
+    }
+
+    /// Create, update, or delete variables in a Figma file.
+    ///
+    /// `POST /v1/files/:file_key/variables`
+    pub async fn post_variables(
+        &self,
+        file_key: &str,
+        body: &PostVariablesBody,
+    ) -> Result<PostVariablesResponse, FigmaError> {
+        let url = format!("{BASE_URL}/v1/files/{file_key}/variables");
+        let resp = self
+            .client
+            .post(&url)
+            .header("X-Figma-Token", &self.token)
+            .json(body)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(FigmaError::Api {
+                status,
+                message: body,
+            });
+        }
+
+        Ok(resp.json().await?)
+    }
+}

--- a/sdk/core/src/figma/color.rs
+++ b/sdk/core/src/figma/color.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Parse Spectrum token color strings into Figma's 0–1 float RGBA format.
+
+use super::types::FigmaColor;
+use super::FigmaError;
+
+/// Parse a Spectrum token color value into Figma's `{ r, g, b, a }` format.
+///
+/// Supported input formats:
+/// - `rgb(R, G, B)` where R, G, B are 0–255 integers
+/// - `rgba(R, G, B, A)` where A is a 0–1 float
+/// - `#RRGGBB`, `#RGB`, `#RRGGBBAA` hex
+pub fn parse_color(value: &str) -> Result<FigmaColor, FigmaError> {
+    let s = value.trim();
+
+    if let Some(inner) = s.strip_prefix("rgba(").and_then(|s| s.strip_suffix(')')) {
+        let parts = parse_number_list(inner)?;
+        if parts.len() != 4 {
+            return Err(FigmaError::UnsupportedColorFormat(value.to_string()));
+        }
+        return Ok(FigmaColor {
+            r: parts[0] / 255.0,
+            g: parts[1] / 255.0,
+            b: parts[2] / 255.0,
+            a: parts[3],
+        });
+    }
+
+    if let Some(inner) = s.strip_prefix("rgb(").and_then(|s| s.strip_suffix(')')) {
+        let parts = parse_number_list(inner)?;
+        if parts.len() != 3 {
+            return Err(FigmaError::UnsupportedColorFormat(value.to_string()));
+        }
+        return Ok(FigmaColor {
+            r: parts[0] / 255.0,
+            g: parts[1] / 255.0,
+            b: parts[2] / 255.0,
+            a: 1.0,
+        });
+    }
+
+    if let Some(hex) = s.strip_prefix('#') {
+        return parse_hex(hex, value);
+    }
+
+    Err(FigmaError::UnsupportedColorFormat(value.to_string()))
+}
+
+fn parse_number_list(s: &str) -> Result<Vec<f64>, FigmaError> {
+    s.split(',')
+        .map(|p| {
+            p.trim()
+                .parse::<f64>()
+                .map_err(|_| FigmaError::UnsupportedColorFormat(s.to_string()))
+        })
+        .collect()
+}
+
+fn parse_hex(hex: &str, original: &str) -> Result<FigmaColor, FigmaError> {
+    let err = || FigmaError::UnsupportedColorFormat(original.to_string());
+    match hex.len() {
+        6 => {
+            let r = u8::from_str_radix(&hex[0..2], 16).map_err(|_| err())?;
+            let g = u8::from_str_radix(&hex[2..4], 16).map_err(|_| err())?;
+            let b = u8::from_str_radix(&hex[4..6], 16).map_err(|_| err())?;
+            Ok(FigmaColor {
+                r: r as f64 / 255.0,
+                g: g as f64 / 255.0,
+                b: b as f64 / 255.0,
+                a: 1.0,
+            })
+        }
+        3 => {
+            let r = u8::from_str_radix(&hex[0..1], 16).map_err(|_| err())?;
+            let g = u8::from_str_radix(&hex[1..2], 16).map_err(|_| err())?;
+            let b = u8::from_str_radix(&hex[2..3], 16).map_err(|_| err())?;
+            Ok(FigmaColor {
+                r: (r * 17) as f64 / 255.0,
+                g: (g * 17) as f64 / 255.0,
+                b: (b * 17) as f64 / 255.0,
+                a: 1.0,
+            })
+        }
+        8 => {
+            let r = u8::from_str_radix(&hex[0..2], 16).map_err(|_| err())?;
+            let g = u8::from_str_radix(&hex[2..4], 16).map_err(|_| err())?;
+            let b = u8::from_str_radix(&hex[4..6], 16).map_err(|_| err())?;
+            let a = u8::from_str_radix(&hex[6..8], 16).map_err(|_| err())?;
+            Ok(FigmaColor {
+                r: r as f64 / 255.0,
+                g: g as f64 / 255.0,
+                b: b as f64 / 255.0,
+                a: a as f64 / 255.0,
+            })
+        }
+        _ => Err(err()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-6
+    }
+
+    fn assert_color(c: &FigmaColor, r: f64, g: f64, b: f64, a: f64) {
+        assert!(
+            approx_eq(c.r, r) && approx_eq(c.g, g) && approx_eq(c.b, b) && approx_eq(c.a, a),
+            "expected ({r}, {g}, {b}, {a}), got ({}, {}, {}, {})",
+            c.r,
+            c.g,
+            c.b,
+            c.a
+        );
+    }
+
+    #[test]
+    fn rgb_integer_channels() {
+        let c = parse_color("rgb(255, 128, 0)").unwrap();
+        assert_color(&c, 1.0, 128.0 / 255.0, 0.0, 1.0);
+    }
+
+    #[test]
+    fn rgba_with_alpha() {
+        let c = parse_color("rgba(0, 0, 0, 0.5)").unwrap();
+        assert_color(&c, 0.0, 0.0, 0.0, 0.5);
+    }
+
+    #[test]
+    fn hex_6_digit() {
+        let c = parse_color("#ff8000").unwrap();
+        assert_color(&c, 1.0, 128.0 / 255.0, 0.0, 1.0);
+    }
+
+    #[test]
+    fn hex_3_digit() {
+        let c = parse_color("#fff").unwrap();
+        assert_color(&c, 1.0, 1.0, 1.0, 1.0);
+    }
+
+    #[test]
+    fn hex_8_digit_with_alpha() {
+        let c = parse_color("#ff800080").unwrap();
+        assert_color(&c, 1.0, 128.0 / 255.0, 0.0, 128.0 / 255.0);
+    }
+
+    #[test]
+    fn hex_black() {
+        let c = parse_color("#000000").unwrap();
+        assert_color(&c, 0.0, 0.0, 0.0, 1.0);
+    }
+
+    #[test]
+    fn rgb_with_whitespace() {
+        let c = parse_color("  rgb( 10 , 20 , 30 )  ").unwrap();
+        assert_color(&c, 10.0 / 255.0, 20.0 / 255.0, 30.0 / 255.0, 1.0);
+    }
+
+    #[test]
+    fn unsupported_format_returns_error() {
+        assert!(parse_color("hsl(0, 100%, 50%)").is_err());
+        assert!(parse_color("not-a-color").is_err());
+        assert!(parse_color("#gg0000").is_err());
+    }
+}

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -303,12 +303,19 @@ fn resolve_value(
         return None;
     }
 
-    // Try top-level value first; fall back to first set mode's value.
+    // Try top-level value first; fall back to a set mode's value.
+    // Prefer "light" (color default) then "desktop" (scale default) so that
+    // aliases which resolve through a set token pick the canonical default-mode
+    // value rather than whichever mode happens to be listed first in the file.
     let value_str = entry.get("value").and_then(|v| v.as_str()).or_else(|| {
         entry
             .get("sets")
             .and_then(|s| s.as_object())
-            .and_then(|sets| sets.values().next())
+            .and_then(|sets| {
+                sets.get("light")
+                    .or_else(|| sets.get("desktop"))
+                    .or_else(|| sets.values().next())
+            })
             .and_then(|mode_entry| mode_entry.get("value"))
             .and_then(|v| v.as_str())
     })?;

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -888,7 +888,7 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        let (_body, summary) = build_export_payload(dir.path(), &meta).unwrap();
         // base-color (flat color) + alias-color (alias→color)
         assert_eq!(summary.variables_created, 2);
         assert!(summary.skipped_alias_unresolved.is_empty());

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -90,6 +90,8 @@ pub fn build_export_payload(
 
     let color_mode_ids = resolve_mode_ids(&color_col.modes, COLOR_MODES);
     let scale_mode_ids = resolve_mode_ids(&scale_col.modes, SCALE_MODES);
+    let color_default_mode = &color_col.default_mode_id;
+    let scale_default_mode = &scale_col.default_mode_id;
 
     // 2. Load all token files from the directory.
     let all_tokens = load_all_tokens(token_dir)?;
@@ -149,14 +151,14 @@ pub fn build_export_payload(
                 &mut summary,
             );
         } else if schema.ends_with(COLOR) {
-            // Flat color token → .Color theme, single mode (light).
+            // Flat color token → .Color theme, default mode (Light).
             process_flat_token(
                 token_name,
                 token_entry,
                 &color_col.id,
                 COLOR_THEME_PREFIX,
                 "COLOR",
-                &color_mode_ids,
+                color_default_mode,
                 &value_index,
                 &existing_var_index,
                 &mut variables,
@@ -170,8 +172,8 @@ pub fn build_export_payload(
                 token_entry,
                 &color_col.id,
                 &scale_col.id,
-                &color_mode_ids,
-                &scale_mode_ids,
+                color_default_mode,
+                scale_default_mode,
                 &value_index,
                 &all_tokens,
                 &existing_var_index,
@@ -186,7 +188,7 @@ pub fn build_export_payload(
             || schema.ends_with(FONT_STYLE)
             || schema.ends_with(FONT_WEIGHT)
         {
-            // Flat non-color token → .Platform scale.
+            // Flat non-color token → .Platform scale, default mode (Desktop).
             let figma_type = schema_to_figma_type(schema);
             process_flat_token(
                 token_name,
@@ -194,7 +196,7 @@ pub fn build_export_payload(
                 &scale_col.id,
                 PLATFORM_SCALE_PREFIX,
                 figma_type,
-                &scale_mode_ids,
+                scale_default_mode,
                 &value_index,
                 &existing_var_index,
                 &mut variables,
@@ -289,6 +291,7 @@ fn build_value_index(tokens: &[(String, Value)]) -> HashMap<String, String> {
 }
 
 /// Resolve a token's value, following alias chains.
+/// For set tokens (no top-level `value`), picks the first mode's value.
 fn resolve_value(
     _name: &str,
     entry: &Value,
@@ -298,7 +301,19 @@ fn resolve_value(
     if depth > 10 {
         return None;
     }
-    let value_str = entry.get("value").and_then(|v| v.as_str())?;
+
+    // Try top-level value first; fall back to first set mode's value.
+    let value_str = entry
+        .get("value")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            entry
+                .get("sets")
+                .and_then(|s| s.as_object())
+                .and_then(|sets| sets.values().next())
+                .and_then(|mode_entry| mode_entry.get("value"))
+                .and_then(|v| v.as_str())
+        })?;
 
     // Check if it's an alias reference: {token-name}
     if value_str.starts_with('{') && value_str.ends_with('}') {
@@ -336,11 +351,12 @@ fn value_to_figma(value_str: &str, figma_type: &str) -> Option<Value> {
             Some(serde_json::to_value(c).unwrap())
         }
         "FLOAT" => {
-            // Strip common suffixes: "px", "em", "rem", "%"
+            // Strip common unit suffixes: px, em, rem, dp, %
             let s = value_str
                 .trim()
                 .trim_end_matches("rem")
                 .trim_end_matches("em")
+                .trim_end_matches("dp")
                 .trim_end_matches("px")
                 .trim_end_matches('%');
             let n: f64 = s.parse().ok()?;
@@ -491,6 +507,7 @@ fn process_scale_set_token(
                 if v.trim()
                     .trim_end_matches("rem")
                     .trim_end_matches("em")
+                    .trim_end_matches("dp")
                     .trim_end_matches("px")
                     .trim_end_matches('%')
                     .parse::<f64>()
@@ -547,7 +564,7 @@ fn process_flat_token(
     collection_id: &str,
     prefix: &str,
     figma_type: &str,
-    mode_ids: &HashMap<String, String>,
+    default_mode_id: &str,
     value_index: &HashMap<String, String>,
     existing_var_index: &HashMap<&str, &str>,
     variables: &mut Vec<VariableAction>,
@@ -586,15 +603,13 @@ fn process_flat_token(
     variables.push(va);
     summary.variables_created += 1;
 
-    // Set value in the first available mode (default mode).
-    if let Some(mode_id) = mode_ids.values().next() {
-        mode_values.push(ModeValueAction {
-            variable_id: var_id,
-            mode_id: mode_id.clone(),
-            value: figma_val,
-        });
-        summary.mode_values_set += 1;
-    }
+    // Set value in the collection's default mode.
+    mode_values.push(ModeValueAction {
+        variable_id: var_id,
+        mode_id: default_mode_id.to_string(),
+        value: figma_val,
+    });
+    summary.mode_values_set += 1;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -603,8 +618,8 @@ fn process_alias_token(
     entry: &Value,
     color_collection_id: &str,
     scale_collection_id: &str,
-    color_mode_ids: &HashMap<String, String>,
-    scale_mode_ids: &HashMap<String, String>,
+    color_default_mode_id: &str,
+    scale_default_mode_id: &str,
     value_index: &HashMap<String, String>,
     all_tokens: &[(String, Value)],
     existing_var_index: &HashMap<&str, &str>,
@@ -650,6 +665,7 @@ fn process_alias_token(
         .trim()
         .trim_end_matches("rem")
         .trim_end_matches("em")
+        .trim_end_matches("dp")
         .trim_end_matches("px")
         .trim_end_matches('%')
         .parse::<f64>()
@@ -666,10 +682,10 @@ fn process_alias_token(
         || (figma_type == "FLOAT"
             && (target_schema.ends_with(OPACITY)
                 || target_schema.ends_with(COLOR_SET)));
-    let (collection_id, prefix, mode_ids) = if is_color {
-        (color_collection_id, COLOR_THEME_PREFIX, color_mode_ids)
+    let (collection_id, prefix, default_mode_id) = if is_color {
+        (color_collection_id, COLOR_THEME_PREFIX, color_default_mode_id)
     } else {
-        (scale_collection_id, PLATFORM_SCALE_PREFIX, scale_mode_ids)
+        (scale_collection_id, PLATFORM_SCALE_PREFIX, scale_default_mode_id)
     };
 
     let figma_val = match value_to_figma(resolved_value, figma_type) {
@@ -683,14 +699,12 @@ fn process_alias_token(
     variables.push(va);
     summary.variables_created += 1;
 
-    if let Some(mode_id) = mode_ids.values().next() {
-        mode_values.push(ModeValueAction {
-            variable_id: var_id,
-            mode_id: mode_id.clone(),
-            value: figma_val,
-        });
-        summary.mode_values_set += 1;
-    }
+    mode_values.push(ModeValueAction {
+        variable_id: var_id,
+        mode_id: default_mode_id.to_string(),
+        value: figma_val,
+    });
+    summary.mode_values_set += 1;
 }
 
 #[cfg(test)]

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -1,0 +1,874 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Convert legacy Spectrum token files into a Figma Variables POST payload.
+//!
+//! Targets the `.Color theme` and `.Platform scale` collections, which use
+//! `{camelCasePrefix}/{kebab-case-token-name}` naming — matching legacy token
+//! names 1:1.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::color::parse_color;
+use super::types::{ModeValueAction, PostVariablesBody, VariableAction, VariablesMeta};
+use super::FigmaError;
+
+// ── Schema URL suffixes ──────────────────────────────────────────────────────
+
+const COLOR_SET: &str = "color-set.json";
+const COLOR: &str = "color.json";
+const SCALE_SET: &str = "scale-set.json";
+const DIMENSION: &str = "dimension.json";
+const OPACITY: &str = "opacity.json";
+const FONT_FAMILY: &str = "font-family.json";
+const FONT_SIZE: &str = "font-size.json";
+const FONT_STYLE: &str = "font-style.json";
+const FONT_WEIGHT: &str = "font-weight.json";
+const ALIAS: &str = "alias.json";
+
+// Schemas we skip (composite types with no Figma Variable equivalent).
+const SKIP_SCHEMAS: &[&str] = &[
+    "typography.json",
+    "drop-shadow.json",
+    "gradient-stop.json",
+    "multiplier.json",
+    "text-align.json",
+    "text-transform.json",
+];
+
+// ── Collection prefixes ──────────────────────────────────────────────────────
+
+const COLOR_THEME_COLLECTION: &str = ".Color theme";
+const COLOR_THEME_PREFIX: &str = "colorTheme";
+const PLATFORM_SCALE_COLLECTION: &str = ".Platform scale";
+const PLATFORM_SCALE_PREFIX: &str = "platformScale";
+
+// ── Mode name mapping ────────────────────────────────────────────────────────
+
+const COLOR_MODES: &[&str] = &["light", "dark", "wireframe"];
+const SCALE_MODES: &[&str] = &["desktop", "mobile"];
+
+/// Summary of an export operation.
+#[derive(Debug, Default)]
+pub struct ExportSummary {
+    pub variables_created: usize,
+    pub mode_values_set: usize,
+    pub skipped_composite: Vec<String>,
+    pub skipped_alias_unresolved: Vec<String>,
+    pub skipped_unknown_schema: Vec<String>,
+}
+
+/// Build a Figma POST payload from legacy token source files.
+///
+/// `existing` is the result of `GET /v1/files/:file_key/variables/local` —
+/// used to look up collection and mode IDs for the target collections.
+pub fn build_export_payload(
+    token_dir: &Path,
+    existing: &VariablesMeta,
+) -> Result<(PostVariablesBody, ExportSummary), FigmaError> {
+    // 1. Look up collection and mode IDs from the existing file.
+    let color_col = find_collection(existing, COLOR_THEME_COLLECTION)
+        .ok_or_else(|| FigmaError::Api {
+            status: 0,
+            message: format!("collection '{COLOR_THEME_COLLECTION}' not found in file"),
+        })?;
+    let scale_col = find_collection(existing, PLATFORM_SCALE_COLLECTION)
+        .ok_or_else(|| FigmaError::Api {
+            status: 0,
+            message: format!("collection '{PLATFORM_SCALE_COLLECTION}' not found in file"),
+        })?;
+
+    let color_mode_ids = resolve_mode_ids(&color_col.modes, COLOR_MODES);
+    let scale_mode_ids = resolve_mode_ids(&scale_col.modes, SCALE_MODES);
+
+    // 2. Load all token files from the directory.
+    let all_tokens = load_all_tokens(token_dir)?;
+
+    // 3. Build a name→value lookup for alias resolution.
+    let value_index = build_value_index(&all_tokens);
+
+    // 4. Process each token.
+    let mut summary = ExportSummary::default();
+    let mut variables: Vec<VariableAction> = Vec::new();
+    let mut mode_values: Vec<ModeValueAction> = Vec::new();
+
+    // Build index of existing variable names → IDs for UPDATE detection.
+    let existing_var_index: HashMap<&str, &str> = existing
+        .variables
+        .values()
+        .map(|v| (v.name.as_str(), v.id.as_str()))
+        .collect();
+
+    for (token_name, token_entry) in &all_tokens {
+        let schema = token_entry
+            .get("$schema")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Skip composite types.
+        if SKIP_SCHEMAS.iter().any(|s| schema.ends_with(s)) {
+            summary.skipped_composite.push(token_name.clone());
+            continue;
+        }
+
+        // Route to the appropriate collection.
+        if schema.ends_with(COLOR_SET) {
+            process_color_set_token(
+                token_name,
+                token_entry,
+                &color_col.id,
+                COLOR_THEME_PREFIX,
+                &color_mode_ids,
+                &value_index,
+                &existing_var_index,
+                &mut variables,
+                &mut mode_values,
+                &mut summary,
+            );
+        } else if schema.ends_with(SCALE_SET) {
+            process_scale_set_token(
+                token_name,
+                token_entry,
+                &scale_col.id,
+                PLATFORM_SCALE_PREFIX,
+                &scale_mode_ids,
+                &value_index,
+                &existing_var_index,
+                &mut variables,
+                &mut mode_values,
+                &mut summary,
+            );
+        } else if schema.ends_with(COLOR) {
+            // Flat color token → .Color theme, single mode (light).
+            process_flat_token(
+                token_name,
+                token_entry,
+                &color_col.id,
+                COLOR_THEME_PREFIX,
+                "COLOR",
+                &color_mode_ids,
+                &value_index,
+                &existing_var_index,
+                &mut variables,
+                &mut mode_values,
+                &mut summary,
+            );
+        } else if schema.ends_with(ALIAS) {
+            // Top-level alias — route based on what it resolves to.
+            process_alias_token(
+                token_name,
+                token_entry,
+                &color_col.id,
+                &scale_col.id,
+                &color_mode_ids,
+                &scale_mode_ids,
+                &value_index,
+                &all_tokens,
+                &existing_var_index,
+                &mut variables,
+                &mut mode_values,
+                &mut summary,
+            );
+        } else if schema.ends_with(DIMENSION)
+            || schema.ends_with(OPACITY)
+            || schema.ends_with(FONT_FAMILY)
+            || schema.ends_with(FONT_SIZE)
+            || schema.ends_with(FONT_STYLE)
+            || schema.ends_with(FONT_WEIGHT)
+        {
+            // Flat non-color token → .Platform scale.
+            let figma_type = schema_to_figma_type(schema);
+            process_flat_token(
+                token_name,
+                token_entry,
+                &scale_col.id,
+                PLATFORM_SCALE_PREFIX,
+                figma_type,
+                &scale_mode_ids,
+                &value_index,
+                &existing_var_index,
+                &mut variables,
+                &mut mode_values,
+                &mut summary,
+            );
+        } else if !schema.is_empty() {
+            summary.skipped_unknown_schema.push(token_name.clone());
+        }
+    }
+
+    let body = PostVariablesBody {
+        variable_collections: vec![],
+        variable_modes: vec![],
+        variables,
+        variable_mode_values: mode_values,
+    };
+
+    Ok((body, summary))
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn find_collection<'a>(
+    meta: &'a VariablesMeta,
+    name: &str,
+) -> Option<&'a super::types::FigmaVariableCollection> {
+    meta.variable_collections.values().find(|c| c.name == name)
+}
+
+/// Map mode names (e.g. "light", "dark") to their Figma mode IDs.
+/// Case-insensitive matching since Figma uses "Light"/"Dark" etc.
+fn resolve_mode_ids(
+    figma_modes: &[super::types::FigmaMode],
+    expected: &[&str],
+) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for mode_name in expected {
+        if let Some(fm) = figma_modes
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(mode_name))
+        {
+            map.insert(mode_name.to_string(), fm.mode_id.clone());
+        }
+    }
+    map
+}
+
+/// Load all legacy JSON token files from a directory into a flat map.
+fn load_all_tokens(dir: &Path) -> Result<Vec<(String, Value)>, FigmaError> {
+    let mut tokens = Vec::new();
+    let mut paths: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|e| FigmaError::Api {
+            status: 0,
+            message: format!("failed to read token directory: {e}"),
+        })?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    paths.sort();
+
+    for path in paths {
+        let text = std::fs::read_to_string(&path).map_err(|e| FigmaError::Api {
+            status: 0,
+            message: format!("failed to read {}: {e}", path.display()),
+        })?;
+        let obj: serde_json::Map<String, Value> =
+            serde_json::from_str(&text).map_err(|e| FigmaError::Api {
+                status: 0,
+                message: format!("failed to parse {}: {e}", path.display()),
+            })?;
+        for (name, entry) in obj {
+            tokens.push((name, entry));
+        }
+    }
+    Ok(tokens)
+}
+
+/// Build a lookup from token name → resolved concrete value string.
+/// Follows alias chains up to 10 levels deep.
+fn build_value_index(tokens: &[(String, Value)]) -> HashMap<String, String> {
+    let by_name: HashMap<&str, &Value> = tokens.iter().map(|(n, v)| (n.as_str(), v)).collect();
+    let mut index = HashMap::new();
+
+    for (name, entry) in tokens {
+        if let Some(resolved) = resolve_value(name, entry, &by_name, 0) {
+            index.insert(name.clone(), resolved);
+        }
+    }
+    index
+}
+
+/// Resolve a token's value, following alias chains.
+fn resolve_value(
+    _name: &str,
+    entry: &Value,
+    by_name: &HashMap<&str, &Value>,
+    depth: usize,
+) -> Option<String> {
+    if depth > 10 {
+        return None;
+    }
+    let value_str = entry.get("value").and_then(|v| v.as_str())?;
+
+    // Check if it's an alias reference: {token-name}
+    if value_str.starts_with('{') && value_str.ends_with('}') {
+        let target_name = &value_str[1..value_str.len() - 1];
+        if let Some(target_entry) = by_name.get(target_name) {
+            return resolve_value(target_name, target_entry, by_name, depth + 1);
+        }
+        return None;
+    }
+
+    Some(value_str.to_string())
+}
+
+fn schema_to_figma_type(schema: &str) -> &'static str {
+    if schema.ends_with(COLOR) {
+        "COLOR"
+    } else if schema.ends_with(DIMENSION)
+        || schema.ends_with(OPACITY)
+        || schema.ends_with(FONT_SIZE)
+        || schema.ends_with(FONT_WEIGHT)
+    {
+        "FLOAT"
+    } else if schema.ends_with(FONT_FAMILY) || schema.ends_with(FONT_STYLE) {
+        "STRING"
+    } else {
+        "STRING"
+    }
+}
+
+/// Convert a raw value string to a Figma-compatible JSON value.
+fn value_to_figma(value_str: &str, figma_type: &str) -> Option<Value> {
+    match figma_type {
+        "COLOR" => {
+            let c = parse_color(value_str).ok()?;
+            Some(serde_json::to_value(c).unwrap())
+        }
+        "FLOAT" => {
+            // Strip common suffixes: "px", "em", "rem", "%"
+            let s = value_str
+                .trim()
+                .trim_end_matches("rem")
+                .trim_end_matches("em")
+                .trim_end_matches("px")
+                .trim_end_matches('%');
+            let n: f64 = s.parse().ok()?;
+            Some(Value::Number(serde_json::Number::from_f64(n)?))
+        }
+        "STRING" => Some(Value::String(value_str.to_string())),
+        _ => None,
+    }
+}
+
+fn make_variable_action(
+    token_name: &str,
+    prefix: &str,
+    collection_id: &str,
+    figma_type: &str,
+    description: Option<&str>,
+    existing_var_index: &HashMap<&str, &str>,
+) -> (VariableAction, String) {
+    let figma_name = format!("{prefix}/{token_name}");
+    let (action, id, var_id) = if let Some(&existing_id) = existing_var_index.get(figma_name.as_str()) {
+        let real_id = existing_id.to_string();
+        ("UPDATE".to_string(), Some(real_id.clone()), real_id)
+    } else {
+        // Figma rejects temp IDs containing '/'; use '__' as separator.
+        let temp_id = figma_name.replace('/', "__");
+        ("CREATE".to_string(), Some(temp_id.clone()), temp_id)
+    };
+
+    let va = VariableAction {
+        action,
+        id,
+        name: figma_name,
+        variable_collection_id: collection_id.to_string(),
+        resolved_type: figma_type.to_string(),
+        description: description.map(String::from),
+        hidden_from_publishing: None,
+        scopes: None,
+        code_syntax: None,
+    };
+    (va, var_id)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_color_set_token(
+    token_name: &str,
+    entry: &Value,
+    collection_id: &str,
+    prefix: &str,
+    mode_ids: &HashMap<String, String>,
+    value_index: &HashMap<String, String>,
+    existing_var_index: &HashMap<&str, &str>,
+    variables: &mut Vec<VariableAction>,
+    mode_values: &mut Vec<ModeValueAction>,
+    summary: &mut ExportSummary,
+) {
+    let sets = match entry.get("sets").and_then(|v| v.as_object()) {
+        Some(s) => s,
+        None => return,
+    };
+
+    // Determine the inner type from first mode entry.
+    let inner_schema = sets
+        .values()
+        .next()
+        .and_then(|v| v.get("$schema"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let figma_type = if inner_schema.ends_with(OPACITY) {
+        "FLOAT"
+    } else {
+        "COLOR"
+    };
+
+    let desc = entry.get("description").and_then(|v| v.as_str());
+    let (va, var_id) =
+        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    variables.push(va);
+    summary.variables_created += 1;
+
+    for &mode_name in COLOR_MODES {
+        let Some(mode_id) = mode_ids.get(mode_name) else {
+            continue;
+        };
+        let Some(mode_entry) = sets.get(mode_name) else {
+            continue;
+        };
+        let raw_value = mode_entry.get("value").and_then(|v| v.as_str());
+        let resolved = raw_value.and_then(|v| {
+            if v.starts_with('{') && v.ends_with('}') {
+                let target = &v[1..v.len() - 1];
+                value_index.get(target).map(|s| s.as_str())
+            } else {
+                Some(v)
+            }
+        });
+
+        if let Some(val_str) = resolved {
+            if let Some(figma_val) = value_to_figma(val_str, figma_type) {
+                mode_values.push(ModeValueAction {
+                    variable_id: var_id.clone(),
+                    mode_id: mode_id.clone(),
+                    value: figma_val,
+                });
+                summary.mode_values_set += 1;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_scale_set_token(
+    token_name: &str,
+    entry: &Value,
+    collection_id: &str,
+    prefix: &str,
+    mode_ids: &HashMap<String, String>,
+    value_index: &HashMap<String, String>,
+    existing_var_index: &HashMap<&str, &str>,
+    variables: &mut Vec<VariableAction>,
+    mode_values: &mut Vec<ModeValueAction>,
+    summary: &mut ExportSummary,
+) {
+    let sets = match entry.get("sets").and_then(|v| v.as_object()) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let inner_schema = sets
+        .values()
+        .next()
+        .and_then(|v| v.get("$schema"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    // If inner entries are aliases, determine type from the first resolved value.
+    let figma_type = if inner_schema.ends_with(ALIAS) {
+        let first_resolved = sets.values().next().and_then(|v| {
+            let raw = v.get("value").and_then(|v| v.as_str())?;
+            if raw.starts_with('{') && raw.ends_with('}') {
+                let target = &raw[1..raw.len() - 1];
+                value_index.get(target).map(|s| s.as_str())
+            } else {
+                Some(raw)
+            }
+        });
+        match first_resolved {
+            Some(v) if parse_color(v).is_ok() => "COLOR",
+            Some(v)
+                if v.trim()
+                    .trim_end_matches("rem")
+                    .trim_end_matches("em")
+                    .trim_end_matches("px")
+                    .trim_end_matches('%')
+                    .parse::<f64>()
+                    .is_ok() =>
+            {
+                "FLOAT"
+            }
+            _ => "STRING",
+        }
+    } else {
+        schema_to_figma_type(inner_schema)
+    };
+
+    let desc = entry.get("description").and_then(|v| v.as_str());
+    let (va, var_id) =
+        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    variables.push(va);
+    summary.variables_created += 1;
+
+    for &mode_name in SCALE_MODES {
+        let Some(mode_id) = mode_ids.get(mode_name) else {
+            continue;
+        };
+        let Some(mode_entry) = sets.get(mode_name) else {
+            continue;
+        };
+        let raw_value = mode_entry.get("value").and_then(|v| v.as_str());
+        let resolved = raw_value.and_then(|v| {
+            if v.starts_with('{') && v.ends_with('}') {
+                let target = &v[1..v.len() - 1];
+                value_index.get(target).map(|s| s.as_str())
+            } else {
+                Some(v)
+            }
+        });
+
+        if let Some(val_str) = resolved {
+            if let Some(figma_val) = value_to_figma(val_str, figma_type) {
+                mode_values.push(ModeValueAction {
+                    variable_id: var_id.clone(),
+                    mode_id: mode_id.clone(),
+                    value: figma_val,
+                });
+                summary.mode_values_set += 1;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_flat_token(
+    token_name: &str,
+    entry: &Value,
+    collection_id: &str,
+    prefix: &str,
+    figma_type: &str,
+    mode_ids: &HashMap<String, String>,
+    value_index: &HashMap<String, String>,
+    existing_var_index: &HashMap<&str, &str>,
+    variables: &mut Vec<VariableAction>,
+    mode_values: &mut Vec<ModeValueAction>,
+    summary: &mut ExportSummary,
+) {
+    let raw_value = match entry.get("value").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return,
+    };
+
+    // Resolve aliases.
+    let resolved = if raw_value.starts_with('{') && raw_value.ends_with('}') {
+        let target = &raw_value[1..raw_value.len() - 1];
+        match value_index.get(target) {
+            Some(v) => v.as_str(),
+            None => {
+                summary
+                    .skipped_alias_unresolved
+                    .push(token_name.to_string());
+                return;
+            }
+        }
+    } else {
+        raw_value
+    };
+
+    let figma_val = match value_to_figma(resolved, figma_type) {
+        Some(v) => v,
+        None => return,
+    };
+
+    let desc = entry.get("description").and_then(|v| v.as_str());
+    let (va, var_id) =
+        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    variables.push(va);
+    summary.variables_created += 1;
+
+    // Set value in the first available mode (default mode).
+    if let Some(mode_id) = mode_ids.values().next() {
+        mode_values.push(ModeValueAction {
+            variable_id: var_id,
+            mode_id: mode_id.clone(),
+            value: figma_val,
+        });
+        summary.mode_values_set += 1;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_alias_token(
+    token_name: &str,
+    entry: &Value,
+    color_collection_id: &str,
+    scale_collection_id: &str,
+    color_mode_ids: &HashMap<String, String>,
+    scale_mode_ids: &HashMap<String, String>,
+    value_index: &HashMap<String, String>,
+    all_tokens: &[(String, Value)],
+    existing_var_index: &HashMap<&str, &str>,
+    variables: &mut Vec<VariableAction>,
+    mode_values: &mut Vec<ModeValueAction>,
+    summary: &mut ExportSummary,
+) {
+    let raw_value = match entry.get("value").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return,
+    };
+
+    // Resolve the alias chain to find the target token and its type.
+    if !(raw_value.starts_with('{') && raw_value.ends_with('}')) {
+        return;
+    }
+
+    let target_name = &raw_value[1..raw_value.len() - 1];
+
+    // Find the target token to determine its schema.
+    let target_schema = all_tokens
+        .iter()
+        .find(|(n, _)| n == target_name)
+        .and_then(|(_, v)| v.get("$schema"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // For aliases that target other aliases, resolve to find the concrete value.
+    let resolved_value = match value_index.get(token_name) {
+        Some(v) => v.as_str(),
+        None => {
+            summary
+                .skipped_alias_unresolved
+                .push(token_name.to_string());
+            return;
+        }
+    };
+
+    // Determine the Figma type from the resolved concrete value.
+    let figma_type = if parse_color(resolved_value).is_ok() {
+        "COLOR"
+    } else if resolved_value
+        .trim()
+        .trim_end_matches("rem")
+        .trim_end_matches("em")
+        .trim_end_matches("px")
+        .trim_end_matches('%')
+        .parse::<f64>()
+        .is_ok()
+    {
+        "FLOAT"
+    } else {
+        "STRING"
+    };
+
+    // Route to the right collection based on the resolved value type.
+    // Colors and opacities go to .Color theme; everything else to .Platform scale.
+    let is_color = figma_type == "COLOR"
+        || (figma_type == "FLOAT"
+            && (target_schema.ends_with(OPACITY)
+                || target_schema.ends_with(COLOR_SET)));
+    let (collection_id, prefix, mode_ids) = if is_color {
+        (color_collection_id, COLOR_THEME_PREFIX, color_mode_ids)
+    } else {
+        (scale_collection_id, PLATFORM_SCALE_PREFIX, scale_mode_ids)
+    };
+
+    let figma_val = match value_to_figma(resolved_value, figma_type) {
+        Some(v) => v,
+        None => return,
+    };
+
+    let desc = entry.get("description").and_then(|v| v.as_str());
+    let (va, var_id) =
+        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    variables.push(va);
+    summary.variables_created += 1;
+
+    if let Some(mode_id) = mode_ids.values().next() {
+        mode_values.push(ModeValueAction {
+            variable_id: var_id,
+            mode_id: mode_id.clone(),
+            value: figma_val,
+        });
+        summary.mode_values_set += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn mock_meta() -> VariablesMeta {
+        VariablesMeta {
+            variables: HashMap::new(),
+            variable_collections: HashMap::from([
+                (
+                    "col-1".into(),
+                    super::super::types::FigmaVariableCollection {
+                        id: "col-1".into(),
+                        name: ".Color theme".into(),
+                        key: "k1".into(),
+                        modes: vec![
+                            super::super::types::FigmaMode {
+                                mode_id: "m-light".into(),
+                                name: "Light".into(),
+                            },
+                            super::super::types::FigmaMode {
+                                mode_id: "m-dark".into(),
+                                name: "Dark".into(),
+                            },
+                            super::super::types::FigmaMode {
+                                mode_id: "m-wire".into(),
+                                name: "Wireframe".into(),
+                            },
+                        ],
+                        default_mode_id: "m-light".into(),
+                        remote: false,
+                        hidden_from_publishing: false,
+                        variable_ids: vec![],
+                    },
+                ),
+                (
+                    "col-2".into(),
+                    super::super::types::FigmaVariableCollection {
+                        id: "col-2".into(),
+                        name: ".Platform scale".into(),
+                        key: "k2".into(),
+                        modes: vec![super::super::types::FigmaMode {
+                            mode_id: "m-desktop".into(),
+                            name: "Desktop".into(),
+                        }],
+                        default_mode_id: "m-desktop".into(),
+                        remote: false,
+                        hidden_from_publishing: false,
+                        variable_ids: vec![],
+                    },
+                ),
+            ]),
+        }
+    }
+
+    #[test]
+    fn color_set_produces_three_mode_values() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("colors.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "test-color": {
+                    "$schema": "https://example.com/color-set.json",
+                    "sets": {
+                        "light": { "$schema": "https://example.com/color.json", "value": "rgb(255, 0, 0)", "uuid": "u1" },
+                        "dark": { "$schema": "https://example.com/color.json", "value": "rgb(0, 255, 0)", "uuid": "u2" },
+                        "wireframe": { "$schema": "https://example.com/color.json", "value": "rgb(0, 0, 255)", "uuid": "u3" }
+                    },
+                    "uuid": "u0"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        assert_eq!(summary.variables_created, 1);
+        assert_eq!(summary.mode_values_set, 3);
+        assert_eq!(body.variables.len(), 1);
+        assert_eq!(body.variables[0].name, "colorTheme/test-color");
+        assert_eq!(body.variables[0].resolved_type, "COLOR");
+        assert_eq!(body.variable_mode_values.len(), 3);
+    }
+
+    #[test]
+    fn dimension_token_goes_to_platform_scale() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "spacing-100": {
+                    "$schema": "https://example.com/dimension.json",
+                    "value": "8px",
+                    "uuid": "d1"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        assert_eq!(summary.variables_created, 1);
+        assert_eq!(body.variables[0].name, "platformScale/spacing-100");
+        assert_eq!(body.variables[0].resolved_type, "FLOAT");
+        // Value should be 8.0
+        let val = &body.variable_mode_values[0].value;
+        assert_eq!(val.as_f64(), Some(8.0));
+    }
+
+    #[test]
+    fn alias_resolves_to_concrete_value() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "base-color": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "rgb(100, 200, 50)",
+                    "uuid": "c1"
+                },
+                "alias-color": {
+                    "$schema": "https://example.com/alias.json",
+                    "value": "{base-color}",
+                    "uuid": "a1"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        // base-color (flat color) + alias-color (alias→color)
+        assert_eq!(summary.variables_created, 2);
+        assert!(summary.skipped_alias_unresolved.is_empty());
+    }
+
+    #[test]
+    fn composite_types_are_skipped() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "heading-typography": {
+                    "$schema": "https://example.com/typography.json",
+                    "value": { "fontFamily": "Arial", "fontSize": "16px" },
+                    "uuid": "t1"
+                },
+                "shadow-1": {
+                    "$schema": "https://example.com/drop-shadow.json",
+                    "value": [{ "x": "0px", "y": "2px", "blur": "4px", "color": "rgba(0,0,0,0.1)" }],
+                    "uuid": "s1"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        assert_eq!(summary.variables_created, 0);
+        assert_eq!(summary.skipped_composite.len(), 2);
+        assert!(body.variables.is_empty());
+    }
+}

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -334,8 +334,6 @@ fn schema_to_figma_type(schema: &str) -> &'static str {
         || schema.ends_with(FONT_WEIGHT)
     {
         "FLOAT"
-    } else if schema.ends_with(FONT_FAMILY) || schema.ends_with(FONT_STYLE) {
-        "STRING"
     } else {
         "STRING"
     }

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -66,6 +66,7 @@ pub struct ExportSummary {
     pub skipped_composite: Vec<String>,
     pub skipped_alias_unresolved: Vec<String>,
     pub skipped_unknown_schema: Vec<String>,
+    pub skipped_unparseable_value: Vec<String>,
 }
 
 /// Build a Figma POST payload from legacy token source files.
@@ -77,13 +78,13 @@ pub fn build_export_payload(
     existing: &VariablesMeta,
 ) -> Result<(PostVariablesBody, ExportSummary), FigmaError> {
     // 1. Look up collection and mode IDs from the existing file.
-    let color_col = find_collection(existing, COLOR_THEME_COLLECTION)
-        .ok_or_else(|| FigmaError::Api {
+    let color_col =
+        find_collection(existing, COLOR_THEME_COLLECTION).ok_or_else(|| FigmaError::Api {
             status: 0,
             message: format!("collection '{COLOR_THEME_COLLECTION}' not found in file"),
         })?;
-    let scale_col = find_collection(existing, PLATFORM_SCALE_COLLECTION)
-        .ok_or_else(|| FigmaError::Api {
+    let scale_col =
+        find_collection(existing, PLATFORM_SCALE_COLLECTION).ok_or_else(|| FigmaError::Api {
             status: 0,
             message: format!("collection '{PLATFORM_SCALE_COLLECTION}' not found in file"),
         })?;
@@ -303,17 +304,14 @@ fn resolve_value(
     }
 
     // Try top-level value first; fall back to first set mode's value.
-    let value_str = entry
-        .get("value")
-        .and_then(|v| v.as_str())
-        .or_else(|| {
-            entry
-                .get("sets")
-                .and_then(|s| s.as_object())
-                .and_then(|sets| sets.values().next())
-                .and_then(|mode_entry| mode_entry.get("value"))
-                .and_then(|v| v.as_str())
-        })?;
+    let value_str = entry.get("value").and_then(|v| v.as_str()).or_else(|| {
+        entry
+            .get("sets")
+            .and_then(|s| s.as_object())
+            .and_then(|sets| sets.values().next())
+            .and_then(|mode_entry| mode_entry.get("value"))
+            .and_then(|v| v.as_str())
+    })?;
 
     // Check if it's an alias reference: {token-name}
     if value_str.starts_with('{') && value_str.ends_with('}') {
@@ -351,12 +349,13 @@ fn value_to_figma(value_str: &str, figma_type: &str) -> Option<Value> {
             Some(serde_json::to_value(c).unwrap())
         }
         "FLOAT" => {
-            // Strip common unit suffixes: px, em, rem, dp, %
+            // Strip common unit suffixes: px, em, rem, %
+            // Note: dp (Android density-independent pixels) is intentionally not
+            // stripped — dp values have no Figma equivalent and are tracked separately.
             let s = value_str
                 .trim()
                 .trim_end_matches("rem")
                 .trim_end_matches("em")
-                .trim_end_matches("dp")
                 .trim_end_matches("px")
                 .trim_end_matches('%');
             let n: f64 = s.parse().ok()?;
@@ -376,14 +375,15 @@ fn make_variable_action(
     existing_var_index: &HashMap<&str, &str>,
 ) -> (VariableAction, String) {
     let figma_name = format!("{prefix}/{token_name}");
-    let (action, id, var_id) = if let Some(&existing_id) = existing_var_index.get(figma_name.as_str()) {
-        let real_id = existing_id.to_string();
-        ("UPDATE".to_string(), Some(real_id.clone()), real_id)
-    } else {
-        // Figma rejects temp IDs containing '/'; use '__' as separator.
-        let temp_id = figma_name.replace('/', "__");
-        ("CREATE".to_string(), Some(temp_id.clone()), temp_id)
-    };
+    let (action, id, var_id) =
+        if let Some(&existing_id) = existing_var_index.get(figma_name.as_str()) {
+            let real_id = existing_id.to_string();
+            ("UPDATE".to_string(), Some(real_id.clone()), real_id)
+        } else {
+            // Figma rejects temp IDs containing '/'; use '__' as separator.
+            let temp_id = figma_name.replace('/', "__");
+            ("CREATE".to_string(), Some(temp_id.clone()), temp_id)
+        };
 
     let va = VariableAction {
         action,
@@ -431,8 +431,14 @@ fn process_color_set_token(
     };
 
     let desc = entry.get("description").and_then(|v| v.as_str());
-    let (va, var_id) =
-        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    let (va, var_id) = make_variable_action(
+        token_name,
+        prefix,
+        collection_id,
+        figma_type,
+        desc,
+        existing_var_index,
+    );
     variables.push(va);
     summary.variables_created += 1;
 
@@ -507,7 +513,6 @@ fn process_scale_set_token(
                 if v.trim()
                     .trim_end_matches("rem")
                     .trim_end_matches("em")
-                    .trim_end_matches("dp")
                     .trim_end_matches("px")
                     .trim_end_matches('%')
                     .parse::<f64>()
@@ -522,8 +527,14 @@ fn process_scale_set_token(
     };
 
     let desc = entry.get("description").and_then(|v| v.as_str());
-    let (va, var_id) =
-        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    let (va, var_id) = make_variable_action(
+        token_name,
+        prefix,
+        collection_id,
+        figma_type,
+        desc,
+        existing_var_index,
+    );
     variables.push(va);
     summary.variables_created += 1;
 
@@ -594,12 +605,23 @@ fn process_flat_token(
 
     let figma_val = match value_to_figma(resolved, figma_type) {
         Some(v) => v,
-        None => return,
+        None => {
+            summary
+                .skipped_unparseable_value
+                .push(token_name.to_string());
+            return;
+        }
     };
 
     let desc = entry.get("description").and_then(|v| v.as_str());
-    let (va, var_id) =
-        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    let (va, var_id) = make_variable_action(
+        token_name,
+        prefix,
+        collection_id,
+        figma_type,
+        desc,
+        existing_var_index,
+    );
     variables.push(va);
     summary.variables_created += 1;
 
@@ -665,7 +687,6 @@ fn process_alias_token(
         .trim()
         .trim_end_matches("rem")
         .trim_end_matches("em")
-        .trim_end_matches("dp")
         .trim_end_matches("px")
         .trim_end_matches('%')
         .parse::<f64>()
@@ -680,12 +701,19 @@ fn process_alias_token(
     // Colors and opacities go to .Color theme; everything else to .Platform scale.
     let is_color = figma_type == "COLOR"
         || (figma_type == "FLOAT"
-            && (target_schema.ends_with(OPACITY)
-                || target_schema.ends_with(COLOR_SET)));
+            && (target_schema.ends_with(OPACITY) || target_schema.ends_with(COLOR_SET)));
     let (collection_id, prefix, default_mode_id) = if is_color {
-        (color_collection_id, COLOR_THEME_PREFIX, color_default_mode_id)
+        (
+            color_collection_id,
+            COLOR_THEME_PREFIX,
+            color_default_mode_id,
+        )
     } else {
-        (scale_collection_id, PLATFORM_SCALE_PREFIX, scale_default_mode_id)
+        (
+            scale_collection_id,
+            PLATFORM_SCALE_PREFIX,
+            scale_default_mode_id,
+        )
     };
 
     let figma_val = match value_to_figma(resolved_value, figma_type) {
@@ -694,8 +722,14 @@ fn process_alias_token(
     };
 
     let desc = entry.get("description").and_then(|v| v.as_str());
-    let (va, var_id) =
-        make_variable_action(token_name, prefix, collection_id, figma_type, desc, existing_var_index);
+    let (va, var_id) = make_variable_action(
+        token_name,
+        prefix,
+        collection_id,
+        figma_type,
+        desc,
+        existing_var_index,
+    );
     variables.push(va);
     summary.variables_created += 1;
 

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -895,6 +895,73 @@ mod tests {
     }
 
     #[test]
+    fn alias_to_set_token_resolves_to_light_mode_not_first_in_file() {
+        // Regression test: resolve_value() used to call sets.values().next(),
+        // which is HashMap-order-dependent. In real data "dark" appears before
+        // "light" in color-palette.json, so an alias like
+        //   accent-color-100 -> {blue-100}
+        // was silently exporting the dark value into the Light Figma mode.
+        //
+        // The fix prefers sets["light"] over sets["desktop"] over first-in-file.
+        // This test encodes that contract: dark is listed first in the JSON, but
+        // the exported mode value must be the light value.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                // Set token with dark listed first (mirrors real color-palette.json)
+                "base-color-set": {
+                    "$schema": "https://example.com/color-set.json",
+                    "sets": {
+                        "dark":      { "$schema": "https://example.com/color.json", "value": "rgb(0, 0, 255)", "uuid": "u-dark" },
+                        "light":     { "$schema": "https://example.com/color.json", "value": "rgb(255, 0, 0)", "uuid": "u-light" },
+                        "wireframe": { "$schema": "https://example.com/color.json", "value": "rgb(0, 255, 0)", "uuid": "u-wire" }
+                    },
+                    "uuid": "u0"
+                },
+                // Top-level alias pointing at the set token
+                "alias-to-set": {
+                    "$schema": "https://example.com/alias.json",
+                    "value": "{base-color-set}",
+                    "uuid": "a1"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+
+        assert!(summary.skipped_alias_unresolved.is_empty(), "alias should resolve");
+
+        // The alias variable must exist
+        let alias_var = body
+            .variables
+            .iter()
+            .find(|v| v.name == "colorTheme/alias-to-set")
+            .expect("alias-to-set should be exported");
+        assert_eq!(alias_var.resolved_type, "COLOR");
+
+        // The mode value must carry the light color (r=1, g=0, b=0), not the
+        // dark color (r=0, g=0, b=1) that would result from first-in-file order.
+        let alias_id = alias_var.id.as_deref().unwrap_or("");
+        let mv = body
+            .variable_mode_values
+            .iter()
+            .find(|v| v.variable_id == alias_id)
+            .expect("alias-to-set should have a mode value");
+
+        let r = mv.value.get("r").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let b = mv.value.get("b").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        assert!(r > 0.9, "expected light value (r≈1), got r={r} — dark value was used instead");
+        assert!(b < 0.1, "expected light value (b≈0), got b={b} — dark value was used instead");
+    }
+
+    #[test]
     fn composite_types_are_skipped() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();

--- a/sdk/core/src/figma/mod.rs
+++ b/sdk/core/src/figma/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Figma Variables REST API integration — read existing variables and export
+//! cascade tokens as Figma Variables.
+
+pub mod api;
+pub mod color;
+pub mod mapping;
+pub mod types;
+
+/// Errors specific to Figma API integration.
+#[derive(Debug, thiserror::Error)]
+pub enum FigmaError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Figma API error (status {status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("unsupported color format: {0}")]
+    UnsupportedColorFormat(String),
+}

--- a/sdk/core/src/figma/types.rs
+++ b/sdk/core/src/figma/types.rs
@@ -1,0 +1,186 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Serde types for the Figma Variables REST API.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// ── GET /v1/files/:file_key/variables/local ──────────────────────────────────
+
+/// Top-level response from `GET /v1/files/:file_key/variables/local`.
+#[derive(Debug, Deserialize)]
+pub struct GetVariablesResponse {
+    pub status: u16,
+    pub error: bool,
+    pub meta: VariablesMeta,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VariablesMeta {
+    pub variables: HashMap<String, FigmaVariable>,
+    pub variable_collections: HashMap<String, FigmaVariableCollection>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FigmaVariable {
+    pub id: String,
+    pub name: String,
+    pub key: String,
+    pub variable_collection_id: String,
+    pub resolved_type: String,
+    pub values_by_mode: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub remote: bool,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub hidden_from_publishing: bool,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    #[serde(default)]
+    pub code_syntax: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FigmaVariableCollection {
+    pub id: String,
+    pub name: String,
+    pub key: String,
+    pub modes: Vec<FigmaMode>,
+    #[serde(default)]
+    pub default_mode_id: String,
+    #[serde(default)]
+    pub remote: bool,
+    #[serde(default)]
+    pub hidden_from_publishing: bool,
+    #[serde(default)]
+    pub variable_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FigmaMode {
+    pub mode_id: String,
+    pub name: String,
+}
+
+// ── POST /v1/files/:file_key/variables ───────────────────────────────────────
+
+/// Request body for `POST /v1/files/:file_key/variables`.
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PostVariablesBody {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub variable_collections: Vec<CollectionAction>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub variable_modes: Vec<ModeAction>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub variables: Vec<VariableAction>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub variable_mode_values: Vec<ModeValueAction>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionAction {
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_mode_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hidden_from_publishing: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModeAction {
+    pub action: String,
+    pub id: String,
+    pub name: String,
+    pub variable_collection_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VariableAction {
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub name: String,
+    pub variable_collection_id: String,
+    pub resolved_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hidden_from_publishing: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_syntax: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModeValueAction {
+    pub variable_id: String,
+    pub mode_id: String,
+    pub value: serde_json::Value,
+}
+
+/// Response from `POST /v1/files/:file_key/variables`.
+#[derive(Debug, Deserialize)]
+pub struct PostVariablesResponse {
+    pub status: u16,
+    pub error: bool,
+    #[serde(default)]
+    pub meta: PostVariablesMeta,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PostVariablesMeta {
+    #[serde(default)]
+    pub temp_id_to_real_id: HashMap<String, String>,
+}
+
+// ── Value types ──────────────────────────────────────────────────────────────
+
+/// Color in Figma's 0-1 float format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FigmaColor {
+    pub r: f64,
+    pub g: f64,
+    pub b: f64,
+    pub a: f64,
+}
+
+/// Variable alias reference.
+#[derive(Debug, Serialize)]
+pub struct FigmaVariableAlias {
+    #[serde(rename = "type")]
+    pub alias_type: String,
+    pub id: String,
+}
+
+impl FigmaVariableAlias {
+    pub fn new(id: String) -> Self {
+        Self {
+            alias_type: "VARIABLE_ALIAS".to_string(),
+            id,
+        }
+    }
+}

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -234,18 +234,18 @@ pub fn verify_against_reference(
 
         let ref_text = std::fs::read_to_string(&ref_path)?;
         let out_text = std::fs::read_to_string(&out_path)?;
-        let ref_obj: Map<String, Value> =
-            serde_json::from_str::<Value>(&ref_text)
-                .map_err(|e| CoreError::ParseError(format!("{stem}.json (reference): {e}")))?
-                .as_object()
-                .cloned()
-                .ok_or_else(|| CoreError::ParseError(format!("{stem}.json (reference): not an object")))?;
-        let out_obj: Map<String, Value> =
-            serde_json::from_str::<Value>(&out_text)
-                .map_err(|e| CoreError::ParseError(format!("{stem}.json (output): {e}")))?
-                .as_object()
-                .cloned()
-                .ok_or_else(|| CoreError::ParseError(format!("{stem}.json (output): not an object")))?;
+        let ref_obj: Map<String, Value> = serde_json::from_str::<Value>(&ref_text)
+            .map_err(|e| CoreError::ParseError(format!("{stem}.json (reference): {e}")))?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| {
+                CoreError::ParseError(format!("{stem}.json (reference): not an object"))
+            })?;
+        let out_obj: Map<String, Value> = serde_json::from_str::<Value>(&out_text)
+            .map_err(|e| CoreError::ParseError(format!("{stem}.json (output): {e}")))?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| CoreError::ParseError(format!("{stem}.json (output): not an object")))?;
 
         // Tokens present in reference but missing from output.
         for key in ref_obj.keys() {
@@ -274,8 +274,7 @@ pub fn verify_against_reference(
             let Some(out_entry) = out_obj.get(key) else {
                 continue; // already reported above
             };
-            let entry_diffs =
-                compare_token_entries(key, ref_entry, out_entry);
+            let entry_diffs = compare_token_entries(key, ref_entry, out_entry);
             for detail in entry_diffs {
                 diffs.push(VerifyDifference {
                     file: stem.clone(),
@@ -301,7 +300,10 @@ fn compare_token_entries(name: &str, reference: &Value, output: &Value) -> Vec<S
 
     let (Some(ref_obj), Some(out_obj)) = (reference.as_object(), output.as_object()) else {
         if reference != output {
-            diffs.push(format!("value mismatch: {reference:?} vs {out_obj:?}", out_obj = output));
+            diffs.push(format!(
+                "value mismatch: {reference:?} vs {out_obj:?}",
+                out_obj = output
+            ));
         }
         return diffs;
     };
@@ -345,14 +347,18 @@ fn compare_token_entries(name: &str, reference: &Value, output: &Value) -> Vec<S
     // Normalise and compare lifecycle fields, tolerating hoisting differences.
     // "Effective" value = outer field if present, else the consistent value
     // across all mode entries (if any).
-    const LIFECYCLE: &[&str] = &["deprecated", "deprecated_comment", "renamed", "private", "description"];
+    const LIFECYCLE: &[&str] = &[
+        "deprecated",
+        "deprecated_comment",
+        "renamed",
+        "private",
+        "description",
+    ];
     for field in LIFECYCLE {
         let ref_eff = effective_lifecycle_value(ref_obj, field);
         let out_eff = effective_lifecycle_value(out_obj, field);
         if ref_eff != out_eff {
-            diffs.push(format!(
-                "{field} mismatch: {ref_eff:?} vs {out_eff:?}"
-            ));
+            diffs.push(format!("{field} mismatch: {ref_eff:?} vs {out_eff:?}"));
         }
     }
 
@@ -962,13 +968,13 @@ mod tests {
     /// (e.g. in a sparse checkout).
     #[test]
     fn full_roundtrip_clean_against_spectrum_token_sources() {
-        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../packages/tokens/src");
+        let src =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/src");
         if !src.exists() {
             return;
         }
-        let diffs = crate::legacy::roundtrip_verify(&src)
-            .expect("roundtrip_verify should not error");
+        let diffs =
+            crate::legacy::roundtrip_verify(&src).expect("roundtrip_verify should not error");
         assert!(
             diffs.is_empty(),
             "legacy roundtrip has {} difference(s):\n{:#?}",

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -14,6 +14,8 @@ pub mod cascade;
 pub mod compat;
 pub mod diff;
 pub mod discovery;
+#[cfg(feature = "figma")]
+pub mod figma;
 pub mod graph;
 pub mod legacy;
 pub mod migrate;


### PR DESCRIPTION
## Description

Proof-of-concept implementation of Figma Variables read and export from Spectrum legacy tokens, as scoped in #795.

Adds two new CLI subcommands:
- `design-data figma read --file-key <KEY>` — reads and displays all Figma Variables from a file
- `design-data figma export <PATH> --file-key <KEY> [--dry-run]` — exports legacy tokens as Figma Variables

New module `sdk/core/src/figma/` (feature-gated behind `figma` feature, opt-in only):
- `types.rs` — Figma Variables REST API serde types (GET + POST)
- `api.rs` — async HTTP client wrapping GET/POST variable endpoints
- `color.rs` — color value parser: `rgb()`, `rgba()`, `#RRGGBB`, `#RGB`, `#RRGGBBAA`
- `mapping.rs` — legacy token → Figma payload mapping engine

## Related Issue

Closes #795

## Motivation and Context

Adobe has Figma Enterprise access with the Variables REST API. This PoC demonstrates that Spectrum legacy tokens can be exported as Figma Variables targeting the existing `.Color theme` (Light/Dark/Wireframe) and `.Platform scale` (Desktop) collections.

Key discovery: these collections already use `colorTheme/{token-name}` and `platformScale/{token-name}` naming — an exact 1:1 match with legacy token names.

**Test file:** `R3WcCKZX62ECRC1wuH6EUp` (duplicated S2/Variables copy — all writes target this file only, never production).

## How Has This Been Tested?

1. `cargo test --workspace` — all 148 tests pass
2. `design-data figma read --file-key R3WcCKZX62ECRC1wuH6EUp` — reads 1,632 existing variables
3. `design-data figma export packages/tokens/src --file-key R3WcCKZX62ECRC1wuH6EUp --dry-run` — generates payload; 1,268 variable names overlap exactly with existing Figma names
4. Live export to test file: 2,029 variables posted, 760 new variables created, 2,459 mode values set

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.