### PR TITLE
docs(site): publish Design Data Specification to docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,8 @@ sdk/target/
 
 # Claude Code local settings (machine-specific)
 .claude/settings.local.json
+.claude/worktrees/
+.mcp.json
 
 # test temporary directories
 temp-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context and commands.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+1. **File issues for remaining work** — create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) — tests, linters, builds
+3. **Update issue status** — close finished work, update in-progress items
+4. **Push to remote** — this is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Verify** — all changes committed and pushed

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -2,5 +2,6 @@
 src/components/*.md
 src/tokens/*.md
 src/registry/*.md
+src/spec/*.md
 
 .cache

--- a/docs/site/eleventy.config.js
+++ b/docs/site/eleventy.config.js
@@ -52,6 +52,9 @@ export default async function (eleventyConfig) {
   eleventyConfig.addCollection("registry", function (api) {
     return api.getFilteredByGlob("src/registry/**/*.md");
   });
+  eleventyConfig.addCollection("spec", function (api) {
+    return api.getFilteredByGlob("src/spec/**/*.md");
+  });
 
   // Apply spectrum-Link to anchors in main article (body content) so links use Spectrum link styling
   eleventyConfig.addTransform("spectrum-body-links", (content, outputPath) => {
@@ -70,7 +73,8 @@ export default async function (eleventyConfig) {
       !outputPath ||
       (!outputPath.includes("/tokens/") &&
         !outputPath.includes("/components/") &&
-        !outputPath.includes("/registry/"))
+        !outputPath.includes("/registry/") &&
+        !outputPath.includes("/spec/"))
     )
       return content;
     return content

--- a/docs/site/moon.yml
+++ b/docs/site/moon.yml
@@ -33,6 +33,11 @@ tasks:
     deps:
       - "markdown-generator:generate"
       - "~:generateToolsPage"
+  copySpec:
+    command:
+      - node
+      - scripts/copy-spec.js
+    platform: system
   build:
     command:
       - pnpm
@@ -41,6 +46,7 @@ tasks:
     platform: node
     deps:
       - "~:copyContent"
+      - "~:copySpec"
   clean:
     command:
       - pnpm

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -18,8 +18,8 @@
     "node": ">=20.x"
   },
   "scripts": {
-    "build": "eleventy",
-    "start": "eleventy --serve",
+    "build": "node scripts/copy-spec.js && eleventy",
+    "start": "node scripts/copy-spec.js && eleventy --serve",
     "clean": "rimraf ../../site .cache",
     "generate:tools": "node scripts/generate-tools-page.js"
   },

--- a/docs/site/scripts/copy-spec.js
+++ b/docs/site/scripts/copy-spec.js
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Copy spec markdown from packages/design-data-spec/spec/ into
+ * docs/site/src/spec/ for 11ty, injecting frontmatter, rewriting
+ * links, and prepending a draft disclaimer banner.
+ *
+ * The source files are the npm package source of truth and must not
+ * be modified — all transformation happens here at copy time.
+ */
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const specSrc = join(__dirname, '../../../packages/design-data-spec/spec');
+const specDest = join(__dirname, '../src/spec');
+
+const DRAFT_BANNER = `<div class="spec-draft-banner" style="margin-block-end: 2rem; padding: 1rem; border-left: 4px solid var(--spectrum-notice-visual-color, #e68619); background: var(--spectrum-notice-background-color, #fff3e0);">
+  <strong>Draft Specification (v1.0.0-draft)</strong> — This specification is under active development. Normative text and schemas may change before the stable 1.0.0 release.
+</div>\n\n`;
+
+mkdirSync(specDest, { recursive: true });
+
+for (const file of readdirSync(specSrc)) {
+  if (!file.endsWith('.md')) continue;
+
+  let content = readFileSync(join(specSrc, file), 'utf8');
+
+  // Derive title from the first # heading
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1] : file.replace('.md', '');
+
+  // Build frontmatter
+  const frontmatter = [
+    '---',
+    `title: "${title}"`,
+    'spec_version: "1.0.0-draft"',
+  ];
+  // index.md needs an explicit permalink so it lives at /spec/ not /spec/index/
+  if (file === 'index.md') {
+    frontmatter.push('permalink: /spec/');
+  }
+  frontmatter.push('---\n');
+
+  // Rewrite sibling links: ](token-format.md) → ](../token-format/)
+  // Special case: ](index.md) → ](../)
+  content = content.replace(
+    /\]\((?!https?:\/\/|#)([a-z0-9-]+)\.md\)/g,
+    (match, slug) => {
+      if (slug === 'index') return '](../)';
+      return `](../${slug}/)`;
+    },
+  );
+
+  // Rewrite schema links: ](../schemas/X) → ](/schemas/X)
+  content = content.replace(
+    /\]\(\.\.\/schemas\/([^)]+)\)/g,
+    '](/schemas/$1)',
+  );
+
+  const output = frontmatter.join('\n') + '\n' + DRAFT_BANNER + content;
+  writeFileSync(join(specDest, file), output);
+}
+
+console.log('Spec files copied to docs/site/src/spec/');

--- a/docs/site/scripts/copy-spec.js
+++ b/docs/site/scripts/copy-spec.js
@@ -64,12 +64,14 @@ for (const file of readdirSync(specSrc)) {
   // Rewrite sibling links: ](token-format.md) → ](../token-format/)
   // Also handles fragment links: ](token-format.md#section) → ](../token-format/#section)
   // Special case: ](index.md) → ](../)
+  // index.md lives at /spec/ so sibling links are relative without ../
+  const isIndex = file === 'index.md';
   content = content.replace(
     /\]\((?!https?:\/\/|#)([a-z0-9-]+)\.md(#[^)]+)?\)/g,
     (match, slug, fragment) => {
       const frag = fragment || '';
-      if (slug === 'index') return `](../${frag})`;
-      return `](../${slug}/${frag})`;
+      if (slug === 'index') return isIndex ? `](./${frag})` : `](../${frag})`;
+      return isIndex ? `](${slug}/${frag})` : `](../${slug}/${frag})`;
     },
   );
 

--- a/docs/site/scripts/copy-spec.js
+++ b/docs/site/scripts/copy-spec.js
@@ -18,7 +18,13 @@ governing permissions and limitations under the License.
  * The source files are the npm package source of truth and must not
  * be modified — all transformation happens here at copy time.
  */
-import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+} from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -30,6 +36,8 @@ const DRAFT_BANNER = `<div class="spec-draft-banner" style="margin-block-end: 2r
   <strong>Draft Specification (v1.0.0-draft)</strong> — This specification is under active development. Normative text and schemas may change before the stable 1.0.0 release.
 </div>\n\n`;
 
+// Remove stale generated files so renamed/deleted chapters don't linger.
+rmSync(specDest, { recursive: true, force: true });
 mkdirSync(specDest, { recursive: true });
 
 for (const file of readdirSync(specSrc)) {
@@ -54,12 +62,14 @@ for (const file of readdirSync(specSrc)) {
   frontmatter.push('---\n');
 
   // Rewrite sibling links: ](token-format.md) → ](../token-format/)
+  // Also handles fragment links: ](token-format.md#section) → ](../token-format/#section)
   // Special case: ](index.md) → ](../)
   content = content.replace(
-    /\]\((?!https?:\/\/|#)([a-z0-9-]+)\.md\)/g,
-    (match, slug) => {
-      if (slug === 'index') return '](../)';
-      return `](../${slug}/)`;
+    /\]\((?!https?:\/\/|#)([a-z0-9-]+)\.md(#[^)]+)?\)/g,
+    (match, slug, fragment) => {
+      const frag = fragment || '';
+      if (slug === 'index') return `](../${frag})`;
+      return `](../${slug}/${frag})`;
     },
   );
 
@@ -72,5 +82,19 @@ for (const file of readdirSync(specSrc)) {
   const output = frontmatter.join('\n') + '\n' + DRAFT_BANNER + content;
   writeFileSync(join(specDest, file), output);
 }
+
+// Restore the 11ty directory data file (deleted by the rmSync above).
+writeFileSync(
+  join(specDest, 'spec.json'),
+  JSON.stringify(
+    {
+      layout: 'base.liquid',
+      tags: ['spec'],
+      permalink: '/spec/{{ page.fileSlug }}/',
+    },
+    null,
+    2,
+  ) + '\n',
+);
 
 console.log('Spec files copied to docs/site/src/spec/');

--- a/docs/site/src/assets/css/base/index.css
+++ b/docs/site/src/assets/css/base/index.css
@@ -203,6 +203,10 @@ footer p:not(.footer-label) {
 }
 
 /* Apply Spectrum heading typography to body headings */
+article :is(table, pre, ul, ol) + :is(h1, h2, h3, h4, h5, h6) {
+  margin-block-start: var(--spacing-large);
+}
+
 article h1,
 article h2,
 article h3,
@@ -237,5 +241,14 @@ article h5 {
 
 article h6 {
   font-size: var(--spectrum-heading-size-xs);
+}
+
+article h1 code,
+article h2 code,
+article h3 code,
+article h4 code,
+article h5 code,
+article h6 code {
+  font-size: inherit;
 }
 

--- a/docs/site/src/data/navigation.js
+++ b/docs/site/src/data/navigation.js
@@ -16,6 +16,7 @@ export default {
     { text: "Tokens", url: "/tokens/" },
     { text: "Registry", url: "/registry/" },
     { text: "AI", url: "/ai/" },
+    { text: "Specification", url: "/spec/" },
     { text: "Tools", url: "/tools/" },
   ],
   bottom: [],

--- a/docs/site/src/includes/layout/header.liquid
+++ b/docs/site/src/includes/layout/header.liquid
@@ -20,6 +20,7 @@ governing permissions and limitations under the License.
     <li><a href="/tokens/">Tokens</a></li>
     <li><a href="/registry/">Registry</a></li>
     <li><a href="/ai/">AI</a></li>
+    <li><a href="/spec/">Specification</a></li>
     <li><a href="/tools/">Tools</a></li>
   </menu>
 </header>

--- a/docs/site/src/spec/spec.json
+++ b/docs/site/src/spec/spec.json
@@ -1,5 +1,0 @@
-{
-  "layout": "base.liquid",
-  "tags": ["spec"],
-  "permalink": "/spec/{{ page.fileSlug }}/"
-}

--- a/docs/site/src/spec/spec.json
+++ b/docs/site/src/spec/spec.json
@@ -1,0 +1,5 @@
+{
+  "layout": "base.liquid",
+  "tags": ["spec"],
+  "permalink": "/spec/{{ page.fileSlug }}/"
+}


### PR DESCRIPTION
## Description

Publishes the 7-chapter Design Data Specification to the docs site at `/spec/`. The spec covers token format, cascade, dimensions, manifests, diff, query, and evolution.

A new `copy-spec.js` preprocessing script transforms the spec source markdown at build time — injecting YAML frontmatter, rewriting inter-chapter links to site-relative URLs, and prepending a draft disclaimer banner. The spec source files in `packages/design-data-spec/spec/` remain untouched (they are the npm package source of truth).

**Resulting URL:** `https://opensource.adobe.com/spectrum-design-data/spec/`

## Related Issue

Supports Phase 4 epic #732 and discussion #714 (Design Data Specification).

## Motivation and Context

The spec is currently only readable by cloning the repo. Publishing it to the docs site gives implementation team leads a shareable URL for review and discussion. The spec is marked `1.0.0-draft` with a prominent banner on every page.

## How Has This Been Tested?

1. `node scripts/copy-spec.js` — generates 8 transformed markdown files in `src/spec/`
2. `pnpm build` (11ty) — builds 116 pages including all 8 spec pages, no errors
3. Verified in built output:
   - Draft disclaimer banner present on all spec pages
   - "Specification" nav link in header
   - Cross-links between chapters resolve correctly (`../token-format/`, `../cascade/`, etc.)
   - Spectrum table CSS classes applied to all tables
   - Schema links rewritten to site-relative paths

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.