### PR TITLE
feat(spec): add taxonomy document and restructure name object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ sdk/target/
 # Claude Code local settings (machine-specific)
 .claude/settings.local.json
 .claude/worktrees/
+**/.claude/
 .mcp.json
 
 # test temporary directories

--- a/docs/rfcs/taxonomy-rfc-draft.md
+++ b/docs/rfcs/taxonomy-rfc-draft.md
@@ -1,0 +1,171 @@
+# Token Taxonomy, Vocabulary, and Formatting — Naming Convention Decomposition
+
+## Summary
+
+This RFC proposes decomposing "naming convention" into three distinct, independently malleable layers — **Token Taxonomy**, **Token Term Vocabulary**, and **Formatting Style** — and restructuring the spec's name object to align with this framework. It also proposes integrating component anatomy into the design data model and separating it from token styling surfaces, which are currently conflated in the registry.
+
+This builds on:
+- [#661 — Spectrum Design System Glossary](https://github.com/adobe/spectrum-design-data/discussions/661) (registry infrastructure)
+- [#646 — Token Schema Structure and Validation System](https://github.com/adobe/spectrum-design-data/discussions/646) (analytical model)
+- [#714 — Design Data Specification (umbrella)](https://github.com/adobe/spectrum-design-data/discussions/714)
+- Nate Baldwin's "Naming conventions & shared taxonomy" onsite presentation (April 1, 2026)
+
+## Motivation
+
+"Naming conventions" is too broad a term for use when discussing malleability across platform teams. A token name like `accent-background-color-hover` embeds multiple independent decisions:
+
+1. **Which concepts** are represented and in what hierarchy → taxonomy
+2. **Which words** describe each concept → vocabulary
+3. **How the words are rendered** (casing, delimiters, abbreviations, order) → formatting
+
+Each layer has a different malleability profile:
+
+| Layer | Shared? | Platform-malleable? |
+|---|---|---|
+| **Token taxonomy** | Yes — shared concept hierarchy | No — changing order/categories changes meaning |
+| **Token term vocabulary** | Yes — canonical terms at foundation level | Partially — platforms can map terms (e.g. `hover` → `highlighted` for iOS) |
+| **Formatting style** | Default exists for legacy compat | Yes — platforms own casing, delimiters, abbreviations |
+
+Additionally, the current spec's name object has a single `property` field that conflates multiple concepts (component anatomy, styling surface, CSS property). This makes structured querying and validation difficult.
+
+## Proposal
+
+### 1. Restructured name object
+
+The current name object fields:
+```
+property (REQUIRED), component, variant, state, colorScheme, scale, contrast
+```
+
+Proposed name object aligned with a semantic/layout token taxonomy:
+
+**Semantic fields** (advisory validation against registry):
+
+| Field | Category | Description |
+|---|---|---|
+| `property` | Property | Narrowed: now just the CSS/styling attribute (color, width, padding, gap) |
+| `component` | Component | Component scope (button, checkbox, etc.) |
+| `structure` | Structure | Reusable visual patterns across components (base, container, list, accessory) |
+| `substructure` | Sub-structure | Child within a structure (e.g. "item" in "list-item") |
+| `anatomy` | Anatomy | Visible named part of a component (icon, label, track, handle) |
+| `object` | Object | Styling surface (background, border, edge, visual) |
+| `variant` | Variant | Variant within a component |
+| `state` | State | Interactive or semantic state |
+| `orientation` | Orientation | Direction/order (vertical, horizontal) |
+| `position` | Position | Location relative to another object (affixed) |
+| `size` | Size | Relative t-shirt sizing (small, medium, large) |
+| `density` | Density | Space within/around component parts (spacious, compact) |
+| `shape` | Shape | Overall component shape (uniform) |
+
+**Dimension fields** (strict validation against declared modes):
+
+| Field | Description |
+|---|---|
+| `colorScheme` | light / dark / wireframe |
+| `scale` | Platform density (desktop, mobile) — distinct from semantic `size` |
+| `contrast` | Contrast level (regular, high) |
+| Additional keys | Platform-declared dimensions |
+
+### 2. Component anatomy vs. token objects
+
+These are currently conflated in `anatomy-terms.json` (24 terms) but serve different purposes:
+
+**Component anatomy** — the visible, named parts of a component as defined by designers. Appears in component specification diagrams. Should be declared per component in component schemas.
+
+An audit of 65 S2 component docs found 133 unique anatomy terms across three tiers:
+- **Primitives** (~25-30): Reusable across many components — icon, label, track, handle, fill, title, description, container
+- **Composites** (~15-20): Another component used as a part — checkbox, close button, popover, avatar
+- **Component-specific** (~40+): Unique to one component — loupe, gripper, tour step counter
+
+**Token objects / styling surfaces** — where a visual property is applied on a UI element. NOT anatomy. Only 4 of 65 components list "background" as anatomy; for most, background is a styling surface, not a visible named part.
+
+Current `anatomy-terms.json` terms like `background`, `border`, `edge`, `visual` belong in a separate `token-objects.json` registry.
+
+### 3. Three registries
+
+| Registry | Purpose | Validates field |
+|---|---|---|
+| Component Anatomy | Visible parts of components (from designer specs) | `anatomy` |
+| Token Objects | Styling surfaces referenced in token names | `object` |
+| Taxonomy Categories | Allowed values within each concept category | `structure`, `orientation`, `position`, `size`, `density`, `shape` |
+
+Plus existing registries for `component`, `variant`, `state` (unchanged).
+
+### 4. Formatting as serialization
+
+The name object is unordered structured data. Concept ordering, casing, and delimiters are serialization concerns owned by the output formatter.
+
+**Default serialization** (legacy format):
+```
+{component}-{structure}-{substructure}-{anatomy}-{object}-{property}-{orientation}-{position}-{size}-{density}-{shape}-{state}
+```
+
+**Platform manifests** can declare formatting rules:
+- `conceptOrder` — ordered list of fields for serialization
+- `casing` — kebab-case, camelCase, PascalCase, SCREAMING_SNAKE_CASE
+- `delimiter` — character(s) separating concepts
+- `abbreviations` — term → short form mappings
+
+### 5. Platform dimension autonomy
+
+Platform manifests should be able to:
+- **Declare new dimensions** (e.g. iOS `framework: [UIKit, SwiftUI]`)
+- **Restrict foundation dimension modes** (e.g. iOS `scale: [mobile]` only, excluding desktop)
+- **Map vocabulary** (e.g. `hover` → `highlighted`)
+- **Configure formatting** per platform
+
+## Examples
+
+**Legacy:** `accent-background-color-hover`
+```json
+{ "name": { "variant": "accent", "object": "background", "property": "color", "state": "hover" } }
+```
+
+**Semantic/layout:** `base-padding-vertical-small`
+```json
+{ "name": { "structure": "base", "property": "padding", "orientation": "vertical", "size": "small" } }
+```
+
+**With anatomy:** `slider-handle-width`
+```json
+{ "name": { "component": "slider", "anatomy": "handle", "property": "width" } }
+```
+
+**Same token, different platform formatting:**
+```
+accent-background-color-hover          (default, kebab-case)
+ACCENT_BACKGROUND_COLOR_HOVER          (SCREAMING_SNAKE_CASE)
+AccentBgColorHover                     (PascalCase + abbreviations)
+accent-bgColor-hov                     (mixed case + abbreviations)
+```
+
+## Relationship to prior RFCs
+
+| RFC | Relationship |
+|---|---|
+| [#661 — Glossary](https://github.com/adobe/spectrum-design-data/discussions/661) | Registry infrastructure this builds on. Phase 5 (RFC #646 reconciliation) is subsumed by this work. |
+| [#646 — Token Schema](https://github.com/adobe/spectrum-design-data/discussions/646) | Analytical model that informed the original name object. This RFC evolves the name object with taxonomy alignment and anatomy integration. |
+| [#714 — Spec umbrella](https://github.com/adobe/spectrum-design-data/discussions/714) | This RFC adds `taxonomy.md` to the spec document set. |
+| [#715 — Distributed Architecture](https://github.com/adobe/spectrum-design-data/discussions/715) | Platform autonomy model for dimensions and formatting aligns with the distributed architecture vision. |
+
+## Open questions
+
+1. **Anatomy audit scope** — The 133 terms from S2 docs have significant data quality issues (compound entries, inconsistent naming). How much cleanup should block the spec work vs. be done incrementally?
+
+2. **`property` field migration** — Making `property` REQUIRED but narrowing its semantics is a breaking change for existing cascade-format tokens. What migration path works for in-progress work?
+
+3. **Taxonomy scoping** — The 8 categories above are for semantic/layout tokens. What other token type taxonomies need to be defined (color, typography, motion)?
+
+4. **`structure` vs `component`** — Nate's presentation draws a clear distinction (structures are reusable visual patterns; components are specific UI elements). In practice, where does the line fall? Is a "card" a structure or a component?
+
+5. **Validation strictness** — Should new taxonomy fields (`orientation`, `position`, `density`, `shape`) start as advisory warnings or strict errors?
+
+6. **Platform dimension restrictions** — When iOS excludes `desktop` mode, should tokens with `scale: "desktop"` become invisible to iOS tooling, or should they resolve to the default?
+
+## Implementation phases
+
+1. **Component anatomy audit & schema integration** — Clean up S2 anatomy data, add anatomy to component schemas, split `anatomy-terms.json`
+2. **Name object restructuring** — Update spec, schema, create `taxonomy.md`
+3. **Formatting & serialization** — Document ordering as serialization, design formatting config
+4. **Platform autonomy** — Structure manifest extensions for dimensions, vocabulary, formatting
+5. **Registry ↔ spec validation bridge** — Per-field validation rules with tiered strictness

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -2,6 +2,6 @@
 src/components/*.md
 src/tokens/*.md
 src/registry/*.md
-src/spec/*.md
+src/spec/
 
 .cache

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -64,7 +64,42 @@
     },
     "extensions": {
       "type": "object",
-      "description": "Platform-local tokens or dimensions; structure validated by separate documents.",
+      "description": "Platform-local tokens, dimensions, and formatting rules.",
+      "properties": {
+        "formatting": {
+          "type": "object",
+          "description": "Rules for serializing structured name objects into platform-specific token name strings.",
+          "properties": {
+            "conceptOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true,
+              "description": "Ordered list of name object field names for serialization."
+            },
+            "casing": {
+              "type": "string",
+              "enum": ["kebab-case", "camelCase", "PascalCase", "SCREAMING_SNAKE_CASE"],
+              "description": "Casing style for serialized token names. Default: kebab-case."
+            },
+            "delimiter": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Character(s) separating concepts in the serialized string. Default: -."
+            },
+            "abbreviations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Map of full term to abbreviated form, applied after ordering and before casing."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
       "additionalProperties": true
     }
   },

--- a/packages/design-data-spec/schemas/manifest.schema.json
+++ b/packages/design-data-spec/schemas/manifest.schema.json
@@ -74,10 +74,24 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "minLength": 1
+                "enum": [
+                  "variant",
+                  "component",
+                  "structure",
+                  "substructure",
+                  "anatomy",
+                  "object",
+                  "property",
+                  "orientation",
+                  "position",
+                  "size",
+                  "density",
+                  "shape",
+                  "state"
+                ]
               },
               "uniqueItems": true,
-              "description": "Ordered list of name object field names for serialization."
+              "description": "Ordered list of semantic field names for serialization."
             },
             "casing": {
               "type": "string",

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -10,12 +10,13 @@ This document is the top-level overview for the **Design Data Specification**: a
 The specification defines:
 
 1. **Token format** — structured token identity (`name`), literal `value` or alias `$ref`, and lifecycle metadata ([Token format](token-format.md)).
-2. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
-3. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
-4. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
-5. **Semantic diff** — change taxonomy, token identity rules, and property-level change tracking for comparing dataset versions ([Diff](diff.md)).
-6. **Query notation** — filter syntax for selecting tokens by structured fields ([Query](query.md)).
-7. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
+2. **Taxonomy** — concept categories, token term vocabulary, formatting style, and the distinction between component anatomy and token objects ([Taxonomy](taxonomy.md)).
+3. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
+4. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
+5. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
+6. **Semantic diff** — change taxonomy, token identity rules, and property-level change tracking for comparing dataset versions ([Diff](diff.md)).
+7. **Query notation** — filter syntax for selecting tokens by structured fields ([Query](query.md)).
+8. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
 
 ## Conformance
 
@@ -52,6 +53,7 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 | Document                        | Role                                                             |
 | ------------------------------- | ---------------------------------------------------------------- |
 | [Token format](token-format.md) | Token `name`, `value` / `$ref`, value types, lifecycle metadata. |
+| [Taxonomy](taxonomy.md)         | Concept categories, vocabulary, formatting, anatomy vs objects.  |
 | [Cascade](cascade.md)           | Layers, specificity, resolution algorithm.                       |
 | [Dimensions](dimensions.md)     | Dimension declarations, built-in dimensions, coverage.           |
 | [Manifest](manifest.md)         | Platform manifest fields and validation expectations.            |

--- a/packages/design-data-spec/spec/manifest.md
+++ b/packages/design-data-spec/spec/manifest.md
@@ -38,6 +38,21 @@ Each override object **MUST** include enough information to identify a target to
 
 **RECOMMENDED:** `extensions` follows the same structural conventions as foundation token files (tokens, dimensions) and **SHOULD** be validated with the same Layer 1 and Layer 2 rules.
 
+#### `extensions.formatting`
+
+A platform **MAY** declare formatting rules that control how structured name objects are serialized into flat token name strings for that platform. See [Taxonomy — Platform formatting configuration](taxonomy.md#platform-formatting-configuration) for motivation and examples.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `conceptOrder` | array of string | Ordered list of name object field names for serialization. Each entry **MUST** be a valid semantic field name (see [Token format — Semantic fields](token-format.md#semantic-fields)). Omitted fields are appended in the default order defined in [Taxonomy — Default serialization](taxonomy.md#default-serialization-legacy-format). |
+| `casing` | string | One of: `kebab-case`, `camelCase`, `PascalCase`, `SCREAMING_SNAKE_CASE`. Default: `kebab-case`. |
+| `delimiter` | string | Character(s) separating concepts in the serialized string (e.g. `-`, `_`, `.`, `/`). Default: `-`. |
+| `abbreviations` | object | Map of full term → abbreviated form (e.g. `{ "background": "bg" }`). Abbreviations are applied after concept ordering and before casing. |
+
+**NORMATIVE:** When `extensions.formatting` is absent, the default serialization defined in [Taxonomy](taxonomy.md#default-serialization-legacy-format) is used.
+
+**NORMATIVE:** A formatter applying `extensions.formatting` **MUST** produce deterministic output — the same name object and formatting configuration **MUST** always yield the same string.
+
 ## Validation
 
 **NORMATIVE:** Manifests **MUST** pass Layer 1 JSON Schema validation.

--- a/packages/design-data-spec/spec/taxonomy.md
+++ b/packages/design-data-spec/spec/taxonomy.md
@@ -1,0 +1,172 @@
+# Taxonomy
+
+**Spec version:** `1.0.0-draft` (see [Overview](index.md))
+
+This document defines the **token taxonomy**: a hierarchical system of concept categories that classify design tokens, the **token term vocabulary** of allowed words within each category, and the **formatting style** rules that control serialization of structured token names into platform-consumable strings.
+
+## Motivation
+
+"Naming convention" is too broad a term when discussing malleability across platform teams. A token name like `accent-background-color-hover` embeds multiple independent decisions:
+
+1. **Which concepts** are represented and in what hierarchy (taxonomy).
+2. **Which words** describe each concept (vocabulary).
+3. **How the words are rendered** — casing, delimiters, abbreviations, concept order (formatting).
+
+Each layer has a different malleability profile: the taxonomy is shared across all platforms; the vocabulary is shared with platform-aware compromises; the formatting is platform-malleable.
+
+## Three layers of naming
+
+### Layer 1: Token taxonomy
+
+A **token taxonomy** is a hierarchical set of concept categories for classifying design ideas and use cases. It creates a clear, consistent, and predictable shared language across disciplines and teams.
+
+The taxonomy is **NORMATIVE** and **shared** — all platforms use the same concept categories in the same hierarchy. Changing the taxonomy changes the meaning of token names across the entire ecosystem.
+
+Taxonomies are **scoped to specific token types** for clarity. The semantic/layout taxonomy defined in this document is one such scope; additional taxonomies (e.g. for color tokens) will be defined in future spec versions.
+
+### Layer 2: Token term vocabulary
+
+The **token term vocabulary** is the set of specific words used to describe each conceptual option within the taxonomy. The vocabulary creates a shared language across disciplines and teams.
+
+The vocabulary is **NORMATIVE at the foundation level** — the foundation defines canonical terms. Platforms **MAY** declare vocabulary mappings (e.g. `hover` → `highlighted` for iOS) in their [manifest](manifest.md) for platform-specific consumption.
+
+### Layer 3: Formatting style
+
+**Formatting style** defines rules for altering the appearance of a token's name for platform-specific consumption and usability needs. This includes concept ordering, casing, delimiters, and abbreviations.
+
+Formatting is **platform-malleable** — each platform manifest **MAY** declare its own formatting rules. The foundation defines a default formatting style for legacy compatibility.
+
+**NORMATIVE:** The name object defined in [Token format](token-format.md) is unordered structured data. Concept ordering is purely a serialization concern and **MUST NOT** affect cascade resolution, specificity, or validation.
+
+## Principles
+
+The taxonomy is designed with three guiding principles:
+
+1. **Object-oriented** — Designers and developers think in terms of how they would construct components, rather than abstract semantic ideas.
+2. **Agnostic (with compromises)** — Platform-agnostic terms are used except when platforms have specific terms for the same concept. In those cases, the most common or clear term is used.
+3. **Verified** — Multiple existing components must be rebuildable using the taxonomy system, and consumers must find them reasonably understandable or learnable.
+
+## Semantic / layout token taxonomy
+
+The following concept categories are defined for semantic and layout tokens, ordered from broad to specific. This ordering is the **default serialization order** for legacy format output; it is not a conformance requirement for stored name objects.
+
+**NORMATIVE:** Each category listed below corresponds to an OPTIONAL field on the token [name object](token-format.md). Tokens **MAY** use any subset of these fields.
+
+| Category | Name object field | Answers | Description |
+| --- | --- | --- | --- |
+| Structure | `structure` | What? | Individual objects or object categories that have shared styling. Distinctly different from "components" in that they represent structures and visual patterns that can or do occur across many varieties of components. |
+| Sub-structure | `substructure` | What? | A structure within an element that should only exist within the context of its parent structure. |
+| Component | `component` | What? | Component scope when the token is component-scoped. |
+| Anatomy | `anatomy` | What? | A visible, named part of a component as defined by designers. |
+| Object | `object` | Where? | The styling surface to which a visual property is applied (e.g. background, border, edge). |
+| Property | `property` | Where? | The stylistic attribute being defined (e.g. color, width, padding, gap). |
+| Orientation | `orientation` | When/Why? | The direction or order of structures and elements within a component or pattern. |
+| Position | `position` | When/Why? | The location of an object relative to another, with or without respect to directional order. |
+| Size | `size` | When/Why? | Relative terms used to create relationships and patterns of usage across multiple tokens and token types. |
+| Density | `density` | When/Why? | Options that create more or less space within or around the parts of a component. |
+| Shape | `shape` | When/Why? | Relative to the overall shape of a component (e.g. "uniform" creates a 1:1 padding ratio between horizontal and vertical padding). |
+
+Additional categories for variant and state are inherited from the existing name object:
+
+| Category | Name object field | Description |
+| --- | --- | --- |
+| Variant | `variant` | Variant within a component (e.g. accent, negative, primary). |
+| State | `state` | Interactive or semantic state (e.g. hover, focus, disabled). |
+
+**NOTE:** The categories above are filtered for semantic and layout token taxonomies. Additional categories do and will exist for other token types (e.g. color, typography). The taxonomy is built to scale as new concepts and terms are identified.
+
+## Component anatomy vs. token objects
+
+Two concepts that are often conflated but serve different purposes:
+
+### Component anatomy
+
+**Component anatomy** refers to the visible, named parts of a component as defined by designers. These are the parts called out in component specification diagrams (e.g. icon, label, track, handle, hold icon).
+
+Component anatomy is declared per component in [component schemas](../../component-schemas/) and validated against the anatomy registry. A token referencing a component's anatomy part (e.g. `slider` + `handle`) can be validated as a legitimate combination.
+
+Anatomy parts fall into three tiers:
+
+| Tier | Description | Examples |
+| --- | --- | --- |
+| Primitive | Reusable across many components | icon, label, track, handle, fill, divider, title, description |
+| Composite | Another component used as a named part | checkbox, close button, popover, avatar |
+| Component-specific | Unique to one component | loupe, gripper, opacity checkerboard |
+
+### Token objects (styling surfaces)
+
+**Token objects** (or styling surfaces) describe *where* a visual property is applied on a UI element. These are NOT anatomy — they are abstract styling targets that exist on any element regardless of its component type.
+
+| Object | Description |
+| --- | --- |
+| `background` | Background surface or fill |
+| `border` | Border or outline |
+| `edge` | Outer boundary of component (used in spacing tokens) |
+| `visual` | Visible graphic element area (may be inset from edge) |
+| `content` | Main content area |
+
+Token objects are stored in a separate registry from anatomy parts. Both may appear in the same token name — e.g. a token for the background color of a slider's handle would reference anatomy `handle` and object `background`.
+
+## Name object field categories
+
+Name object fields fall into two categories with different validation behavior:
+
+### Semantic fields
+
+Semantic fields describe identity, structure, and intent. They are used for querying and organization but do **not** participate in cascade resolution or specificity calculation.
+
+**NORMATIVE:** Semantic field values are validated against the design system registry with **advisory** severity (warning, not error). Values not in the registry are permitted but flagged.
+
+Fields: `structure`, `substructure`, `component`, `anatomy`, `object`, `property`, `variant`, `state`, `orientation`, `position`, `size`, `density`, `shape`.
+
+### Dimension fields
+
+Dimension fields represent axes of variation that drive the [cascade](cascade.md) resolution algorithm and [specificity](cascade.md#semantic-specificity) calculation.
+
+**NORMATIVE:** Dimension field values are validated against declared [dimension](dimensions.md) modes with **strict** severity (error). An invalid mode value would silently fail to match any context during cascade resolution.
+
+Fields: `colorScheme`, `scale`, `contrast`, and any additional dimension keys declared in the dataset's dimension catalog.
+
+See [Dimensions](dimensions.md) for dimension declarations, modes, and defaults.
+
+## Default serialization (legacy format)
+
+The **default serialization** produces a kebab-case string from the name object using the following concept order:
+
+```
+{component}-{structure}-{substructure}-{anatomy}-{object}-{property}-{orientation}-{position}-{size}-{density}-{shape}-{state}
+```
+
+Omitted fields are skipped. Variant, when present, replaces component at the start of the string.
+
+This ordering is preserved for backward compatibility with the current `@adobe/spectrum-tokens` package. It is a serialization convention, not a structural requirement.
+
+**NORMATIVE:** A conforming formatter **MUST** produce deterministic output for a given name object and formatting configuration. Two name objects that differ only in field ordering **MUST** produce identical serialized strings.
+
+## Platform formatting configuration
+
+A platform [manifest](manifest.md) **MAY** declare formatting rules in its `extensions.formatting` section:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `conceptOrder` | array of strings | Ordered list of name object fields for serialization. |
+| `casing` | string | One of: `kebab-case`, `camelCase`, `PascalCase`, `SCREAMING_SNAKE_CASE`. |
+| `delimiter` | string | Character(s) separating concepts (e.g. `-`, `_`, `.`, `/`). |
+| `abbreviations` | object | Map of full term → abbreviated form (e.g. `{ "background": "bg" }`). |
+
+When no platform formatting is declared, the default serialization above is used.
+
+## Scalability
+
+The taxonomy and terms are built to scale as new concepts and terms are identified:
+
+- New concept categories **MAY** be added to the taxonomy in minor spec versions.
+- New terms **MAY** be added to the vocabulary registry without spec version changes.
+- New token type taxonomies (beyond semantic/layout) **MAY** be defined in future spec versions.
+- Platform manifests **MAY** extend the vocabulary with platform-specific terms and formatting.
+
+## References
+
+* [#661 — Spectrum Design System Glossary](https://github.com/adobe/spectrum-design-data/discussions/661)
+* [#646 — Token Schema Structure and Validation System](https://github.com/adobe/spectrum-design-data/discussions/646)
+* Nate Baldwin, "Naming conventions & shared taxonomy" — Design Data & Platforms onsite, April 1, 2026

--- a/packages/design-data-spec/spec/taxonomy.md
+++ b/packages/design-data-spec/spec/taxonomy.md
@@ -134,10 +134,10 @@ See [Dimensions](dimensions.md) for dimension declarations, modes, and defaults.
 The **default serialization** produces a kebab-case string from the name object using the following concept order:
 
 ```
-{component}-{structure}-{substructure}-{anatomy}-{object}-{property}-{orientation}-{position}-{size}-{density}-{shape}-{state}
+{variant}-{component}-{structure}-{substructure}-{anatomy}-{object}-{property}-{orientation}-{position}-{size}-{density}-{shape}-{state}
 ```
 
-Omitted fields are skipped. Variant, when present, replaces component at the start of the string.
+Omitted fields are skipped. All fields are independent — `variant` and `component` **MAY** both appear in the same token name (e.g. a token with `component: "button"` and `variant: "accent"` serializes as `accent-button-...`).
 
 This ordering is preserved for backward compatibility with the current `@adobe/spectrum-tokens` package. It is a serialization convention, not a structural requirement.
 
@@ -145,14 +145,7 @@ This ordering is preserved for backward compatibility with the current `@adobe/s
 
 ## Platform formatting configuration
 
-A platform [manifest](manifest.md) **MAY** declare formatting rules in its `extensions.formatting` section:
-
-| Option | Type | Description |
-| --- | --- | --- |
-| `conceptOrder` | array of strings | Ordered list of name object fields for serialization. |
-| `casing` | string | One of: `kebab-case`, `camelCase`, `PascalCase`, `SCREAMING_SNAKE_CASE`. |
-| `delimiter` | string | Character(s) separating concepts (e.g. `-`, `_`, `.`, `/`). |
-| `abbreviations` | object | Map of full term → abbreviated form (e.g. `{ "background": "bg" }`). |
+A platform [manifest](manifest.md) **MAY** declare formatting rules in its [`extensions.formatting`](manifest.md#extensionsformatting) section to control concept ordering, casing, delimiters, and abbreviations. The normative contract for these fields is defined in [Manifest — `extensions.formatting`](manifest.md#extensionsformatting).
 
 When no platform formatting is declared, the default serialization above is used.
 
@@ -167,6 +160,8 @@ The taxonomy and terms are built to scale as new concepts and terms are identifi
 
 ## References
 
+* [#806 — Token Taxonomy, Vocabulary, and Formatting](https://github.com/adobe/spectrum-design-data/discussions/806)
 * [#661 — Spectrum Design System Glossary](https://github.com/adobe/spectrum-design-data/discussions/661)
 * [#646 — Token Schema Structure and Validation System](https://github.com/adobe/spectrum-design-data/discussions/646)
+* [Manifest — `extensions.formatting`](manifest.md#extensionsformatting) — normative contract for platform formatting rules
 * Nate Baldwin, "Naming conventions & shared taxonomy" — Design Data & Platforms onsite, April 1, 2026

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -25,18 +25,38 @@ The **name object** identifies the token in a structured way. Implementations us
 
 **NORMATIVE fields** (all string unless noted):
 
+Name object fields are divided into **semantic fields** (identity, structure, intent) and **dimension fields** (axes of variation for cascade resolution). See [Taxonomy](taxonomy.md) for the full concept category hierarchy, component anatomy vs. token objects, and serialization rules.
+
+#### Semantic fields
+
+| Field           | Status   | Taxonomy category | Description                                                                                     |
+| --------------- | -------- | ----------------- | ----------------------------------------------------------------------------------------------- |
+| `property`      | REQUIRED | Property          | The stylistic attribute being defined (e.g. `color`, `width`, `padding`, `gap`).                |
+| `component`     | OPTIONAL | Component         | Component name when the token is component-scoped.                                              |
+| `structure`     | OPTIONAL | Structure         | Reusable visual pattern or object category (e.g. `base`, `container`, `list`, `accessory`). Distinct from `component`. |
+| `substructure`  | OPTIONAL | Sub-structure     | A structure that only exists within its parent structure (e.g. `item` in `list-item`).           |
+| `anatomy`       | OPTIONAL | Anatomy           | A visible, named part of a component as defined by designers (e.g. `handle`, `icon`, `label`). See [Taxonomy — Component anatomy](taxonomy.md#component-anatomy). |
+| `object`        | OPTIONAL | Object            | Styling surface to which a visual property is applied (e.g. `background`, `border`, `edge`). See [Taxonomy — Token objects](taxonomy.md#token-objects-styling-surfaces). |
+| `variant`       | OPTIONAL | Variant           | Variant within a component (e.g. `accent`, `negative`, `primary`).                              |
+| `state`         | OPTIONAL | State             | Interactive or semantic state (e.g. `hover`, `focus`, `disabled`).                              |
+| `orientation`   | OPTIONAL | Orientation       | Direction or order of structures and elements (e.g. `vertical`, `horizontal`).                  |
+| `position`      | OPTIONAL | Position          | Location of an object relative to another (e.g. `affixed`).                                     |
+| `size`          | OPTIONAL | Size              | Relative t-shirt sizing for relationships across tokens (e.g. `small`, `medium`, `large`).      |
+| `density`       | OPTIONAL | Density           | Space within or around component parts (e.g. `spacious`, `compact`).                            |
+| `shape`         | OPTIONAL | Shape             | Relative to overall component shape (e.g. `uniform`).                                           |
+
+#### Dimension fields
+
 | Field           | Status   | Description                                                                                     |
 | --------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `property`      | REQUIRED | Stable property key (e.g. semantic role of the token).                                          |
-| `component`     | OPTIONAL | Component name when the token is component-scoped.                                              |
-| `variant`       | OPTIONAL | Variant within a component.                                                                     |
-| `state`         | OPTIONAL | Interactive or semantic state.                                                                  |
 | `colorScheme`   | OPTIONAL | Dimension: light / dark / wireframe / etc.                                                      |
-| `scale`         | OPTIONAL | Dimension: t-shirt size or density scale.                                                       |
-| `contrast`      | OPTIONAL | Dimension: contrast level.                                                                      |
+| `scale`         | OPTIONAL | Dimension: platform density scale (e.g. `desktop`, `mobile`). Distinct from semantic `size`.    |
+| `contrast`      | OPTIONAL | Dimension: contrast level (e.g. `regular`, `high`).                                             |
 | Additional keys | OPTIONAL | Other dimensions declared in the dataset’s dimension catalog (see [Dimensions](dimensions.md)). |
 
-**RECOMMENDED:** Name objects use a consistent key ordering in authored files for diffs; this is not a conformance requirement.
+**NORMATIVE:** Semantic fields are validated against the design system registry with **advisory** severity (warning). Dimension fields are validated against declared dimension modes with **strict** severity (error). See [Taxonomy — Name object field categories](taxonomy.md#name-object-field-categories).
+
+**RECOMMENDED:** Name objects use a consistent key ordering in authored files for diffs; this is not a conformance requirement. Concept ordering for serialized names is defined in [Taxonomy — Default serialization](taxonomy.md#default-serialization-legacy-format).
 
 ### Alias (`$ref`)
 
@@ -64,7 +84,7 @@ The following OPTIONAL fields implement the token lifecycle model described in [
 
 ```json
 {
-  "name": { "property": "button-background-primary" },
+  "name": { "component": "button", "object": "background", "property": "color", "variant": "primary" },
   "value": "#0265dc",
   "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
   "introduced": "1.0.0",
@@ -118,8 +138,8 @@ Example:
 
 ```json
 [
-  { "name": { "property": "background-color-default" }, "value": "#f5f5f5", "uuid": "..." },
-  { "name": { "property": "background-color-default", "colorScheme": "dark" }, "value": "#1e1e1e", "uuid": "..." }
+  { "name": { "object": "background", "property": "color" }, "value": "#f5f5f5", "uuid": "..." },
+  { "name": { "object": "background", "property": "color", "colorScheme": "dark" }, "value": "#1e1e1e", "uuid": "..." }
 ]
 ```
 


### PR DESCRIPTION
## Description

Decomposes "naming convention" into three layers (taxonomy, vocabulary, formatting) per Nate Baldwin's onsite framework. Adds new spec document `taxonomy.md` and restructures the `token-format.md` name object with new semantic fields. Separates semantic fields from dimension fields with different validation strictness. Distinguishes component anatomy (designer-defined visible parts) from token objects (styling surfaces).

### Changes

**New files:**
- `packages/design-data-spec/spec/taxonomy.md` — concept categories, token term vocabulary, formatting style, component anatomy vs token objects, serialization rules
- `docs/rfcs/taxonomy-rfc-draft.md` — local copy of RFC discussion body

**Modified:**
- `packages/design-data-spec/spec/token-format.md` — restructured name object: 13 semantic fields + 3 dimension fields
- `packages/design-data-spec/spec/index.md` — added Taxonomy to scope and normative references
- `packages/design-data-spec/spec/manifest.md` — added normative `extensions.formatting` contract
- `packages/design-data-spec/schemas/manifest.schema.json` — added `extensions.formatting` sub-schema with typed fields and `conceptOrder` enum constraint
- `.gitignore` — ignore nested `.claude/` directories
- `docs/site/.gitignore` — ignore entire generated `src/spec/` directory

## Related Issue

- RFC: #806 — Token Taxonomy, Vocabulary, and Formatting
- Builds on: #661 (Glossary), #646 (Token Schema), #714 (Spec umbrella)

## Motivation and Context

"Naming convention" conflates three independent concerns with different malleability profiles. The current `property` field mashes together component anatomy, styling surfaces, and CSS properties. This change makes the name object structurally expressive enough for validation, querying, and platform-specific formatting.

Based on Nate Baldwin's "Naming conventions & shared taxonomy" onsite presentation (April 1, 2026) and an audit of 65 S2 component docs.

## How Has This Been Tested?

Spec/docs/schema-only change. The spec is in `1.0.0-draft` status.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.