### PR TITLE
ci(docs): overlay design-data-spec/spec from beta when building docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,6 +40,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Overlay design-data-spec/spec from beta
+        run: |
+          git fetch origin beta:beta
+          git checkout beta -- packages/design-data-spec/spec/
+          echo "::notice::Spec docs sourced from beta branch ($(git rev-parse beta))"
       - uses: moonrepo/setup-toolchain@v0
         with:
           auto-install: true


### PR DESCRIPTION
## Description

Adds a step to the `deploy-docs.yml` workflow that overlays `packages/design-data-spec/spec/` from `origin/beta` before the 11ty docs build runs. Only the spec markdown files are affected; everything else (site content, tokens, visualizers) continues to build from `main`.

## Related Issue

N/A — temporary workflow shim; remove the overlay step once `beta` merges to `main`.

## Motivation and Context

Spec proposals 010 (composite tokens, #817) and 012 (string-name escape hatch, #820) are merged on `beta` but `beta` is not yet ready to land on `main`. This lets the published spec at https://opensource.adobe.com/spectrum-design-data/spec/ reflect the latest proposals without a full beta merge.

The overlay is scoped to `packages/design-data-spec/spec/*.md` — the only files consumed by `docs/site/scripts/copy-spec.js`. Schema, conformance, fields, and rules changes on `beta` are not affected.

## How Has This Been Tested?

Overlay verified locally:
```sh
git checkout origin/beta -- packages/design-data-spec/spec/
moon run site:copySpec
grep -c "composite\|string-name" docs/site/src/spec/token-format.md  # → 7
git checkout HEAD -- packages/design-data-spec/spec/
```

Both new sections ("Composite value types" and "String-name escape hatch") appeared in the rendered output.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.