### PR TITLE
fix(plugin): conform marketplace.json to Claude Code schema

### DIFF
--- a/.changeset/fix-marketplace-schema.md
+++ b/.changeset/fix-marketplace-schema.md
@@ -1,0 +1,5 @@
+---
+"@adobe/s2-docs-mcp": patch
+---
+
+Conform `.claude-plugin/marketplace.json` to the Claude Code plugin marketplace schema so `/plugin marketplace add adobe/spectrum-design-data` succeeds. Adds the required top-level `name` and `owner` fields, and replaces the non-schema `path` field on the plugin entry with `source: "./tools/s2-docs-mcp"`. Updates the install instructions in the docs site to the canonical `s2-docs@spectrum-design-data` form.

--- a/.changeset/fix-marketplace-schema.md
+++ b/.changeset/fix-marketplace-schema.md
@@ -2,4 +2,8 @@
 "@adobe/s2-docs-mcp": patch
 ---
 
-Conform `.claude-plugin/marketplace.json` to the Claude Code plugin marketplace schema so `/plugin marketplace add adobe/spectrum-design-data` succeeds. Adds the required top-level `name` and `owner` fields, and replaces the non-schema `path` field on the plugin entry with `source: "./tools/s2-docs-mcp"`. Updates the install instructions in the docs site to the canonical `s2-docs@spectrum-design-data` form.
+Conform `.claude-plugin/marketplace.json` to the Claude Code plugin marketplace schema so
+`/plugin marketplace add adobe/spectrum-design-data` succeeds. Adds required top-level `name`
+and `owner` fields, replaces the non-schema `path` field on the plugin entry with
+`source: "./tools/s2-docs-mcp"`, and updates the docs install snippet to the canonical
+`s2-docs@spectrum-design-data` form.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,9 +1,15 @@
 {
+  "name": "spectrum-design-data",
+  "description": "Adobe Spectrum design tokens, component schemas, and Spectrum 2 docs for Claude Code.",
+  "owner": {
+    "name": "Adobe",
+    "email": "garthdb@adobe.com"
+  },
   "plugins": [
     {
       "name": "s2-docs",
       "description": "Spectrum 2 component documentation on-demand. Fetches S2 design guidelines, component options, and usage patterns without loading a persistent MCP server.",
-      "path": "tools/s2-docs-mcp"
+      "source": "./tools/s2-docs-mcp"
     }
   ]
 }

--- a/docs/site/src/pages/ai.md
+++ b/docs/site/src/pages/ai.md
@@ -20,7 +20,7 @@ Add the Spectrum Design Data marketplace, then install the skill:
 
 ```
 /plugin marketplace add adobe/spectrum-design-data
-/plugin install s2-docs
+/plugin install s2-docs@spectrum-design-data
 ```
 
 After install, start a new session and ask something like _"which Spectrum component should I use for a searchable dropdown?"_ — the skill fetches the relevant docs automatically.


### PR DESCRIPTION
## Description

Fixes `.claude-plugin/marketplace.json` to conform to the Claude Code plugin marketplace schema so that `/plugin marketplace add adobe/spectrum-design-data` works correctly. Also updates the install snippet in the docs site to the canonical form.

**Three bugs in the original file:**
1. Missing required top-level `name` field (string, kebab-case)
2. Missing required top-level `owner` object
3. Plugin entry used `path` (not in the schema) instead of `source: "./tools/s2-docs-mcp"`

## Related Issue

Reported by @svoisen when following the install instructions on the docs site.

## Motivation and Context

Users following the AI setup docs hit a schema validation error immediately when trying to add the marketplace. The original file was written before the Claude Code marketplace schema stabilized.

## How Has This Been Tested?

- `claude plugin validate /path/to/repo` → ✔ Validation passed
- Local end-to-end: `/plugin marketplace add` (local path) succeeded
- Local end-to-end: `/plugin install s2-docs@spectrum-design-data` succeeded
- Plugin was then uninstalled and the local marketplace removed to clean up

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.