### PR TITLE
fix(plugin): drop commander runtime dep from s2-docs bin

### DIFF
--- a/.changeset/fix-s2-docs-bin-no-commander.md
+++ b/.changeset/fix-s2-docs-bin-no-commander.md
@@ -1,0 +1,12 @@
+---
+"@adobe/s2-docs-mcp": patch
+---
+
+Drop the `commander` runtime dependency from `bin/s2-docs.js`. Claude Code
+plugin installs do not run `npm install` for the plugin's own
+`dependencies`, so the previous CLI crashed on first use with
+`Cannot find package 'commander'`. The rewritten bin uses Node's built-in
+`process.argv` for the same five subcommands (`list`, `get`, `search`,
+`use-case`, `stats`) and produces identical JSON output. Bumps
+`.claude-plugin/plugin.json` to `1.0.1` so existing users with the broken
+`1.0.0` cache get the fix automatically on `/plugin marketplace update`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,9 +579,6 @@ importers:
       "@modelcontextprotocol/sdk":
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)
-      commander:
-        specifier: ^13.1.0
-        version: 13.1.0
 
   tools/s2-docs-transformer:
     dependencies:

--- a/tools/s2-docs-mcp/.claude-plugin/plugin.json
+++ b/tools/s2-docs-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "s2-docs",
   "description": "Spectrum 2 component documentation on-demand. Fetches S2 design guidelines, component options, and usage patterns without loading a persistent MCP server.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Adobe"
   },

--- a/tools/s2-docs-mcp/bin/s2-docs.js
+++ b/tools/s2-docs-mcp/bin/s2-docs.js
@@ -11,7 +11,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Command } from "commander";
 import {
   getAllComponents,
   getComponentsByCategory,
@@ -52,30 +51,66 @@ const USE_CASE_MAP = {
   indicator: "status",
 };
 
-const program = new Command();
+const HELP = `Usage: s2-docs <command> [args]
 
-program
-  .name("s2-docs")
-  .description("Query Spectrum 2 component documentation")
-  .version("1.0.0");
+Commands:
+  list [--category <c>]      List components (optionally filter by category)
+  get <name>                  Get docs for a specific component
+  search <query> [--content]  Search by name; --content searches doc bodies
+  use-case <phrase>           Find components matching a use case
+  stats                       Show documentation coverage statistics
 
-program
-  .command("list")
-  .description("List available S2 components")
-  .option(
-    "-c, --category <category>",
-    `Filter by category (${CATEGORIES.join(", ")})`,
-  )
-  .action((opts) => {
-    if (opts.category) {
-      const components = getComponentsByCategory(opts.category);
-      console.log(
-        JSON.stringify(
-          { category: opts.category, count: components.length, components },
-          null,
-          2,
-        ),
-      );
+Categories: ${CATEGORIES.join(", ")}
+`;
+
+function emit(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+function takeFlag(args, ...names) {
+  for (const name of names) {
+    const i = args.indexOf(name);
+    if (i !== -1) {
+      args.splice(i, 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+function takeOption(args, ...names) {
+  for (const name of names) {
+    const i = args.indexOf(name);
+    if (i !== -1) {
+      const value = args[i + 1];
+      if (value === undefined) fail(`Missing value for ${name}`);
+      args.splice(i, 2);
+      return value;
+    }
+  }
+  return undefined;
+}
+
+const argv = process.argv.slice(2);
+
+if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+  process.stdout.write(HELP);
+  process.exit(0);
+}
+
+const [command, ...rest] = argv;
+
+switch (command) {
+  case "list": {
+    const category = takeOption(rest, "--category", "-c");
+    if (category) {
+      const components = getComponentsByCategory(category);
+      emit({ category, count: components.length, components });
     } else {
       const components = getAllComponents();
       const byCategory = components.reduce((acc, comp) => {
@@ -83,119 +118,87 @@ program
         acc[comp.category].push({ name: comp.name, slug: comp.slug });
         return acc;
       }, {});
-      console.log(
-        JSON.stringify(
-          { total: components.length, categories: byCategory },
-          null,
-          2,
-        ),
-      );
+      emit({ total: components.length, categories: byCategory });
     }
-  });
+    break;
+  }
 
-program
-  .command("get <name>")
-  .description("Get documentation for a specific component")
-  .action((name) => {
+  case "get": {
+    const name = rest[0];
+    if (!name) fail("Usage: s2-docs get <name>");
     const component = findComponentByName(name);
-    if (!component) {
-      console.error(`Component not found: ${name}`);
-      process.exit(1);
-    }
+    if (!component) fail(`Component not found: ${name}`);
     const documentation = getComponentDoc(component.category, component.slug);
-    console.log(JSON.stringify({ component, documentation }, null, 2));
-  });
+    emit({ component, documentation });
+    break;
+  }
 
-program
-  .command("search <query>")
-  .description("Search components by name or content")
-  .option("--content", "Search within component content (slower)")
-  .action((query, opts) => {
-    if (opts.content) {
+  case "search": {
+    const useContent = takeFlag(rest, "--content");
+    const query = rest[0];
+    if (!query) fail("Usage: s2-docs search <query> [--content]");
+    if (useContent) {
       const results = searchInContent(query);
-      console.log(
-        JSON.stringify(
-          {
-            query,
-            found: results.length,
-            results: results.map((r) => ({
-              component: r.component.name,
-              category: r.component.category,
-              slug: r.component.slug,
-              matches: r.matches,
-            })),
-          },
-          null,
-          2,
-        ),
-      );
+      emit({
+        query,
+        found: results.length,
+        results: results.map((r) => ({
+          component: r.component.name,
+          category: r.component.category,
+          slug: r.component.slug,
+          matches: r.matches,
+        })),
+      });
     } else {
       const components = searchComponents(query);
-      console.log(
-        JSON.stringify(
-          {
-            query,
-            found: components.length,
-            components: components.map((c) => ({
-              name: c.name,
-              slug: c.slug,
-              category: c.category,
-              url: c.url,
-            })),
-          },
-          null,
-          2,
-        ),
-      );
+      emit({
+        query,
+        found: components.length,
+        components: components.map((c) => ({
+          name: c.name,
+          slug: c.slug,
+          category: c.category,
+          url: c.url,
+        })),
+      });
     }
-  });
+    break;
+  }
 
-program
-  .command("use-case <phrase>")
-  .description("Find components matching a use case")
-  .action((phrase) => {
+  case "use-case": {
+    const phrase = rest[0];
+    if (!phrase) fail('Usage: s2-docs use-case "<phrase>"');
     const lower = phrase.toLowerCase();
     const matched = Object.entries(USE_CASE_MAP).find(([key]) =>
       lower.includes(key),
     )?.[1];
     if (matched) {
       const components = getComponentsByCategory(matched);
-      console.log(
-        JSON.stringify(
-          {
-            useCase: phrase,
-            suggestedCategory: matched,
-            components: components.map((c) => ({ name: c.name, slug: c.slug })),
-          },
-          null,
-          2,
-        ),
-      );
+      emit({
+        useCase: phrase,
+        suggestedCategory: matched,
+        components: components.map((c) => ({ name: c.name, slug: c.slug })),
+      });
     } else {
       const results = searchInContent(phrase);
-      console.log(
-        JSON.stringify(
-          {
-            useCase: phrase,
-            found: results.length,
-            components: results.slice(0, 5).map((r) => ({
-              name: r.component.name,
-              category: r.component.category,
-              relevantContent: r.matches[0]?.line,
-            })),
-          },
-          null,
-          2,
-        ),
-      );
+      emit({
+        useCase: phrase,
+        found: results.length,
+        components: results.slice(0, 5).map((r) => ({
+          name: r.component.name,
+          category: r.component.category,
+          relevantContent: r.matches[0]?.line,
+        })),
+      });
     }
-  });
+    break;
+  }
 
-program
-  .command("stats")
-  .description("Show documentation coverage statistics")
-  .action(() => {
-    console.log(JSON.stringify(getStats(), null, 2));
-  });
+  case "stats": {
+    emit(getStats());
+    break;
+  }
 
-program.parse();
+  default:
+    fail(`Unknown command: ${command}\n\n${HELP}`);
+}

--- a/tools/s2-docs-mcp/package.json
+++ b/tools/s2-docs-mcp/package.json
@@ -39,8 +39,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "commander": "^13.1.0"
+    "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "engines": {
     "node": ">=20.12.0"


### PR DESCRIPTION
## Description

The `s2-docs` plugin's CLI (`bin/s2-docs.js`) crashed on first use with `ERR_MODULE_NOT_FOUND: commander` after install via `/plugin marketplace add adobe/spectrum-design-data` + `/plugin install s2-docs@spectrum-design-data` (PR #834 fix).

**Root cause:** Per Anthropic's [plugins reference](https://code.claude.com/docs/en/plugins-reference#persistent-data-directory), Claude Code does **not** run `npm install` for a plugin's `dependencies` — the cache contains only the files declared in `package.json#files`, no `node_modules/`. The documented escape hatch for plugins that need runtime deps is a `SessionStart` hook that installs them into `${CLAUDE_PLUGIN_DATA}/`. I confirmed this experimentally: I tried switching the marketplace `source` from a relative path to an `npm` source first, but neither variant produces a `node_modules/` in the cache.

**Fix:** Drop the only runtime dep on the plugin's CLI path. `commander` was used for trivial subcommand routing; replacing it with built-in `process.argv` parsing is ~40 lines, preserves all five subcommands (`list`, `get`, `search`, `use-case`, `stats`) and matching JSON output, and eliminates the install-time install step entirely. The MCP server entry point (`src/cli.js`, used by `npx @adobe/s2-docs-mcp`) keeps its `@modelcontextprotocol/sdk` dep — that path goes through `npx` which does install deps, so it was never broken.

## Related Issue

Reported by garthdb after attempting to use the skill installed via PR #834.

## Motivation and Context

Without this fix the plugin is unusable. The skill's `lookup.js` shells out to `bin/s2-docs.js`, which fails immediately on the bare `commander` import.

## How Has This Been Tested?

- `claude plugin validate` → ✔ Validation passed
- `node bin/s2-docs.js stats` / `use-case "form input"` / `list --category inputs` / `get Button` / `search picker` — all return the same JSON shape as before
- `cd /tmp && claude plugin marketplace add /path/to/repo && claude plugin install s2-docs@spectrum-design-data` → cache populated at `1.0.1/`
- `node ~/.claude/plugins/cache/spectrum-design-data/s2-docs/1.0.1/skills/s2-docs/scripts/lookup.js use-case "form input"` → returns the expected component list, no missing-module error
- Cleanup: uninstalled the plugin and removed the local marketplace from user settings

## Rollout note for already-installed users

Anyone who installed the broken `1.0.0` from PR #834 needs to refresh, otherwise their cache still has the commander-importing bin:

```
/plugin marketplace update
/plugin uninstall s2-docs
/plugin install s2-docs@spectrum-design-data
```

The `plugin.json` version bump to `1.0.1` should make `/plugin update` work too once Claude Code's update detector kicks in, but a clean reinstall is the surefire path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.