### PR TITLE
docs(spec): phase 6.0 slots and events audit

### DIFF
--- a/packages/design-data-spec/audits/events.audit.md
+++ b/packages/design-data-spec/audits/events.audit.md
@@ -87,7 +87,7 @@ Coverage: 26 components emit custom events.
 
 **Lifecycle pair**: `sp-opened` / `sp-closed` — overlay lifecycle events on components that have popups (picker, tooltip).
 
-**Cancelable events** (application can `preventDefault`): `sp-accordion-item-toggle`, `alert-banner::close`, `sp-dropzone-should-accept`, `tag::delete`
+**Cancelable events** (application can `preventDefault`): `sp-accordion-item-toggle` (accordion), `close` (alert-banner), `sp-dropzone-should-accept` (drop-zone), `delete` (tag)
 
 ***
 

--- a/packages/design-data-spec/audits/events.audit.md
+++ b/packages/design-data-spec/audits/events.audit.md
@@ -1,0 +1,224 @@
+# Events Audit — Phase 6.0 Component Contract
+
+**Status**: Draft\
+**Date**: 2026-05-12\
+**Scope**: Web (SWC + RSP) + iOS (spectrum-ios Preview). Android not yet accessible.\
+**Purpose**: Decide whether `events` belongs in the RFC-A v1 component-format schema.
+
+***
+
+## Background
+
+This audit inventories the current event surface across Spectrum component implementations. "Events" means:
+
+* **SWC**: Custom DOM events dispatched by components (`dispatchEvent(new CustomEvent(...))`)
+* **RSP**: Callback props — functions passed as props and called on user interaction (`onPress`, `onChange`, etc.)
+* **iOS**: Closure parameters in `init()` called on interaction (`action: () -> Void`) and `@Binding` parameters that serve as two-way event channels
+
+The current `@adobe/spectrum-component-api-schemas` does **not** capture events. The `state` field captures interactive *states* (hover, focus, pressed) but not *event emissions*.
+
+***
+
+## Platform Inventory
+
+### Platform 1: Spectrum Web Components (SWC)
+
+Source: `~/Spectrum/spectrum-web-components/1st-gen/packages/`\
+Coverage: 26 components emit custom events.
+
+| Component     | Event name                      | Cancelable | Description                                  |
+| ------------- | ------------------------------- | ---------- | -------------------------------------------- |
+| accordion     | `sp-accordion-item-toggle`      | ✓          | accordion item toggled                       |
+| action-button | `change`                        |            | selected state changed                       |
+| action-button | `longpress`                     |            | synthesized long press (≥300ms or Space+Alt) |
+| action-group  | `change`                        |            | selection changed                            |
+| alert-banner  | `close`                         | ✓          | banner dismissed                             |
+| breadcrumbs   | `change`                        |            | breadcrumb item selected                     |
+| breadcrumbs   | `breadcrumb-select`             |            | individual item selected (internal)          |
+| checkbox      | `change`                        |            | checked state changed                        |
+| color-area    | `input`                         |            | value changing (continuous)                  |
+| color-area    | `change`                        |            | value committed                              |
+| color-slider  | `input`                         |            | value changing (continuous)                  |
+| color-slider  | `change`                        |            | value committed                              |
+| color-wheel   | `input`                         |            | value changing (continuous)                  |
+| color-wheel   | `change`                        |            | value committed                              |
+| dialog        | `close`                         |            | dialog closed                                |
+| drop-zone     | `sp-dropzone-should-accept`     | ✓          | confirm file acceptance                      |
+| drop-zone     | `sp-dropzone-dragover`          |            | files dragged over                           |
+| drop-zone     | `sp-dropzone-dragleave`         |            | files dragged out                            |
+| drop-zone     | `sp-dropzone-drop`              |            | files dropped                                |
+| menu          | `change`                        |            | value changed                                |
+| menu          | `sp-menu-submenu-opened`        |            | submenu opened                               |
+| menu          | `sp-menu-submenu-closed`        |            | submenu closed                               |
+| menu          | `close`                         |            | menu closed                                  |
+| menu-item     | `sp-menu-item-added-or-updated` |            | item registered with parent                  |
+| number-field  | `input`                         |            | value changing                               |
+| number-field  | `change`                        |            | value committed                              |
+| picker        | `change`                        |            | selection changed                            |
+| picker        | `sp-opened`                     |            | overlay opened                               |
+| picker        | `sp-closed`                     |            | overlay closed                               |
+| radio         | `change`                        |            | selected                                     |
+| radio-group   | `change`                        |            | selection changed                            |
+| search        | `submit`                        |            | form submitted                               |
+| search        | `change`                        |            | value committed                              |
+| search        | `input`                         |            | value changing                               |
+| slider        | `input`                         |            | value changing (continuous)                  |
+| slider        | `change`                        |            | value committed                              |
+| slider        | `sp-slider-handle-ready`        |            | handle registered                            |
+| switch        | `change`                        |            | checked state changed                        |
+| table         | `change`                        |            | selection changed                            |
+| table         | `rangeChanged`                  |            | visible range changed                        |
+| table         | `sorted`                        |            | sort column/order changed                    |
+| tabs          | `change`                        |            | active tab changed                           |
+| tabs          | `sp-tabs-scroll`                |            | tabs scrolled                                |
+| tag           | `delete`                        | ✓          | tag removed                                  |
+| textfield     | `input`                         |            | value changing                               |
+| textfield     | `change`                        |            | value committed                              |
+| toast         | `close`                         |            | toast closed/expired                         |
+| tooltip       | `sp-opened`                     |            | tooltip shown                                |
+| tooltip       | `sp-closed`                     |            | tooltip hidden                               |
+| tray          | `close`                         |            | tray closed                                  |
+
+#### SWC event patterns
+
+**Prefixed events** (`sp-*`): SWC uses `sp-` prefix for component-internal coordination events and overlay lifecycle events. These are typically not for application consumption.
+
+**Standard DOM event names**: `change`, `input`, `close`, `submit` — these align with HTML platform conventions.
+
+**Lifecycle pair**: `sp-opened` / `sp-closed` — overlay lifecycle events on components that have popups (picker, tooltip).
+
+**Cancelable events** (application can `preventDefault`): `sp-accordion-item-toggle`, `alert-banner::close`, `sp-dropzone-should-accept`, `tag::delete`
+
+***
+
+### Platform 2: React Spectrum (RSP)
+
+Source: `~/Spectrum/react-spectrum/packages/@react-spectrum/`\
+Coverage: \~30 components, all using callback prop pattern.
+
+| Prop name                            | Components                                                                                                      | Signature                                | Semantics                                |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| `onChange`                           | checkbox, combobox, datepicker, numberfield, radio, searchfield, slider, switch, tag-group, textfield, textarea | varies by value type                     | value committed (or continuous for some) |
+| `onSelectionChange`                  | actiongroup, listview, menu, picker, table, tabs                                                                | `(key: Key) => void`                     | selection changed                        |
+| `onAction`                           | actionbar, actiongroup, breadcrumbs, listview, menu, table                                                      | `(key: Key) => void`                     | item activated                           |
+| `onPress`                            | button, link                                                                                                    | `(e: PressEvent) => void`                | pointer/keyboard press completed         |
+| `onPressStart`                       | button                                                                                                          | `(e: PressEvent) => void`                | press began                              |
+| `onPressEnd`                         | button                                                                                                          | `(e: PressEvent) => void`                | press ended                              |
+| `onPressChange`                      | button                                                                                                          | `(isPressed: boolean) => void`           | pressed state changed                    |
+| `onOpenChange`                       | combobox, datepicker, menu, picker, tooltip                                                                     | `(isOpen: boolean) => void`              | open/close state changed                 |
+| `onDismiss`                          | dialog                                                                                                          | `() => void`                             | dismiss button clicked                   |
+| `onDismiss`                          | toast                                                                                                           | `() => void`                             | toast closed                             |
+| `onFocus`                            | combobox, datepicker, numberfield, picker, searchfield, textfield, textarea                                     | `() => void`                             | focus gained                             |
+| `onBlur`                             | combobox, datepicker, numberfield, picker, searchfield, textfield, textarea                                     | `() => void`                             | focus lost                               |
+| `onClear`                            | searchfield                                                                                                     | `() => void`                             | clear button pressed                     |
+| `onSubmit`                           | searchfield                                                                                                     | `(value: string) => void`                | search submitted                         |
+| `onDrop`                             | dropzone                                                                                                        | `(e: DropEvent) => void`                 | files dropped                            |
+| `onDropEnter`                        | dropzone                                                                                                        | `(e: DropEvent) => void`                 | drag entered                             |
+| `onDropExit`                         | dropzone                                                                                                        | `(e: DropEvent) => void`                 | drag exited                              |
+| `onSort`                             | table                                                                                                           | `(descriptor: SortDescriptor) => void`   | column sorted                            |
+| `onResizeStart/onResize/onResizeEnd` | table                                                                                                           | `(widths: Map<Key, ColumnSize>) => void` | column resize                            |
+| `onExpandedChange`                   | table                                                                                                           | `(expandedKeys: Set<Key>) => void`       | row expanded                             |
+| `onLoadMore`                         | combobox, listview, picker                                                                                      | `() => void`                             | async pagination trigger                 |
+| `onChangeEnd`                        | slider                                                                                                          | `(value: number) => void`                | drag completed                           |
+| `onRemove`                           | tag-group                                                                                                       | `(key: Key) => void`                     | tag removed                              |
+| `onOpenChange`                       | accordion                                                                                                       | `(openKeys: Set<Key>) => void`           | expanded items changed                   |
+| `onKeyDown` / `onKeyUp`              | button                                                                                                          | DOM keyboard events                      | low-level keyboard                       |
+
+#### RSP event patterns
+
+**`on[Property]Change`**: Most common pattern. Signals the value of a named property changed. Unambiguous: `onSelectionChange`, `onOpenChange`, `onExpandedChange`.
+
+**`onAction`**: Distinct from `onChange` — signals intentional user activation of an item (as opposed to selection state change). Used in collections (menu, list, actiongroup).
+
+**`onPress` family**: Lower-level press lifecycle for pointer/keyboard interaction. Mostly on button/link.
+
+**Focus events**: `onFocus` / `onBlur` on all form fields. Platform-standard.
+
+***
+
+### Platform 3: iOS (spectrum-ios — Preview)
+
+Source: `~/Spectrum/spectrum-ios/Sources/SpectrumComponents/`
+
+| Component      | Event mechanism          | Name        | Signature                        |
+| -------------- | ------------------------ | ----------- | -------------------------------- |
+| SPButton       | closure param            | `action`    | `@MainActor () -> Void`          |
+| SPToggleButton | `@Binding`               | `isOn`      | `Binding<Bool>`                  |
+| SPPicker       | `@Binding`               | `selection` | `Binding<Value>`                 |
+| SPToast        | closure in action struct | `handler`   | `@Sendable @escaping () -> Void` |
+
+**iOS finding**: iOS uses two patterns for "events":
+
+1. **Action closures** (`action: () -> Void`) — equivalent to `onPress`
+2. **`@Binding` parameters** — two-way state channels; closer to controlled `onChange` than discrete events
+
+The iOS `@Binding` pattern has no direct web equivalent. It's a SwiftUI idiom for two-way state binding that merges the "current value" and "onChange" into one parameter. This is a semantic model difference, not just a naming difference.
+
+***
+
+## Cross-Platform Event Taxonomy
+
+Despite different surface APIs, the same **semantic categories** appear across platforms:
+
+| Category                    | SWC                       | RSP                              | iOS        | Notes                       |
+| --------------------------- | ------------------------- | -------------------------------- | ---------- | --------------------------- |
+| Value committed             | `change`                  | `onChange`                       | `@Binding` | Discrete value change       |
+| Value changing (continuous) | `input`                   | `onChange` (slider)              | —          | During drag/typing          |
+| Selection changed           | `change`                  | `onSelectionChange` / `onAction` | `@Binding` | Collection item selected    |
+| Open/close lifecycle        | `sp-opened` / `sp-closed` | `onOpenChange`                   | —          | Overlay visibility          |
+| Press/activate              | (DOM click)               | `onPress`                        | `action:`  | Pointer/keyboard activation |
+| Dismiss/close               | `close`                   | `onDismiss`                      | —          | Modal dismissal             |
+| Form submit                 | `submit`                  | `onSubmit`                       | —          | Form action                 |
+| Focus in/out                | (DOM focus/blur)          | `onFocus` / `onBlur`             | —          | Focus management            |
+| Item deleted/removed        | `delete` (cancelable)     | `onRemove`                       | —          | Removal gesture             |
+| Drag lifecycle              | `sp-dropzone-*`           | `onDrop/Enter/Exit`              | —          | Drop zone interaction       |
+
+**Semantic alignment is good**. The underlying concepts are the same; the naming convention and delivery mechanism differ by platform.
+
+***
+
+## Recommendation
+
+**DEFER events from RFC-A v1.**
+
+Rationale:
+
+1. **The naming model is not cross-platform stable**. SWC uses DOM event strings (`change`, `sp-opened`), RSP uses camelCase callback props (`onChange`, `onOpenChange`), and iOS uses closure params with different names (`action`, `@Binding`). A normative spec would need to define canonical event names and map all three — that mapping work hasn't been done.
+
+2. **RSP conflates two distinct semantics in one prop name**. `onChange` on checkbox means "checked changed"; `onChange` on slider means "continuous drag value"; `onSelectionChange` on picker means "committed selection". A normative event schema needs to distinguish continuous vs. committed, selection vs. activation. This taxonomy work is a prerequisite.
+
+3. **SWC uses `sp-` prefixed internal coordination events** (`sp-menu-item-added-or-updated`, `sp-slider-handle-ready`) that are implementation details, not component contracts. The audit scope should distinguish public vs. internal events, and that line isn't drawn today.
+
+4. **Events don't block Phase 6.4 SPEC rules**. The cross-reference validation planned for Phase 6.4 checks token name-object fields (`component`, `variant`, `state`, `anatomy`) against component declarations. It doesn't need event declarations to function.
+
+5. **iOS `@Binding` is a different model** than discrete events. Forcing a mapping now, before iOS component coverage is broader, would either over-constrain iOS or produce a spec section that doesn't match the iOS implementation.
+
+**Recommended path for events**:
+
+* Define a platform-neutral event taxonomy (value-change, activate, open/close, dismiss, form-submit, focus, remove) in a follow-up spec amendment after Phase 6.1-6.5 lands
+* Map SWC event names, RSP prop names, and iOS mechanisms to that taxonomy in the RFC-A follow-up
+* Don't block Phase 6.1+ on events
+
+**Evidence that would shift this recommendation**:
+
+* If the team defines an explicit canonical event name convention before Phase 6.1 starts → could include in v1
+* If a SPEC rule requires event declarations (not currently planned for 6.4) → must include in v1
+* If iOS reaches parity on >10 components before v1 → reconsider iOS mapping
+
+***
+
+## Open Questions
+
+1. **Internal vs. public events**: SWC emits coordination events like `sp-menu-item-added-or-updated` that consumers shouldn't listen to. Should the spec define a `public: false` flag on event declarations, or should internal events simply not be declared?
+2. **Continuous vs. committed semantics**: Should event declarations distinguish "fires on every value change during interaction" (RSP slider `onChange`) vs. "fires when interaction completes" (RSP slider `onChangeEnd` / SWC `change`)? This matters for tooling that generates bindings.
+3. **Cancelable events**: SWC has cancelable events (tag `delete`, alert-banner `close`, dropzone `should-accept`). Should cancelability be a first-class field in event declarations?
+4. **iOS `@Binding` as event surface**: When iOS component coverage expands, the spec needs a way to declare that a component has a two-way binding param (not just a one-shot callback). This may need a distinct schema field vs. one-way events.
+
+***
+
+## References
+
+* Issue: [#827 Phase 6.0: Slots & events data audit](https://github.com/adobe/spectrum-design-data/issues/827)
+* Epic: [#828 Phase 6: Component Contract](https://github.com/adobe/spectrum-design-data/issues/828)
+* RFC: [Discussion #832 Component Contract in Design Data Spec](https://github.com/adobe/spectrum-design-data/discussions/832)
+* Slots audit: [`audits/slots.audit.md`](./slots.audit.md)

--- a/packages/design-data-spec/audits/events.audit.md
+++ b/packages/design-data-spec/audits/events.audit.md
@@ -156,6 +156,118 @@ The iOS `@Binding` pattern has no direct web equivalent. It's a SwiftUI idiom fo
 
 ***
 
+## Per-Component Cross-Platform Matrix
+
+Each row is one semantic event. `—` means the platform has no equivalent. *(internal)* marks SWC coordination events not intended for application consumption.
+
+| Component           | Semantic                    | SWC                                          | RSP                                   | iOS                                     |
+| ------------------- | --------------------------- | -------------------------------------------- | ------------------------------------- | --------------------------------------- |
+| **accordion**       | items expanded/collapsed    | `sp-accordion-item-toggle` ✓cancelable       | `onOpenChange(openKeys: Set<Key>)`    | —                                       |
+| **action-bar**      | action button pressed       | —                                            | `onAction(key: Key)`                  | —                                       |
+| **action-bar**      | clear selection             | —                                            | `onClearSelection()`                  | —                                       |
+| **action-button**   | selected state changed      | `change`                                     | `onChange`                            | —                                       |
+| **action-button**   | long press                  | `longpress`                                  | —                                     | —                                       |
+| **action-group**    | selection changed           | `change`                                     | `onSelectionChange(key: Key)`         | —                                       |
+| **action-group**    | item activated              | —                                            | `onAction(key: Key)`                  | —                                       |
+| **alert-banner**    | dismissed                   | `close` ✓cancelable                          | —                                     | —                                       |
+| **breadcrumbs**     | item selected               | `change`, `breadcrumb-select`                | `onAction(key: Key)`                  | —                                       |
+| **button**          | press completed             | *(DOM click)*                                | `onPress(e: PressEvent)`              | `action: () -> Void`                    |
+| **button**          | press started               | —                                            | `onPressStart(e: PressEvent)`         | —                                       |
+| **button**          | press ended                 | —                                            | `onPressEnd(e: PressEvent)`           | —                                       |
+| **button**          | pressed state changed       | —                                            | `onPressChange(isPressed: bool)`      | —                                       |
+| **checkbox**        | checked state changed       | `change`                                     | `onChange(isSelected: bool)`          | —                                       |
+| **color-area**      | value changing (continuous) | `input`                                      | —                                     | —                                       |
+| **color-area**      | value committed             | `change`                                     | —                                     | —                                       |
+| **color-slider**    | value changing (continuous) | `input`                                      | —                                     | —                                       |
+| **color-slider**    | value committed             | `change`                                     | —                                     | —                                       |
+| **color-wheel**     | value changing (continuous) | `input`                                      | —                                     | —                                       |
+| **color-wheel**     | value committed             | `change`                                     | —                                     | —                                       |
+| **combobox**        | selection changed           | —                                            | `onSelectionChange(key: Key \| null)` | —                                       |
+| **combobox**        | text input changed          | —                                            | `onChange(value: string)`             | —                                       |
+| **combobox**        | open/close                  | —                                            | `onOpenChange(isOpen: bool)`          | —                                       |
+| **combobox**        | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **combobox**        | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **combobox**        | async load more             | —                                            | `onLoadMore()`                        | —                                       |
+| **date-picker**     | value changed               | —                                            | `onChange(date)`                      | —                                       |
+| **date-picker**     | open/close                  | —                                            | `onOpenChange(isOpen: bool)`          | —                                       |
+| **date-picker**     | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **date-picker**     | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **dialog**          | dismissed/closed            | `close`                                      | `onDismiss()`                         | —                                       |
+| **drop-zone**       | accept decision             | `sp-dropzone-should-accept` ✓cancelable      | —                                     | —                                       |
+| **drop-zone**       | drag entered                | `sp-dropzone-dragover`                       | `onDropEnter(e: DropEvent)`           | —                                       |
+| **drop-zone**       | drag exited                 | `sp-dropzone-dragleave`                      | `onDropExit(e: DropEvent)`            | —                                       |
+| **drop-zone**       | files dropped               | `sp-dropzone-drop`                           | `onDrop(e: DropEvent)`                | —                                       |
+| **link**            | pressed                     | *(DOM click)*                                | `onPress(e: PressEvent)`              | —                                       |
+| **list-view**       | selection changed           | —                                            | `onSelectionChange(key: Key)`         | —                                       |
+| **list-view**       | item activated              | —                                            | `onAction(key: Key)`                  | —                                       |
+| **list-view**       | async load more             | —                                            | `onLoadMore()`                        | —                                       |
+| **menu**            | selection changed           | `change`                                     | `onSelectionChange(key: Key)`         | —                                       |
+| **menu**            | item activated              | —                                            | `onAction(key: Key)`                  | —                                       |
+| **menu**            | closed                      | `close`                                      | —                                     | —                                       |
+| **menu**            | submenu opened              | `sp-menu-submenu-opened`                     | —                                     | —                                       |
+| **menu**            | submenu closed              | `sp-menu-submenu-closed`                     | —                                     | —                                       |
+| **menu-item**       | registered with parent      | `sp-menu-item-added-or-updated` *(internal)* | —                                     | —                                       |
+| **number-field**    | value changing              | `input`                                      | —                                     | —                                       |
+| **number-field**    | value committed             | `change`                                     | `onChange(value: number)`             | —                                       |
+| **number-field**    | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **number-field**    | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **picker**          | selection changed           | `change`                                     | `onSelectionChange(key: Key)`         | `selection: Binding<Value>`             |
+| **picker**          | overlay opened              | `sp-opened`                                  | `onOpenChange(true)`                  | —                                       |
+| **picker**          | overlay closed              | `sp-closed`                                  | `onOpenChange(false)`                 | —                                       |
+| **picker**          | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **picker**          | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **picker**          | async load more             | —                                            | `onLoadMore()`                        | —                                       |
+| **radio**           | selected                    | `change`                                     | `onChange(isSelected: bool)`          | —                                       |
+| **radio-group**     | selection changed           | `change`                                     | —                                     | —                                       |
+| **search-field**    | value changing              | `input`                                      | —                                     | —                                       |
+| **search-field**    | value committed             | `change`                                     | `onChange(value: string)`             | —                                       |
+| **search-field**    | cleared                     | —                                            | `onClear()`                           | —                                       |
+| **search-field**    | submitted                   | `submit`                                     | `onSubmit(value: string)`             | —                                       |
+| **search-field**    | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **search-field**    | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **slider**          | value changing (continuous) | `input`                                      | `onChange(value: number)`             | —                                       |
+| **slider**          | value committed             | `change`                                     | `onChangeEnd(value: number)`          | —                                       |
+| **slider**          | handle registered           | `sp-slider-handle-ready` *(internal)*        | —                                     | —                                       |
+| **switch**          | toggled                     | `change`                                     | `onChange(isSelected: bool)`          | `isOn: Binding<Bool>`                   |
+| **table**           | selection changed           | `change`                                     | `onSelectionChange(keys: Set<Key>)`   | —                                       |
+| **table**           | row activated               | —                                            | `onAction(key: Key)`                  | —                                       |
+| **table**           | column sorted               | `sorted`                                     | `onSort(descriptor: SortDescriptor)`  | —                                       |
+| **table**           | visible range changed       | `rangeChanged`                               | —                                     | —                                       |
+| **table**           | column resize start         | —                                            | `onResizeStart(widths: Map)`          | —                                       |
+| **table**           | column resizing             | —                                            | `onResize(widths: Map)`               | —                                       |
+| **table**           | column resize end           | —                                            | `onResizeEnd(widths: Map)`            | —                                       |
+| **table**           | row expanded                | —                                            | `onExpandedChange(keys: Set<Key>)`    | —                                       |
+| **tabs**            | active tab changed          | `change`                                     | `onSelectionChange(key: Key)`         | —                                       |
+| **tabs**            | scrolled                    | `sp-tabs-scroll`                             | —                                     | —                                       |
+| **tag / tag-group** | tag removed                 | `delete` ✓cancelable                         | `onRemove(key: Key)`                  | —                                       |
+| **tag-group**       | selection changed           | —                                            | `onChange(keys: Set<Key>)`            | —                                       |
+| **text-field**      | value changing              | `input`                                      | —                                     | —                                       |
+| **text-field**      | value committed             | `change`                                     | `onChange(value: string)`             | —                                       |
+| **text-field**      | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **text-field**      | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **text-area**       | value changing              | `input`                                      | —                                     | —                                       |
+| **text-area**       | value committed             | `change`                                     | `onChange(value: string)`             | —                                       |
+| **text-area**       | focus gained                | —                                            | `onFocus()`                           | —                                       |
+| **text-area**       | focus lost                  | —                                            | `onBlur()`                            | —                                       |
+| **toast**           | closed/expired              | `close`                                      | `onDismiss()`                         | `handler: () -> Void` (action CTA only) |
+| **tooltip**         | opened                      | `sp-opened`                                  | `onOpenChange(true)`                  | —                                       |
+| **tooltip**         | closed                      | `sp-closed`                                  | `onOpenChange(false)`                 | —                                       |
+| **tray**            | closed                      | `close`                                      | —                                     | —                                       |
+
+### Notable cross-platform gaps
+
+| Pattern                 | SWC                                                       | RSP                                      | iOS               | Gap                                                      |
+| ----------------------- | --------------------------------------------------------- | ---------------------------------------- | ----------------- | -------------------------------------------------------- |
+| Focus/blur on fields    | *(DOM native)*                                            | `onFocus` / `onBlur` props               | —                 | SWC relies on native DOM; RSP explicit; iOS absent       |
+| Continuous vs committed | `input` + `change`                                        | `onChange` + `onChangeEnd` (slider only) | —                 | RSP collapses both into `onChange` for most fields       |
+| Cancelable events       | `delete`, `close`, `sp-dropzone-should-accept`            | *(none)*                                 | —                 | No RSP/iOS equivalent for cancelable guard events        |
+| Internal coordination   | `sp-menu-item-added-or-updated`, `sp-slider-handle-ready` | *(none)*                                 | —                 | SWC has no public/internal boundary in naming            |
+| Overlay lifecycle       | `sp-opened` / `sp-closed` (component events)              | `onOpenChange(bool)` (prop)              | —                 | Same concept, opposite model (push vs. pull)             |
+| Press lifecycle         | *(DOM events)*                                            | `onPress/Start/End/Change`               | `action:`         | iOS only exposes completed press; RSP has full lifecycle |
+| Two-way binding         | *(not a pattern)*                                         | *(not a pattern)*                        | `@Binding<Value>` | iOS `@Binding` has no web equivalent                     |
+
+***
+
 ## Cross-Platform Event Taxonomy
 
 Despite different surface APIs, the same **semantic categories** appear across platforms:

--- a/packages/design-data-spec/audits/slots.audit.md
+++ b/packages/design-data-spec/audits/slots.audit.md
@@ -60,9 +60,9 @@ Coverage: 37 components audited, all with `@slot` JSDoc annotations and shadow D
 | tooltip             | `icon`                                                           |
 | tray                | — (default only)                                                 |
 
-Components with **default slot only**: accordion, action-bar, checkbox, close-button, divider, drop-zone, illustrated-message, link, menu, popover, progress-bar, progress-circle, tray
+Components with **default slot only**: accordion, action-bar, checkbox, close-button, drop-zone, illustrated-message, link, menu, popover, progress-bar, progress-circle, tray
 
-Components with **no slots**: avatar, divider, link, status-light
+Components with **no slots**: avatar, divider, status-light
 
 #### SWC slot naming patterns
 
@@ -122,15 +122,15 @@ RSP and SWC are **broadly aligned** on named content slots:
 Source: `~/Spectrum/spectrum-ios/Sources/SpectrumComponents/`\
 Coverage: \~7 components. All marked **🚧 Preview** as of Sept 2025. iOS implementation is significantly earlier-stage than web.
 
-| Component      | [**@ViewBuilder**](https://github.com/ViewBuilder) params (slots) |
-| -------------- | ----------------------------------------------------------------- |
-| SPButton       | `label: () -> Label`                                              |
-| SPToggleButton | `label: (Bool) -> Label`                                          |
-| SPMenu         | `content: () -> Content`, `label: () -> Label`                    |
-| SPPicker       | none (internal construction)                                      |
-| SPToast        | none (data model, not view)                                       |
-| SPPopUpButton  | none (uses fixed SPPopUpLabel)                                    |
-| Icon           | none (display-only)                                               |
+| Component      | **`@ViewBuilder`** params (slots)              |
+| -------------- | ---------------------------------------------- |
+| SPButton       | `label: () -> Label`                           |
+| SPToggleButton | `label: (Bool) -> Label`                       |
+| SPMenu         | `content: () -> Content`, `label: () -> Label` |
+| SPPicker       | none (internal construction)                   |
+| SPToast        | none (data model, not view)                    |
+| SPPopUpButton  | none (uses fixed SPPopUpLabel)                 |
+| Icon           | none (display-only)                            |
 
 **iOS finding**: The iOS implementation is too early-stage and too limited in component coverage to drive normative spec decisions. Of the \~80 components in `@adobe/spectrum-component-api-schemas`, only \~5 have iOS implementations at all. The `@ViewBuilder` parameter names don't yet show a stable naming pattern.
 

--- a/packages/design-data-spec/audits/slots.audit.md
+++ b/packages/design-data-spec/audits/slots.audit.md
@@ -1,0 +1,193 @@
+# Slots Audit — Phase 6.0 Component Contract
+
+**Status**: Draft\
+**Date**: 2026-05-12\
+**Scope**: Web (SWC + RSP) + iOS (spectrum-ios Preview). Android not yet accessible.\
+**Purpose**: Decide whether `slots` belongs in the RFC-A v1 component-format schema.
+
+***
+
+## Background
+
+This audit inventories the current slot surface across Spectrum component implementations. "Slots" here means named content-projection points: shadow DOM `<slot>` elements in SWC, named `ReactNode` props in RSP, and `@ViewBuilder` closure parameters in iOS SwiftUI.
+
+The current `@adobe/spectrum-component-api-schemas` does **not** capture slots. Fields like `label` and `icon` exist as **data props** (text strings and workflow-icon refs), not as content-injection declarations. This is the gap RFC-A v1 must decide whether to close.
+
+***
+
+## Platform Inventory
+
+### Platform 1: Spectrum Web Components (SWC)
+
+Source: `~/Spectrum/spectrum-web-components/1st-gen/packages/`\
+Coverage: 37 components audited, all with `@slot` JSDoc annotations and shadow DOM `<slot>` declarations.
+
+#### Summary table (components with named slots)
+
+| Component           | Named slots (beyond default)                                     |
+| ------------------- | ---------------------------------------------------------------- |
+| accordion           | — (default only)                                                 |
+| action-bar          | — (default only)                                                 |
+| action-button       | `icon`                                                           |
+| alert-banner        | `action`                                                         |
+| badge               | `icon`                                                           |
+| breadcrumbs         | `icon` (action menu icon), `root`                                |
+| button              | `icon`                                                           |
+| checkbox            | — (default only)                                                 |
+| close-button        | — (default only)                                                 |
+| coachmark           | `cover-photo`, `heading`, `description`, `actions`, `step-count` |
+| color-area          | `gradient`                                                       |
+| color-slider        | `gradient`                                                       |
+| color-wheel         | `gradient`                                                       |
+| combobox            | `tooltip`                                                        |
+| contextual-help     | `heading`, `link`                                                |
+| dialog              | `hero`, `heading`, `footer`, `button`                            |
+| drop-zone           | — (default only)                                                 |
+| field-group         | `help-text`, `negative-help-text`                                |
+| help-text           | `negative-help-text`                                             |
+| illustrated-message | `heading`, `description`                                         |
+| menu                | — (default only)                                                 |
+| menu-item           | `description`, `icon`, `value`, `submenu`                        |
+| number-field        | `help-text`, `negative-help-text`                                |
+| picker              | `label`, `description`, `tooltip`                                |
+| popover             | — (default only)                                                 |
+| radio-group         | `help-text`, `negative-help-text`                                |
+| search              | `help-text`, `negative-help-text`                                |
+| slider              | `handle`                                                         |
+| tag                 | `avatar`, `icon`                                                 |
+| textfield           | `help-text`, `negative-help-text`                                |
+| toast               | `action`                                                         |
+| tooltip             | `icon`                                                           |
+| tray                | — (default only)                                                 |
+
+Components with **default slot only**: accordion, action-bar, checkbox, close-button, divider, drop-zone, illustrated-message, link, menu, popover, progress-bar, progress-circle, tray
+
+Components with **no slots**: avatar, divider, link, status-light
+
+#### SWC slot naming patterns
+
+* **`default`** — primary content injection (universal)
+* **`icon`** — leading decorative icon (action-button, badge, button, menu-item, tag, tooltip)
+* **`action`** — secondary interactive button (alert-banner, toast)
+* **`help-text` / `negative-help-text`** — assistive text pair (field components)
+* **`heading` / `description`** — structured header + body pair (contextual-help, dialog, coachmark, illustrated-message)
+* **`label`** — placeholder/label text (picker)
+* **`gradient`** — custom visualization (color pickers)
+* **`hero`** — large media header (dialog)
+* **`footer`** — supplemental content area (dialog)
+* **`button`** — action buttons area (dialog)
+* **`tooltip`** — floating overlay (combobox, picker)
+* **`submenu`** — nested menu (menu-item)
+* **`avatar`** — identity image (tag)
+* **`handle`** — custom drag handle(s) (slider)
+* **`root`** — pinned first item (breadcrumbs)
+
+***
+
+### Platform 2: React Spectrum (RSP)
+
+Source: `~/Spectrum/react-spectrum/packages/@react-spectrum/`\
+Coverage: \~30 components audited. RSP has no shadow DOM — slots map to named `ReactNode` props.
+
+#### Key named ReactNode props (slot-equivalents)
+
+| Prop name      | Components that use it                                                                                   | SWC slot equivalent                         |
+| -------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `children`     | All components                                                                                           | `default` slot                              |
+| `icon`         | button, combobox, datepicker, numberfield, searchfield, textfield, textarea                              | `icon` slot                                 |
+| `label`        | combobox, datepicker, meter, numberfield, picker, progress-bar, searchfield, slider, textfield, textarea | `label` slot (picker) / data prop elsewhere |
+| `description`  | combobox, datepicker, numberfield, picker, searchfield, textfield, textarea                              | varies                                      |
+| `errorMessage` | combobox, datepicker, numberfield, picker, searchfield, textfield, textarea                              | `negative-help-text` slot                   |
+| `badge`        | —                                                                                                        | not in SWC                                  |
+
+#### Alignment assessment
+
+RSP and SWC are **broadly aligned** on named content slots:
+
+* `icon` is consistent across both platforms
+* `help-text`/`negative-help-text` in SWC ↔ `description`/`errorMessage` in RSP (semantic match, naming differs)
+* `default` children ↔ `children` prop (equivalent)
+* Both platforms have an `action` / secondary button pattern (SWC: `action` slot on toast/alert-banner; RSP: `onAction` callback + action button in toast)
+
+**Naming divergence**:
+
+* SWC uses kebab-case slot names (`help-text`, `negative-help-text`, `cover-photo`)
+* RSP uses camelCase prop names (`errorMessage`, `coverPhoto` if it existed)
+* The semantic intent is the same; normalization rule needed in spec
+
+***
+
+### Platform 3: iOS (spectrum-ios — Preview)
+
+Source: `~/Spectrum/spectrum-ios/Sources/SpectrumComponents/`\
+Coverage: \~7 components. All marked **🚧 Preview** as of Sept 2025. iOS implementation is significantly earlier-stage than web.
+
+| Component      | [**@ViewBuilder**](https://github.com/ViewBuilder) params (slots) |
+| -------------- | ----------------------------------------------------------------- |
+| SPButton       | `label: () -> Label`                                              |
+| SPToggleButton | `label: (Bool) -> Label`                                          |
+| SPMenu         | `content: () -> Content`, `label: () -> Label`                    |
+| SPPicker       | none (internal construction)                                      |
+| SPToast        | none (data model, not view)                                       |
+| SPPopUpButton  | none (uses fixed SPPopUpLabel)                                    |
+| Icon           | none (display-only)                                               |
+
+**iOS finding**: The iOS implementation is too early-stage and too limited in component coverage to drive normative spec decisions. Of the \~80 components in `@adobe/spectrum-component-api-schemas`, only \~5 have iOS implementations at all. The `@ViewBuilder` parameter names don't yet show a stable naming pattern.
+
+***
+
+## Cross-Platform Slot Taxonomy
+
+Based on the SWC and RSP inventory, these slot categories appear stable enough to codify:
+
+| Slot category       | SWC name             | RSP equivalent         | Semantics                        |
+| ------------------- | -------------------- | ---------------------- | -------------------------------- |
+| Default content     | `default`            | `children`             | Primary content projection       |
+| Leading icon        | `icon`               | `icon` prop            | Decorative icon at content start |
+| Field label         | `label` (picker)     | `label` prop           | Human-readable identifier        |
+| Helper text         | `help-text`          | `description` prop     | Non-error guidance               |
+| Error text          | `negative-help-text` | `errorMessage` prop    | Validation failure message       |
+| Call-to-action      | `action`             | (action button in JSX) | Secondary interactive slot       |
+| Section heading     | `heading`            | (heading in JSX)       | Structural heading               |
+| Section description | `description`        | (description in JSX)   | Structural body text             |
+| Media hero          | `hero`               | (image in JSX)         | Large header media               |
+| Supplemental footer | `footer`             | (footer in JSX)        | Below-content area               |
+| Nested overlay      | `tooltip`            | (Tooltip wrapper)      | Floating annotation              |
+
+***
+
+## Recommendation
+
+**INCLUDE basic slots in RFC-A v1.**
+
+Rationale:
+
+1. **The slot surface is stable on web**. SWC and RSP show consistent slot semantics across 30+ components. The naming differs (kebab vs camelCase) but the concepts are the same.
+2. **Slots are needed for cross-reference SPEC rules**. Phase 6.4 plans SPEC rules that validate token name-object fields (e.g. `anatomy`) against component declarations. Those rules need slots to be declared somewhere.
+3. **Token binding declarations ([#845](https://github.com/adobe/spectrum-design-data/issues/845))** planned for Phase 6.7 will specify which tokens bind to which component anatomy parts — slots are a prerequisite.
+4. **The schema risk is low**. A simple `slots` array with `{ name, description, required }` shape covers all observed patterns. It can be OPTIONAL in v1 with no validation implications.
+
+**Scope for v1**: Web-derived slot vocabulary only (`default`, `icon`, `label`, `help-text`, `negative-help-text`, `action`, `heading`, `description`, `hero`, `footer`, `tooltip`). iOS deferred until iOS component coverage reaches parity.
+
+**Evidence that would shift this recommendation**:
+
+* If Phase 6.4 SPEC rules can be written without slot declarations → could defer
+* If iOS team reports naming patterns are finalized and differ materially from SWC → must wait for reconciliation
+
+***
+
+## Open Questions
+
+1. **Slot identity across platforms**: Should the spec define a canonical slot name (e.g. `icon`) and map platform-specific names to it, or require platforms to use the canonical name directly?
+2. **Required vs optional slots**: Should `required: true` be allowed on slot declarations (e.g. `default` on button is effectively required)? Could feed into validator warnings.
+3. **Typed slots**: SWC occasionally constrains what can go in a slot (e.g. `handle` slot accepts only `sp-slider-handle`). Should slot declarations include a `accepts` field?
+4. **iOS slot names**: Once spectrum-ios exits Preview and more components are implemented, their `@ViewBuilder` param names should be added to the cross-platform table and reconciled.
+
+***
+
+## References
+
+* Issue: [#827 Phase 6.0: Slots & events data audit](https://github.com/adobe/spectrum-design-data/issues/827)
+* Epic: [#828 Phase 6: Component Contract](https://github.com/adobe/spectrum-design-data/issues/828)
+* RFC: [Discussion #832 Component Contract in Design Data Spec](https://github.com/adobe/spectrum-design-data/discussions/832)
+* Token binding declarations: [#845 Phase 6.7](https://github.com/adobe/spectrum-design-data/issues/845)


### PR DESCRIPTION
## Description

Adds cross-platform audit documents to `packages/design-data-spec/audits/` as deliverables for Phase 6.0 of the Component Contract epic (#827).

- **`slots.audit.md`** — Inventories slot surfaces across SWC (37 components, `@slot` JSDoc + shadow DOM), RSP (~30 components, named ReactNode props), and spectrum-ios Preview (7 components, `@ViewBuilder` params). Includes a cross-platform slot taxonomy and recommendation.
- **`events.audit.md`** — Inventories event surfaces across SWC (26 components, custom DOM events), RSP (~30 components, callback props), and spectrum-ios (closures + `@Binding`). Includes a full per-component cross-platform matrix, a semantic taxonomy, a cross-platform gaps table, and a recommendation.

## Related Issue

Closes #827 (Phase 6.0: Slots & events data audit)
Part of #828 ([Epic] Phase 6: Component Contract)
Scoped under [Discussion #832](https://github.com/adobe/spectrum-design-data/discussions/832) (RFC-A Component Contract)

## Motivation and Context

Phase 6 (Component Contract) needs data on whether slots and events are stable enough to include in RFC-A v1 before authoring the normative spec chapters (6.1–6.5).

**Slots recommendation: include in RFC-A v1.** SWC and RSP show a stable named-slot vocabulary across 30+ components (`default`, `icon`, `label`, `help-text`, `negative-help-text`, `action`, `heading`, etc.). Slots are a prerequisite for Phase 6.4 cross-reference SPEC rules and Phase 6.7 token binding declarations. iOS deferred until component coverage reaches parity.

**Events recommendation: defer from RFC-A v1.** DOM event strings (SWC), React callback prop names (RSP), and iOS closure/`@Binding` params are not cross-platform consistent in naming, semantics (continuous vs. committed), or scope (public vs. internal coordination). A canonical event taxonomy is a prerequisite. The per-component matrix and gaps table in `events.audit.md` are intended as the reference document for that future work.

## How Has This Been Tested?

Documentation files — no code changes. Content derived from direct inventory of three component repos (all on latest `main`):
- `~/Spectrum/spectrum-web-components` — SWC `@slot` and `@event` JSDoc
- `~/Spectrum/react-spectrum` — RSP TypeScript prop interfaces
- `~/Spectrum/spectrum-ios` — spectrum-ios SwiftUI `init()` signatures

remark linter passes (enforced by pre-commit hook).

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.