### PR TITLE
docs(spec): phase 6.1 component format spec chapter and schema

### DIFF
--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -154,3 +154,39 @@ rules:
     message: 'Token "{name}" uses a string name instead of a name object — treat as tech debt and plan remediation'
     spec_ref: spec/token-format.md#string-name-escape-hatch
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-018
+    name: component-name-exists
+    severity: error
+    category: reference-integrity
+    assert: Token name-object 'component' field value MUST match the 'name' of a declared component in the dataset.
+    message: "Token '{token}' references undeclared component '{component}'"
+    spec_ref: spec/component-format.md#name
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-019
+    name: component-variant-valid
+    severity: error
+    category: reference-integrity
+    assert: Token name-object 'variant' field value MUST match a value in the declared 'variant' option enum for the referenced component, when that enum exists.
+    message: "Token '{token}' has variant '{variant}' which is not declared on component '{component}'"
+    spec_ref: spec/component-format.md#options
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-020
+    name: component-anatomy-valid
+    severity: error
+    category: reference-integrity
+    assert: Token name-object 'anatomy' field value MUST match the 'name' of a declared anatomy part on the referenced component.
+    message: "Token '{token}' references undeclared anatomy part '{anatomy}' on component '{component}'"
+    spec_ref: spec/component-format.md#anatomy-stub
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-021
+    name: component-slot-vocabulary
+    severity: warning
+    category: tech-debt
+    assert: Component slot declarations with a 'name' outside the canonical slot vocabulary SHOULD include a 'description' field documenting the custom slot's purpose.
+    message: "Component '{component}' has custom slot '{slot}' with no description — add a description or use a canonical slot name"
+    spec_ref: spec/component-format.md#canonical-slot-vocabulary
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -185,8 +185,17 @@ rules:
   - id: SPEC-021
     name: component-slot-vocabulary
     severity: warning
-    category: tech-debt
+    category: component-contract
     assert: Component slot declarations with a 'name' outside the canonical slot vocabulary SHOULD include a 'description' field documenting the custom slot's purpose.
     message: "Component '{component}' has custom slot '{slot}' with no description — add a description or use a canonical slot name"
     spec_ref: spec/component-format.md#canonical-slot-vocabulary
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-022
+    name: component-state-valid
+    severity: error
+    category: reference-integrity
+    assert: Token name-object 'state' field value MUST match the 'name' of a declared state on the referenced component, when state declarations are present.
+    message: "Token '{token}' references undeclared state '{state}' on component '{component}'"
+    spec_ref: spec/component-format.md#spec-rules
     introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "title": "Design data component declaration",
+  "description": "Layer 1 structural schema for a component declaration. Semantic cross-reference rules (component-name-exists, component-variant-valid, etc.) are Layer 2.",
+  "type": "object",
+  "required": ["$id", "name", "displayName", "meta"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "specVersion": {
+      "const": "1.0.0-draft"
+    },
+    "$id": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical identifier for this component declaration."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 1,
+      "description": "Machine identifier (kebab-case). Must match the value used in token name-object 'component' fields."
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable component name (e.g. 'Button')."
+    },
+    "description": {
+      "type": "string",
+      "description": "Plain-text description of the component's purpose."
+    },
+    "meta": {
+      "$ref": "#/$defs/meta"
+    },
+    "options": {
+      "$ref": "#/$defs/optionsMap"
+    },
+    "slots": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/slotDeclaration"
+      },
+      "description": "Named content injection points. See spec/component-format.md#slots."
+    },
+    "anatomy": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/anatomyPart"
+      },
+      "description": "Named visible parts of the component. Full spec in spec/anatomy-format.md (Phase 6.2)."
+    },
+    "states": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/stateDeclaration"
+      },
+      "description": "Per-component state declarations. Full spec in spec/state-model.md (Phase 6.3)."
+    },
+    "lifecycle": {
+      "$ref": "#/$defs/lifecycle"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "meta": {
+      "type": "object",
+      "required": ["category", "documentationUrl"],
+      "properties": {
+        "category": {
+          "type": "string",
+          "enum": [
+            "actions",
+            "containers",
+            "data visualization",
+            "feedback",
+            "inputs",
+            "navigation",
+            "status",
+            "typography"
+          ],
+          "description": "Design system category for this component."
+        },
+        "documentationUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the component's documentation page."
+        }
+      },
+      "additionalProperties": false
+    },
+    "optionsMap": {
+      "type": "object",
+      "description": "Component API options. Each key is a camelCase option name; each value is an option descriptor.",
+      "additionalProperties": {
+        "$ref": "#/$defs/optionDescriptor"
+      }
+    },
+    "optionDescriptor": {
+      "type": "object",
+      "description": "JSON Schema-compatible descriptor for a single component option.",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "string",
+                "boolean",
+                "number",
+                "integer",
+                "object",
+                "array",
+                "null"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "string",
+                  "boolean",
+                  "number",
+                  "integer",
+                  "object",
+                  "array",
+                  "null"
+                ]
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Exhaustive list of permitted values."
+        },
+        "default": {
+          "description": "Default value when the option is not specified."
+        },
+        "description": {
+          "type": "string",
+          "description": "Plain-text description of what the option controls."
+        },
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "Reference to a shared type schema."
+        }
+      },
+      "additionalProperties": false
+    },
+    "slotDeclaration": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Slot identifier. Should come from the canonical slot vocabulary."
+        },
+        "description": {
+          "type": "string",
+          "description": "What content belongs in this slot."
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether consumers must populate this slot."
+        }
+      },
+      "additionalProperties": false
+    },
+    "anatomyPart": {
+      "type": "object",
+      "required": ["name"],
+      "description": "Named visible part of a component. Full spec in spec/anatomy-format.md (Phase 6.2).",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Anatomy part identifier (e.g. 'icon', 'label', 'handle')."
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "contains": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Informative: anatomy part names nested within this part."
+        }
+      },
+      "additionalProperties": false
+    },
+    "stateDeclaration": {
+      "type": "object",
+      "required": ["name"],
+      "description": "Per-component state declaration. Full spec in spec/state-model.md (Phase 6.3).",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "State identifier (e.g. 'hover', 'focus', 'disabled')."
+        },
+        "trigger": {
+          "type": "string",
+          "enum": ["prop", "interaction"],
+          "description": "'prop' for persistent prop-driven states (isDisabled); 'interaction' for runtime states (hover, focus, pressed)."
+        },
+        "precedence": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Resolution precedence; higher integer wins when multiple states are active simultaneously."
+        },
+        "layered": {
+          "type": "boolean",
+          "default": false,
+          "description": "true for states that compose with others (e.g. focus ring layered over hover)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "lifecycle": {
+      "type": "object",
+      "description": "Version lifecycle metadata, mirroring the token lifecycle pattern.",
+      "properties": {
+        "introduced": {
+          "type": "string",
+          "description": "Spec version when this component declaration was added (e.g. '1.0.0-draft')."
+        },
+        "deprecated": {
+          "type": "string",
+          "description": "Spec version when this component was deprecated. Truthy = deprecated."
+        },
+        "deprecated_comment": {
+          "type": "string",
+          "description": "Human-readable explanation of the deprecation and migration path."
+        },
+        "replaced_by": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1
+            }
+          ],
+          "description": "name value(s) of the replacement component(s)."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -11,7 +11,8 @@
       "format": "uri"
     },
     "specVersion": {
-      "const": "1.0.0-draft"
+      "type": "string",
+      "description": "Spec version this document targets (e.g. '1.0.0-draft')."
     },
     "$id": {
       "type": "string",
@@ -241,11 +242,11 @@
           "type": "string",
           "description": "Spec version when this component was deprecated. Truthy = deprecated."
         },
-        "deprecated_comment": {
+        "deprecatedComment": {
           "type": "string",
           "description": "Human-readable explanation of the deprecation and migration path."
         },
-        "replaced_by": {
+        "replacedBy": {
           "oneOf": [
             { "type": "string", "minLength": 1 },
             {

--- a/packages/design-data-spec/spec/component-format.md
+++ b/packages/design-data-spec/spec/component-format.md
@@ -12,7 +12,7 @@ Scoped under [RFC-A — Component Contract in Design Data Spec](https://github.c
 
 A component declaration is a **single JSON object** in a `.json` file. One file per component. Files live under a `components/` directory within a design-data package.
 
-**NORMATIVE:** Each component declaration file **MUST** validate against the Layer 1 schema [`component.schema.json`](../schemas/component.schema.json) (canonical `$id`: `https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json`).
+**NORMATIVE:** Each component declaration file **MUST** validate against the Layer 1 schema [`component.schema.json`](../schemas/component.schema.json) (canonical `$id`: `https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json`). Layer 1 and Layer 2 validation are defined in the [validation layers](index.md#validation-layers) section of the overview.
 
 ## Component object
 
@@ -29,15 +29,15 @@ A component declaration **MUST** contain:
 
 ### Optional fields
 
-| Field         | Type            | Description                                                           |
-| ------------- | --------------- | --------------------------------------------------------------------- |
-| `specVersion` | `"1.0.0-draft"` | Declares which spec version this document targets.                    |
-| `description` | string          | Plain-text description of the component's purpose.                    |
-| `options`     | object          | Component API options — see [Options](#options).                      |
-| `slots`       | array           | Named content injection points — see [Slots](#slots).                 |
-| `anatomy`     | array           | Named anatomy parts — see [Anatomy (stub)](#anatomy-stub).            |
-| `states`      | array           | Per-component state declarations — see [States (stub)](#states-stub). |
-| `lifecycle`   | object          | Version lifecycle metadata — see [Lifecycle](#lifecycle).             |
+| Field         | Type   | Description                                                                                                                                |
+| ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `specVersion` | string | Declares which spec version this document targets. Currently `"1.0.0-draft"`; future stable releases will accept their own version string. |
+| `description` | string | Plain-text description of the component's purpose.                                                                                         |
+| `options`     | object | Component API options — see [Options](#options).                                                                                           |
+| `slots`       | array  | Named content injection points — see [Slots](#slots).                                                                                      |
+| `anatomy`     | array  | Named anatomy parts — see [Anatomy (stub)](#anatomy-stub).                                                                                 |
+| `states`      | array  | Per-component state declarations — see [States (stub)](#states-stub).                                                                      |
+| `lifecycle`   | object | Version lifecycle metadata — see [Lifecycle](#lifecycle).                                                                                  |
 
 **NORMATIVE:** No properties beyond those listed above are permitted at the top level of a component declaration. Additional fields **MUST** cause a Layer 1 schema error.
 
@@ -168,7 +168,7 @@ The following slot names are defined by the cross-platform audit and **SHOULD** 
   },
   {
     "name": "icon",
-    "description": "Icon placed at the start of the button. Required when hideLabel is true."
+    "description": "Icon placed at the start of the button. Required when isLabelHidden is true."
   }
 ]
 ```
@@ -228,12 +228,12 @@ See [`spec/state-model.md`](state-model.md) for the full state resolution algori
 
 The `lifecycle` block tracks a component declaration's version history. It mirrors the per-token lifecycle pattern from [`spec/token-format.md`](token-format.md#lifecycle-and-metadata).
 
-| Field                | Type            | Description                                                                    |
-| -------------------- | --------------- | ------------------------------------------------------------------------------ |
-| `introduced`         | string          | Spec version when this component declaration was added (e.g. `"1.0.0-draft"`). |
-| `deprecated`         | string          | Spec version when this component was deprecated. Truthy = deprecated.          |
-| `deprecated_comment` | string          | Human-readable explanation of the deprecation and migration path.              |
-| `replaced_by`        | string or array | `name` value(s) of the replacement component(s).                               |
+| Field               | Type            | Description                                                                    |
+| ------------------- | --------------- | ------------------------------------------------------------------------------ |
+| `introduced`        | string          | Spec version when this component declaration was added (e.g. `"1.0.0-draft"`). |
+| `deprecated`        | string          | Spec version when this component was deprecated. Truthy = deprecated.          |
+| `deprecatedComment` | string          | Human-readable explanation of the deprecation and migration path.              |
+| `replacedBy`        | string or array | `name` value(s) of the replacement component(s).                               |
 
 ```json
 "lifecycle": {
@@ -245,12 +245,13 @@ The `lifecycle` block tracks a component declaration's version history. It mirro
 
 The following rules are added to the Layer 2 rule catalog (`rules/rules.yaml`) by this chapter. New component cross-reference rules start at SPEC-018 to avoid collision with existing token rules (SPEC-001–SPEC-017).
 
-| Rule ID  | Name                        | Severity | Assert                                                                                                                                                                                  |
-| -------- | --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SPEC-018 | `component-name-exists`     | error    | Token `component` field value **MUST** match the `name` of a declared component in the dataset.                                                                                         |
-| SPEC-019 | `component-variant-valid`   | error    | Token `variant` field value **MUST** match a value in the declared `variant` option enum for the referenced component (when that enum exists).                                          |
-| SPEC-020 | `component-anatomy-valid`   | error    | Token `anatomy` field value **MUST** match the `name` of a declared anatomy part on the referenced component.                                                                           |
-| SPEC-021 | `component-slot-vocabulary` | warning  | Component `slots` entries with a `name` outside the canonical vocabulary **SHOULD** include a `description`. Custom slot names without descriptions are surfaced as tech-debt warnings. |
+| Rule ID  | Name                        | Severity | Assert                                                                                                                                                                        |
+| -------- | --------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SPEC-018 | `component-name-exists`     | error    | Token `component` field value **MUST** match the `name` of a declared component in the dataset.                                                                               |
+| SPEC-019 | `component-variant-valid`   | error    | Token `variant` field value **MUST** match a value in the declared `variant` option enum for the referenced component (when that enum exists).                                |
+| SPEC-020 | `component-anatomy-valid`   | error    | Token `anatomy` field value **MUST** match the `name` of a declared anatomy part on the referenced component.                                                                 |
+| SPEC-021 | `component-slot-vocabulary` | warning  | Component `slots` entries with a `name` outside the canonical vocabulary **SHOULD** include a `description`. Custom slot names without descriptions are surfaced as warnings. |
+| SPEC-022 | `component-state-valid`     | error    | Token `state` field value **MUST** match the `name` of a declared state on the referenced component (when state declarations are present).                                    |
 
 ## Full example
 
@@ -287,10 +288,10 @@ A complete button component declaration:
     },
     "isDisabled": { "type": "boolean", "default": false },
     "isPending": { "type": "boolean", "default": false },
-    "hideLabel": { "type": "boolean", "default": false },
+    "isLabelHidden": { "type": "boolean", "default": false },
     "icon": {
       "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/types/workflow-icon.json",
-      "description": "Icon placed at the start of the button. Required when hideLabel is true."
+      "description": "Icon placed at the start of the button. Required when isLabelHidden is true."
     },
     "staticColor": {
       "type": "string",

--- a/packages/design-data-spec/spec/component-format.md
+++ b/packages/design-data-spec/spec/component-format.md
@@ -1,0 +1,325 @@
+# Component format
+
+**Spec version:** `1.0.0-draft` (see [Overview](index.md))
+
+This document defines the normative **component declaration** object: identity (`$id`, `name`, `displayName`), component metadata (`meta`), API options (`options`), named content slots (`slots`), anatomy parts (`anatomy`), state model (`states`), and lifecycle metadata.
+
+Component declarations close the structural gap between the token name-object's `component`, `variant`, `anatomy`, and `state` fields and the declared surface of each component. Before this chapter, a token referencing `component: "button"` with `variant: "foo"` was undetectable as invalid because no machine-readable component contract existed in the same spec. After this chapter, validators enforce cross-reference rules (see [SPEC rules](#spec-rules)).
+
+Scoped under [RFC-A — Component Contract in Design Data Spec](https://github.com/adobe/spectrum-design-data/discussions/832). See also [rfc-coordination.md](../docs/rfc-coordination.md).
+
+## Document shape
+
+A component declaration is a **single JSON object** in a `.json` file. One file per component. Files live under a `components/` directory within a design-data package.
+
+**NORMATIVE:** Each component declaration file **MUST** validate against the Layer 1 schema [`component.schema.json`](../schemas/component.schema.json) (canonical `$id`: `https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json`).
+
+## Component object
+
+### Required fields
+
+A component declaration **MUST** contain:
+
+| Field         | Type              | Description                                                                           |
+| ------------- | ----------------- | ------------------------------------------------------------------------------------- |
+| `$id`         | URI string        | Canonical identifier for this component declaration.                                  |
+| `name`        | kebab-case string | Machine identifier; used as the value of the `component` field in token name objects. |
+| `displayName` | string            | Human-readable component name (e.g. `"Button"`).                                      |
+| `meta`        | object            | Category and documentation link — see [Meta](#meta).                                  |
+
+### Optional fields
+
+| Field         | Type            | Description                                                           |
+| ------------- | --------------- | --------------------------------------------------------------------- |
+| `specVersion` | `"1.0.0-draft"` | Declares which spec version this document targets.                    |
+| `description` | string          | Plain-text description of the component's purpose.                    |
+| `options`     | object          | Component API options — see [Options](#options).                      |
+| `slots`       | array           | Named content injection points — see [Slots](#slots).                 |
+| `anatomy`     | array           | Named anatomy parts — see [Anatomy (stub)](#anatomy-stub).            |
+| `states`      | array           | Per-component state declarations — see [States (stub)](#states-stub). |
+| `lifecycle`   | object          | Version lifecycle metadata — see [Lifecycle](#lifecycle).             |
+
+**NORMATIVE:** No properties beyond those listed above are permitted at the top level of a component declaration. Additional fields **MUST** cause a Layer 1 schema error.
+
+### `$id`
+
+**NORMATIVE:** The `$id` **MUST** be a valid URI identifying this component declaration document. The recommended pattern is:
+
+```
+https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/{name}.json
+```
+
+where `{name}` matches the component's `name` field.
+
+### `name`
+
+**NORMATIVE:** `name` **MUST** match the pattern `^[a-z][a-z0-9-]*$` — lower-case kebab-case, non-empty.
+
+**NORMATIVE:** `name` **MUST** be unique within a dataset. No two component declarations in the same design-data package may share a `name` value.
+
+**NORMATIVE:** Token name-object `component` field values **MUST** match the `name` of a declared component in the dataset (rule SPEC-018). An undeclared `component` value is a validation error.
+
+### Meta
+
+**NORMATIVE:** `meta` **MUST** contain:
+
+| Field              | Type          | Values                                                                                                    |
+| ------------------ | ------------- | --------------------------------------------------------------------------------------------------------- |
+| `category`         | string (enum) | `actions`, `containers`, `data visualization`, `feedback`, `inputs`, `navigation`, `status`, `typography` |
+| `documentationUrl` | URI string    | Link to the component's documentation page.                                                               |
+
+```json
+"meta": {
+  "category": "actions",
+  "documentationUrl": "https://spectrum.adobe.com/page/button/"
+}
+```
+
+## Options
+
+The `options` block declares the component's API surface — the configurable properties that affect its appearance or behavior. It mirrors the shape of `@adobe/spectrum-component-api-schemas` for backward compatibility.
+
+**NORMATIVE:** `options` **MUST** be a JSON object. Each key is an option name; each value is an **option descriptor**.
+
+### Option descriptor
+
+An option descriptor is a JSON object with the following fields:
+
+| Field         | Type            | Required | Description                                                                      |
+| ------------- | --------------- | -------- | -------------------------------------------------------------------------------- |
+| `type`        | string or array | OPTIONAL | JSON Schema primitive type(s): `"string"`, `"boolean"`, `"number"`, `"integer"`. |
+| `enum`        | array           | OPTIONAL | Exhaustive list of permitted values.                                             |
+| `default`     | any             | OPTIONAL | Default value when the option is not specified.                                  |
+| `description` | string          | OPTIONAL | Plain-text description of what the option controls.                              |
+| `$ref`        | URI string      | OPTIONAL | Reference to a shared type schema (e.g. `workflow-icon.json`).                   |
+
+**NORMATIVE:** Each key in `options` **MUST** be camelCase.
+
+**NORMATIVE:** Boolean option names **MUST** begin with `is` or `has` (e.g. `isDisabled`, `hasIcon`).
+
+**NORMATIVE:** When `enum` is present, token name-object `variant` field values referencing this component **MUST** be drawn from the declared `variant` option enum (rule SPEC-019). Other option enums are informative for tooling but do not currently drive SPEC rules.
+
+```json
+"options": {
+  "variant": {
+    "type": "string",
+    "enum": ["accent", "negative", "primary", "secondary"],
+    "default": "accent",
+    "description": "Visual emphasis level."
+  },
+  "size": {
+    "type": "string",
+    "enum": ["s", "m", "l", "xl"],
+    "default": "m"
+  },
+  "isDisabled": {
+    "type": "boolean",
+    "default": false
+  },
+  "icon": {
+    "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/types/workflow-icon.json",
+    "description": "Icon placed at the start of the button. Required when hideLabel is true."
+  }
+}
+```
+
+## Slots
+
+The `slots` block declares the component's named **content injection points** — the positions where consumers place child content. Slot declarations are derived from the cross-platform audit in [`audits/slots.audit.md`](../audits/slots.audit.md).
+
+**NORMATIVE:** `slots` **MUST** be a JSON array. Each element is a **slot declaration**.
+
+### Slot declaration
+
+| Field         | Type    | Required | Description                                                                 |
+| ------------- | ------- | -------- | --------------------------------------------------------------------------- |
+| `name`        | string  | REQUIRED | Slot identifier. **SHOULD** come from the canonical vocabulary (see below). |
+| `description` | string  | OPTIONAL | Plain-text description of what content goes in this slot.                   |
+| `required`    | boolean | OPTIONAL | Whether consumers **MUST** populate this slot. Default: `false`.            |
+
+### Canonical slot vocabulary
+
+The following slot names are defined by the cross-platform audit and **SHOULD** be used in preference to custom names:
+
+| Name                 | Semantics                                                               |
+| -------------------- | ----------------------------------------------------------------------- |
+| `default`            | Primary content (text, children). The main content slot.                |
+| `icon`               | Decorative icon at the leading edge of the component.                   |
+| `label`              | Human-readable identifier / placeholder text (distinct from `default`). |
+| `help-text`          | Non-error guidance text below a form field.                             |
+| `negative-help-text` | Validation error message for a form field.                              |
+| `action`             | Secondary interactive button or call-to-action.                         |
+| `heading`            | Section or dialog heading.                                              |
+| `description`        | Section or dialog body text (distinct from `help-text`).                |
+| `hero`               | Large header media (e.g. dialog hero image).                            |
+| `footer`             | Below-content supplemental area (e.g. dialog footer).                   |
+| `tooltip`            | Floating annotation attached to the component.                          |
+
+**NORMATIVE:** Custom slot names are permitted but **SHOULD** be documented in the slot's `description` field (rule SPEC-021 fires a warning for undocumented custom names).
+
+**RECOMMENDED:** Components **SHOULD** declare a `default` slot when they accept primary child content.
+
+```json
+"slots": [
+  {
+    "name": "default",
+    "description": "Text label of the button.",
+    "required": false
+  },
+  {
+    "name": "icon",
+    "description": "Icon placed at the start of the button. Required when hideLabel is true."
+  }
+]
+```
+
+## Anatomy (stub)
+
+The `anatomy` block declares the component's named **visual parts** — the anatomy terms used in token name-object `anatomy` fields. Full normative definition is in [`spec/anatomy-format.md`](anatomy-format.md) (Phase 6.2).
+
+**NORMATIVE:** `anatomy` **MUST** be a JSON array. Each element is an anatomy part object.
+
+**NORMATIVE:** Token name-object `anatomy` field values referencing this component **MUST** match the `name` of a declared anatomy part (rule SPEC-020).
+
+Each anatomy part carries at minimum:
+
+| Field         | Type             | Required | Description                                                    |
+| ------------- | ---------------- | -------- | -------------------------------------------------------------- |
+| `name`        | string           | REQUIRED | Anatomy part identifier (e.g. `icon`, `label`, `handle`).      |
+| `description` | string           | OPTIONAL | Plain-text description of the part.                            |
+| `required`    | boolean          | OPTIONAL | Whether this part is always present. Default: `false`.         |
+| `contains`    | array of strings | OPTIONAL | Informative: other anatomy part names nested within this part. |
+
+See [`spec/anatomy-format.md`](anatomy-format.md) for constraints, cross-field validation, and the full anatomy part schema.
+
+```json
+"anatomy": [
+  { "name": "icon", "description": "Leading icon." },
+  { "name": "label", "description": "Button text.", "required": true }
+]
+```
+
+## States (stub)
+
+The `states` block declares the component's **interactive and semantic states** — the state terms used in token name-object `state` fields. Full normative definition is in [`spec/state-model.md`](state-model.md) (Phase 6.3).
+
+**NORMATIVE:** `states` **MUST** be a JSON array. Each element is a state declaration object.
+
+Each state carries at minimum:
+
+| Field        | Type    | Required | Description                                                                                                                               |
+| ------------ | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`       | string  | REQUIRED | State identifier (e.g. `hover`, `focus`, `disabled`).                                                                                     |
+| `trigger`    | string  | OPTIONAL | `"prop"` for persistent prop-driven states (e.g. `isDisabled`) or `"interaction"` for runtime interaction states (hover, focus, pressed). |
+| `precedence` | integer | OPTIONAL | Resolution precedence; higher integer wins when multiple states are active.                                                               |
+| `layered`    | boolean | OPTIONAL | `true` for states that compose with others (e.g. focus ring over hover). Default: `false`.                                                |
+
+See [`spec/state-model.md`](state-model.md) for the full state resolution algorithm, trigger semantics, and precedence rules.
+
+```json
+"states": [
+  { "name": "hover",    "trigger": "interaction", "precedence": 50 },
+  { "name": "focus",    "trigger": "interaction", "precedence": 60, "layered": true },
+  { "name": "disabled", "trigger": "prop",        "precedence": 100 }
+]
+```
+
+## Lifecycle
+
+The `lifecycle` block tracks a component declaration's version history. It mirrors the per-token lifecycle pattern from [`spec/token-format.md`](token-format.md#lifecycle-and-metadata).
+
+| Field                | Type            | Description                                                                    |
+| -------------------- | --------------- | ------------------------------------------------------------------------------ |
+| `introduced`         | string          | Spec version when this component declaration was added (e.g. `"1.0.0-draft"`). |
+| `deprecated`         | string          | Spec version when this component was deprecated. Truthy = deprecated.          |
+| `deprecated_comment` | string          | Human-readable explanation of the deprecation and migration path.              |
+| `replaced_by`        | string or array | `name` value(s) of the replacement component(s).                               |
+
+```json
+"lifecycle": {
+  "introduced": "1.0.0-draft"
+}
+```
+
+## SPEC rules
+
+The following rules are added to the Layer 2 rule catalog (`rules/rules.yaml`) by this chapter. New component cross-reference rules start at SPEC-018 to avoid collision with existing token rules (SPEC-001–SPEC-017).
+
+| Rule ID  | Name                        | Severity | Assert                                                                                                                                                                                  |
+| -------- | --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SPEC-018 | `component-name-exists`     | error    | Token `component` field value **MUST** match the `name` of a declared component in the dataset.                                                                                         |
+| SPEC-019 | `component-variant-valid`   | error    | Token `variant` field value **MUST** match a value in the declared `variant` option enum for the referenced component (when that enum exists).                                          |
+| SPEC-020 | `component-anatomy-valid`   | error    | Token `anatomy` field value **MUST** match the `name` of a declared anatomy part on the referenced component.                                                                           |
+| SPEC-021 | `component-slot-vocabulary` | warning  | Component `slots` entries with a `name` outside the canonical vocabulary **SHOULD** include a `description`. Custom slot names without descriptions are surfaced as tech-debt warnings. |
+
+## Full example
+
+A complete button component declaration:
+
+```json
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+  "specVersion": "1.0.0-draft",
+  "name": "button",
+  "displayName": "Button",
+  "description": "Buttons allow users to perform an action or to navigate to another page.",
+  "meta": {
+    "category": "actions",
+    "documentationUrl": "https://spectrum.adobe.com/page/button/"
+  },
+  "options": {
+    "variant": {
+      "type": "string",
+      "enum": ["accent", "negative", "primary", "secondary"],
+      "default": "accent",
+      "description": "Visual emphasis level."
+    },
+    "style": {
+      "type": "string",
+      "enum": ["fill", "outline"],
+      "default": "fill"
+    },
+    "size": {
+      "type": "string",
+      "enum": ["s", "m", "l", "xl"],
+      "default": "m"
+    },
+    "isDisabled": { "type": "boolean", "default": false },
+    "isPending": { "type": "boolean", "default": false },
+    "hideLabel": { "type": "boolean", "default": false },
+    "icon": {
+      "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/types/workflow-icon.json",
+      "description": "Icon placed at the start of the button. Required when hideLabel is true."
+    },
+    "staticColor": {
+      "type": "string",
+      "enum": ["white", "black"],
+      "description": "Static color for use on colored backgrounds. Must not be set for the default variant."
+    }
+  },
+  "slots": [
+    {
+      "name": "default",
+      "description": "Text label of the button.",
+      "required": false
+    },
+    {
+      "name": "icon",
+      "description": "Icon placed at the start of the button."
+    }
+  ],
+  "anatomy": [
+    { "name": "icon",  "description": "Leading icon." },
+    { "name": "label", "description": "Button text.", "required": true }
+  ],
+  "states": [
+    { "name": "hover",    "trigger": "interaction", "precedence": 50 },
+    { "name": "focus",    "trigger": "interaction", "precedence": 60, "layered": true },
+    { "name": "disabled", "trigger": "prop",        "precedence": 100 }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}
+```

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -11,12 +11,13 @@ The specification defines:
 
 1. **Token format** — structured token identity (`name`), literal `value` or alias `$ref`, and lifecycle metadata ([Token format](token-format.md)).
 2. **Taxonomy** — concept categories, token term vocabulary, formatting style, and the distinction between component anatomy and token objects ([Taxonomy](taxonomy.md)).
-3. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
-4. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
-5. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
-6. **Semantic diff** — change taxonomy, token identity rules, and property-level change tracking for comparing dataset versions ([Diff](diff.md)).
-7. **Query notation** — filter syntax for selecting tokens by structured fields ([Query](query.md)).
-8. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
+3. **Component format** — component declaration shape: API options, named content slots, anatomy parts, state model, and cross-reference validation rules ([Component format](component-format.md)).
+4. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
+5. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
+6. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
+7. **Semantic diff** — change taxonomy, token identity rules, and property-level change tracking for comparing dataset versions ([Diff](diff.md)).
+8. **Query notation** — filter syntax for selecting tokens by structured fields ([Query](query.md)).
+9. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
 
 ## Conformance
 
@@ -50,16 +51,17 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 
 ## Normative references (sibling documents)
 
-| Document                        | Role                                                             |
-| ------------------------------- | ---------------------------------------------------------------- |
-| [Token format](token-format.md) | Token `name`, `value` / `$ref`, value types, lifecycle metadata. |
-| [Taxonomy](taxonomy.md)         | Concept categories, vocabulary, formatting, anatomy vs objects.  |
-| [Cascade](cascade.md)           | Layers, specificity, resolution algorithm.                       |
-| [Dimensions](dimensions.md)     | Dimension declarations, built-in dimensions, coverage.           |
-| [Manifest](manifest.md)         | Platform manifest fields and validation expectations.            |
-| [Diff](diff.md)                 | Semantic diff change taxonomy, token identity, property changes. |
-| [Query](query.md)               | Filter notation for selecting tokens by structured fields.       |
-| [Evolution](evolution.md)       | Deprecation lifecycle, migration windows, change classification. |
+| Document                                | Role                                                                                           |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                               |
+| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                |
+| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ Phase 6.2), states (→ Phase 6.3), lifecycle. |
+| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                     |
+| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                         |
+| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                          |
+| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                               |
+| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                     |
+| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                               |
 
 ## JSON Schema `$id` and versioning
 
@@ -76,11 +78,11 @@ Packaged copies in this repository live under `packages/design-data-spec/schemas
 
 ## Relationship to existing Adobe packages
 
-| Package / area                          | Relationship                                                                                                                                                                                                                                                            |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@adobe/spectrum-tokens`                | **Current** token JSON under `packages/tokens/` is the **legacy** shape (e.g. `color-set`, `scale-set`). This spec defines the **target** format; backward-compat schemas and migration are Phase 1 ([#723](https://github.com/adobe/spectrum-design-data/issues/723)). |
-| `@adobe/design-system-registry`         | Registry enums and component metadata MAY be referenced by validation rules (e.g. component association); exact coupling is Layer 2.                                                                                                                                    |
-| `@adobe/spectrum-component-api-schemas` | Component schemas MAY be cross-checked by graph rules; not required for Layer 1 structural validation.                                                                                                                                                                  |
+| Package / area                          | Relationship                                                                                                                                                                                                                                                                 |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@adobe/spectrum-tokens`                | **Current** token JSON under `packages/tokens/` is the **legacy** shape (e.g. `color-set`, `scale-set`). This spec defines the **target** format; backward-compat schemas and migration are Phase 1 ([#723](https://github.com/adobe/spectrum-design-data/issues/723)).      |
+| `@adobe/design-system-registry`         | Registry enums and component metadata MAY be referenced by validation rules (e.g. component association); exact coupling is Layer 2.                                                                                                                                         |
+| `@adobe/spectrum-component-api-schemas` | Will become a thin adapter over component declarations in `packages/design-data-spec/components/` (Phase 6.5). Until migration, existing schemas remain authoritative. Cross-reference rules SPEC-018–SPEC-020 apply when component declarations are present in the dataset. |
 
 ## Umbrella discussions
 


### PR DESCRIPTION
## Description

Adds the normative `component-format.md` spec chapter and companion JSON Schema as Phase 6.1 of the Component Contract epic. This is the envelope chapter — anatomy (6.2) and state model (6.3) are cross-referenced as forthcoming chapters.

**Files changed:**
- `spec/component-format.md` (new) — normative spec chapter
- `schemas/component.schema.json` (new) — JSON Schema Draft 2020-12, v0 path
- `spec/index.md` — add component-format.md to scope list and normative references table
- `rules/rules.yaml` — add SPEC-018 through SPEC-021

## Related Issue

Part of #828 ([Epic] Phase 6: Component Contract)
Scoped under [RFC-A Discussion #832](https://github.com/adobe/spectrum-design-data/discussions/832)
Follows #849 (Phase 6.0 slots/events audit)

## Motivation and Context

Before this chapter, a token with `component: "button"` and `variant: "foo"` was undetectable as invalid — component options lived in a disjoint package with no cross-reference validation. This chapter makes design-data-spec the single source of truth for the component contract.

**What the spec chapter defines:**
- Required fields: `$id`, `name` (kebab-case slug), `displayName`, `meta` (category + documentationUrl)
- `options` block — mirrors `@adobe/spectrum-component-api-schemas` property shape for backward compat; NORMATIVE rules on camelCase naming and boolean prefixes
- `slots` block — per Phase 6.0 audit recommendation; canonical slot vocabulary (`default`, `icon`, `label`, `help-text`, etc.); `{ name, description, required }` shape
- `anatomy` stub — schema-valid shape; normative definition deferred to `spec/anatomy-format.md` (Phase 6.2)
- `states` stub — schema-valid shape with `trigger`/`precedence`/`layered`; normative definition deferred to `spec/state-model.md` (Phase 6.3)
- `lifecycle` — mirrors token lifecycle metadata pattern
- Full button example

**New SPEC rules (SPEC-018–021):**
- SPEC-018 `component-name-exists` (error) — token `component` field must match a declared component `name`
- SPEC-019 `component-variant-valid` (error) — token `variant` field must match declared variant enum
- SPEC-020 `component-anatomy-valid` (error) — token `anatomy` field must match declared anatomy part
- SPEC-021 `component-slot-vocabulary` (warning) — custom slot names should have descriptions

## How Has This Been Tested?

Documentation and schema files. The JSON Schema is structurally valid (prettier ran via pre-commit hook). The button example in the spec validates against `component.schema.json` by hand inspection.

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.