### PR TITLE
docs(design-data-spec): phase 6.2 anatomy declarations spec and schema

### DIFF
--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -199,3 +199,12 @@ rules:
     message: "Token '{token}' references undeclared state '{state}' on component '{component}'"
     spec_ref: spec/component-format.md#spec-rules
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-023
+    name: anatomy-custom-part-documented
+    severity: warning
+    category: component-contract
+    assert: Anatomy part declarations with a 'name' outside the canonical anatomy vocabulary SHOULD include a 'description' field.
+    message: "Component '{component}' has custom anatomy part '{part}' with no description"
+    spec_ref: spec/anatomy-format.md#canonical-anatomy-vocabulary
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -208,3 +208,21 @@ rules:
     message: "Component '{component}' has custom anatomy part '{part}' with no description"
     spec_ref: spec/anatomy-format.md#canonical-anatomy-vocabulary
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-024
+    name: anatomy-part-name-unique
+    severity: error
+    category: component-contract
+    assert: Anatomy part names within a single component's anatomy array MUST be unique.
+    message: "Component '{component}' declares duplicate anatomy part name '{part}'"
+    spec_ref: spec/anatomy-format.md#name
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-025
+    name: anatomy-requires-component
+    severity: error
+    category: reference-integrity
+    assert: A token name object MUST NOT include an 'anatomy' field unless a 'component' field is also present.
+    message: "Token '{token}' has 'anatomy' field without a 'component' field"
+    spec_ref: spec/anatomy-format.md#cross-reference-with-token-name-objects
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/anatomy-part.schema.json
+++ b/packages/design-data-spec/schemas/anatomy-part.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/anatomy-part.schema.json",
   "title": "Anatomy part declaration",
-  "description": "Layer 1 structural schema for a single anatomy part object within a component declaration. Semantic rules (component-anatomy-valid, anatomy-custom-part-documented) are Layer 2.",
+  "description": "Layer 1 structural schema for a single anatomy part object within a component declaration. Semantic rules (component-anatomy-valid, anatomy-custom-part-documented, anatomy-part-name-unique, anatomy-requires-component) are Layer 2.",
   "type": "object",
   "required": ["name"],
   "properties": {
@@ -27,6 +27,7 @@
         "type": "string",
         "pattern": "^[a-z][a-z0-9-]*$"
       },
+      "uniqueItems": true,
       "description": "Informative list of child anatomy part names nested within this part. Does not carry enforcement semantics."
     }
   },

--- a/packages/design-data-spec/schemas/anatomy-part.schema.json
+++ b/packages/design-data-spec/schemas/anatomy-part.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/anatomy-part.schema.json",
+  "title": "Anatomy part declaration",
+  "description": "Layer 1 structural schema for a single anatomy part object within a component declaration. Semantic rules (component-anatomy-valid, anatomy-custom-part-documented) are Layer 2.",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 1,
+      "description": "Kebab-case anatomy part identifier. Must match the value used in token name-object 'anatomy' fields."
+    },
+    "description": {
+      "type": "string",
+      "description": "Plain-text description of the part's visual role and boundaries."
+    },
+    "required": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether this part is always rendered regardless of component configuration."
+    },
+    "contains": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "description": "Informative list of child anatomy part names nested within this part. Does not carry enforcement semantics."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/design-data-spec/spec/anatomy-format.md
+++ b/packages/design-data-spec/spec/anatomy-format.md
@@ -27,7 +27,7 @@ An anatomy part is a **JSON object** that appears as an element of a component d
 
 **NORMATIVE:** `name` **MUST** match the pattern `^[a-z][a-z0-9-]*$` — lower-case kebab-case, non-empty.
 
-**NORMATIVE:** `name` **MUST** be unique within the `anatomy` array of a single component declaration. No two anatomy part objects in the same component may share a `name` value.
+**NORMATIVE:** `name` **MUST** be unique within the `anatomy` array of a single component declaration (rule SPEC-024). Duplicate `name` values on the same component are a validation error.
 
 **NORMATIVE:** Token name-object `anatomy` field values referencing a component **MUST** match the `name` of a declared anatomy part on that component (rule SPEC-020). An undeclared `anatomy` value is a validation error.
 
@@ -94,7 +94,7 @@ Token name objects use an `anatomy` field to scope a token to a specific visible
 
 See [Token format — Name object](token-format.md#name-object) for the full name object field catalog.
 
-**NORMATIVE:** The `anatomy` field in a token name object **MUST NOT** be present unless the token's `component` field is also present. Anatomy is always scoped to a component.
+**NORMATIVE:** The `anatomy` field in a token name object **MUST NOT** be present unless the token's `component` field is also present (rule SPEC-025). Anatomy is always scoped to a component.
 
 ```json
 {
@@ -110,12 +110,14 @@ See [Token format — Name object](token-format.md#name-object) for the full nam
 
 ## SPEC rules
 
-The following rules in the Layer 2 rule catalog (`rules/rules.yaml`) apply to anatomy part declarations. SPEC-020 was introduced in Phase 6.1 (component-format); SPEC-023 is introduced by this chapter.
+The following rules in the Layer 2 rule catalog (`rules/rules.yaml`) apply to anatomy part declarations. SPEC-020 was introduced in Phase 6.1 (component-format); SPEC-023, SPEC-024, and SPEC-025 are introduced by this chapter.
 
 | Rule ID  | Name                             | Severity | Assert                                                                                                                                                    |
 | -------- | -------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | SPEC-020 | `component-anatomy-valid`        | error    | Token `anatomy` field value **MUST** match the `name` of a declared anatomy part on the referenced component.                                             |
 | SPEC-023 | `anatomy-custom-part-documented` | warning  | Anatomy part declarations with a `name` outside the canonical anatomy vocabulary **SHOULD** include a `description` field documenting the part's purpose. |
+| SPEC-024 | `anatomy-part-name-unique`       | error    | Anatomy part `name` values **MUST** be unique within a single component's `anatomy` array.                                                                |
+| SPEC-025 | `anatomy-requires-component`     | error    | A token name object **MUST NOT** include an `anatomy` field unless a `component` field is also present.                                                   |
 
 ## Full example
 

--- a/packages/design-data-spec/spec/anatomy-format.md
+++ b/packages/design-data-spec/spec/anatomy-format.md
@@ -1,0 +1,165 @@
+# Anatomy format
+
+**Spec version:** `1.0.0-draft` (see [Overview](index.md))
+
+This document defines the normative **anatomy part declaration** object: the named visual sub-parts of a component that appear as values of the `anatomy` field in token name objects. Anatomy declarations complete the machine-readable contract introduced by the component declaration (see [Component format — Anatomy stub](component-format.md#anatomy-stub)) and enable cross-reference validation between tokens and component surfaces.
+
+Scoped under [RFC-A — Component Contract in Design Data Spec](https://github.com/adobe/spectrum-design-data/discussions/832). See also [Component format](component-format.md).
+
+## Anatomy part object
+
+An anatomy part is a **JSON object** that appears as an element of a component declaration's `anatomy` array. Each anatomy part object **MUST** validate against the standalone schema [`anatomy-part.schema.json`](../schemas/anatomy-part.schema.json) (canonical `$id`: `https://opensource.adobe.com/spectrum-design-data/schemas/v0/anatomy-part.schema.json`).
+
+**NORMATIVE:** `anatomy` **MUST** be a JSON array within the component declaration. Each element **MUST** be an anatomy part object.
+
+### Fields
+
+| Field         | Type             | Required | Description                                                                                                              |
+| ------------- | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `name`        | string           | REQUIRED | Kebab-case identifier. **MUST** match the pattern `^[a-z][a-z0-9-]*$`.                                                   |
+| `description` | string           | OPTIONAL | Plain-text description of the part's visual role and boundaries.                                                         |
+| `required`    | boolean          | OPTIONAL | Whether this part is always rendered regardless of configuration. Default: `false`.                                      |
+| `contains`    | array of strings | OPTIONAL | Informative list of child anatomy part names nested within this part (e.g. a `field` contains `["label", "help-text"]`). |
+
+**NORMATIVE:** No properties beyond those listed above are permitted in an anatomy part object. Additional fields **MUST** cause a Layer 1 schema error.
+
+### `name`
+
+**NORMATIVE:** `name` **MUST** match the pattern `^[a-z][a-z0-9-]*$` — lower-case kebab-case, non-empty.
+
+**NORMATIVE:** `name` **MUST** be unique within the `anatomy` array of a single component declaration. No two anatomy part objects in the same component may share a `name` value.
+
+**NORMATIVE:** Token name-object `anatomy` field values referencing a component **MUST** match the `name` of a declared anatomy part on that component (rule SPEC-020). An undeclared `anatomy` value is a validation error.
+
+### `description`
+
+**OPTIONAL.** A plain-text description of the anatomy part's visual role (e.g. `"Background fill track behind the progress indicator."`).
+
+**RECOMMENDED:** Custom anatomy part names (those outside the [canonical anatomy vocabulary](#canonical-anatomy-vocabulary)) **SHOULD** include a `description` to document intent (rule SPEC-023 fires a warning for undocumented custom names).
+
+### `required`
+
+**OPTIONAL.** A boolean indicating whether the anatomy part is always present in the component's rendered output, regardless of its configuration options. Defaults to `false`.
+
+When `required` is `true`, the anatomy part is unconditionally rendered (e.g. a `label` that cannot be hidden). When `false` or omitted, the part may or may not appear depending on component props.
+
+### `contains`
+
+**OPTIONAL.** An informative list of child anatomy part `name` values that are visually or structurally nested within this part. This field is for documentation and tooling assistance; it does not carry enforcement semantics.
+
+**RECOMMENDED:** When a part logically encloses other declared anatomy parts, authors **SHOULD** use `contains` to make the nesting explicit.
+
+Each string in `contains` **MUST** match the pattern `^[a-z][a-z0-9-]*$`. References to anatomy part names not declared on the same component are permitted (they may refer to sub-component anatomy in layered designs) but validators **MAY** surface a warning for unresolved references.
+
+```json
+"anatomy": [
+  {
+    "name": "field",
+    "description": "Input field wrapper enclosing the label and help text.",
+    "contains": ["label", "help-text"]
+  },
+  { "name": "label",     "description": "Primary text label.", "required": true },
+  { "name": "help-text", "description": "Guidance text below the field." }
+]
+```
+
+## Canonical anatomy vocabulary
+
+The following anatomy part names are defined by the cross-platform design audit and **SHOULD** be used in preference to custom names when their semantics match. Using canonical names enables cross-component tooling, documentation generation, and token audits.
+
+| Name                  | Semantics                                                                |
+| --------------------- | ------------------------------------------------------------------------ |
+| `body`                | Primary content area of a component (e.g. card body, dialog body).       |
+| `checkmark`           | Selection indicator used in checkbox or radio components.                |
+| `disclosure-triangle` | Expand/collapse indicator for accordion, tree, or disclosure components. |
+| `field`               | Input field wrapper (encloses label, input surface, and help text).      |
+| `handle`              | Drag handle for resizable or sortable components.                        |
+| `header`              | Top section of a panel, card, or dialog.                                 |
+| `icon`                | Decorative or semantic icon placed within a component.                   |
+| `label`               | Primary text label identifying the component or its value.               |
+| `picker`              | Dropdown trigger area (the visible affordance, not the overlay).         |
+| `progress-bar`        | Visual progress fill track indicating completion level.                  |
+| `swatch`              | Color or pattern preview area.                                           |
+| `thumbnail`           | Image preview area within a component.                                   |
+| `track`               | Background rail for slider or progress bar components.                   |
+| `value`               | Numeric or text display value shown within a component.                  |
+
+Custom part names are permitted. When a custom name is used, the anatomy part object **SHOULD** include a `description` field explaining its visual role (rule SPEC-023).
+
+## Cross-reference with token name objects
+
+Token name objects use an `anatomy` field to scope a token to a specific visible part of a component. The `anatomy` field value must correspond to a part declared in the component's `anatomy` array.
+
+**NORMATIVE:** A token name-object `anatomy` field value **MUST** match the `name` of a declared anatomy part on the component identified by the token's `component` field (rule SPEC-020). An `anatomy` value that does not match any declared part name is a validation error.
+
+See [Token format — Name object](token-format.md#name-object) for the full name object field catalog.
+
+**NORMATIVE:** The `anatomy` field in a token name object **MUST NOT** be present unless the token's `component` field is also present. Anatomy is always scoped to a component.
+
+```json
+{
+  "name": {
+    "component": "slider",
+    "anatomy": "handle",
+    "property": "background-color",
+    "state": "hover"
+  },
+  "value": "#0265dc"
+}
+```
+
+## SPEC rules
+
+The following rules in the Layer 2 rule catalog (`rules/rules.yaml`) apply to anatomy part declarations. SPEC-020 was introduced in Phase 6.1 (component-format); SPEC-023 is introduced by this chapter.
+
+| Rule ID  | Name                             | Severity | Assert                                                                                                                                                    |
+| -------- | -------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SPEC-020 | `component-anatomy-valid`        | error    | Token `anatomy` field value **MUST** match the `name` of a declared anatomy part on the referenced component.                                             |
+| SPEC-023 | `anatomy-custom-part-documented` | warning  | Anatomy part declarations with a `name` outside the canonical anatomy vocabulary **SHOULD** include a `description` field documenting the part's purpose. |
+
+## Full example
+
+A complete `anatomy` array for a slider component, demonstrating canonical names, a custom name, and `contains` usage:
+
+```json
+"anatomy": [
+  {
+    "name": "track",
+    "description": "Background rail spanning the slider's full range.",
+    "required": true
+  },
+  {
+    "name": "progress-bar",
+    "description": "Filled portion of the track indicating the current value.",
+    "required": true
+  },
+  {
+    "name": "handle",
+    "description": "Draggable thumb positioned at the current value.",
+    "required": true
+  },
+  {
+    "name": "label",
+    "description": "Text label identifying the slider.",
+    "required": false
+  },
+  {
+    "name": "value",
+    "description": "Numeric display of the current slider value.",
+    "required": false
+  },
+  {
+    "name": "tick-marks",
+    "description": "Discrete step indicators along the track. Present only when step markers are enabled.",
+    "required": false
+  },
+  {
+    "name": "range-group",
+    "description": "Wrapper grouping the track and both handles for a range slider variant.",
+    "required": false,
+    "contains": ["track", "progress-bar", "handle"]
+  }
+]
+```
+
+In this example, `tick-marks` and `range-group` are custom names outside the canonical vocabulary. Both include a `description` to satisfy rule SPEC-023. The `range-group` part uses `contains` to declare that it encloses `track`, `progress-bar`, and `handle`.

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -12,6 +12,7 @@ The specification defines:
 1. **Token format** — structured token identity (`name`), literal `value` or alias `$ref`, and lifecycle metadata ([Token format](token-format.md)).
 2. **Taxonomy** — concept categories, token term vocabulary, formatting style, and the distinction between component anatomy and token objects ([Taxonomy](taxonomy.md)).
 3. **Component format** — component declaration shape: API options, named content slots, anatomy parts, state model, and cross-reference validation rules ([Component format](component-format.md)).
+   3a. **Anatomy format** — anatomy part declaration shape: field constraints, canonical anatomy vocabulary, and cross-reference rules for token `anatomy` field values ([Anatomy format](anatomy-format.md)).
 4. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
 5. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
 6. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
@@ -51,17 +52,18 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 
 ## Normative references (sibling documents)
 
-| Document                                | Role                                                                                           |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                               |
-| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                |
-| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ Phase 6.2), states (→ Phase 6.3), lifecycle. |
-| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                     |
-| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                         |
-| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                          |
-| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                               |
-| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                     |
-| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                               |
+| Document                                | Role                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                                       |
+| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                        |
+| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ anatomy-format.md), states (→ Phase 6.3), lifecycle. |
+| [Anatomy format](anatomy-format.md)     | Anatomy part declarations: field constraints, canonical vocabulary, SPEC-020/SPEC-023.                 |
+| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                             |
+| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                                 |
+| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                                  |
+| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                                       |
+| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                             |
+| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                                       |
 
 ## JSON Schema `$id` and versioning
 

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -52,18 +52,18 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 
 ## Normative references (sibling documents)
 
-| Document                                | Role                                                                                                   |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                                       |
-| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                        |
-| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ anatomy-format.md), states (→ Phase 6.3), lifecycle. |
-| [Anatomy format](anatomy-format.md)     | Anatomy part declarations: field constraints, canonical vocabulary, SPEC-020/SPEC-023.                 |
-| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                             |
-| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                                 |
-| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                                  |
-| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                                       |
-| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                             |
-| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                                       |
+| Document                                | Role                                                                                                     |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                                         |
+| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                          |
+| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ anatomy-format.md), states (→ Phase 6.3), lifecycle.   |
+| [Anatomy format](anatomy-format.md)     | Anatomy part declarations: field constraints, canonical vocabulary, SPEC-020/SPEC-023/SPEC-024/SPEC-025. |
+| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                               |
+| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                                   |
+| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                                    |
+| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                                         |
+| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                               |
+| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                                         |
 
 ## JSON Schema `$id` and versioning
 

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -12,7 +12,7 @@ The specification defines:
 1. **Token format** — structured token identity (`name`), literal `value` or alias `$ref`, and lifecycle metadata ([Token format](token-format.md)).
 2. **Taxonomy** — concept categories, token term vocabulary, formatting style, and the distinction between component anatomy and token objects ([Taxonomy](taxonomy.md)).
 3. **Component format** — component declaration shape: API options, named content slots, anatomy parts, state model, and cross-reference validation rules ([Component format](component-format.md)).
-   3a. **Anatomy format** — anatomy part declaration shape: field constraints, canonical anatomy vocabulary, and cross-reference rules for token `anatomy` field values ([Anatomy format](anatomy-format.md)).
+   * **Anatomy format** — anatomy part declaration shape: field constraints, canonical anatomy vocabulary, and cross-reference rules for token `anatomy` field values ([Anatomy format](anatomy-format.md)).
 4. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
 5. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
 6. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).


### PR DESCRIPTION
## Description

Implements Phase 6.2 of the Design Data Specification: the normative `anatomy-format.md` spec chapter and its companion standalone JSON Schema.

**Files added/modified:**

- `packages/design-data-spec/spec/anatomy-format.md` — new normative chapter defining the anatomy part declaration object, canonical anatomy vocabulary (14 terms), cross-reference rules with token name objects, and a full slider example
- `packages/design-data-spec/schemas/anatomy-part.schema.json` — new standalone JSON Schema Draft 2020-12 for a single anatomy part object (`$id` under `v0/`, `additionalProperties: false`)
- `packages/design-data-spec/spec/index.md` — added `anatomy-format.md` to the Scope list (item 3a) and the normative references table
- `packages/design-data-spec/rules/rules.yaml` — added SPEC-023 (`anatomy-custom-part-documented`, warning) after SPEC-022

**Note:** `schemas/component.schema.json` was intentionally not modified; the stub `anatomyPart` `$def` there remains as-is. The anatomy chapter provides the authoritative normative text and the new standalone schema document.

## Related Issue

Closes #828. Scoped under [RFC-A — Component Contract in Design Data Spec](https://github.com/adobe/spectrum-design-data/discussions/832).

## Motivation and Context

Phase 6.1 (component-format.md) stubbed the `anatomy` block and referenced `anatomy-format.md` (Phase 6.2) for full normative text. This PR delivers that chapter, completing the anatomy contract so validators can enforce SPEC-020 and surface SPEC-023 warnings for undocumented custom part names.

## How Has This Been Tested?

- Pre-commit hook ran remark lint on both `.md` files and prettier on the JSON schema and YAML — all passed with no warnings
- Manually reviewed schema structure against existing `component.schema.json` `anatomyPart` `$def` for consistency
- Verified SPEC-023 entry in rules.yaml follows the established YAML structure (id, name, severity, category, assert, message, spec_ref, introduced_in)

## Screenshots (if appropriate):

N/A — documentation and schema only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.