### PR TITLE
docs(design-data-spec): phase 6.3 state model spec and schema

### DIFF
--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -226,3 +226,12 @@ rules:
     message: "Token '{token}' has 'anatomy' field without a 'component' field"
     spec_ref: spec/anatomy-format.md#cross-reference-with-token-name-objects
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-026
+    name: state-custom-name-documented
+    severity: warning
+    category: component-contract
+    assert: State declarations with a 'name' outside the canonical state vocabulary SHOULD include a 'description' field.
+    message: "Component '{component}' has custom state '{state}' with no description"
+    spec_ref: spec/state-model.md#canonical-state-vocabulary
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -205,12 +205,15 @@
     "stateDeclaration": {
       "type": "object",
       "required": ["name"],
-      "description": "Per-component state declaration. Full spec in spec/state-model.md (Phase 6.3).",
+      "description": "Per-component state declaration. Full spec in spec/state-model.md.",
       "properties": {
         "name": {
           "type": "string",
           "minLength": 1,
           "description": "State identifier (e.g. 'hover', 'focus', 'disabled')."
+        },
+        "description": {
+          "type": "string"
         },
         "trigger": {
           "type": "string",

--- a/packages/design-data-spec/schemas/state-declaration.schema.json
+++ b/packages/design-data-spec/schemas/state-declaration.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/state-declaration.schema.json",
+  "title": "State declaration",
+  "description": "Layer 1 structural schema for a single state declaration object within a component declaration. Semantic rules (component-state-valid, state-custom-name-documented) are Layer 2.",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 1,
+      "description": "Kebab-case state identifier. Must match the value used in token name-object 'state' fields."
+    },
+    "description": {
+      "type": "string",
+      "description": "Plain-text description of the state's semantics and the conditions under which it is active."
+    },
+    "trigger": {
+      "type": "string",
+      "enum": ["prop", "interaction"],
+      "description": "'prop' for persistent prop-driven states (e.g. isDisabled); 'interaction' for transient runtime interaction states (hover, focus, pressed)."
+    },
+    "precedence": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Resolution precedence. Higher value wins when multiple non-layered states are active simultaneously. Defaults to 0 when omitted."
+    },
+    "layered": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, this state composes on top of the winning non-layered state rather than competing with it. Use for focus rings, selection overlays, and similar compositing states."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -12,7 +12,8 @@ The specification defines:
 1. **Token format** — structured token identity (`name`), literal `value` or alias `$ref`, and lifecycle metadata ([Token format](token-format.md)).
 2. **Taxonomy** — concept categories, token term vocabulary, formatting style, and the distinction between component anatomy and token objects ([Taxonomy](taxonomy.md)).
 3. **Component format** — component declaration shape: API options, named content slots, anatomy parts, state model, and cross-reference validation rules ([Component format](component-format.md)).
-   * **Anatomy format** — anatomy part declaration shape: field constraints, canonical anatomy vocabulary, and cross-reference rules for token `anatomy` field values ([Anatomy format](anatomy-format.md)).
+   3a. **Anatomy format** — anatomy part declaration shape: field constraints, canonical anatomy vocabulary, and cross-reference rules for token `anatomy` field values ([Anatomy format](anatomy-format.md)).
+   3b. **State model** — state declaration shape: trigger semantics, precedence and resolution algorithm, canonical state vocabulary, and cross-reference rules for token `state` field values ([State model](state-model.md)).
 4. **Cascade and resolution** — layered data (foundation, platform, product), specificity, and how a context picks a winning value ([Cascade](cascade.md)).
 5. **Dimensions** — declared modes, defaults, and coverage expectations ([Dimensions](dimensions.md)).
 6. **Platform manifest** — how a platform repo pins foundation data, filters tokens, and applies typed overrides ([Manifest](manifest.md)).
@@ -52,18 +53,19 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 
 ## Normative references (sibling documents)
 
-| Document                                | Role                                                                                                     |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                                         |
-| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                          |
-| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ anatomy-format.md), states (→ Phase 6.3), lifecycle.   |
-| [Anatomy format](anatomy-format.md)     | Anatomy part declarations: field constraints, canonical vocabulary, SPEC-020/SPEC-023/SPEC-024/SPEC-025. |
-| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                               |
-| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                                   |
-| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                                    |
-| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                                         |
-| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                               |
-| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                                         |
+| Document                                | Role                                                                                                        |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [Token format](token-format.md)         | Token `name`, `value` / `$ref`, value types, lifecycle metadata.                                            |
+| [Taxonomy](taxonomy.md)                 | Concept categories, vocabulary, formatting, anatomy vs objects.                                             |
+| [Component format](component-format.md) | Component declaration: options, slots, anatomy (→ anatomy-format.md), states (→ state-model.md), lifecycle. |
+| [Anatomy format](anatomy-format.md)     | Anatomy part declarations: field constraints, canonical vocabulary, SPEC-020/SPEC-023/SPEC-024/SPEC-025.    |
+| [State model](state-model.md)           | State declarations: trigger semantics, precedence algorithm, canonical vocabulary, SPEC-022/SPEC-026.       |
+| [Cascade](cascade.md)                   | Layers, specificity, resolution algorithm.                                                                  |
+| [Dimensions](dimensions.md)             | Dimension declarations, built-in dimensions, coverage.                                                      |
+| [Manifest](manifest.md)                 | Platform manifest fields and validation expectations.                                                       |
+| [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                                            |
+| [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                                  |
+| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                                            |
 
 ## JSON Schema `$id` and versioning
 

--- a/packages/design-data-spec/spec/state-model.md
+++ b/packages/design-data-spec/spec/state-model.md
@@ -1,0 +1,245 @@
+# State model
+
+**Spec version:** `1.0.0-draft` (see [Overview](index.md))
+
+This document defines the normative **state declaration** object: the named conditions that affect a component's visual appearance or token resolution, declared in the `states` array of a component declaration. State declarations complete the machine-readable contract introduced by the component declaration (see [Component format — States stub](component-format.md#states-stub)) and enable cross-reference validation between tokens and component surfaces.
+
+Scoped under [RFC-A — Component Contract in Design Data Spec](https://github.com/adobe/spectrum-design-data/discussions/832). See also [Component format](component-format.md).
+
+## Introduction
+
+A **component state** is a named condition under which a component's visual presentation differs from its baseline. States drive token resolution: when a component is in a given state, the design system selects tokens scoped to that state name rather than (or layered on top of) the baseline tokens.
+
+State names appear in the `state` field of token name objects (see [Token format — Name object](token-format.md#name-object)). A token with `"state": "hover"` applies only when the component is in the `hover` state. For this cross-reference to be machine-enforceable, state declarations **MUST** be present on the component declaration.
+
+States fall into two trigger types:
+
+* **`prop`** — set by a persistent component API property (e.g. `isDisabled`, `isSelected`). The state remains active until the property value changes.
+* **`interaction`** — set by runtime user interaction (hover, focus, pressed, dragging). The state is transient and is cleared when the interaction ends.
+
+Full normative rules for the `states` array within a component declaration are in this document. The component declaration format is defined in [`spec/component-format.md`](component-format.md).
+
+## State declaration object
+
+A state declaration is a **JSON object** that appears as an element of a component declaration's `states` array. Each state declaration object **MUST** validate against the standalone schema [`state-declaration.schema.json`](../schemas/state-declaration.schema.json) (canonical `$id`: `https://opensource.adobe.com/spectrum-design-data/schemas/v0/state-declaration.schema.json`).
+
+**NORMATIVE:** `states` **MUST** be a JSON array within the component declaration. Each element **MUST** be a state declaration object.
+
+### Fields
+
+| Field         | Type    | Required | Description                                                                                                                                |
+| ------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`        | string  | REQUIRED | Kebab-case state identifier. **MUST** match the pattern `^[a-z][a-z0-9-]*$`. Used as the value of the `state` field in token name objects. |
+| `description` | string  | OPTIONAL | Plain-text description of the state's semantics and the conditions under which it is active.                                               |
+| `trigger`     | string  | OPTIONAL | `"prop"` for persistent prop-driven states; `"interaction"` for runtime interaction states. See [Trigger semantics](#trigger-semantics).   |
+| `precedence`  | integer | OPTIONAL | Resolution precedence; higher value wins when multiple non-layered states are active simultaneously. Defaults to `0` if omitted.           |
+| `layered`     | boolean | OPTIONAL | When `true`, this state composes on top of the winning non-layered state rather than competing with it. Default: `false`.                  |
+
+**NORMATIVE:** No properties beyond those listed above are permitted in a state declaration object. Additional fields **MUST** cause a Layer 1 schema error.
+
+### `name`
+
+**NORMATIVE:** `name` **MUST** match the pattern `^[a-z][a-z0-9-]*$` — lower-case kebab-case, non-empty.
+
+**NORMATIVE:** `name` **MUST** be unique within the `states` array of a single component declaration. No two state declaration objects in the same component may share a `name` value.
+
+**NORMATIVE:** Token name-object `state` field values referencing a component **MUST** match the `name` of a declared state on that component, when state declarations are present (rule SPEC-022). An undeclared `state` value is a validation error.
+
+### `description`
+
+**OPTIONAL.** A plain-text description of the state's semantics and the conditions that activate it (e.g. `"Applied while the pointer is positioned over the component."`).
+
+**RECOMMENDED:** Custom state names (those outside the [canonical state vocabulary](#canonical-state-vocabulary)) **SHOULD** include a `description` to document intent (rule SPEC-026 fires a warning for undocumented custom names).
+
+### `trigger`
+
+**OPTIONAL.** One of two string values:
+
+* `"prop"` — the state is driven by a persistent component API property. The state is active as long as the property holds a truthy or specific value (e.g. `isDisabled: true`).
+* `"interaction"` — the state is driven by transient user interaction. The state activates when the interaction begins and clears when it ends.
+
+When `trigger` is omitted, the trigger type is unspecified. Validators **MAY** warn for state declarations without a `trigger` when the component has states listed in the canonical vocabulary with a known trigger type.
+
+### `precedence`
+
+**OPTIONAL.** A non-negative integer indicating this state's weight in the resolution algorithm. When multiple non-layered states are simultaneously active, the state with the highest `precedence` integer wins for token selection.
+
+When `precedence` is omitted, it is treated as `0`.
+
+**RECOMMENDED:** Components **SHOULD** declare explicit `precedence` values when two or more states could be active simultaneously, to avoid relying on declaration-order tie-breaking.
+
+### `layered`
+
+**OPTIONAL.** A boolean indicating whether this state composes on top of the winning non-layered state instead of competing with it. Default: `false`.
+
+When `layered: true`, the state does not participate in the non-layered precedence competition. Instead, after the winning non-layered state is determined, all active `layered: true` states are applied on top of it in order of their `precedence` values (higher precedence layered states apply last / outermost).
+
+Typical use: focus ring states (`focus`, `focus-visible`) that must be visible regardless of whether the component is also in a `hover` or `selected` state.
+
+## Trigger semantics
+
+### `prop` trigger
+
+A `prop` state is driven by a component API property. The state is persistent: it is active for the full duration that the property holds its activating value and is cleared only when the property changes.
+
+Examples:
+
+* `isDisabled: true` activates the `disabled` state.
+* `isSelected: true` activates the `selected` state.
+* `isIndeterminate: true` activates the `indeterminate` state.
+* `isReadOnly: true` activates the `read-only` state.
+
+`prop` states are typically mutually exclusive with each other in practice (a component is either disabled or selected, rarely both), but the spec permits multiple `prop` states to be simultaneously active; the precedence algorithm resolves which token set applies.
+
+### `interaction` trigger
+
+An `interaction` state is driven by transient user input. The state is active only while the interaction is occurring and is automatically cleared when the interaction ends.
+
+Examples:
+
+* `hover` — active while a pointer device is positioned over the component's interactive area.
+* `focus` — active while the component holds keyboard focus.
+* `focus-visible` — active when focus was received via keyboard navigation (not pointer).
+* `active` / `pressed` — active while a pointer button or key is held down.
+* `dragging` — active while a drag-and-drop gesture originating from the component is in progress.
+
+`interaction` states may overlay `prop` states (e.g. a disabled button may still receive a hover event on some platforms). When both are active, the precedence algorithm determines which token set wins, or, if the interaction state is `layered: true`, the interaction state's tokens are applied on top.
+
+## Precedence and resolution algorithm
+
+The following algorithm is **NORMATIVE** for conforming validators and renderers that implement state-aware token resolution.
+
+**Inputs:** A set of currently active state names for a given component instance.
+
+**Algorithm:**
+
+1. Partition the active states into two groups:
+   * **Non-layered states:** states with `layered: false` (or `layered` omitted).
+   * **Layered states:** states with `layered: true`.
+
+2. Among non-layered states, select the **winning state**:
+   * Compare `precedence` values. The state with the highest `precedence` integer wins.
+   * If `precedence` is omitted, treat it as `0`.
+   * If two non-layered states tie on `precedence`, the state that appears **earlier** in the component's `states` array wins. **MUST** be treated as a tie; implementations **SHOULD** emit a warning (see SPEC-006 for the analogous cascade tie rule).
+
+3. Resolve tokens for the winning non-layered state. If no non-layered state is active, resolve the `default` state (or baseline tokens when no `default` state is declared).
+
+4. For each active layered state, in ascending `precedence` order (lowest first, so the highest-precedence layered state is applied last and sits outermost):
+   * Apply the layered state's tokens on top of the tokens resolved in step 3. Tokens explicitly declared for the layered state override the corresponding tokens from the non-layered resolution.
+
+5. The resulting merged token set is the resolved appearance for the component instance in its current state combination.
+
+**Example:** A checkbox is simultaneously `selected` (precedence 80) and `hover` (precedence 50). `focus` (precedence 60, layered) is also active.
+
+* Non-layered active states: `selected` (80), `hover` (50). Winner: `selected`.
+* Layered active state: `focus`. Applied on top of `selected`.
+* Resolution: `selected` tokens, with `focus` tokens composited over them.
+
+## Canonical state vocabulary
+
+The following state names are defined by the cross-platform design audit and **SHOULD** be used in preference to custom names when their semantics match. Using canonical names enables cross-component tooling, documentation generation, and token audits.
+
+| Name            | Trigger     | Precedence | Layered | Semantics                                                                 |
+| --------------- | ----------- | ---------- | ------- | ------------------------------------------------------------------------- |
+| `default`       | —           | 0          | false   | No special state; baseline component appearance.                          |
+| `hover`         | interaction | 50         | false   | Pointer device is positioned over the component's interactive area.       |
+| `dragging`      | interaction | 55         | false   | A drag-and-drop gesture originating from this component is in progress.   |
+| `focus`         | interaction | 60         | true    | Component holds keyboard or programmatic focus.                           |
+| `focus-visible` | interaction | 65         | true    | Focus received via keyboard navigation; used for visible focus ring only. |
+| `active`        | interaction | 70         | false   | Pointer button or activation key is currently held down.                  |
+| `pressed`       | interaction | 70         | false   | Alias for `active`; prefer `active` for new declarations.                 |
+| `invalid`       | prop        | 75         | false   | Component value has failed validation.                                    |
+| `valid`         | prop        | 75         | false   | Component value has passed validation.                                    |
+| `selected`      | prop        | 80         | false   | Component is in a selected state (checkbox checked, tab active, etc.).    |
+| `indeterminate` | prop        | 85         | false   | Component has partial selection (tri-state checkbox mixed state).         |
+| `read-only`     | prop        | 90         | false   | Component value is visible but not editable by the user.                  |
+| `disabled`      | prop        | 100        | false   | Component is non-interactive; all user input is suppressed.               |
+
+Custom state names are permitted. When a custom name is used, the state declaration object **SHOULD** include a `description` field explaining its semantics (rule SPEC-026).
+
+**NORMATIVE:** The values in the canonical vocabulary table (trigger type, precedence, layered) are **RECOMMENDED defaults**. A component declaration MAY override any of these values for a canonical state name by explicitly declaring a different value in the state declaration object. When overriding a canonical default, the `description` **SHOULD** explain the deviation.
+
+## Cross-reference with token name objects
+
+Token name objects use a `state` field to scope a token to a specific component state. The `state` field value must correspond to a state declared in the component's `states` array.
+
+**NORMATIVE:** A token name-object `state` field value **MUST** match the `name` of a declared state on the component identified by the token's `component` field, when state declarations are present on that component (rule SPEC-022). A `state` value that does not match any declared state name is a validation error.
+
+See [Token format — Name object](token-format.md#name-object) for the full name object field catalog.
+
+**NORMATIVE:** The `state` field in a token name object **MUST NOT** be present unless the token's `component` field is also present. States are always scoped to a component.
+
+```json
+{
+  "name": {
+    "component": "checkbox",
+    "anatomy": "checkmark",
+    "property": "color",
+    "state": "selected"
+  },
+  "value": "#0265dc"
+}
+```
+
+## SPEC rules
+
+The following rules in the Layer 2 rule catalog (`rules/rules.yaml`) apply to state declarations. SPEC-022 was introduced in Phase 6.1 (component-format); SPEC-026 is introduced by this chapter.
+
+| Rule ID  | Name                           | Severity | Assert                                                                                                                                              |
+| -------- | ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SPEC-022 | `component-state-valid`        | error    | Token `state` field value **MUST** match the `name` of a declared state on the referenced component (when state declarations are present).          |
+| SPEC-026 | `state-custom-name-documented` | warning  | State declarations with a `name` outside the canonical state vocabulary **SHOULD** include a `description` field documenting the state's semantics. |
+
+## Full example
+
+A complete `states` array for a checkbox component, demonstrating prop states (`selected`, `indeterminate`, `disabled`), interaction states (`hover`, `focus` with `layered: true`, `pressed`), and explicit precedence values:
+
+```json
+"states": [
+  {
+    "name": "default",
+    "description": "Baseline unchecked checkbox appearance.",
+    "trigger": "prop",
+    "precedence": 0
+  },
+  {
+    "name": "hover",
+    "description": "Applied while a pointer device is positioned over the checkbox.",
+    "trigger": "interaction",
+    "precedence": 50
+  },
+  {
+    "name": "focus",
+    "description": "Applied while the checkbox holds keyboard or programmatic focus. Composes on top of the active non-layered state.",
+    "trigger": "interaction",
+    "precedence": 60,
+    "layered": true
+  },
+  {
+    "name": "pressed",
+    "description": "Applied while the pointer button or Space key is held down during activation.",
+    "trigger": "interaction",
+    "precedence": 70
+  },
+  {
+    "name": "selected",
+    "description": "Applied when isSelected is true (checkbox checked).",
+    "trigger": "prop",
+    "precedence": 80
+  },
+  {
+    "name": "indeterminate",
+    "description": "Applied when isIndeterminate is true (tri-state mixed selection).",
+    "trigger": "prop",
+    "precedence": 85
+  },
+  {
+    "name": "disabled",
+    "description": "Applied when isDisabled is true. Suppresses all user input.",
+    "trigger": "prop",
+    "precedence": 100
+  }
+]
+```
+
+In this example, if the checkbox is simultaneously `selected` (80) and `hover` (50) with `focus` (60, layered) active, the resolution is: `selected` wins the non-layered competition; `focus` tokens are then applied on top of the `selected` tokens.


### PR DESCRIPTION
## Description

Adds Phase 6.3 of the Spectrum Design Data Specification: the normative `state-model.md` chapter and its companion `state-declaration.schema.json` JSON Schema (Draft 2020-12).

**Files changed:**

- `packages/design-data-spec/spec/state-model.md` — new normative chapter defining the state declaration object, trigger semantics (`prop` vs `interaction`), the precedence and resolution algorithm, canonical state vocabulary (13 entries), cross-reference rules, SPEC rules table, and a full checkbox example.
- `packages/design-data-spec/schemas/state-declaration.schema.json` — new standalone Layer 1 schema for a single state declaration object (`$id` under `v0/`, `additionalProperties: false`). Adds `description` field (also now added to the `stateDeclaration` inline def in component.schema.json).
- `packages/design-data-spec/spec/index.md` — adds `state-model.md` to the Scope section (item 3b) and to the normative references table; updates the Component format row to link `→ state-model.md` instead of `→ Phase 6.3`.
- `packages/design-data-spec/rules/rules.yaml` — adds SPEC-026 `state-custom-name-documented` (warning): custom state names outside the canonical vocabulary SHOULD include a `description`.

## Related Issue

Closes #828

## Motivation and Context

Phase 6.1 (component-format.md) introduced the `states` block as a stub with minimal normative text and SPEC-022 (`component-state-valid`, error). Phase 6.3 promotes that stub to a full normative chapter so that:

- The state resolution algorithm is machine-enforceable and documented.
- Canonical state names (`disabled`, `hover`, `focus`, `selected`, etc.) have standard precedence and trigger values, reducing cross-component inconsistency.
- The `layered` compositing model (focus rings over hover/selected) is formally specified.
- SPEC-026 encourages documentation of custom state names.

## How Has This Been Tested?

- lint-staged ran remark and prettier over all modified `.md` and `.json` files during commit with no errors.
- The JSON Schema was authored to match the existing `anatomy-part.schema.json` pattern and passes structural review.
- SPEC-026 follows the same pattern as SPEC-023 (`anatomy-custom-part-documented`).

## Screenshots (if appropriate):

N/A — documentation-only change.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
