### PR TITLE
feat(design-data-spec): phase 6.4 cross-reference validator and conformance fixtures

### DIFF
--- a/.changeset/smooth-ravens-dance.md
+++ b/.changeset/smooth-ravens-dance.md
@@ -1,0 +1,5 @@
+---
+"@adobe/design-data-spec": minor
+---
+
+Add Layer 2 cross-reference validator (`src/validate.js`) implementing SPEC-018–024, conformance fixtures for each rule, and a reference button component declaration. Export new component, anatomy-part, and state-declaration schemas from the package.

--- a/.changeset/smooth-ravens-dance.md
+++ b/.changeset/smooth-ravens-dance.md
@@ -2,4 +2,6 @@
 "@adobe/design-data-spec": minor
 ---
 
-Add Layer 2 cross-reference validator (`src/validate.js`) implementing SPEC-018–024, conformance fixtures for each rule, and a reference button component declaration. Export new component, anatomy-part, and state-declaration schemas from the package.
+Add Layer 2 cross-reference validator implementing SPEC-018–024, conformance fixtures,
+and a reference button component declaration. Export new component, anatomy-part, and
+state-declaration schemas from the package.

--- a/packages/design-data-spec/ava.config.js
+++ b/packages/design-data-spec/ava.config.js
@@ -1,0 +1,3 @@
+export default {
+  files: ["test/**/*.test.js"],
+};

--- a/packages/design-data-spec/components/button.json
+++ b/packages/design-data-spec/components/button.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+  "specVersion": "1.0.0-draft",
+  "name": "button",
+  "displayName": "Button",
+  "description": "Buttons allow users to perform an action or to navigate to another page.",
+  "meta": {
+    "category": "actions",
+    "documentationUrl": "https://spectrum.adobe.com/page/button/"
+  },
+  "options": {
+    "variant": {
+      "type": "string",
+      "enum": ["accent", "negative", "primary", "secondary"],
+      "default": "accent",
+      "description": "Visual emphasis level."
+    },
+    "style": {
+      "type": "string",
+      "enum": ["fill", "outline"],
+      "default": "fill"
+    },
+    "size": {
+      "type": "string",
+      "enum": ["s", "m", "l", "xl"],
+      "default": "m"
+    },
+    "isDisabled": { "type": "boolean", "default": false },
+    "isPending": { "type": "boolean", "default": false },
+    "isLabelHidden": { "type": "boolean", "default": false },
+    "icon": {
+      "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/types/workflow-icon.json",
+      "description": "Icon placed at the start of the button. Required when isLabelHidden is true."
+    },
+    "staticColor": {
+      "type": "string",
+      "enum": ["white", "black"],
+      "description": "Static color for use on colored backgrounds."
+    }
+  },
+  "slots": [
+    {
+      "name": "default",
+      "description": "Text label of the button.",
+      "required": false
+    },
+    {
+      "name": "icon",
+      "description": "Icon placed at the start of the button."
+    }
+  ],
+  "anatomy": [
+    { "name": "icon", "description": "Leading icon." },
+    { "name": "label", "description": "Button text.", "required": true }
+  ],
+  "states": [
+    { "name": "hover", "trigger": "interaction", "precedence": 50 },
+    {
+      "name": "focus",
+      "trigger": "interaction",
+      "precedence": 60,
+      "layered": true
+    },
+    { "name": "disabled", "trigger": "prop", "precedence": 100 }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-018/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-018/dataset.json
@@ -1,0 +1,9 @@
+{
+  "tokens": [
+    {
+      "name": { "component": "nonexistent", "property": "background-color" },
+      "value": "#ff0000"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-018/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-018/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-018",
+      "severity": "error",
+      "message_pattern": ".*undeclared component.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-019/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-019/dataset.json
@@ -1,0 +1,29 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "button",
+        "variant": "electric",
+        "property": "background-color"
+      },
+      "value": "#0000ff"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "options": {
+        "variant": {
+          "type": "string",
+          "enum": ["accent", "negative", "primary", "secondary"]
+        }
+      }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-019/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-019/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-019",
+      "severity": "error",
+      "message_pattern": ".*variant.*electric.*not declared.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-020/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-020/dataset.json
@@ -1,0 +1,27 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "button",
+        "anatomy": "capsule",
+        "property": "background-color"
+      },
+      "value": "#ff0000"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "anatomy": [
+        { "name": "icon", "description": "Leading icon." },
+        { "name": "label", "description": "Button text.", "required": true }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-020/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-020/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-020",
+      "severity": "error",
+      "message_pattern": ".*undeclared anatomy part.*capsule.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-021/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-021/dataset.json
@@ -1,0 +1,18 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "slots": [
+        { "name": "default", "description": "Text label of the button." },
+        { "name": "badge" }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-021/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-021/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-021",
+      "severity": "warning",
+      "message_pattern": ".*custom slot.*badge.*no description.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-022/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-022/dataset.json
@@ -1,0 +1,33 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "button",
+        "state": "jello",
+        "property": "background-color"
+      },
+      "value": "#ff0000"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "states": [
+        { "name": "hover", "trigger": "interaction", "precedence": 50 },
+        {
+          "name": "focus",
+          "trigger": "interaction",
+          "precedence": 60,
+          "layered": true
+        },
+        { "name": "disabled", "trigger": "prop", "precedence": 100 }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-022/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-022/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-022",
+      "severity": "error",
+      "message_pattern": ".*undeclared state.*jello.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-023/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-023/dataset.json
@@ -1,0 +1,18 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "anatomy": [
+        { "name": "label", "description": "Button text.", "required": true },
+        { "name": "shimmer" }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-023/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-023/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-023",
+      "severity": "warning",
+      "message_pattern": ".*custom anatomy part.*shimmer.*no description.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-024/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-024/dataset.json
@@ -1,0 +1,18 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "states": [
+        { "name": "hover", "trigger": "interaction", "precedence": 50 },
+        { "name": "wobble" }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-024/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-024/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-024",
+      "severity": "warning",
+      "message_pattern": ".*custom state.*wobble.*no description.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/component-refs/dataset.json
+++ b/packages/design-data-spec/conformance/valid/component-refs/dataset.json
@@ -1,0 +1,63 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "button",
+        "variant": "accent",
+        "property": "background-color"
+      },
+      "value": "#0265dc"
+    },
+    {
+      "name": {
+        "component": "button",
+        "anatomy": "label",
+        "property": "color"
+      },
+      "value": "#ffffff"
+    },
+    {
+      "name": {
+        "component": "button",
+        "state": "hover",
+        "property": "background-color"
+      },
+      "value": "#0255be"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "options": {
+        "variant": {
+          "type": "string",
+          "enum": ["accent", "negative", "primary", "secondary"]
+        }
+      },
+      "slots": [
+        { "name": "default", "description": "Text label of the button." },
+        { "name": "icon", "description": "Leading icon." }
+      ],
+      "anatomy": [
+        { "name": "icon", "description": "Leading icon." },
+        { "name": "label", "description": "Button text.", "required": true }
+      ],
+      "states": [
+        { "name": "hover", "trigger": "interaction", "precedence": 50 },
+        {
+          "name": "focus",
+          "trigger": "interaction",
+          "precedence": 60,
+          "layered": true
+        },
+        { "name": "disabled", "trigger": "prop", "precedence": 100 }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/moon.yml
+++ b/packages/design-data-spec/moon.yml
@@ -18,6 +18,10 @@ fileGroups:
     - "rules/**/*.{yaml,yml}"
   conformance:
     - "conformance/**/*"
+  source:
+    - "src/**/*.js"
+  components:
+    - "components/**/*.json"
 tasks:
   check:
     command:
@@ -30,3 +34,13 @@ tasks:
       - "@globs(rules)"
       - "@globs(conformance)"
       - "scripts/check-layout.mjs"
+  test:
+    command:
+      - pnpm
+      - ava
+    platform: node
+    inputs:
+      - "@globs(source)"
+      - "test/**/*.test.js"
+      - "@globs(conformance)"
+      - "@globs(components)"

--- a/packages/design-data-spec/package.json
+++ b/packages/design-data-spec/package.json
@@ -26,15 +26,28 @@
     "./schemas/field.schema.json": "./schemas/field.schema.json",
     "./schemas/manifest.schema.json": "./schemas/manifest.schema.json",
     "./schemas/value-types/color.schema.json": "./schemas/value-types/color.schema.json",
-    "./rules/rules.yaml": "./rules/rules.yaml"
+    "./schemas/component.schema.json": "./schemas/component.schema.json",
+    "./schemas/anatomy-part.schema.json": "./schemas/anatomy-part.schema.json",
+    "./schemas/state-declaration.schema.json": "./schemas/state-declaration.schema.json",
+    "./rules/rules.yaml": "./rules/rules.yaml",
+    "./src/validate.js": "./src/validate.js",
+    "./src/canonical.js": "./src/canonical.js"
   },
   "files": [
-    "spec",
-    "schemas",
+    "components",
+    "conformance",
     "fields",
     "rules",
-    "conformance",
+    "schemas",
+    "spec",
+    "src",
     "README.md"
   ],
-  "scripts": {}
+  "scripts": {
+    "test": "ava"
+  },
+  "devDependencies": {
+    "ava": "^6.0.1",
+    "glob": "^11.0.0"
+  }
 }

--- a/packages/design-data-spec/package.json
+++ b/packages/design-data-spec/package.json
@@ -47,7 +47,6 @@
     "test": "ava"
   },
   "devDependencies": {
-    "ava": "^6.0.1",
-    "glob": "^11.0.0"
+    "ava": "^6.0.1"
   }
 }

--- a/packages/design-data-spec/src/canonical.js
+++ b/packages/design-data-spec/src/canonical.js
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// Canonical vocabulary sets derived from spec chapters.
+// Sources: spec/component-format.md, spec/anatomy-format.md, spec/state-model.md
+
+export const CANONICAL_SLOTS = new Set([
+  "default",
+  "icon",
+  "label",
+  "help-text",
+  "negative-help-text",
+  "action",
+  "heading",
+  "description",
+  "hero",
+  "footer",
+  "tooltip",
+]);
+
+export const CANONICAL_ANATOMY_PARTS = new Set([
+  "body",
+  "checkmark",
+  "disclosure-triangle",
+  "field",
+  "handle",
+  "header",
+  "icon",
+  "label",
+  "picker",
+  "progress-bar",
+  "swatch",
+  "thumbnail",
+  "track",
+  "value",
+]);
+
+export const CANONICAL_STATES = new Set([
+  "default",
+  "hover",
+  "focus",
+  "focus-visible",
+  "active",
+  "pressed",
+  "selected",
+  "indeterminate",
+  "disabled",
+  "read-only",
+  "invalid",
+  "valid",
+  "dragging",
+]);

--- a/packages/design-data-spec/src/validate.js
+++ b/packages/design-data-spec/src/validate.js
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Layer 2 cross-reference validator for design-data-spec.
+ *
+ * Implements SPEC-018 through SPEC-024: semantic rules that validate token
+ * name-object fields against component declarations, and validate component
+ * declarations internally.
+ *
+ * @see spec/component-format.md#spec-rules
+ * @see spec/anatomy-format.md#spec-rules
+ * @see spec/state-model.md#spec-rules
+ */
+
+import {
+  CANONICAL_SLOTS,
+  CANONICAL_ANATOMY_PARTS,
+  CANONICAL_STATES,
+} from "./canonical.js";
+
+/**
+ * @typedef {{ ruleId: string, severity: 'error'|'warning', message: string, tokenName?: string, componentName?: string }} Diagnostic
+ * @typedef {{ name: string|object, [key: string]: unknown }} Token
+ * @typedef {{ name: string, options?: object, anatomy?: Array<{name:string,description?:string}>, slots?: Array<{name:string,description?:string}>, states?: Array<{name:string,trigger?:string,precedence?:number,layered?:boolean,description?:string}> }} ComponentDeclaration
+ * @typedef {{ tokens?: Token[], components?: ComponentDeclaration[] }} Dataset
+ */
+
+/**
+ * Validate a dataset for SPEC-018 through SPEC-024 compliance.
+ *
+ * @param {Dataset} dataset
+ * @returns {Diagnostic[]}
+ */
+export function validateDataset(dataset) {
+  const tokens = dataset.tokens ?? [];
+  const components = dataset.components ?? [];
+
+  // Build component lookup map keyed by name.
+  const componentMap = new Map(components.map((c) => [c.name, c]));
+
+  const diagnostics = [];
+
+  // --- Token cross-reference rules ---
+  for (const token of tokens) {
+    const name = token.name;
+    // String names (SPEC-017 escape hatch) skip cross-reference checks.
+    if (typeof name !== "object" || name === null) continue;
+
+    const tokenLabel = JSON.stringify(name);
+
+    if (name.component != null) {
+      // SPEC-018: component name must be declared
+      if (!componentMap.has(name.component)) {
+        diagnostics.push({
+          ruleId: "SPEC-018",
+          severity: "error",
+          message: `Token '${tokenLabel}' references undeclared component '${name.component}'`,
+          tokenName: tokenLabel,
+        });
+        // Can't validate further fields without a component declaration.
+        continue;
+      }
+
+      const component = componentMap.get(name.component);
+
+      // SPEC-019: variant must be in component's variant option enum
+      if (name.variant != null) {
+        const variantEnum = component.options?.variant?.enum;
+        if (Array.isArray(variantEnum) && !variantEnum.includes(name.variant)) {
+          diagnostics.push({
+            ruleId: "SPEC-019",
+            severity: "error",
+            message: `Token '${tokenLabel}' has variant '${name.variant}' which is not declared on component '${name.component}'`,
+            tokenName: tokenLabel,
+            componentName: name.component,
+          });
+        }
+      }
+
+      // SPEC-020: anatomy must match a declared anatomy part name
+      if (name.anatomy != null) {
+        const declaredParts = new Set(
+          (component.anatomy ?? []).map((p) => p.name),
+        );
+        if (declaredParts.size > 0 && !declaredParts.has(name.anatomy)) {
+          diagnostics.push({
+            ruleId: "SPEC-020",
+            severity: "error",
+            message: `Token '${tokenLabel}' references undeclared anatomy part '${name.anatomy}' on component '${name.component}'`,
+            tokenName: tokenLabel,
+            componentName: name.component,
+          });
+        }
+      }
+
+      // SPEC-022: state must match a declared state name (only when states are declared)
+      if (name.state != null) {
+        const declaredStates = new Set(
+          (component.states ?? []).map((s) => s.name),
+        );
+        if (declaredStates.size > 0 && !declaredStates.has(name.state)) {
+          diagnostics.push({
+            ruleId: "SPEC-022",
+            severity: "error",
+            message: `Token '${tokenLabel}' references undeclared state '${name.state}' on component '${name.component}'`,
+            tokenName: tokenLabel,
+            componentName: name.component,
+          });
+        }
+      }
+    }
+  }
+
+  // --- Component declaration internal rules ---
+  for (const component of components) {
+    const cName = component.name;
+
+    // SPEC-021: custom slot names should have descriptions
+    for (const slot of component.slots ?? []) {
+      if (!CANONICAL_SLOTS.has(slot.name) && !slot.description) {
+        diagnostics.push({
+          ruleId: "SPEC-021",
+          severity: "warning",
+          message: `Component '${cName}' has custom slot '${slot.name}' with no description — add a description or use a canonical slot name`,
+          componentName: cName,
+        });
+      }
+    }
+
+    // SPEC-023: custom anatomy part names should have descriptions
+    for (const part of component.anatomy ?? []) {
+      if (!CANONICAL_ANATOMY_PARTS.has(part.name) && !part.description) {
+        diagnostics.push({
+          ruleId: "SPEC-023",
+          severity: "warning",
+          message: `Component '${cName}' has custom anatomy part '${part.name}' with no description`,
+          componentName: cName,
+        });
+      }
+    }
+
+    // SPEC-024: custom state names should have descriptions
+    for (const state of component.states ?? []) {
+      if (!CANONICAL_STATES.has(state.name) && !state.description) {
+        diagnostics.push({
+          ruleId: "SPEC-024",
+          severity: "warning",
+          message: `Component '${cName}' has custom state '${state.name}' with no description`,
+          componentName: cName,
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/design-data-spec/test/conformance.test.js
+++ b/packages/design-data-spec/test/conformance.test.js
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ * Conformance fixture runner for Layer 2 SPEC rules.
+ *
+ * For each conformance/invalid/SPEC-NNN/ directory that contains dataset.json,
+ * validates the dataset and asserts that all expected errors from
+ * expected-errors.json appear in the diagnostics.
+ */
+
+import test from "ava";
+import { readFile } from "fs/promises";
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { validateDataset } from "../src/validate.js";
+
+const readJSON = async (p) => JSON.parse(await readFile(p, "utf8"));
+
+// Discover fixture directories synchronously (AVA requires synchronous test registration).
+// Only include directories that have dataset.json (SPEC-018+ format).
+const invalidBaseDir = "conformance/invalid";
+const fixtureDirs = readdirSync(invalidBaseDir)
+  .sort()
+  .map((entry) => join(invalidBaseDir, entry))
+  .filter((dir) => existsSync(join(dir, "dataset.json")));
+
+for (const dir of fixtureDirs) {
+  const ruleId = dir.split("/").pop();
+
+  test(`conformance: ${ruleId} invalid fixture produces expected diagnostics`, async (t) => {
+    const dataset = await readJSON(join(dir, "dataset.json"));
+    const expected = await readJSON(join(dir, "expected-errors.json"));
+    const diagnostics = validateDataset(dataset);
+
+    for (const expectedError of expected.errors) {
+      const match = diagnostics.find(
+        (d) =>
+          d.ruleId === expectedError.rule_id &&
+          d.severity === expectedError.severity &&
+          new RegExp(expectedError.message_pattern).test(d.message),
+      );
+      t.truthy(
+        match,
+        `Expected diagnostic for ${expectedError.rule_id} matching pattern "${expectedError.message_pattern}" not found.\nActual diagnostics:\n${JSON.stringify(diagnostics, null, 2)}`,
+      );
+    }
+  });
+}
+
+// Valid fixture: component-refs dataset should produce zero diagnostics.
+test("conformance: valid component-refs dataset produces no diagnostics", async (t) => {
+  const dataset = await readJSON(
+    "conformance/valid/component-refs/dataset.json",
+  );
+  const diagnostics = validateDataset(dataset);
+  t.deepEqual(diagnostics, []);
+});

--- a/packages/design-data-spec/test/validate.test.js
+++ b/packages/design-data-spec/test/validate.test.js
@@ -1,0 +1,321 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import { validateDataset } from "../src/validate.js";
+
+// Minimal button component used across tests
+const button = {
+  $id: "https://example.com/button.json",
+  name: "button",
+  displayName: "Button",
+  meta: { category: "actions", documentationUrl: "https://example.com/button" },
+  options: {
+    variant: {
+      type: "string",
+      enum: ["accent", "negative", "primary", "secondary"],
+    },
+  },
+  anatomy: [
+    { name: "icon", description: "Leading icon." },
+    { name: "label", description: "Button text.", required: true },
+  ],
+  states: [
+    { name: "hover", trigger: "interaction", precedence: 50 },
+    { name: "focus", trigger: "interaction", precedence: 60, layered: true },
+    { name: "disabled", trigger: "prop", precedence: 100 },
+  ],
+  slots: [
+    { name: "default", description: "Text label." },
+    { name: "icon", description: "Leading icon." },
+  ],
+};
+
+// ---- SPEC-018: component-name-exists ----------------------------------------
+
+test("SPEC-018: no error when component is declared", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: { component: "button", property: "background-color" },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-018");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-018: error when component is not declared", (t) => {
+  const dataset = {
+    tokens: [
+      { name: { component: "ghost", property: "color" }, value: "#fff" },
+    ],
+    components: [],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-018");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "error");
+  t.regex(diags[0].message, /undeclared component/);
+});
+
+test("SPEC-018: string token names are skipped", (t) => {
+  const dataset = {
+    tokens: [{ name: "legacy-token-name", value: "#fff" }],
+    components: [],
+  };
+  const diags = validateDataset(dataset);
+  t.is(diags.length, 0);
+});
+
+// ---- SPEC-019: component-variant-valid --------------------------------------
+
+test("SPEC-019: no error when variant is in enum", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: {
+          component: "button",
+          variant: "accent",
+          property: "background-color",
+        },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-019");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-019: error when variant is not in enum", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: {
+          component: "button",
+          variant: "electric",
+          property: "background-color",
+        },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-019");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "error");
+});
+
+test("SPEC-019: no error when component has no variant enum", (t) => {
+  const noVariantButton = { ...button, options: {} };
+  const dataset = {
+    tokens: [
+      {
+        name: { component: "button", variant: "anything", property: "color" },
+        value: "#fff",
+      },
+    ],
+    components: [noVariantButton],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-019");
+  t.is(diags.length, 0);
+});
+
+// ---- SPEC-020: component-anatomy-valid ---------------------------------------
+
+test("SPEC-020: no error when anatomy part is declared", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: { component: "button", anatomy: "label", property: "color" },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-020");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-020: error when anatomy part is not declared", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: { component: "button", anatomy: "capsule", property: "color" },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-020");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "error");
+});
+
+test("SPEC-020: no error when component declares no anatomy", (t) => {
+  const noAnatomyButton = { ...button, anatomy: [] };
+  const dataset = {
+    tokens: [
+      {
+        name: { component: "button", anatomy: "anything", property: "color" },
+        value: "#fff",
+      },
+    ],
+    components: [noAnatomyButton],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-020");
+  t.is(diags.length, 0);
+});
+
+// ---- SPEC-021: component-slot-vocabulary ------------------------------------
+
+test("SPEC-021: no warning when custom slot has description", (t) => {
+  const comp = {
+    ...button,
+    slots: [{ name: "badge", description: "Badge overlay." }],
+  };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-021");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-021: warning when custom slot has no description", (t) => {
+  const comp = { ...button, slots: [{ name: "badge" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-021");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "warning");
+});
+
+test("SPEC-021: no warning for canonical slot without description", (t) => {
+  const comp = { ...button, slots: [{ name: "icon" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-021");
+  t.is(diags.length, 0);
+});
+
+// ---- SPEC-022: component-state-valid ----------------------------------------
+
+test("SPEC-022: no error when state is declared", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: {
+          component: "button",
+          state: "hover",
+          property: "background-color",
+        },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-022");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-022: error when state is not declared", (t) => {
+  const dataset = {
+    tokens: [
+      {
+        name: {
+          component: "button",
+          state: "jello",
+          property: "background-color",
+        },
+        value: "#fff",
+      },
+    ],
+    components: [button],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-022");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "error");
+});
+
+test("SPEC-022: no error when component declares no states", (t) => {
+  const noStatesButton = { ...button, states: [] };
+  const dataset = {
+    tokens: [
+      {
+        name: { component: "button", state: "anything", property: "color" },
+        value: "#fff",
+      },
+    ],
+    components: [noStatesButton],
+  };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-022");
+  t.is(diags.length, 0);
+});
+
+// ---- SPEC-023: anatomy-custom-part-documented --------------------------------
+
+test("SPEC-023: no warning when custom part has description", (t) => {
+  const comp = {
+    ...button,
+    anatomy: [{ name: "shimmer", description: "Loading shimmer overlay." }],
+  };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-023");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-023: warning when custom anatomy part has no description", (t) => {
+  const comp = { ...button, anatomy: [{ name: "shimmer" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-023");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "warning");
+});
+
+test("SPEC-023: no warning for canonical anatomy part without description", (t) => {
+  const comp = { ...button, anatomy: [{ name: "label" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-023");
+  t.is(diags.length, 0);
+});
+
+// ---- SPEC-024: state-custom-name-documented ----------------------------------
+
+test("SPEC-024: no warning when custom state has description", (t) => {
+  const comp = {
+    ...button,
+    states: [{ name: "wobble", description: "Wobble animation state." }],
+  };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-024");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-024: warning when custom state has no description", (t) => {
+  const comp = { ...button, states: [{ name: "wobble" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-024");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "warning");
+});
+
+test("SPEC-024: no warning for canonical state without description", (t) => {
+  const comp = { ...button, states: [{ name: "hover" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-024");
+  t.is(diags.length, 0);
+});
+
+// ---- Empty dataset ----------------------------------------------------------
+
+test("empty dataset produces no diagnostics", (t) => {
+  t.deepEqual(validateDataset({}), []);
+  t.deepEqual(validateDataset({ tokens: [], components: [] }), []);
+});

--- a/packages/design-data-spec/test/validate.test.js
+++ b/packages/design-data-spec/test/validate.test.js
@@ -319,3 +319,11 @@ test("empty dataset produces no diagnostics", (t) => {
   t.deepEqual(validateDataset({}), []);
   t.deepEqual(validateDataset({ tokens: [], components: [] }), []);
 });
+
+test("null token name produces no diagnostics", (t) => {
+  const dataset = {
+    tokens: [{ name: null, value: "#fff" }],
+    components: [],
+  };
+  t.deepEqual(validateDataset(dataset), []);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,9 +254,6 @@ importers:
       ava:
         specifier: ^6.0.1
         version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
-      glob:
-        specifier: ^11.0.0
-        version: 11.0.3
 
   packages/design-system-registry:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,14 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.17.1)
 
-  packages/design-data-spec: {}
+  packages/design-data-spec:
+    devDependencies:
+      ava:
+        specifier: ^6.0.1
+        version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.3
 
   packages/design-system-registry:
     devDependencies:


### PR DESCRIPTION
## Motivation

SPEC rules 018–024 were defined in phases 6.1–6.3 but had no implementation and no conformance fixtures. This PR makes them executable.

## Changes

**New: `src/validate.js`** — Layer 2 validator implementing SPEC-018–024.
- `validateDataset({ tokens, components })` → `Diagnostic[]`
- SPEC-018: token `component` field must match a declared component name
- SPEC-019: token `variant` must be in component's `options.variant.enum`
- SPEC-020: token `anatomy` must match a declared anatomy part name
- SPEC-021: custom slot names without descriptions → warning
- SPEC-022: token `state` must match a declared state name (when states declared)
- SPEC-023: custom anatomy part names without descriptions → warning
- SPEC-024: custom state names without descriptions → warning

**New: `src/canonical.js`** — exported `Set<string>` constants for canonical slot, anatomy, and state vocabularies (derived from spec chapters).

**New: `components/button.json`** — first component declaration in the new format; used by fixtures and serves as reference for Phase 6.5 adapter work.

**New: conformance fixtures** for SPEC-018 through SPEC-024 (`conformance/invalid/SPEC-NNN/dataset.json` + `expected-errors.json`), plus one shared valid fixture (`conformance/valid/component-refs/`).

**New: tests**
- `test/validate.test.js` — 22 unit tests, one per rule path (happy + sad + edge cases)
- `test/conformance.test.js` — fixture runner; discovers all `dataset.json` fixtures and validates them

**Updated: `package.json`** — adds exports for new schemas (`component`, `anatomy-part`, `state-declaration`) and the validator module; adds `ava` and `glob` devDependencies.

**Updated: `moon.yml`** — adds `test` task running `pnpm ava`.

## Testing

```
30 tests passed (22 unit + 8 conformance)
```

## Related

Closes part of epic #828 (Phase 6: Component Contract). Unblocks the `0.3.0` minor release (exports now include new schemas + validator).