### PR TITLE
feat(cli): add design-data primer subcommand for agent session start

### DIFF
--- a/.changeset/phase-8-1-primer.md
+++ b/.changeset/phase-8-1-primer.md
@@ -1,0 +1,5 @@
+---
+"design-data-cli": patch
+---
+
+feat(cli): add `design-data primer` subcommand for agent session start

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -34,6 +34,8 @@ use design_data_core::schema::SchemaRegistry;
 use design_data_core::validate;
 use miette::{IntoDiagnostic, WrapErr};
 
+const SPEC_VERSION: &str = "1.0.0-draft";
+
 /// Spectrum Design Data tooling — validate and migrate design tokens.
 #[derive(Parser)]
 #[command(name = "design-data", version, about)]
@@ -143,9 +145,9 @@ enum Commands {
         /// Override taxonomy fields directory
         #[arg(long, value_name = "DIR")]
         fields_dir: Option<PathBuf>,
-        /// Directory containing spec-format dimension declaration JSON files
+        /// Override dimensions directory
         #[arg(long, value_name = "DIR")]
-        dimensions_path: Option<PathBuf>,
+        dimensions_dir: Option<PathBuf>,
     },
     /// Create or update a product-context.json document for a product-layer working copy
     Write {
@@ -858,14 +860,14 @@ fn run_primer(
     format: OutputFormat,
     components_dir: Option<PathBuf>,
     fields_dir: Option<PathBuf>,
-    dimensions_path: Option<PathBuf>,
+    dimensions_dir: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
     let graph = TokenGraph::from_json_dir(path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
     let token_count = graph.tokens.len();
 
-    let dims_dir = dimensions_path.or_else(default_dimensions_path);
+    let dims_dir = dimensions_dir.or_else(default_dimensions_path);
     let dimensions: Vec<serde_json::Value> = if let Some(dir) = dims_dir {
         TokenGraph::load_spec_dimensions(&dir)
             .unwrap_or_default()
@@ -888,7 +890,7 @@ fn run_primer(
             .unwrap_or_else(|| PathBuf::from("packages/design-data-spec/components")),
     );
 
-    let mut taxonomy_fields: Vec<serde_json::Value> = fields_dir
+    let taxonomy_fields: Vec<serde_json::Value> = fields_dir
         .or_else(default_fields_path)
         .map(|dir| {
             let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -904,18 +906,23 @@ fn run_primer(
                     let raw = std::fs::read_to_string(&p).ok()?;
                     let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
                     let name = v.get("name")?.as_str()?.to_string();
-                    Some(serde_json::json!({
+                    let required = v.get("required").and_then(|r| r.as_bool()).unwrap_or(false);
+                    let mut field = serde_json::json!({
                         "name": name,
-                        "description": v.get("description"),
-                        "required": v.get("required").and_then(|r| r.as_bool()).unwrap_or(false),
-                    }))
+                        "required": required,
+                    });
+                    if let Some(desc) = v.get("description") {
+                        if !desc.is_null() {
+                            field["description"] = desc.clone();
+                        }
+                    }
+                    Some(field)
                 })
                 .collect();
             fields.sort_by_key(|f| f["name"].as_str().unwrap_or("").to_string());
             fields
         })
         .unwrap_or_default();
-    taxonomy_fields.sort_by_key(|f| f["name"].as_str().unwrap_or("").to_string());
 
     let manifest: serde_json::Value = {
         let mp = path.join("manifest.json");
@@ -930,7 +937,7 @@ fn run_primer(
     };
 
     let payload = serde_json::json!({
-        "specVersion": "1.0.0-draft",
+        "specVersion": SPEC_VERSION,
         "tokenCount": token_count,
         "dimensions": dimensions,
         "components": components,
@@ -953,7 +960,8 @@ fn run_primer(
                     let default = d["defaultMode"].as_str().unwrap_or("");
                     let mode_str = d["modes"]
                         .as_array()
-                        .unwrap_or(&vec![])
+                        .map(Vec::as_slice)
+                        .unwrap_or(&[])
                         .iter()
                         .filter_map(|m| m.as_str())
                         .map(|m| {
@@ -968,17 +976,18 @@ fn run_primer(
                     format!("{name} ({mode_str})")
                 })
                 .collect();
+            const COMPONENT_PREVIEW_COUNT: usize = 8;
             let comp_count = components.len();
-            let comp_preview = if comp_count > 8 {
+            let comp_preview = if comp_count > COMPONENT_PREVIEW_COUNT {
                 format!(
                     "{}, … and {} more",
-                    components[..8].join(", "),
-                    comp_count - 8
+                    components[..COMPONENT_PREVIEW_COUNT].join(", "),
+                    comp_count - COMPONENT_PREVIEW_COUNT
                 )
             } else {
                 components.join(", ")
             };
-            println!("Spec version:  1.0.0-draft");
+            println!("Spec version:  {SPEC_VERSION}");
             println!("Token count:   {token_count}");
             println!("Dimensions:    {}", dim_summary.join(", "));
             println!("Components:    {comp_preview}");
@@ -1007,7 +1016,7 @@ fn run_write(output: &Path, rationale: Option<&str>) -> miette::Result<ExitCode>
         let mut map = serde_json::Map::new();
         map.insert(
             "specVersion".to_string(),
-            serde_json::Value::String("1.0.0-draft".to_string()),
+            serde_json::Value::String(SPEC_VERSION.to_string()),
         );
         map.insert(
             "layer".to_string(),
@@ -1154,10 +1163,10 @@ fn main() -> ExitCode {
             format,
             components_dir,
             fields_dir,
-            dimensions_path,
+            dimensions_dir,
         } => {
             let target = path.unwrap_or_else(|| PathBuf::from("."));
-            run_primer(&target, format, components_dir, fields_dir, dimensions_path)
+            run_primer(&target, format, components_dir, fields_dir, dimensions_dir)
         }
         Commands::Write { output, rationale } => {
             run_write(&output, rationale.as_deref())

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -129,6 +129,24 @@ enum Commands {
         #[command(subcommand)]
         sub: FigmaSub,
     },
+    /// Emit a structural overview of the dataset for agent session start
+    Primer {
+        /// Path to the token dataset directory
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = OutputFormat::Pretty)]
+        format: OutputFormat,
+        /// Override components directory
+        #[arg(long, value_name = "DIR")]
+        components_dir: Option<PathBuf>,
+        /// Override taxonomy fields directory
+        #[arg(long, value_name = "DIR")]
+        fields_dir: Option<PathBuf>,
+        /// Directory containing spec-format dimension declaration JSON files
+        #[arg(long, value_name = "DIR")]
+        dimensions_path: Option<PathBuf>,
+    },
     /// Create or update a product-context.json document for a product-layer working copy
     Write {
         /// Path to the product context JSON file to create or update
@@ -286,6 +304,22 @@ fn default_dimensions_path() -> Option<PathBuf> {
     let candidates = [
         PathBuf::from("packages/design-data-spec/dimensions"),
         PathBuf::from("../packages/design-data-spec/dimensions"),
+    ];
+    candidates.into_iter().find(|c| c.is_dir())
+}
+
+fn default_components_path() -> Option<PathBuf> {
+    let candidates = [
+        PathBuf::from("packages/design-data-spec/components"),
+        PathBuf::from("../packages/design-data-spec/components"),
+    ];
+    candidates.into_iter().find(|c| c.is_dir())
+}
+
+fn default_fields_path() -> Option<PathBuf> {
+    let candidates = [
+        PathBuf::from("packages/design-data-spec/fields"),
+        PathBuf::from("../packages/design-data-spec/fields"),
     ];
     candidates.into_iter().find(|c| c.is_dir())
 }
@@ -799,6 +833,166 @@ fn run_figma_read(file_key: &str, token: &str, format: OutputFormat) -> miette::
     Ok(ExitCode::SUCCESS)
 }
 
+fn scan_json_name_field(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return vec![];
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().and_then(|x| x.to_str()) != Some("json") {
+                return None;
+            }
+            let raw = std::fs::read_to_string(&p).ok()?;
+            let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+            v.get("name")?.as_str().map(|s| s.to_string())
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+fn run_primer(
+    path: &Path,
+    format: OutputFormat,
+    components_dir: Option<PathBuf>,
+    fields_dir: Option<PathBuf>,
+    dimensions_path: Option<PathBuf>,
+) -> miette::Result<ExitCode> {
+    let graph = TokenGraph::from_json_dir(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+    let token_count = graph.tokens.len();
+
+    let dims_dir = dimensions_path.or_else(default_dimensions_path);
+    let dimensions: Vec<serde_json::Value> = if let Some(dir) = dims_dir {
+        TokenGraph::load_spec_dimensions(&dir)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|d| {
+                serde_json::json!({
+                    "name": d.name,
+                    "modes": d.modes,
+                    "defaultMode": d.default_mode,
+                })
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let components = scan_json_name_field(
+        &components_dir
+            .or_else(default_components_path)
+            .unwrap_or_else(|| PathBuf::from("packages/design-data-spec/components")),
+    );
+
+    let mut taxonomy_fields: Vec<serde_json::Value> = fields_dir
+        .or_else(default_fields_path)
+        .map(|dir| {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                return vec![];
+            };
+            let mut fields: Vec<serde_json::Value> = entries
+                .flatten()
+                .filter_map(|e| {
+                    let p = e.path();
+                    if p.extension().and_then(|x| x.to_str()) != Some("json") {
+                        return None;
+                    }
+                    let raw = std::fs::read_to_string(&p).ok()?;
+                    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+                    let name = v.get("name")?.as_str()?.to_string();
+                    Some(serde_json::json!({
+                        "name": name,
+                        "description": v.get("description"),
+                        "required": v.get("required").and_then(|r| r.as_bool()).unwrap_or(false),
+                    }))
+                })
+                .collect();
+            fields.sort_by_key(|f| f["name"].as_str().unwrap_or("").to_string());
+            fields
+        })
+        .unwrap_or_default();
+    taxonomy_fields.sort_by_key(|f| f["name"].as_str().unwrap_or("").to_string());
+
+    let manifest: serde_json::Value = {
+        let mp = path.join("manifest.json");
+        if mp.is_file() {
+            std::fs::read_to_string(&mp)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or(serde_json::Value::Null)
+        } else {
+            serde_json::Value::Null
+        }
+    };
+
+    let payload = serde_json::json!({
+        "specVersion": "1.0.0-draft",
+        "tokenCount": token_count,
+        "dimensions": dimensions,
+        "components": components,
+        "taxonomyFields": taxonomy_fields,
+        "manifest": manifest,
+    });
+
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&payload).into_diagnostic()?
+            );
+        }
+        OutputFormat::Pretty => {
+            let dim_summary: Vec<String> = dimensions
+                .iter()
+                .map(|d| {
+                    let name = d["name"].as_str().unwrap_or("");
+                    let default = d["defaultMode"].as_str().unwrap_or("");
+                    let mode_str = d["modes"]
+                        .as_array()
+                        .unwrap_or(&vec![])
+                        .iter()
+                        .filter_map(|m| m.as_str())
+                        .map(|m| {
+                            if m == default {
+                                format!("{m}*")
+                            } else {
+                                m.to_string()
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("|");
+                    format!("{name} ({mode_str})")
+                })
+                .collect();
+            let comp_count = components.len();
+            let comp_preview = if comp_count > 8 {
+                format!(
+                    "{}, … and {} more",
+                    components[..8].join(", "),
+                    comp_count - 8
+                )
+            } else {
+                components.join(", ")
+            };
+            println!("Spec version:  1.0.0-draft");
+            println!("Token count:   {token_count}");
+            println!("Dimensions:    {}", dim_summary.join(", "));
+            println!("Components:    {comp_preview}");
+            println!("Fields:        {}", taxonomy_fields.len());
+            println!(
+                "Manifest:      {}",
+                if manifest.is_null() { "none" } else { "present" }
+            );
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
 fn run_write(output: &Path, rationale: Option<&str>) -> miette::Result<ExitCode> {
     let mut doc: serde_json::Value = if output.exists() {
         let raw = std::fs::read_to_string(output)
@@ -955,6 +1149,16 @@ fn main() -> ExitCode {
                 dry_run,
             } => run_figma_export(&path, &file_key, &token, dry_run),
         },
+        Commands::Primer {
+            path,
+            format,
+            components_dir,
+            fields_dir,
+            dimensions_path,
+        } => {
+            let target = path.unwrap_or_else(|| PathBuf::from("."));
+            run_primer(&target, format, components_dir, fields_dir, dimensions_path)
+        }
         Commands::Write { output, rationale } => {
             run_write(&output, rationale.as_deref())
         }

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -230,7 +230,7 @@ fn primer_emits_json_with_required_fields() {
             "json",
             "--components-dir",
             components.to_str().expect("utf8 path"),
-            "--dimensions-path",
+            "--dimensions-dir",
             dimensions.to_str().expect("utf8 path"),
             "--fields-dir",
             fields.to_str().expect("utf8 path"),
@@ -250,15 +250,15 @@ fn primer_emits_json_with_required_fields() {
         "tokenCount must be positive"
     );
     assert!(
-        !doc["dimensions"].as_array().unwrap_or(&vec![]).is_empty(),
+        doc["dimensions"].as_array().map_or(false, |a| !a.is_empty()),
         "dimensions must be non-empty"
     );
     assert!(
-        !doc["components"].as_array().unwrap_or(&vec![]).is_empty(),
+        doc["components"].as_array().map_or(false, |a| !a.is_empty()),
         "components must be non-empty"
     );
     assert!(
-        !doc["taxonomyFields"].as_array().unwrap_or(&vec![]).is_empty(),
+        doc["taxonomyFields"].as_array().map_or(false, |a| !a.is_empty()),
         "taxonomyFields must be non-empty"
     );
 }
@@ -276,7 +276,7 @@ fn primer_components_are_sorted() {
             "json",
             "--components-dir",
             components.to_str().expect("utf8 path"),
-            "--dimensions-path",
+            "--dimensions-dir",
             dimensions.to_str().expect("utf8 path"),
             "--fields-dir",
             fields.to_str().expect("utf8 path"),
@@ -317,7 +317,7 @@ fn primer_pretty_output_contains_token_count() {
             src.to_str().expect("utf8 path"),
             "--components-dir",
             components.to_str().expect("utf8 path"),
-            "--dimensions-path",
+            "--dimensions-dir",
             dimensions.to_str().expect("utf8 path"),
             "--fields-dir",
             fields.to_str().expect("utf8 path"),
@@ -325,4 +325,13 @@ fn primer_pretty_output_contains_token_count() {
         .assert()
         .success()
         .stdout(contains("Token count:"));
+}
+
+#[test]
+fn primer_fails_on_nonexistent_path() {
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args(["primer", "/nonexistent/path/that/does/not/exist"])
+        .assert()
+        .failure();
 }

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -191,3 +191,138 @@ fn write_creates_parent_dirs() {
     let doc: serde_json::Value = serde_json::from_str(&content).expect("valid json");
     assert_eq!(doc["specVersion"], "1.0.0-draft");
 }
+
+fn primer_paths() -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = manifest.join("../../packages/tokens/src");
+    let components = manifest.join("../../packages/design-data-spec/components");
+    let dimensions = manifest.join("../../packages/design-data-spec/dimensions");
+    let fields = manifest.join("../../packages/design-data-spec/fields");
+    assert!(src.is_dir(), "expected token sources at {}", src.display());
+    assert!(
+        components.is_dir(),
+        "expected components at {}",
+        components.display()
+    );
+    assert!(
+        dimensions.is_dir(),
+        "expected dimensions at {}",
+        dimensions.display()
+    );
+    assert!(
+        fields.is_dir(),
+        "expected fields at {}",
+        fields.display()
+    );
+    (src, components, dimensions, fields)
+}
+
+#[test]
+fn primer_emits_json_with_required_fields() {
+    let (src, components, dimensions, fields) = primer_paths();
+
+    let output = Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "primer",
+            src.to_str().expect("utf8 path"),
+            "--format",
+            "json",
+            "--components-dir",
+            components.to_str().expect("utf8 path"),
+            "--dimensions-path",
+            dimensions.to_str().expect("utf8 path"),
+            "--fields-dir",
+            fields.to_str().expect("utf8 path"),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output).expect("primer --format json must emit valid JSON");
+
+    assert_eq!(doc["specVersion"], "1.0.0-draft");
+    assert!(
+        doc["tokenCount"].as_u64().unwrap_or(0) > 0,
+        "tokenCount must be positive"
+    );
+    assert!(
+        !doc["dimensions"].as_array().unwrap_or(&vec![]).is_empty(),
+        "dimensions must be non-empty"
+    );
+    assert!(
+        !doc["components"].as_array().unwrap_or(&vec![]).is_empty(),
+        "components must be non-empty"
+    );
+    assert!(
+        !doc["taxonomyFields"].as_array().unwrap_or(&vec![]).is_empty(),
+        "taxonomyFields must be non-empty"
+    );
+}
+
+#[test]
+fn primer_components_are_sorted() {
+    let (src, components, dimensions, fields) = primer_paths();
+
+    let output = Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "primer",
+            src.to_str().expect("utf8 path"),
+            "--format",
+            "json",
+            "--components-dir",
+            components.to_str().expect("utf8 path"),
+            "--dimensions-path",
+            dimensions.to_str().expect("utf8 path"),
+            "--fields-dir",
+            fields.to_str().expect("utf8 path"),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let doc: serde_json::Value = serde_json::from_slice(&output).expect("valid json");
+    let names: Vec<&str> = doc["components"]
+        .as_array()
+        .expect("components is an array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+
+    assert!(!names.is_empty(), "components list must not be empty");
+    for window in names.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "components must be sorted: {:?} > {:?}",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+#[test]
+fn primer_pretty_output_contains_token_count() {
+    let (src, components, dimensions, fields) = primer_paths();
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "primer",
+            src.to_str().expect("utf8 path"),
+            "--components-dir",
+            components.to_str().expect("utf8 path"),
+            "--dimensions-path",
+            dimensions.to_str().expect("utf8 path"),
+            "--fields-dir",
+            fields.to_str().expect("utf8 path"),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("Token count:"));
+}


### PR DESCRIPTION
## Description

Adds the `design-data primer` subcommand — Phase 8.1 of the Agent-Readable Surface. This command gives an agent a structural overview of the active dataset at session start.

**Output fields:**
- `specVersion` — always `1.0.0-draft`
- `tokenCount` — number of tokens loaded from the dataset
- `dimensions` — each dimension with its modes and default mode
- `components` — sorted list of component names from the design-data-spec
- `taxonomyFields` — taxonomy field metadata (name, description, required)
- `manifest` — contents of `manifest.json` if present, null otherwise

Supports `--format json` (full JSON output) and `--format pretty` (human-readable summary, the default). All paths auto-detect from CWD candidates; explicit overrides available via `--components-dir`, `--fields-dir`, and `--dimensions-path`.

**Example output:**
```
Spec version:  1.0.0-draft
Token count:   2834
Dimensions:    colorScheme (light*|dark), scale (desktop*|mobile), contrast (regular*|high)
Components:    accordion, action-bar, action-button, action-group, action-menu, alert-banner, alert-dialog, avatar, … and N more
Fields:        8
Manifest:      none
```

## Related Issue

Closes #865

## Motivation and Context

Phase 8 (Agent-Readable Surface) requires a session-start operation so an agent can orient itself to the dataset structure before performing targeted operations. `primer` is the first of four Phase 8 sub-issues and is a prerequisite for the MCP server (#867).

## How Has This Been Tested?

Three new integration tests in `sdk/cli/tests/cli_validate.rs`:
- `primer_emits_json_with_required_fields` — verifies specVersion, tokenCount > 0, non-empty dimensions/components/taxonomyFields
- `primer_components_are_sorted` — verifies alphabetical component ordering
- `primer_pretty_output_contains_token_count` — verifies pretty-format token count line

All 9 CLI integration tests pass (`cargo test -p design-data-cli`).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.