### PR TITLE
feat(cli): add design-data component subcommand for agent component lookup

### DIFF
--- a/.changeset/phase-8-2-component.md
+++ b/.changeset/phase-8-2-component.md
@@ -1,0 +1,5 @@
+---
+"design-data-cli": patch
+---
+
+feat(cli): add `design-data component <ID>` subcommand for agent component lookup

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1015,7 +1015,7 @@ fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<Ex
     // Reject IDs that could escape the components directory via path traversal.
     if !id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
         || id.is_empty()
-        || !id.chars().next().map_or(false, |c| c.is_ascii_lowercase())
+        || !id.chars().next().is_some_and(|c| c.is_ascii_lowercase())
     {
         eprintln!("Invalid component ID '{id}'. IDs must match ^[a-z][a-z0-9-]*$");
         return Ok(ExitCode::from(1));

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -149,6 +149,15 @@ enum Commands {
         #[arg(long, value_name = "DIR")]
         dimensions_dir: Option<PathBuf>,
     },
+    /// Return the full component declaration for a given component identifier
+    Component {
+        /// Component identifier (e.g. "button", "action-bar")
+        #[arg(value_name = "ID")]
+        id: String,
+        /// Override components directory
+        #[arg(long, value_name = "DIR")]
+        components_dir: Option<PathBuf>,
+    },
     /// Create or update a product-context.json document for a product-layer working copy
     Write {
         /// Path to the product context JSON file to create or update
@@ -1002,6 +1011,33 @@ fn run_primer(
     Ok(ExitCode::SUCCESS)
 }
 
+fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<ExitCode> {
+    let dir = components_dir
+        .or_else(default_components_path)
+        .ok_or_else(|| miette::miette!("could not locate components directory"))?;
+
+    let file = dir.join(format!("{id}.json"));
+    if file.is_file() {
+        let raw = std::fs::read_to_string(&file)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read {}", file.display()))?;
+        let doc: serde_json::Value = serde_json::from_str(&raw)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to parse {}", file.display()))?;
+        println!("{}", serde_json::to_string_pretty(&doc).into_diagnostic()?);
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let available = scan_json_name_field(&dir);
+    eprintln!("Component '{id}' not found.");
+    if available.is_empty() {
+        eprintln!("No components found in {}", dir.display());
+    } else {
+        eprintln!("Available components: {}", available.join(", "));
+    }
+    Ok(ExitCode::from(1))
+}
+
 fn run_write(output: &Path, rationale: Option<&str>) -> miette::Result<ExitCode> {
     let mut doc: serde_json::Value = if output.exists() {
         let raw = std::fs::read_to_string(output)
@@ -1168,6 +1204,7 @@ fn main() -> ExitCode {
             let target = path.unwrap_or_else(|| PathBuf::from("."));
             run_primer(&target, format, components_dir, fields_dir, dimensions_dir)
         }
+        Commands::Component { id, components_dir } => run_component(&id, components_dir),
         Commands::Write { output, rationale } => {
             run_write(&output, rationale.as_deref())
         }

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1012,6 +1012,15 @@ fn run_primer(
 }
 
 fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<ExitCode> {
+    // Reject IDs that could escape the components directory via path traversal.
+    if !id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        || id.is_empty()
+        || !id.chars().next().map_or(false, |c| c.is_ascii_lowercase())
+    {
+        eprintln!("Invalid component ID '{id}'. IDs must match ^[a-z][a-z0-9-]*$");
+        return Ok(ExitCode::from(1));
+    }
+
     let dir = components_dir
         .or_else(default_components_path)
         .ok_or_else(|| miette::miette!("could not locate components directory"))?;

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -335,3 +335,52 @@ fn primer_fails_on_nonexistent_path() {
         .assert()
         .failure();
 }
+
+fn component_dir() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest.join("../../packages/design-data-spec/components");
+    assert!(dir.is_dir(), "expected components at {}", dir.display());
+    dir
+}
+
+#[test]
+fn component_button_returns_json() {
+    let dir = component_dir();
+
+    let output = Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "component",
+            "button",
+            "--components-dir",
+            dir.to_str().expect("utf8 path"),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let doc: serde_json::Value =
+        serde_json::from_slice(&output).expect("component output must be valid JSON");
+
+    assert_eq!(doc["name"], "button");
+    assert!(doc["tokenBindings"].is_array(), "tokenBindings must be present");
+    assert!(doc["anatomy"].is_array(), "anatomy must be present");
+}
+
+#[test]
+fn component_nonexistent_fails() {
+    let dir = component_dir();
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .args([
+            "component",
+            "nonexistent-xyz",
+            "--components-dir",
+            dir.to_str().expect("utf8 path"),
+        ])
+        .assert()
+        .failure();
+}

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -384,3 +384,21 @@ fn component_nonexistent_fails() {
         .assert()
         .failure();
 }
+
+#[test]
+fn component_path_traversal_rejected() {
+    let dir = component_dir();
+
+    for bad_id in &["../button", "/etc/passwd", "button.json", "Button", "button/x"] {
+        Command::cargo_bin("design-data")
+            .expect("binary design-data")
+            .args([
+                "component",
+                bad_id,
+                "--components-dir",
+                dir.to_str().expect("utf8 path"),
+            ])
+            .assert()
+            .failure();
+    }
+}


### PR DESCRIPTION
## Description

Adds the `design-data component <ID>` subcommand — Phase 8.2 of the Agent-Readable Surface. Returns the full component declaration for a given component identifier as JSON.

```
design-data component button
design-data component action-bar --components-dir ./custom/components
```

**Behavior:**
- Reads `<components-dir>/<id>.json` and outputs it as pretty-printed JSON
- On unknown ID: exits non-zero and prints available component identifiers to stderr
- Components dir auto-detected from CWD; override with `--components-dir`

**Output includes** (per spec `describe_component`): `name`, `displayName`, `meta`, `options`, `anatomy`, `states`, `tokenBindings` (Phase 6.7 data), `lifecycle`

## Related Issue

Closes #866

## Motivation and Context

Phase 8 (Agent-Readable Surface) needs a way for an agent to retrieve the full contract for a specific component after using `primer` to orient itself. This is the CLI face of `describe_component` defined in `spec/agent-surface.md` and is a prerequisite for the MCP server (#867).

## How Has This Been Tested?

Two new integration tests in `sdk/cli/tests/cli_validate.rs`:
- `component_button_returns_json` — verifies valid JSON output, `name == "button"`, `tokenBindings` and `anatomy` are arrays
- `component_nonexistent_fails` — verifies non-zero exit for unknown identifier

All 12 CLI integration tests pass (`cargo test -p design-data-cli`).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.