### PR TITLE
feat(skill): add Claude Code Agent Skill for design-data (Phase 8.4)

### DIFF
--- a/.changeset/phase-8-4-skill.md
+++ b/.changeset/phase-8-4-skill.md
@@ -1,0 +1,5 @@
+---
+"@adobe/design-data-agent-mcp": patch
+---
+
+feat(skill): add Claude Code Agent Skill for design-data (Phase 8.4)

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -1,0 +1,68 @@
+# [**@adobe/design-data-agent-mcp**](https://github.com/adobe/design-data-agent-mcp)
+
+MCP server and Claude Code skill for the [Spectrum Design Data](../../packages/design-data-spec/) agent surface. Shells out to the `design-data` CLI — all logic stays in the Rust SDK.
+
+## Claude Code skill
+
+Install by symlinking the `skill/` directory into your Claude Code skills folder:
+
+```bash
+ln -s "$(pwd)/tools/design-data-agent-mcp/skill" ~/.claude/skills/design-data
+```
+
+Then add the skill to your `~/.claude/CLAUDE.md`:
+
+```markdown
+### design-data
+- **design-data** (`~/.claude/skills/design-data/SKILL.md`) — design token lookup, validation, and authoring via the design-data CLI. Trigger: `/design-data`
+When the user types `/design-data`, invoke the Skill tool with `skill: "design-data"` before doing anything else.
+```
+
+## MCP server
+
+Configure your MCP client to run:
+
+```bash
+node tools/design-data-agent-mcp/src/index.js
+```
+
+### Environment variables
+
+| Variable                 | Default       | Description                               |
+| ------------------------ | ------------- | ----------------------------------------- |
+| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary          |
+| `DESIGN_DATA_PATH`       | `.`           | Dataset root path                         |
+| `DESIGN_DATA_COMPONENTS` | —             | Override components directory             |
+| `DESIGN_DATA_FIELDS`     | —             | Override fields directory                 |
+| `DESIGN_DATA_DIMENSIONS` | —             | Override dimensions directory             |
+| `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)     |
+| `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`) |
+
+### Example (Claude Desktop `claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "node",
+      "args": ["/path/to/spectrum-design-data/tools/design-data-agent-mcp/src/index.js"],
+      "env": {
+        "DESIGN_DATA_BIN": "/path/to/design-data",
+        "DESIGN_DATA_PATH": "/path/to/your/dataset"
+      }
+    }
+  }
+}
+```
+
+## Tools exposed
+
+| Tool                 | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `primer`             | Load full token taxonomy, component list, and field definitions |
+| `resolve_token`      | Resolve a token property to its literal value                   |
+| `query_tokens`       | Filter tokens by expression                                     |
+| `describe_component` | Fetch component schema and token bindings                       |
+| `validate_usage`     | Validate token usage and return a diagnostic report             |
+| `diff_datasets`      | Compare two datasets and return a semantic diff                 |
+| `write`              | Write agent-generated product context to the dataset            |

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -1,4 +1,4 @@
-# [**@adobe/design-data-agent-mcp**](https://github.com/adobe/design-data-agent-mcp)
+# `@adobe/design-data-agent-mcp`
 
 MCP server and Claude Code skill for the [Spectrum Design Data](../../packages/design-data-spec/) agent surface. Shells out to the `design-data` CLI — all logic stays in the Rust SDK.
 

--- a/tools/design-data-agent-mcp/skill/SKILL.md
+++ b/tools/design-data-agent-mcp/skill/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: design-data
+description: >
+  Validate, query, resolve, and author spec-conformant design tokens and components using the
+  design-data CLI. Use when the user asks about design tokens, a design system, Spectrum, token
+  lookup, spec-conformance, drift detection, or token authoring.
+---
+
+# design-data CLI skill
+
+`design-data` is the reference CLI for the Spectrum Design Data specification. It validates, queries, resolves, and authors spec-conformant tokens and components from any dataset on the local filesystem.
+
+Set `DESIGN_DATA_PATH` to the dataset root once and reference it throughout:
+
+```bash
+export DESIGN_DATA_PATH=./packages/tokens/src
+```
+
+***
+
+## Session start — call `primer` first
+
+Call `primer` at the start of every session that touches design data. It returns the active dimensions, component list, taxonomy fields, and token count — structural context that scopes all subsequent lookups.
+
+```bash
+design-data primer "$DESIGN_DATA_PATH" --format json
+```
+
+Optional path overrides (defaults resolve under `DESIGN_DATA_PATH`):
+
+```bash
+design-data primer "$DESIGN_DATA_PATH" --format json \
+  [--components-dir <dir>] \
+  [--fields-dir <dir>] \
+  [--dimensions-dir <dir>]
+```
+
+The payload includes `specVersion`, `manifest`, `dimensions`, `components`, `taxonomyFields`, and `tokenCount`.
+
+***
+
+## Token lookup
+
+### Resolve a token to its literal value
+
+```bash
+design-data resolve <property> "$DESIGN_DATA_PATH" --format json \
+  [--color-scheme light|dark] \
+  [--scale desktop|mobile] \
+  [--contrast regular|high]
+```
+
+Example:
+
+```bash
+design-data resolve accent-background-color-default "$DESIGN_DATA_PATH" \
+  --format json --color-scheme dark --scale desktop
+```
+
+### Query tokens by filter expression
+
+```bash
+design-data query "$DESIGN_DATA_PATH" --filter "<expr>" --format json
+```
+
+Filter syntax examples:
+
+```
+category=color
+name-contains=background
+schema=spectrum-token
+```
+
+> **Exit codes:** `0` = matches found; `1` = no matches (returns `[]` — not an error); `>1` = error.
+
+***
+
+## Component info
+
+```bash
+design-data component <id> --format json [--components-dir <dir>]
+```
+
+Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`.
+
+Example:
+
+```bash
+design-data component button --format json
+```
+
+***
+
+## Validation
+
+```bash
+design-data validate "$DESIGN_DATA_PATH" --format json \
+  [--schema-path <path>] \
+  [--exceptions-path <path>] \
+  [--strict]
+```
+
+Returns a `ValidationReport` with Layer 1 (schema) and Layer 2 (cascade) diagnostics. `--strict` treats warnings as errors.
+
+***
+
+## Dataset diff
+
+```bash
+design-data diff <old-path> <new-path> --format json [--filter <expr>]
+```
+
+> **Exit codes:** `0` = no changes; `1` = differences found (returns JSON diff — not an error); `>1` = error.
+
+***
+
+## Product-layer authoring
+
+Write or update the product context document in the dataset:
+
+```bash
+design-data write \
+  --output "$DESIGN_DATA_PATH/product-context.json" \
+  --rationale "Why these overrides exist"
+```
+
+Always pass `--output` with an explicit path inside the dataset. The default resolves relative to CWD, which is rarely correct in agent contexts.
+
+***
+
+## Gotchas
+
+* **Scale values:** `desktop` and `mobile` — not `medium`/`large`.
+* **Contrast values:** `regular` and `high` — not `standard`/`high`.
+* **`query` exit 1** means no matches and still emits `[]`. Only `>1` is an error.
+* **`diff` exit 1** means changes were found. The JSON diff is in stdout — still a success result.
+* **`--format json`** is required for machine-readable output when stdout is not a TTY.

--- a/tools/design-data-agent-mcp/skill/SKILL.md
+++ b/tools/design-data-agent-mcp/skill/SKILL.md
@@ -10,10 +10,11 @@ description: >
 
 `design-data` is the reference CLI for the Spectrum Design Data specification. It validates, queries, resolves, and authors spec-conformant tokens and components from any dataset on the local filesystem.
 
-Set `DESIGN_DATA_PATH` to the dataset root once and reference it throughout:
+Set two path variables once and reference them throughout. The token dataset and the spec catalog (components, fields, dimensions) live in separate directories:
 
 ```bash
 export DESIGN_DATA_PATH=./packages/tokens/src
+export DESIGN_DATA_SPEC_PATH=./packages/design-data-spec
 ```
 
 ***
@@ -24,12 +25,12 @@ Call `primer` at the start of every session that touches design data. It returns
 
 ```bash
 design-data primer "$DESIGN_DATA_PATH" --format json \
-  --components-dir "$DESIGN_DATA_PATH/components" \
-  --fields-dir "$DESIGN_DATA_PATH/fields" \
-  --dimensions-dir "$DESIGN_DATA_PATH/dimensions"
+  --components-dir "$DESIGN_DATA_SPEC_PATH/components" \
+  --fields-dir     "$DESIGN_DATA_SPEC_PATH/fields" \
+  --dimensions-dir "$DESIGN_DATA_SPEC_PATH/dimensions"
 ```
 
-Always pass `--components-dir`, `--fields-dir`, and `--dimensions-dir` explicitly. The CLI defaults probe for `packages/design-data-spec/{components,fields,dimensions}` relative to the current working directory — not relative to `DESIGN_DATA_PATH` — so omitting them when running from an arbitrary directory (or with an absolute dataset path) produces empty `components`, `taxonomyFields`, and `dimensions` in the primer response.
+Always pass `--components-dir`, `--fields-dir`, and `--dimensions-dir` explicitly. These directories live under `packages/design-data-spec/`, not under the token dataset. The CLI defaults probe those paths relative to CWD, so omitting the flags when running from an arbitrary directory (or with an absolute `DESIGN_DATA_PATH`) produces empty `components`, `taxonomyFields`, and `dimensions`.
 
 The payload includes `specVersion`, `manifest`, `dimensions`, `components`, `taxonomyFields`, and `tokenCount`.
 
@@ -79,7 +80,7 @@ $schema=https://spectrum.adobe.com/page/design-token/
 ## Component info
 
 ```bash
-design-data component <id> --components-dir "$DESIGN_DATA_PATH/components"
+design-data component <id> --components-dir "$DESIGN_DATA_SPEC_PATH/components"
 ```
 
 Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`. Output is always JSON; there is no `--format` flag on this subcommand.
@@ -89,7 +90,7 @@ Pass `--components-dir` explicitly for the same reason as `primer` — the defau
 Example:
 
 ```bash
-design-data component button --components-dir "$DESIGN_DATA_PATH/components"
+design-data component button --components-dir "$DESIGN_DATA_SPEC_PATH/components"
 ```
 
 ***

--- a/tools/design-data-agent-mcp/skill/SKILL.md
+++ b/tools/design-data-agent-mcp/skill/SKILL.md
@@ -63,12 +63,17 @@ design-data resolve accent-background-color-default "$DESIGN_DATA_PATH" \
 design-data query "$DESIGN_DATA_PATH" --filter "<expr>" --format json
 ```
 
+Valid filter keys: `property`, `component`, `variant`, `state`, `colorScheme`, `scale`, `contrast`, `uuid`, `$schema`. Any other key is a parse error.
+
 Filter syntax examples:
 
 ```
-category=color
-name-contains=background
-schema=spectrum-token
+property=background-color
+property=*background*
+component=button
+component=button,state=hover
+property=background-color|property=border-color
+$schema=https://spectrum.adobe.com/page/design-token/
 ```
 
 > **Exit codes:** `0` = matches found; `1` = no matches (returns `[]` — not an error); `>1` = error.
@@ -78,15 +83,15 @@ schema=spectrum-token
 ## Component info
 
 ```bash
-design-data component <id> --format json [--components-dir <dir>]
+design-data component <id> [--components-dir <dir>]
 ```
 
-Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`.
+Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`. Output is always JSON; there is no `--format` flag on this subcommand.
 
 Example:
 
 ```bash
-design-data component button --format json
+design-data component button
 ```
 
 ***

--- a/tools/design-data-agent-mcp/skill/SKILL.md
+++ b/tools/design-data-agent-mcp/skill/SKILL.md
@@ -23,17 +23,13 @@ export DESIGN_DATA_PATH=./packages/tokens/src
 Call `primer` at the start of every session that touches design data. It returns the active dimensions, component list, taxonomy fields, and token count — structural context that scopes all subsequent lookups.
 
 ```bash
-design-data primer "$DESIGN_DATA_PATH" --format json
-```
-
-Optional path overrides (defaults resolve under `DESIGN_DATA_PATH`):
-
-```bash
 design-data primer "$DESIGN_DATA_PATH" --format json \
-  [--components-dir <dir>] \
-  [--fields-dir <dir>] \
-  [--dimensions-dir <dir>]
+  --components-dir "$DESIGN_DATA_PATH/components" \
+  --fields-dir "$DESIGN_DATA_PATH/fields" \
+  --dimensions-dir "$DESIGN_DATA_PATH/dimensions"
 ```
+
+Always pass `--components-dir`, `--fields-dir`, and `--dimensions-dir` explicitly. The CLI defaults probe for `packages/design-data-spec/{components,fields,dimensions}` relative to the current working directory — not relative to `DESIGN_DATA_PATH` — so omitting them when running from an arbitrary directory (or with an absolute dataset path) produces empty `components`, `taxonomyFields`, and `dimensions` in the primer response.
 
 The payload includes `specVersion`, `manifest`, `dimensions`, `components`, `taxonomyFields`, and `tokenCount`.
 
@@ -83,15 +79,17 @@ $schema=https://spectrum.adobe.com/page/design-token/
 ## Component info
 
 ```bash
-design-data component <id> [--components-dir <dir>]
+design-data component <id> --components-dir "$DESIGN_DATA_PATH/components"
 ```
 
 Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`. Output is always JSON; there is no `--format` flag on this subcommand.
 
+Pass `--components-dir` explicitly for the same reason as `primer` — the default probes CWD-relative paths that won't resolve in agent contexts.
+
 Example:
 
 ```bash
-design-data component button
+design-data component button --components-dir "$DESIGN_DATA_PATH/components"
 ```
 
 ***

--- a/tools/design-data-agent-mcp/skill/SKILL.md
+++ b/tools/design-data-agent-mcp/skill/SKILL.md
@@ -60,7 +60,7 @@ design-data resolve accent-background-color-default "$DESIGN_DATA_PATH" \
 design-data query "$DESIGN_DATA_PATH" --filter "<expr>" --format json
 ```
 
-Valid filter keys: `property`, `component`, `variant`, `state`, `colorScheme`, `scale`, `contrast`, `uuid`, `$schema`. Any other key is a parse error.
+Valid filter keys: `property`, `component`, `variant`, `state`, `colorScheme`, `scale`, `contrast`, `uuid`, `$schema`. Any other key is a parse error. The dimension keys (`colorScheme`, `scale`, `contrast`) accept the same enum values as the `resolve` flags (`light`/`dark`, `desktop`/`mobile`, `regular`/`high`).
 
 Filter syntax examples:
 
@@ -104,7 +104,7 @@ design-data validate "$DESIGN_DATA_PATH" --format json \
   [--strict]
 ```
 
-Returns a `ValidationReport` with Layer 1 (schema) and Layer 2 (cascade) diagnostics. `--strict` treats warnings as errors.
+Returns a `ValidationReport` object: `{ layer: 1|2, errors: [...], warnings: [...] }` where each diagnostic has `rule_id` (e.g. `"SPEC-002"`), `severity` (`"error"` | `"warning"`), and `message`. Layer 1 is schema validation; Layer 2 is cascade-rule validation. `--strict` treats warnings as errors.
 
 ***
 
@@ -130,6 +130,8 @@ design-data write \
 
 Always pass `--output` with an explicit path inside the dataset. The default resolves relative to CWD, which is rarely correct in agent contexts.
 
+Generates a product-context scaffold at the output path (`specVersion`, `layer: "product"`, `rationale`, attribution metadata). Creates the file if absent; overwrites if it already exists. The confirmation string returned to stdout on success is a plain text message — not JSON.
+
 ***
 
 ## Gotchas
@@ -138,4 +140,4 @@ Always pass `--output` with an explicit path inside the dataset. The default res
 * **Contrast values:** `regular` and `high` — not `standard`/`high`.
 * **`query` exit 1** means no matches and still emits `[]`. Only `>1` is an error.
 * **`diff` exit 1** means changes were found. The JSON diff is in stdout — still a success result.
-* **`--format json`** is required for machine-readable output when stdout is not a TTY.
+* **`--format json`** — always pass this in agent and script contexts; the CLI pretty-prints when stdout is a TTY.


### PR DESCRIPTION
## Description

Adds the Claude Code Agent Skill for the design-data agent surface (Phase 8.4 of #830).

- `tools/design-data-agent-mcp/skill/SKILL.md` — the skill file; install by symlinking to `~/.claude/skills/design-data/`
- `tools/design-data-agent-mcp/README.md` — install instructions for both the skill and MCP server

The skill teaches Claude Code to:
1. Call `primer` at session start to load structural context
2. Use `resolve` / `query` for token lookup with correct dimension values (`desktop`/`mobile`, `regular`/`high`)
3. Use `component` for component contracts
4. Use `validate` for usage diagnostics
5. Use `diff` for dataset comparison
6. Use `write` for product-layer authoring (with explicit `--output` path)

Includes a Gotchas section covering the dimension enum values and exit-code semantics for `query` (exit 1 = empty result) and `diff` (exit 1 = changes found).

## Related Issue

Closes #868

Depends on #874 (Phase 8.3 MCP server), merged.

## Motivation and Context

The skill lets Claude Code drive the design-data surface via the CLI without the MCP server running. Per the agent-surface spec, the skill shells out to the CLI so its description stays small and the heavy lifting happens out-of-band.

## How Has This Been Tested?

- Skill file lints cleanly (remark)
- Symlink install verified locally: `ln -s "$(pwd)/tools/design-data-agent-mcp/skill" ~/.claude/skills/design-data`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.