### PR TITLE
feat(spec): document blocks — typed prose for tokens, components, anatomy (Phase 9)

### DIFF
--- a/.changeset/phase-9-document-blocks.md
+++ b/.changeset/phase-9-document-blocks.md
@@ -2,4 +2,4 @@
 "@adobe/design-data-spec": minor
 ---
 
-feat(spec): document blocks — typed prose attachable to tokens, components, and anatomy parts (Phase 9)
+feat(spec): document blocks — typed prose for tokens, components, and anatomy (Phase 9)

--- a/.changeset/phase-9-document-blocks.md
+++ b/.changeset/phase-9-document-blocks.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-design-data-spec": minor
+---
+
+feat(spec): document blocks — typed prose attachable to tokens, components, and anatomy parts (Phase 9)

--- a/.changeset/phase-9-document-blocks.md
+++ b/.changeset/phase-9-document-blocks.md
@@ -1,5 +1,5 @@
 ---
-"@adobe/spectrum-design-data-spec": minor
+"@adobe/design-data-spec": minor
 ---
 
 feat(spec): document blocks — typed prose attachable to tokens, components, and anatomy parts (Phase 9)

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -252,7 +252,8 @@ rules:
     assert: >
       A document block's agents field, when present, SHOULD contain phrasing that differs from
       content. An identical copy provides no agent-specific value and SHOULD be omitted or refined.
-    message: "Document block on '{entity}' has agents text identical to content — tailor it for agent consumption or omit the agents field"
+      Applies to tokens, components, and anatomy parts.
+    message: "'{entity}' has a document block whose agents text is identical to content — tailor it for agent consumption or omit the agents field"
     spec_ref: spec/document-blocks.md
     introduced_in: "1.0.0-draft"
 
@@ -263,6 +264,7 @@ rules:
     assert: >
       An entity that carries a non-empty documentBlocks array SHOULD include at least one block
       with type 'purpose' to document the entity's intent.
+      Applies to tokens, components, and anatomy parts.
     message: "'{entity}' has documentBlocks but no purpose block — add a block with type 'purpose'"
     spec_ref: spec/document-blocks.md
     introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -244,3 +244,25 @@ rules:
     message: "Component '{component}' tokenBindings references unknown token '{token}'"
     spec_ref: spec/component-format.md#token-bindings
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-028
+    name: document-block-agents-equals-content
+    severity: warning
+    category: completeness
+    assert: >
+      A document block's agents field, when present, SHOULD contain phrasing that differs from
+      content. An identical copy provides no agent-specific value and SHOULD be omitted or refined.
+    message: "Document block on '{entity}' has agents text identical to content — tailor it for agent consumption or omit the agents field"
+    spec_ref: spec/document-blocks.md
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-029
+    name: document-block-missing-purpose
+    severity: warning
+    category: completeness
+    assert: >
+      An entity that carries a non-empty documentBlocks array SHOULD include at least one block
+      with type 'purpose' to document the entity's intent.
+    message: "'{entity}' has documentBlocks but no purpose block — add a block with type 'purpose'"
+    spec_ref: spec/document-blocks.md
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/anatomy-part.schema.json
+++ b/packages/design-data-spec/schemas/anatomy-part.schema.json
@@ -33,6 +33,7 @@
     "documentBlocks": {
       "type": "array",
       "items": { "$ref": "document-block.schema.json" },
+      "minItems": 1,
       "description": "Typed prose blocks for this anatomy part. See spec/document-blocks.md (Phase 9)."
     }
   },

--- a/packages/design-data-spec/schemas/anatomy-part.schema.json
+++ b/packages/design-data-spec/schemas/anatomy-part.schema.json
@@ -29,6 +29,11 @@
       },
       "uniqueItems": true,
       "description": "Informative list of child anatomy part names nested within this part. Does not carry enforcement semantics."
+    },
+    "documentBlocks": {
+      "type": "array",
+      "items": { "$ref": "document-block.schema.json" },
+      "description": "Typed prose blocks for this anatomy part. See spec/document-blocks.md (Phase 9)."
     }
   },
   "additionalProperties": false

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -72,6 +72,7 @@
     "documentBlocks": {
       "type": "array",
       "items": { "$ref": "document-block.schema.json" },
+      "minItems": 1,
       "description": "Typed prose blocks for this component. See spec/document-blocks.md (Phase 9)."
     }
   },

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -68,6 +68,11 @@
       "type": "array",
       "items": { "$ref": "#/$defs/tokenBinding" },
       "description": "Tokens this component uses, including foundation/structure tokens not scoped to the component in their name-object. See spec/component-format.md#token-bindings (Phase 6.7)."
+    },
+    "documentBlocks": {
+      "type": "array",
+      "items": { "$ref": "document-block.schema.json" },
+      "description": "Typed prose blocks for this component. See spec/document-blocks.md (Phase 9)."
     }
   },
   "additionalProperties": false,
@@ -203,6 +208,11 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Informative: anatomy part names nested within this part."
+        },
+        "documentBlocks": {
+          "type": "array",
+          "items": { "$ref": "document-block.schema.json" },
+          "description": "Typed prose blocks for this anatomy part. See spec/document-blocks.md (Phase 9)."
         }
       },
       "additionalProperties": false

--- a/packages/design-data-spec/schemas/document-block.schema.json
+++ b/packages/design-data-spec/schemas/document-block.schema.json
@@ -32,5 +32,12 @@
       "description": "Anti-pattern to avoid. Meaningful only on do-dont blocks."
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "if": {
+    "properties": { "type": { "const": "do-dont" } },
+    "required": ["type"]
+  },
+  "then": {
+    "anyOf": [{ "required": ["do"] }, { "required": ["dont"] }]
+  }
 }

--- a/packages/design-data-spec/schemas/document-block.schema.json
+++ b/packages/design-data-spec/schemas/document-block.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/document-block.schema.json",
+  "title": "Document block",
+  "description": "A typed prose block attachable to tokens, components, or anatomy parts. See spec/document-blocks.md.",
+  "type": "object",
+  "required": ["type", "content"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["purpose", "guideline", "accessibility", "do-dont", "examples"],
+      "description": "Block type. One of: purpose, guideline, accessibility, do-dont, examples."
+    },
+    "content": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable prose for this block."
+    },
+    "agents": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional LLM-tuned rephrasing of content for agent consumption. Should differ from content."
+    },
+    "do": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Recommended practice. Meaningful only on do-dont blocks."
+    },
+    "dont": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Anti-pattern to avoid. Meaningful only on do-dont blocks."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -180,6 +180,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/componentBinding" },
           "description": "Reverse index: components that declare this token in their tokenBindings. Optional and derivable from component files."
+        },
+        "documentBlocks": {
+          "type": "array",
+          "items": { "$ref": "document-block.schema.json" },
+          "description": "Typed prose blocks for this token. See spec/document-blocks.md (Phase 9)."
         }
       },
       "additionalProperties": false
@@ -258,6 +263,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/componentBinding" },
           "description": "Reverse index: components that declare this token in their tokenBindings. Optional and derivable from component files."
+        },
+        "documentBlocks": {
+          "type": "array",
+          "items": { "$ref": "document-block.schema.json" },
+          "description": "Typed prose blocks for this token. See spec/document-blocks.md (Phase 9)."
         }
       },
       "additionalProperties": false

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -184,6 +184,7 @@
         "documentBlocks": {
           "type": "array",
           "items": { "$ref": "document-block.schema.json" },
+          "minItems": 1,
           "description": "Typed prose blocks for this token. See spec/document-blocks.md (Phase 9)."
         }
       },
@@ -267,6 +268,7 @@
         "documentBlocks": {
           "type": "array",
           "items": { "$ref": "document-block.schema.json" },
+          "minItems": 1,
           "description": "Typed prose blocks for this token. See spec/document-blocks.md (Phase 9)."
         }
       },

--- a/packages/design-data-spec/spec/component-format.md
+++ b/packages/design-data-spec/spec/component-format.md
@@ -29,16 +29,17 @@ A component declaration **MUST** contain:
 
 ### Optional fields
 
-| Field           | Type   | Description                                                                                                                                |
-| --------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `specVersion`   | string | Declares which spec version this document targets. Currently `"1.0.0-draft"`; future stable releases will accept their own version string. |
-| `description`   | string | Plain-text description of the component's purpose.                                                                                         |
-| `options`       | object | Component API options — see [Options](#options).                                                                                           |
-| `slots`         | array  | Named content injection points — see [Slots](#slots).                                                                                      |
-| `anatomy`       | array  | Named anatomy parts — see [Anatomy (stub)](#anatomy-stub).                                                                                 |
-| `states`        | array  | Per-component state declarations — see [States (stub)](#states-stub).                                                                      |
-| `lifecycle`     | object | Version lifecycle metadata — see [Lifecycle](#lifecycle).                                                                                  |
-| `tokenBindings` | array  | Tokens this component uses — see [Token bindings](#token-bindings) (Phase 6.7).                                                            |
+| Field            | Type   | Description                                                                                                                                |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `specVersion`    | string | Declares which spec version this document targets. Currently `"1.0.0-draft"`; future stable releases will accept their own version string. |
+| `description`    | string | Plain-text description of the component's purpose.                                                                                         |
+| `options`        | object | Component API options — see [Options](#options).                                                                                           |
+| `slots`          | array  | Named content injection points — see [Slots](#slots).                                                                                      |
+| `anatomy`        | array  | Named anatomy parts — see [Anatomy (stub)](#anatomy-stub).                                                                                 |
+| `states`         | array  | Per-component state declarations — see [States (stub)](#states-stub).                                                                      |
+| `lifecycle`      | object | Version lifecycle metadata — see [Lifecycle](#lifecycle).                                                                                  |
+| `tokenBindings`  | array  | Tokens this component uses — see [Token bindings](#token-bindings) (Phase 6.7).                                                            |
+| `documentBlocks` | array  | Typed prose blocks for this component — see [Document blocks](#document-blocks) (Phase 9).                                                 |
 
 **NORMATIVE:** No properties beyond those listed above are permitted at the top level of a component declaration. Additional fields **MUST** cause a Layer 1 schema error.
 
@@ -347,5 +348,36 @@ A complete button component declaration:
   "lifecycle": {
     "introduced": "1.0.0-draft"
   }
+}
+```
+
+## Document blocks
+
+**Phase 9.** Component declarations MAY carry a `documentBlocks` array at the top level, and individual anatomy parts MAY carry their own `documentBlocks` arrays. See [spec/document-blocks.md](document-blocks.md) for the full block schema, type vocabulary, and SPEC rules.
+
+```json
+{
+  "name": "button",
+  "displayName": "Button",
+  "meta": { "category": "actions", "documentationUrl": "https://spectrum.adobe.com/page/button/" },
+  "documentBlocks": [
+    {
+      "type": "purpose",
+      "content": "Buttons trigger a discrete action or event.",
+      "agents": "Use Button when the user must trigger an action. For navigation, use Link."
+    }
+  ],
+  "anatomy": [
+    {
+      "name": "label",
+      "required": true,
+      "documentBlocks": [
+        {
+          "type": "guideline",
+          "content": "Button labels should be action verbs (Save, Delete, Submit)."
+        }
+      ]
+    }
+  ]
 }
 ```

--- a/packages/design-data-spec/spec/document-blocks.md
+++ b/packages/design-data-spec/spec/document-blocks.md
@@ -1,0 +1,180 @@
+# Document blocks
+
+**Spec version:** `1.0.0-draft` (see [Overview](index.md))
+
+This document defines **document blocks**: typed prose objects attachable to tokens, components, and anatomy parts. Blocks carry design guidance — intent, usage rules, accessibility notes, do/don't pairs, and examples — alongside the structured data they describe, making that guidance machine-readable and queryable by agents.
+
+Design guidance like "accent backgrounds are for primary CTAs only" or "don't combine `negative` with `subtle`" previously lived in scattered Markdown documents invisible to the spec's resolver, validator, and agent surface. Document blocks attach that prose directly to the entities it describes so it cascades with the tokens and components it governs.
+
+Inspired by the [Design System Documentation Spec (DSDS)](https://designsystemdocspec.org/) document-block model.
+
+Scoped under RFC-D / Phase 9. See [rfc-coordination.md](../docs/rfc-coordination.md).
+
+## Document block shape
+
+A document block is a JSON object conforming to [`document-block.schema.json`](../schemas/document-block.schema.json).
+
+### Required fields
+
+| Field     | Type   | Description                              |
+| --------- | ------ | ---------------------------------------- |
+| `type`    | string | Block type — one of the five types below |
+| `content` | string | Human-readable prose for this block      |
+
+### Optional fields
+
+| Field    | Type   | Description                                                 |
+| -------- | ------ | ----------------------------------------------------------- |
+| `agents` | string | LLM-tuned rephrasing of `content` for agent consumption     |
+| `do`     | string | Recommended practice — meaningful only on `do-dont` blocks  |
+| `dont`   | string | Anti-pattern to avoid — meaningful only on `do-dont` blocks |
+
+**NORMATIVE:** `type` and `content` are required on every document block. A block with an empty string for either field **MUST** fail Layer 1 schema validation.
+
+**NORMATIVE:** `do` and `dont` are defined on all block shapes (Layer 1 does not restrict them by type), but implementations SHOULD treat them as meaningful only on `do-dont` blocks. Using them on other block types is valid but has no defined semantics.
+
+**RECOMMENDED:** When `agents` is present, its content SHOULD differ meaningfully from `content`. An `agents` value identical to `content` provides no agent-specific value and SHOULD be omitted or refined (see SPEC-028).
+
+## Block types
+
+### `purpose`
+
+Describes the intent and design role of the entity. Answers "what is this for?"
+
+```json
+{
+  "type": "purpose",
+  "content": "Accent background tokens represent the primary brand call-to-action surface. They establish hierarchy by drawing attention to the most important interactive element on screen.",
+  "agents": "Use accent-background tokens on the highest-priority interactive element. They signal 'primary action here' to users."
+}
+```
+
+### `guideline`
+
+A usage rule or constraint. Answers "how should this be used?"
+
+```json
+{
+  "type": "guideline",
+  "content": "Accent backgrounds should appear on no more than one element per focal area. Multiple accent surfaces compete for attention and dilute the hierarchy signal."
+}
+```
+
+### `accessibility`
+
+Accessibility notes specific to this entity — contrast behavior, screen reader considerations, or interaction semantics.
+
+```json
+{
+  "type": "accessibility",
+  "content": "Accent background tokens must maintain a minimum 3:1 contrast ratio against the surface they sit on in both light and dark schemes. The high-contrast dimension variant provides an alternative that meets 4.5:1."
+}
+```
+
+### `do-dont`
+
+A paired recommended practice and anti-pattern. The `do` and `dont` fields carry the pairing; `content` provides context or a summary heading.
+
+```json
+{
+  "type": "do-dont",
+  "content": "Combining semantic backgrounds",
+  "do": "Use accent-background for the primary CTA and informative-background for supporting UI.",
+  "dont": "Combine accent-background with negative-background in the same focal area — both are high-attention surfaces and the pairing creates visual conflict."
+}
+```
+
+### `examples`
+
+Concrete usage examples — code snippets, component references, or scenario descriptions.
+
+```json
+{
+  "type": "examples",
+  "content": "A primary Button uses accent-background-color-default. A disabled Button uses gray-background-color-default. A destructive Button uses negative-background-color-default."
+}
+```
+
+## Attachment points
+
+**NORMATIVE:** Document blocks MAY be attached to the following entities.
+
+### Tokens
+
+Add a `documentBlocks` array at the top level of a token object:
+
+```json
+{
+  "name": { "property": "background-color", "variant": "accent" },
+  "value": "#0265DC",
+  "documentBlocks": [
+    {
+      "type": "purpose",
+      "content": "Primary call-to-action background. Use for the most important interactive element in a focal area."
+    },
+    {
+      "type": "guideline",
+      "content": "Limit to one accent background per focal area to preserve hierarchy."
+    }
+  ]
+}
+```
+
+### Components
+
+Add a `documentBlocks` array at the top level of a component declaration:
+
+```json
+{
+  "name": "button",
+  "displayName": "Button",
+  "meta": { "category": "actions", "documentationUrl": "https://spectrum.adobe.com/page/button/" },
+  "documentBlocks": [
+    {
+      "type": "purpose",
+      "content": "Buttons trigger an action or event, such as submitting a form, opening a dialog, or performing a destructive operation.",
+      "agents": "Use Button when the user needs to trigger a discrete action. For navigation, use a Link instead."
+    }
+  ]
+}
+```
+
+### Anatomy parts
+
+Add a `documentBlocks` array within an anatomy part object:
+
+```json
+{
+  "name": "label",
+  "required": true,
+  "description": "Button text visible to the user.",
+  "documentBlocks": [
+    {
+      "type": "guideline",
+      "content": "Button labels should be action verbs (Save, Delete, Submit). Avoid noun-only labels like 'Confirmation'."
+    }
+  ]
+}
+```
+
+## SPEC rules
+
+| Rule ID  | Severity | Name                                 | Assert                                                                   |
+| -------- | -------- | ------------------------------------ | ------------------------------------------------------------------------ |
+| SPEC-028 | warning  | document-block-agents-equals-content | A block's `agents` field SHOULD differ from `content`                    |
+| SPEC-029 | warning  | document-block-missing-purpose       | An entity with `documentBlocks` SHOULD have at least one `purpose` block |
+
+Both rules are `warning` severity — they do not block validation.
+
+## `agents` field guidance
+
+The `agents` field exists to let documentation authors provide LLM-optimized phrasing alongside human prose. Human content may use visual formatting cues, assumed visual context, or prose conventions that agents process poorly. The `agents` field carries alternative phrasing tuned for programmatic consumption.
+
+**RECOMMENDED:** `agents` text SHOULD:
+
+* Omit references to visual appearance that agents cannot act on ("the blue button")
+* Use explicit, unambiguous phrasing ("Use Button when triggering an action, not Link")
+* Include the token or component name explicitly rather than relying on surrounding context
+* Be shorter and more directive than `content` where possible
+
+When no agent-specific rephrasing is needed, omit the `agents` field entirely. A duplicate of `content` adds size with no benefit.

--- a/packages/design-data-spec/spec/document-blocks.md
+++ b/packages/design-data-spec/spec/document-blocks.md
@@ -75,6 +75,8 @@ Accessibility notes specific to this entity — contrast behavior, screen reader
 
 A paired recommended practice and anti-pattern. The `do` and `dont` fields carry the pairing; `content` provides context or a summary heading.
 
+**NORMATIVE:** A `do-dont` block **MUST** include at least one of `do` or `dont`. A `do-dont` block with neither field **MUST** fail Layer 1 schema validation.
+
 ```json
 {
   "type": "do-dont",
@@ -97,7 +99,7 @@ Concrete usage examples — code snippets, component references, or scenario des
 
 ## Attachment points
 
-**NORMATIVE:** Document blocks MAY be attached to the following entities.
+**NORMATIVE:** Document blocks MAY be attached to the following entities. When `documentBlocks` is present, it **MUST** contain at least one block — an empty array **MUST** fail Layer 1 schema validation.
 
 ### Tokens
 

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -63,6 +63,9 @@ enum Commands {
         /// Directory containing spec-format dimension declaration JSON files
         #[arg(long, value_name = "DIR")]
         dimensions_path: Option<PathBuf>,
+        /// Directory containing spec-format component declaration JSON files (enables SPEC-028/029 on components)
+        #[arg(long, value_name = "DIR")]
+        components_path: Option<PathBuf>,
         /// Treat warnings as errors
         #[arg(long)]
         strict: bool,
@@ -449,6 +452,7 @@ fn run_validate(
     schema_path: Option<PathBuf>,
     exceptions_path: Option<PathBuf>,
     dimensions_path: Option<PathBuf>,
+    components_path: Option<PathBuf>,
     strict: bool,
 ) -> miette::Result<ExitCode> {
     if !validate::engine_ready() {
@@ -461,11 +465,17 @@ fn run_validate(
     let exceptions = load_exceptions(exceptions_path.as_deref())?;
 
     let dims_dir = dimensions_path.or_else(default_dimensions_path);
+    let comps_dir = components_path.or_else(default_components_path);
 
-    let report =
-        validate::validate_all_with_options(path, &registry, &exceptions, dims_dir.as_deref())
-            .into_diagnostic()
-            .wrap_err("validation failed")?;
+    let report = validate::validate_all_with_options(
+        path,
+        &registry,
+        &exceptions,
+        dims_dir.as_deref(),
+        comps_dir.as_deref(),
+    )
+    .into_diagnostic()
+    .wrap_err("validation failed")?;
 
     match format {
         OutputFormat::Json => {
@@ -1123,6 +1133,7 @@ fn main() -> ExitCode {
             schema_path,
             exceptions_path,
             dimensions_path,
+            components_path,
             strict,
         } => {
             let target = path.unwrap_or_else(|| PathBuf::from("."));
@@ -1132,6 +1143,7 @@ fn main() -> ExitCode {
                 schema_path,
                 exceptions_path,
                 dimensions_path,
+                components_path,
                 strict,
             )
         }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -18,6 +18,14 @@ use serde_json::Value;
 use crate::discovery::discover_json_files;
 use crate::CoreError;
 
+/// One component declaration (spec-format JSON), loaded for relational rules.
+#[derive(Debug, Clone)]
+pub struct ComponentRecord {
+    pub name: String,
+    pub file: PathBuf,
+    pub raw: Value,
+}
+
 /// One dimension declaration (new spec shape), when present in a JSON file.
 #[derive(Debug, Clone)]
 pub struct DimensionRecord {
@@ -46,6 +54,7 @@ pub struct TokenRecord {
 pub struct TokenGraph {
     pub tokens: HashMap<String, TokenRecord>,
     pub dimensions: Vec<DimensionRecord>,
+    pub components: Vec<ComponentRecord>,
     /// Secondary index: UUID value → primary key in `tokens`.
     ///
     /// Required for cascade-format alias resolution: cascade token keys are
@@ -205,6 +214,7 @@ impl TokenGraph {
         Self {
             tokens,
             dimensions: Vec::new(),
+            components: Vec::new(),
             uuid_index,
         }
     }
@@ -212,6 +222,34 @@ impl TokenGraph {
     /// Attach dimension records (e.g. from conformance fixtures).
     pub fn with_dimensions(mut self, dimensions: Vec<DimensionRecord>) -> Self {
         self.dimensions = dimensions;
+        self
+    }
+
+    /// Load spec-format component declarations from a catalog directory.
+    ///
+    /// Each file must be a JSON object with a `name` field (component identifier).
+    /// Silently skips files that do not match this shape.
+    pub fn load_spec_components(dir: &Path) -> Result<Vec<ComponentRecord>, CoreError> {
+        let mut out = Vec::new();
+        for path in discover_json_files(dir)? {
+            let text = std::fs::read_to_string(&path)?;
+            let value: Value = serde_json::from_str(&text)?;
+            if let Some(obj) = value.as_object() {
+                if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
+                    out.push(ComponentRecord {
+                        name: name.to_string(),
+                        file: path,
+                        raw: value,
+                    });
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Attach component records loaded from a components directory.
+    pub fn with_components(mut self, components: Vec<ComponentRecord>) -> Self {
+        self.components = components;
         self
     }
 }

--- a/sdk/core/src/validate/mod.rs
+++ b/sdk/core/src/validate/mod.rs
@@ -47,15 +47,20 @@ pub fn validate_all_with_exceptions(
     schema_registry: &SchemaRegistry,
     naming_exceptions: &HashSet<String>,
 ) -> Result<ValidationReport, CoreError> {
-    validate_all_with_options(data_path, schema_registry, naming_exceptions, None)
+    validate_all_with_options(data_path, schema_registry, naming_exceptions, None, None)
 }
 
 /// Full validation with all options.
+///
+/// `dimensions_path` — optional directory of spec-format dimension JSON files.
+/// `components_path` — optional directory of spec-format component JSON files;
+/// when provided, SPEC-028 and SPEC-029 also check components and anatomy parts.
 pub fn validate_all_with_options(
     data_path: &Path,
     schema_registry: &SchemaRegistry,
     naming_exceptions: &HashSet<String>,
     dimensions_path: Option<&Path>,
+    components_path: Option<&Path>,
 ) -> Result<ValidationReport, CoreError> {
     let mut report = structural::validate_structural(data_path, schema_registry)?;
     let mut graph = TokenGraph::from_json_dir(data_path)?;
@@ -63,6 +68,12 @@ pub fn validate_all_with_options(
         if dir.is_dir() {
             let dims = TokenGraph::load_spec_dimensions(dir)?;
             graph = graph.with_dimensions(dims);
+        }
+    }
+    if let Some(dir) = components_path {
+        if dir.is_dir() {
+            let comps = TokenGraph::load_spec_components(dir)?;
+            graph = graph.with_components(comps);
         }
     }
     let rel = relational::validate_relational(&graph, naming_exceptions);

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -39,7 +39,7 @@ fn embedded_registry() -> &'static RegistryData {
     REGISTRY.get_or_init(RegistryData::embedded)
 }
 
-/// All default catalog rules (SPEC-001 … SPEC-029).
+/// All default catalog rules. See packages/design-data-spec/rules/rules.yaml for the full catalog.
 pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
     vec![
         Box::new(spec001::Rule),

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -22,6 +22,8 @@ mod spec011;
 mod spec012;
 mod spec013;
 mod spec017;
+mod spec028;
+mod spec029;
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
@@ -37,7 +39,7 @@ fn embedded_registry() -> &'static RegistryData {
     REGISTRY.get_or_init(RegistryData::embedded)
 }
 
-/// All default catalog rules (SPEC-001 … SPEC-017).
+/// All default catalog rules (SPEC-001 … SPEC-029).
 pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
     vec![
         Box::new(spec001::Rule),
@@ -54,6 +56,8 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec012::Rule),
         Box::new(spec013::Rule),
         Box::new(spec017::Rule),
+        Box::new(spec028::Rule),
+        Box::new(spec029::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec028.rs
+++ b/sdk/core/src/validate/rules/spec028.rs
@@ -12,11 +12,40 @@
 //!
 //! Warns when a document block's `agents` field is present but identical to `content`.
 //! An identical copy adds size with no agent-specific value and should be omitted.
+//! Applies to tokens, components, and anatomy parts.
+
+use std::path::Path;
+
+use serde_json::Value;
 
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
 
 pub struct Rule;
+
+fn check_blocks(blocks: &[Value], entity_label: &str, file: &Path, out: &mut Vec<Diagnostic>) {
+    for block in blocks {
+        let Some(content) = block.get("content").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(agents) = block.get("agents").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if agents == content {
+            out.push(Diagnostic {
+                file: file.to_path_buf(),
+                token: None,
+                rule_id: Some("SPEC-028".to_string()),
+                severity: Severity::Warning,
+                message: format!(
+                    "{entity_label} has a document block whose agents text is identical to content — tailor it for agent consumption or omit the agents field"
+                ),
+                instance_path: None,
+                schema_path: None,
+            });
+        }
+    }
+}
 
 impl ValidationRule for Rule {
     fn id(&self) -> &'static str {
@@ -29,33 +58,30 @@ impl ValidationRule for Rule {
 
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
+
         for t in ctx.graph.tokens.values() {
-            let Some(blocks) = t.raw.get("documentBlocks").and_then(|v| v.as_array()) else {
-                continue;
-            };
-            for block in blocks {
-                let Some(content) = block.get("content").and_then(|v| v.as_str()) else {
-                    continue;
-                };
-                let Some(agents) = block.get("agents").and_then(|v| v.as_str()) else {
-                    continue;
-                };
-                if agents == content {
-                    out.push(Diagnostic {
-                        file: t.file.clone(),
-                        token: Some(t.name.clone()),
-                        rule_id: Some(self.id().to_string()),
-                        severity: Severity::Warning,
-                        message: format!(
-                            "Token '{}' has a document block whose agents text is identical to content — tailor it for agent consumption or omit the agents field",
-                            t.name
-                        ),
-                        instance_path: None,
-                        schema_path: None,
-                    });
+            if let Some(blocks) = t.raw.get("documentBlocks").and_then(|v| v.as_array()) {
+                check_blocks(blocks, &format!("Token '{}'", t.name), &t.file, &mut out);
+            }
+        }
+
+        for comp in &ctx.graph.components {
+            let comp_label = format!("Component '{}'", comp.name);
+            if let Some(blocks) = comp.raw.get("documentBlocks").and_then(|v| v.as_array()) {
+                check_blocks(blocks, &comp_label, &comp.file, &mut out);
+            }
+            if let Some(anatomy) = comp.raw.get("anatomy").and_then(|v| v.as_array()) {
+                for part in anatomy {
+                    let part_name = part.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                    let part_label =
+                        format!("Component '{}' anatomy part '{}'", comp.name, part_name);
+                    if let Some(blocks) = part.get("documentBlocks").and_then(|v| v.as_array()) {
+                        check_blocks(blocks, &part_label, &comp.file, &mut out);
+                    }
                 }
             }
         }
+
         out
     }
 }
@@ -66,12 +92,11 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::graph::{TokenGraph, TokenRecord};
-    use crate::report::Severity;
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
     use crate::registry::RegistryData;
-    use crate::validate::rule::ValidationContext;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
     use crate::validate::rules::spec028::Rule;
-    use crate::validate::rule::ValidationRule;
 
     fn make_graph(raw: serde_json::Value) -> TokenGraph {
         let mut g = TokenGraph::default();
@@ -90,8 +115,30 @@ mod tests {
         g
     }
 
+    fn make_graph_with_component(comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.components.push(ComponentRecord {
+            name: comp_raw
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("test-comp")
+                .to_string(),
+            file: PathBuf::from("test-comp.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
     fn run(raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    fn run_comp(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph_with_component(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
         let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
@@ -140,5 +187,52 @@ mod tests {
             ]
         }));
         assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn component_agents_equals_content_warns() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Triggers an action.", "agents": "Triggers an action."}
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-028"));
+        assert!(diags[0].message.contains("Component 'button'"));
+    }
+
+    #[test]
+    fn component_agents_differs_no_warning() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Triggers an action.", "agents": "Use Button to trigger a discrete action."}
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn anatomy_part_agents_equals_content_warns() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "anatomy": [
+                {
+                    "name": "label",
+                    "documentBlocks": [
+                        {"type": "guideline", "content": "Use action verbs.", "agents": "Use action verbs."}
+                    ]
+                }
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-028"));
+        assert!(diags[0].message.contains("anatomy part 'label'"));
     }
 }

--- a/sdk/core/src/validate/rules/spec028.rs
+++ b/sdk/core/src/validate/rules/spec028.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-028: document-block-agents-equals-content
+//!
+//! Warns when a document block's `agents` field is present but identical to `content`.
+//! An identical copy adds size with no agent-specific value and should be omitted.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-028"
+    }
+
+    fn name(&self) -> &'static str {
+        "document-block-agents-equals-content"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(blocks) = t.raw.get("documentBlocks").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for block in blocks {
+                let Some(content) = block.get("content").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let Some(agents) = block.get("agents").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if agents == content {
+                    out.push(Diagnostic {
+                        file: t.file.clone(),
+                        token: Some(t.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Warning,
+                        message: format!(
+                            "Token '{}' has a document block whose agents text is identical to content — tailor it for agent consumption or omit the agents field",
+                            t.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{TokenGraph, TokenRecord};
+    use crate::report::Severity;
+    use crate::registry::RegistryData;
+    use crate::validate::rule::ValidationContext;
+    use crate::validate::rules::spec028::Rule;
+    use crate::validate::rule::ValidationRule;
+
+    fn make_graph(raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.tokens.insert(
+            "t".into(),
+            TokenRecord {
+                name: "t".into(),
+                file: PathBuf::from("test.tokens.json"),
+                index: 0,
+                schema_url: None,
+                uuid: None,
+                alias_target: None,
+                raw,
+            },
+        );
+        g
+    }
+
+    fn run(raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn no_document_blocks_no_warning() {
+        let diags = run(json!({"name": {"property": "color"}, "value": "#fff"}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn agents_differs_no_warning() {
+        let diags = run(json!({
+            "name": {"property": "color"},
+            "value": "#fff",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Primary CTA color.", "agents": "Use for the primary call-to-action element."}
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn agents_equals_content_warns() {
+        let diags = run(json!({
+            "name": {"property": "color"},
+            "value": "#fff",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Primary CTA color.", "agents": "Primary CTA color."}
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-028"));
+    }
+
+    #[test]
+    fn no_agents_field_no_warning() {
+        let diags = run(json!({
+            "name": {"property": "color"},
+            "value": "#fff",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Primary CTA color."}
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec029.rs
+++ b/sdk/core/src/validate/rules/spec029.rs
@@ -4,19 +4,45 @@
 // of the License at http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software distributed under
-// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// the License is licensed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
 //! SPEC-029: document-block-missing-purpose
 //!
-//! Warns when a token has a non-empty `documentBlocks` array but no block with type "purpose".
-//! An entity with document blocks should declare its intent via at least one purpose block.
+//! Warns when an entity has a non-empty `documentBlocks` array but no block with
+//! type "purpose". Applies to tokens, components, and anatomy parts.
+
+use std::path::Path;
+
+use serde_json::Value;
 
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
 
 pub struct Rule;
+
+fn check_purpose(blocks: &[Value], entity_label: &str, file: &Path, out: &mut Vec<Diagnostic>) {
+    if blocks.is_empty() {
+        return;
+    }
+    let has_purpose = blocks
+        .iter()
+        .any(|b| b.get("type").and_then(|v| v.as_str()) == Some("purpose"));
+    if !has_purpose {
+        out.push(Diagnostic {
+            file: file.to_path_buf(),
+            token: None,
+            rule_id: Some("SPEC-029".to_string()),
+            severity: Severity::Warning,
+            message: format!(
+                "{entity_label} has documentBlocks but no purpose block — add a block with type 'purpose'"
+            ),
+            instance_path: None,
+            schema_path: None,
+        });
+    }
+}
 
 impl ValidationRule for Rule {
     fn id(&self) -> &'static str {
@@ -29,31 +55,30 @@ impl ValidationRule for Rule {
 
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
+
         for t in ctx.graph.tokens.values() {
-            let Some(blocks) = t.raw.get("documentBlocks").and_then(|v| v.as_array()) else {
-                continue;
-            };
-            if blocks.is_empty() {
-                continue;
-            }
-            let has_purpose = blocks.iter().any(|b| {
-                b.get("type").and_then(|v| v.as_str()) == Some("purpose")
-            });
-            if !has_purpose {
-                out.push(Diagnostic {
-                    file: t.file.clone(),
-                    token: Some(t.name.clone()),
-                    rule_id: Some(self.id().to_string()),
-                    severity: Severity::Warning,
-                    message: format!(
-                        "Token '{}' has documentBlocks but no purpose block — add a block with type 'purpose'",
-                        t.name
-                    ),
-                    instance_path: None,
-                    schema_path: None,
-                });
+            if let Some(blocks) = t.raw.get("documentBlocks").and_then(|v| v.as_array()) {
+                check_purpose(blocks, &format!("Token '{}'", t.name), &t.file, &mut out);
             }
         }
+
+        for comp in &ctx.graph.components {
+            let comp_label = format!("Component '{}'", comp.name);
+            if let Some(blocks) = comp.raw.get("documentBlocks").and_then(|v| v.as_array()) {
+                check_purpose(blocks, &comp_label, &comp.file, &mut out);
+            }
+            if let Some(anatomy) = comp.raw.get("anatomy").and_then(|v| v.as_array()) {
+                for part in anatomy {
+                    let part_name = part.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+                    let part_label =
+                        format!("Component '{}' anatomy part '{}'", comp.name, part_name);
+                    if let Some(blocks) = part.get("documentBlocks").and_then(|v| v.as_array()) {
+                        check_purpose(blocks, &part_label, &comp.file, &mut out);
+                    }
+                }
+            }
+        }
+
         out
     }
 }
@@ -64,12 +89,11 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::graph::{TokenGraph, TokenRecord};
-    use crate::report::Severity;
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
     use crate::registry::RegistryData;
-    use crate::validate::rule::ValidationContext;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
     use crate::validate::rules::spec029::Rule;
-    use crate::validate::rule::ValidationRule;
 
     fn make_graph(raw: serde_json::Value) -> TokenGraph {
         let mut g = TokenGraph::default();
@@ -88,8 +112,30 @@ mod tests {
         g
     }
 
+    fn make_graph_with_component(comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.components.push(ComponentRecord {
+            name: comp_raw
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("test-comp")
+                .to_string(),
+            file: PathBuf::from("test-comp.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
     fn run(raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    fn run_comp(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph_with_component(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
         let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
@@ -138,5 +184,53 @@ mod tests {
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].severity, Severity::Warning);
         assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-029"));
+    }
+
+    #[test]
+    fn component_without_purpose_warns() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "documentBlocks": [
+                {"type": "guideline", "content": "Use for primary actions."}
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-029"));
+        assert!(diags[0].message.contains("Component 'button'"));
+    }
+
+    #[test]
+    fn component_with_purpose_no_warning() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Triggers a discrete action."},
+                {"type": "guideline", "content": "Use for primary actions."}
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn anatomy_part_without_purpose_warns() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "anatomy": [
+                {
+                    "name": "label",
+                    "documentBlocks": [
+                        {"type": "guideline", "content": "Use action verbs."}
+                    ]
+                }
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-029"));
+        assert!(diags[0].message.contains("anatomy part 'label'"));
     }
 }

--- a/sdk/core/src/validate/rules/spec029.rs
+++ b/sdk/core/src/validate/rules/spec029.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-029: document-block-missing-purpose
+//!
+//! Warns when a token has a non-empty `documentBlocks` array but no block with type "purpose".
+//! An entity with document blocks should declare its intent via at least one purpose block.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-029"
+    }
+
+    fn name(&self) -> &'static str {
+        "document-block-missing-purpose"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        for t in ctx.graph.tokens.values() {
+            let Some(blocks) = t.raw.get("documentBlocks").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            if blocks.is_empty() {
+                continue;
+            }
+            let has_purpose = blocks.iter().any(|b| {
+                b.get("type").and_then(|v| v.as_str()) == Some("purpose")
+            });
+            if !has_purpose {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "Token '{}' has documentBlocks but no purpose block — add a block with type 'purpose'",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{TokenGraph, TokenRecord};
+    use crate::report::Severity;
+    use crate::registry::RegistryData;
+    use crate::validate::rule::ValidationContext;
+    use crate::validate::rules::spec029::Rule;
+    use crate::validate::rule::ValidationRule;
+
+    fn make_graph(raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.tokens.insert(
+            "t".into(),
+            TokenRecord {
+                name: "t".into(),
+                file: PathBuf::from("test.tokens.json"),
+                index: 0,
+                schema_url: None,
+                uuid: None,
+                alias_target: None,
+                raw,
+            },
+        );
+        g
+    }
+
+    fn run(raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn no_document_blocks_no_warning() {
+        let diags = run(json!({"name": {"property": "color"}, "value": "#fff"}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn empty_document_blocks_no_warning() {
+        let diags = run(json!({
+            "name": {"property": "color"},
+            "value": "#fff",
+            "documentBlocks": []
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn has_purpose_block_no_warning() {
+        let diags = run(json!({
+            "name": {"property": "color"},
+            "value": "#fff",
+            "documentBlocks": [
+                {"type": "purpose", "content": "Primary CTA color."},
+                {"type": "guideline", "content": "Use sparingly."}
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn blocks_without_purpose_warns() {
+        let diags = run(json!({
+            "name": {"property": "color"},
+            "value": "#fff",
+            "documentBlocks": [
+                {"type": "guideline", "content": "Use sparingly."},
+                {"type": "examples", "content": "Applied to the primary button."}
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-029"));
+    }
+}


### PR DESCRIPTION
## Description

Implements Phase 9 (RFC-D): document blocks — typed prose objects attachable to tokens, components, and anatomy parts. Blocks carry design guidance (intent, usage rules, accessibility notes, do/don't pairs, examples) alongside the structured data they describe, making that guidance machine-readable and queryable by agents.

## Related Issue

Closes #831

## Motivation and Context

Design guidance like "accent backgrounds are for primary CTAs only" previously lived in scattered Markdown documents invisible to the spec's resolver, validator, and agent surface. Document blocks attach that prose directly to the entities it describes so it cascades with the tokens and components it governs. Inspired by the [Design System Documentation Spec (DSDS)](https://designsystemdocspec.org/) document-block model.

## How Has This Been Tested?

- `cargo build --workspace` — clean build
- `cargo test --workspace` — 172 tests pass (8 new tests for SPEC-028 and SPEC-029)
- Changeset included for `@adobe/spectrum-design-data-spec`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

### Changes

**New files:**
- `packages/design-data-spec/schemas/document-block.schema.json` — Layer 1 schema; 5 block types (`purpose`, `guideline`, `accessibility`, `do-dont`, `examples`); optional `agents` field for LLM-tuned phrasing
- `packages/design-data-spec/spec/document-blocks.md` — full spec chapter covering shape, block types, attachment points, SPEC rules, agents guidance
- `sdk/core/src/validate/rules/spec028.rs` — SPEC-028: warns when `agents` field is identical to `content`
- `sdk/core/src/validate/rules/spec029.rs` — SPEC-029: warns when a non-empty `documentBlocks` array has no `purpose` block
- `.changeset/phase-9-document-blocks.md`

**Modified files:**
- `packages/design-data-spec/schemas/component.schema.json` — `documentBlocks` added to component top-level and `anatomyPart` $def
- `packages/design-data-spec/schemas/anatomy-part.schema.json` — `documentBlocks` added
- `packages/design-data-spec/schemas/token.schema.json` — `documentBlocks` added to both `tokenWithValue` and `tokenWithRef`
- `packages/design-data-spec/spec/component-format.md` — Document Blocks section added
- `packages/design-data-spec/rules/rules.yaml` — SPEC-028 and SPEC-029 registered
- `sdk/core/src/validate/rules/mod.rs` — SPEC-028 and SPEC-029 registered in `default_rules()`