### PR TITLE
fix(component-schemas): register document-block schema with AJV in test setup

### DIFF
--- a/packages/component-schemas/test/schema-validation.test.js
+++ b/packages/component-schemas/test/schema-validation.test.js
@@ -40,6 +40,9 @@ test.before(async () => {
   ajv = new Ajv({ allErrors: true, strict: false });
   addFormats(ajv);
   ajv.addSchema(
+    await readJSON(resolve(specPkgDir, "schemas/document-block.schema.json")),
+  );
+  ajv.addSchema(
     await readJSON(resolve(specPkgDir, "schemas/anatomy-part.schema.json")),
   );
   ajv.addSchema(


### PR DESCRIPTION
## Description

Fixes a broken test introduced when Phase 9 (PR #877) added `document-block.schema.json` and referenced it from `component.schema.json` via a relative `$ref`. The `component-schemas:test` suite builds an AJV instance from scratch and manually registers each dependency schema — `anatomy-part` and `state-declaration` were registered but `document-block` was not, causing a `MissingRefError` at compile time.

## Related Issue

Closes #877 CI follow-up (`component-schemas:test` failure in the deploy job).

## Motivation and Context

`ajv.compile(componentSchema)` throws when it encounters `$ref: "document-block.schema.json"` and the schema hasn't been added to the AJV instance. One-line fix: add `document-block.schema.json` to the `test.before` setup alongside the other dependency schemas.

## How Has This Been Tested?

- `moon run component-schemas:test` passes locally

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.