### PR TITLE
docs(spec): add agent-readable surface to spec index

### DIFF
--- a/packages/design-data-spec/spec/index.md
+++ b/packages/design-data-spec/spec/index.md
@@ -20,7 +20,8 @@ The specification defines:
 7. **Semantic diff** — change taxonomy, token identity rules, and property-level change tracking for comparing dataset versions ([Diff](diff.md)).
 8. **Query notation** — filter syntax for selecting tokens by structured fields ([Query](query.md)).
 9. **Document blocks** — typed prose blocks attachable to tokens, components, and anatomy parts; makes design guidance machine-readable and agent-queryable ([Document blocks](document-blocks.md)).
-10. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
+10. **Agent-readable surface** — operations and transport contracts (CLI, MCP server, Agent Skill) for AI agents consuming spec-conformant design data; covers session primer, token resolution, validation, query, and component description ([Agent-readable surface](agent-surface.md)).
+11. **Evolution** — deprecation lifecycle, migration windows, change classification, and legacy format contract ([Evolution](evolution.md)).
 
 ## Conformance
 
@@ -67,8 +68,9 @@ Full governance (compatibility tiers, migration, CLI `--spec-version`) is discus
 | [Product context](product-context.md)   | Product-layer context document: rationale, overrides, and extensions.                                       |
 | [Diff](diff.md)                         | Semantic diff change taxonomy, token identity, property changes.                                            |
 | [Query](query.md)                       | Filter notation for selecting tokens by structured fields.                                                  |
-| [Document blocks](document-blocks.md)   | Typed prose blocks (purpose, guideline, accessibility, do-dont, examples) attachable to any entity.         |
-| [Evolution](evolution.md)               | Deprecation lifecycle, migration windows, change classification.                                            |
+| [Document blocks](document-blocks.md)         | Typed prose blocks (purpose, guideline, accessibility, do-dont, examples) attachable to any entity.                      |
+| [Agent-readable surface](agent-surface.md)    | Transport contracts (CLI, MCP, Agent Skill) and operation catalog for AI agents consuming spec-conformant design data.    |
+| [Evolution](evolution.md)                     | Deprecation lifecycle, migration windows, change classification.                                                          |
 
 ## JSON Schema `$id` and versioning
 


### PR DESCRIPTION
## Description

Adds `agent-surface` (Phase 8) to the top-level spec index — it was merged but not referenced from the normative index page.

## Motivation and Context

Phase 8 PRs (#870, #871, #874, #876) and the RFC-C draft (#839) are all merged, but `index.md` was never updated to include `agent-surface.md` in the Scope list or the Normative references table. Anyone reading the spec index to understand its coverage would have no way to discover the agent-readable surface contract.

## Changes

- Adds scope item 10: **Agent-readable surface** (renumbers Evolution from 10 → 11)
- Adds normative references table row for `agent-surface.md`

## How Has This Been Tested?

Doc-only change; verified the link target matches `agent-surface.md` which exists in the same directory.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.