### PR TITLE
feat(spec): accessibility.schema.json + component schema wiring (Phase 7.3)

### DIFF
--- a/.changeset/phase-7-3-accessibility-schema.md
+++ b/.changeset/phase-7-3-accessibility-schema.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-design-data-spec": minor
+---
+
+feat(spec): accessibility.schema.json + component schema wiring (Phase 7.3)

--- a/packages/design-data-spec/conformance/valid/component-with-accessibility.json
+++ b/packages/design-data-spec/conformance/valid/component-with-accessibility.json
@@ -1,0 +1,32 @@
+{
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "accessibility": {
+        "role": "button",
+        "intents": ["trigger"],
+        "focusable": true,
+        "keyboardIntents": ["activate"],
+        "wcag": [
+          { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+        ]
+      },
+      "states": [
+        {
+          "name": "disabled",
+          "trigger": "prop",
+          "precedence": 100,
+          "announce": "Button disabled",
+          "communicates": "disabled",
+          "blocksInteraction": true
+        }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/schemas/accessibility.schema.json
+++ b/packages/design-data-spec/schemas/accessibility.schema.json
@@ -29,6 +29,7 @@
     "wcag": {
       "type": "array",
       "items": { "$ref": "#/$defs/wcagEntry" },
+      "uniqueItems": true,
       "description": "Applicable WCAG 2.x success criteria."
     }
   },

--- a/packages/design-data-spec/schemas/accessibility.schema.json
+++ b/packages/design-data-spec/schemas/accessibility.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/accessibility.schema.json",
+  "title": "Accessibility declaration",
+  "description": "Semantic accessibility vocabulary for a component declaration. See spec/accessibility.md.",
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Semantic role from the canonical vocabulary (e.g. 'button', 'checkbox', 'dialog')."
+    },
+    "intents": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true,
+      "description": "Semantic interaction intents (e.g. 'trigger', 'select', 'expand')."
+    },
+    "focusable": {
+      "type": "boolean",
+      "description": "Whether the component receives keyboard focus via the Tab key by default."
+    },
+    "keyboardIntents": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true,
+      "description": "Keyboard interaction intents when focused (e.g. 'activate', 'expand', 'dismiss')."
+    },
+    "wcag": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/wcagEntry" },
+      "description": "Applicable WCAG 2.x success criteria."
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "wcagEntry": {
+      "type": "object",
+      "required": ["criterion", "level"],
+      "properties": {
+        "criterion": {
+          "type": "string",
+          "pattern": "^[1-4]\\.[0-9]+\\.[0-9]+$",
+          "description": "WCAG 2.x criterion number (e.g. '1.3.1')."
+        },
+        "level": {
+          "type": "string",
+          "enum": ["A", "AA", "AAA"],
+          "description": "WCAG conformance level."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable criterion title (e.g. 'Info and Relationships')."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -252,14 +252,17 @@
         },
         "announce": {
           "type": "string",
+          "minLength": 1,
           "description": "Screen-reader announcement hint for this state transition. See spec/accessibility.md."
         },
         "communicates": {
           "type": "string",
+          "minLength": 1,
           "description": "Semantic meaning conveyed to AT when this state is active (e.g. 'expanded', 'disabled'). See spec/accessibility.md."
         },
         "blocksInteraction": {
           "type": "boolean",
+          "default": false,
           "description": "Whether this state prevents all user interaction. See spec/accessibility.md."
         }
       },

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -74,6 +74,10 @@
       "items": { "$ref": "document-block.schema.json" },
       "minItems": 1,
       "description": "Typed prose blocks for this component. See spec/document-blocks.md (Phase 9)."
+    },
+    "accessibility": {
+      "$ref": "accessibility.schema.json",
+      "description": "Semantic accessibility vocabulary for this component. See spec/accessibility.md (Phase 7)."
     }
   },
   "additionalProperties": false,
@@ -245,6 +249,18 @@
           "type": "boolean",
           "default": false,
           "description": "true for states that compose with others (e.g. focus ring layered over hover)."
+        },
+        "announce": {
+          "type": "string",
+          "description": "Screen-reader announcement hint for this state transition. See spec/accessibility.md."
+        },
+        "communicates": {
+          "type": "string",
+          "description": "Semantic meaning conveyed to AT when this state is active (e.g. 'expanded', 'disabled'). See spec/accessibility.md."
+        },
+        "blocksInteraction": {
+          "type": "boolean",
+          "description": "Whether this state prevents all user interaction. See spec/accessibility.md."
         }
       },
       "additionalProperties": false

--- a/packages/design-data-spec/spec/component-format.md
+++ b/packages/design-data-spec/spec/component-format.md
@@ -40,6 +40,7 @@ A component declaration **MUST** contain:
 | `lifecycle`      | object | Version lifecycle metadata — see [Lifecycle](#lifecycle).                                                                                  |
 | `tokenBindings`  | array  | Tokens this component uses — see [Token bindings](#token-bindings) (Phase 6.7).                                                            |
 | `documentBlocks` | array  | Typed prose blocks for this component — see [Document blocks](#document-blocks) (Phase 9).                                                 |
+| `accessibility`  | object | Semantic accessibility vocabulary — see [Accessibility](accessibility.md) (Phase 7).                                                       |
 
 **NORMATIVE:** No properties beyond those listed above are permitted at the top level of a component declaration. Additional fields **MUST** cause a Layer 1 schema error.
 
@@ -348,6 +349,37 @@ A complete button component declaration:
   "lifecycle": {
     "introduced": "1.0.0-draft"
   }
+}
+```
+
+## Accessibility
+
+**Phase 7.** Component declarations MAY carry an `accessibility` object at the top level. State declarations MAY carry `announce`, `communicates`, and `blocksInteraction` fields. See [spec/accessibility.md](accessibility.md) for the full vocabulary, SPEC rules, and examples.
+
+```json
+{
+  "name": "button",
+  "displayName": "Button",
+  "meta": { "category": "actions", "documentationUrl": "https://spectrum.adobe.com/page/button/" },
+  "accessibility": {
+    "role": "button",
+    "intents": ["trigger"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+    ]
+  },
+  "states": [
+    {
+      "name": "disabled",
+      "trigger": "prop",
+      "precedence": 100,
+      "announce": "Button disabled",
+      "communicates": "disabled",
+      "blocksInteraction": true
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
## Description

Adds `accessibility.schema.json` — a new JSON Schema for the semantic accessibility vocabulary defined in `spec/accessibility.md` — and wires it into `component.schema.json` and `spec/component-format.md`.

**New file: `schemas/accessibility.schema.json`**
- Top-level object with five optional properties: `role`, `intents`, `focusable`, `keyboardIntents`, `wcag`
- `wcagEntry` $def with `criterion` (pattern `^[1-4]\.[0-9]+\.[0-9]+$`), `level` enum (A/AA/AAA), optional `title`
- `additionalProperties: false` at both levels
- No required fields at top level (all fields are optional per spec/accessibility.md)

**Modified: `schemas/component.schema.json`**
- Added `accessibility` property to top-level `properties` (ref to `accessibility.schema.json`)
- Added `announce`, `communicates`, `blocksInteraction` to `$defs.stateDeclaration.properties`

**Modified: `spec/component-format.md`**
- Added `accessibility` row to the optional fields table
- Added `## Accessibility` section with a JSON example showing a button component with full accessibility and state fields

## Related Issue

Closes #884
Part of #829 (Phase 7: Foundation Accessibility)

## Motivation and Context

Phase 7.1 (`spec/accessibility.md`) and Phase 7.2 (`spec/accessibility-adapters.md`) are merged. This PR completes Phase 7.3 by providing the machine-readable schema layer for the vocabulary defined in those spec chapters.

## How Has This Been Tested?

- JSON schema files validated with `node -e "JSON.parse(...)"` — both `accessibility.schema.json` and the updated `component.schema.json` parse without error
- `spec/component-format.md` linted with `pnpm exec remark`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.