### PR TITLE
feat(sdk): accessibility-empty and accessibility-wcag-missing validation rules (Phase 7.4)

### DIFF
--- a/.changeset/phase-7-4-accessibility-rules.md
+++ b/.changeset/phase-7-4-accessibility-rules.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-design-data-spec": minor
+---
+
+feat(spec): SPEC-030/031 accessibility validation rules (Phase 7.4)

--- a/packages/component-schemas/test/schema-validation.test.js
+++ b/packages/component-schemas/test/schema-validation.test.js
@@ -50,6 +50,9 @@ test.before(async () => {
       resolve(specPkgDir, "schemas/state-declaration.schema.json"),
     ),
   );
+  ajv.addSchema(
+    await readJSON(resolve(specPkgDir, "schemas/accessibility.schema.json")),
+  );
 });
 
 test("all component files should validate against component.schema.json", async (t) => {

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -268,3 +268,27 @@ rules:
     message: "'{entity}' has documentBlocks but no purpose block — add a block with type 'purpose'"
     spec_ref: spec/document-blocks.md
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-030
+    name: accessibility-empty
+    severity: warning
+    category: completeness
+    assert: >
+      A component declaration that carries an accessibility object SHOULD populate at least one
+      of the five known fields (role, intents, focusable, keyboardIntents, wcag). An entirely
+      empty accessibility object provides no semantic value and should be populated or removed.
+    message: "Component '{entity}' has an empty accessibility object — populate at least one field or remove the property"
+    spec_ref: spec/accessibility.md
+    introduced_in: "1.0.0-draft"
+
+  - id: SPEC-031
+    name: accessibility-wcag-missing
+    severity: warning
+    category: completeness
+    assert: >
+      A component whose accessibility declaration includes a role SHOULD also include a non-empty
+      wcag array listing applicable WCAG 2.x success criteria. WCAG citations improve audit
+      traceability for components with a named semantic role.
+    message: "Component '{entity}' accessibility has a role but no wcag entries — add applicable WCAG 2.x success criteria"
+    spec_ref: spec/accessibility.md
+    introduced_in: "1.0.0-draft"

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -24,6 +24,8 @@ mod spec013;
 mod spec017;
 mod spec028;
 mod spec029;
+mod spec030;
+mod spec031;
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
@@ -58,6 +60,8 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec017::Rule),
         Box::new(spec028::Rule),
         Box::new(spec029::Rule),
+        Box::new(spec030::Rule),
+        Box::new(spec031::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec030.rs
+++ b/sdk/core/src/validate/rules/spec030.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-030: accessibility-empty
+//!
+//! Warns when a component declaration carries an `accessibility` object but all
+//! five known fields (`role`, `intents`, `focusable`, `keyboardIntents`, `wcag`)
+//! are absent. An empty declaration adds no semantic value and should either be
+//! populated or removed.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+const KNOWN_FIELDS: &[&str] = &["role", "intents", "focusable", "keyboardIntents", "wcag"];
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-030"
+    }
+
+    fn name(&self) -> &'static str {
+        "accessibility-empty"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        for comp in &ctx.graph.components {
+            let Some(acc) = comp.raw.get("accessibility") else {
+                continue;
+            };
+            let Some(obj) = acc.as_object() else {
+                continue;
+            };
+            let has_any = KNOWN_FIELDS.iter().any(|f| obj.contains_key(*f));
+            if !has_any {
+                out.push(Diagnostic {
+                    file: comp.file.clone(),
+                    token: None,
+                    rule_id: Some("SPEC-030".to_string()),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "Component '{}' has an empty accessibility object — populate at least one field or remove the property",
+                        comp.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec030::Rule;
+
+    fn run(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let mut g = TokenGraph::default();
+        g.components.push(ComponentRecord {
+            name: comp_raw
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("test-comp")
+                .to_string(),
+            file: PathBuf::from("test-comp.json"),
+            raw: comp_raw,
+        });
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn no_accessibility_no_warning() {
+        let diags = run(json!({"name": "button", "displayName": "Button"}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn populated_accessibility_no_warning() {
+        let diags = run(json!({
+            "name": "button",
+            "displayName": "Button",
+            "accessibility": { "role": "button", "focusable": true }
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn empty_accessibility_warns() {
+        let diags = run(json!({
+            "name": "button",
+            "displayName": "Button",
+            "accessibility": {}
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-030"));
+        assert!(diags[0].message.contains("Component 'button'"));
+    }
+
+    #[test]
+    fn single_field_no_warning() {
+        let diags = run(json!({
+            "name": "tooltip",
+            "displayName": "Tooltip",
+            "accessibility": { "focusable": false }
+        }));
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec031.rs
+++ b/sdk/core/src/validate/rules/spec031.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-031: accessibility-wcag-missing
+//!
+//! Warns when a component has an `accessibility` object with a `role` field but
+//! no `wcag` entries. Components with a named semantic role SHOULD document the
+//! applicable WCAG 2.x success criteria for audit traceability.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-031"
+    }
+
+    fn name(&self) -> &'static str {
+        "accessibility-wcag-missing"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        for comp in &ctx.graph.components {
+            let Some(acc) = comp.raw.get("accessibility") else {
+                continue;
+            };
+            let Some(obj) = acc.as_object() else {
+                continue;
+            };
+            // Only applies when `role` is present
+            if !obj.contains_key("role") {
+                continue;
+            }
+            let wcag_empty = obj
+                .get("wcag")
+                .and_then(|v| v.as_array())
+                .map(|a| a.is_empty())
+                .unwrap_or(true); // absent counts as empty
+            if wcag_empty {
+                out.push(Diagnostic {
+                    file: comp.file.clone(),
+                    token: None,
+                    rule_id: Some("SPEC-031".to_string()),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "Component '{}' accessibility has a role but no wcag entries — add applicable WCAG 2.x success criteria",
+                        comp.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec031::Rule;
+
+    fn run(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let mut g = TokenGraph::default();
+        g.components.push(ComponentRecord {
+            name: comp_raw
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("test-comp")
+                .to_string(),
+            file: PathBuf::from("test-comp.json"),
+            raw: comp_raw,
+        });
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn no_accessibility_no_warning() {
+        let diags = run(json!({"name": "button", "displayName": "Button"}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn role_with_wcag_no_warning() {
+        let diags = run(json!({
+            "name": "button",
+            "displayName": "Button",
+            "accessibility": {
+                "role": "button",
+                "wcag": [
+                    { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+                ]
+            }
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn role_without_wcag_warns() {
+        let diags = run(json!({
+            "name": "button",
+            "displayName": "Button",
+            "accessibility": { "role": "button" }
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-031"));
+        assert!(diags[0].message.contains("Component 'button'"));
+    }
+
+    #[test]
+    fn role_with_empty_wcag_warns() {
+        let diags = run(json!({
+            "name": "button",
+            "displayName": "Button",
+            "accessibility": { "role": "button", "wcag": [] }
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-031"));
+    }
+
+    #[test]
+    fn no_role_no_warning() {
+        // accessibility present but no role — SPEC-031 should not fire
+        let diags = run(json!({
+            "name": "decoration",
+            "displayName": "Decoration",
+            "accessibility": { "focusable": false }
+        }));
+        assert!(diags.is_empty());
+    }
+}


### PR DESCRIPTION
## Description

Adds SPEC-030 and SPEC-031 Rust validation rules for the accessibility vocabulary defined in `spec/accessibility.md` (Phase 7). Both rules operate on component declarations via `ctx.graph.components`.

**SPEC-030 `accessibility-empty`** (`sdk/core/src/validate/rules/spec030.rs`)
- Warns when a component has an `accessibility` object but none of the five known fields (`role`, `intents`, `focusable`, `keyboardIntents`, `wcag`) are present
- An entirely empty object provides no semantic value

**SPEC-031 `accessibility-wcag-missing`** (`sdk/core/src/validate/rules/spec031.rs`)
- Warns when a component's `accessibility` object has a `role` field but the `wcag` array is absent or empty
- Components with a named role should document applicable WCAG 2.x criteria for audit traceability

Both rules are registered in `mod.rs` and catalogued in `packages/design-data-spec/rules/rules.yaml`.

## Related Issue

Closes #885
Part of #829 (Phase 7: Foundation Accessibility)

## Motivation and Context

Phase 7.3 added the JSON schema layer for accessibility declarations. This PR adds the Layer 2 relational rules that catch incomplete or empty declarations at validation time.

## How Has This Been Tested?

187 Rust tests pass (4 tests for SPEC-030, 5 tests for SPEC-031, all prior tests still pass):
```
test result: ok. 187 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.