### PR TITLE
feat(spec): add accessibility declarations to all foundation components (Phase 7)

### DIFF
--- a/.changeset/phase-7-component-accessibility.md
+++ b/.changeset/phase-7-component-accessibility.md
@@ -1,0 +1,5 @@
+---
+"@adobe/spectrum-design-data-spec": minor
+---
+
+feat(spec): add accessibility declarations to all foundation components (Phase 7)

--- a/packages/design-data-spec/components/accordion.json
+++ b/packages/design-data-spec/components/accordion.json
@@ -513,5 +513,22 @@
       "token": "field-top-to-disclosure-icon-300-spacious",
       "context": "Spacing (top/bottom to disclosure icon)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["expand"],
+    "focusable": true,
+    "keyboardIntents": ["activate", "expand", "collapse"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/action-bar.json
+++ b/packages/design-data-spec/components/action-bar.json
@@ -199,5 +199,16 @@
       "token": "neutral-visual-color",
       "context": "Step visual"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["trigger"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/action-button.json
+++ b/packages/design-data-spec/components/action-button.json
@@ -477,5 +477,23 @@
       "token": "static-black-focus-indicator-color",
       "context": "Focus ring (black)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "button",
+    "intents": ["trigger"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/action-group.json
+++ b/packages/design-data-spec/components/action-group.json
@@ -78,5 +78,16 @@
       "token": "spacing-50",
       "context": "Spacing (horizontal, compact)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["trigger"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/alert-banner.json
+++ b/packages/design-data-spec/components/alert-banner.json
@@ -107,5 +107,15 @@
       "token": "cjk-line-height-100",
       "context": "Text"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.3",
+        "level": "AA",
+        "title": "Status Messages"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/alert-dialog.json
+++ b/packages/design-data-spec/components/alert-dialog.json
@@ -148,5 +148,23 @@
       "token": "negative-visual-color",
       "context": "Icon (error variant)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "dialog",
+    "intents": ["dismiss"],
+    "focusable": false,
+    "keyboardIntents": ["dismiss"],
+    "wcag": [
+      {
+        "criterion": "2.4.3",
+        "level": "A",
+        "title": "Focus Order"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/avatar-group.json
+++ b/packages/design-data-spec/components/avatar-group.json
@@ -136,5 +136,8 @@
       "token": "cjk-line-height-100",
       "context": "Layout"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/avatar.json
+++ b/packages/design-data-spec/components/avatar.json
@@ -180,5 +180,8 @@
       "token": "line-height-100",
       "context": "Text (List view item)"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/badge.json
+++ b/packages/design-data-spec/components/badge.json
@@ -498,5 +498,8 @@
     {
       "token": "cjk-line-height-100"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/body.json
+++ b/packages/design-data-spec/components/body.json
@@ -25,5 +25,8 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "focusable": false
   }
 }

--- a/packages/design-data-spec/components/bottom-navigation-android.json
+++ b/packages/design-data-spec/components/bottom-navigation-android.json
@@ -37,5 +37,22 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
   }
 }

--- a/packages/design-data-spec/components/breadcrumbs.json
+++ b/packages/design-data-spec/components/breadcrumbs.json
@@ -4,7 +4,7 @@
   "specVersion": "1.0.0-draft",
   "name": "breadcrumbs",
   "displayName": "Breadcrumbs",
-  "description": "Breadcrumbs show hierarchy and navigational context for a user’s location within an app.",
+  "description": "Breadcrumbs show hierarchy and navigational context for a user\u2019s location within an app.",
   "meta": {
     "category": "navigation",
     "documentationUrl": "https://spectrum.adobe.com/page/breadcrumbs/"
@@ -259,5 +259,22 @@
       "token": "heading-size-l",
       "context": "Text (breadcrumb item and title, multiline)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/button-group.json
+++ b/packages/design-data-spec/components/button-group.json
@@ -43,5 +43,16 @@
       "token": "spacing-200",
       "context": "Spacing (horizontal)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["trigger"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/button.json
+++ b/packages/design-data-spec/components/button.json
@@ -478,7 +478,7 @@
     },
     {
       "token": "static-white-focus-indicator-color",
-      "context": "Static white – Focus indicator"
+      "context": "Static white \u2013 Focus indicator"
     },
     {
       "token": "transparent-black-900",
@@ -522,7 +522,25 @@
     },
     {
       "token": "static-black-focus-indicator-color",
-      "context": "Static black – Focus indicator"
+      "context": "Static black \u2013 Focus indicator"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "button",
+    "intents": ["trigger"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/calendar.json
+++ b/packages/design-data-spec/components/calendar.json
@@ -100,5 +100,27 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "intents": ["input", "choose"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
   }
 }

--- a/packages/design-data-spec/components/cards.json
+++ b/packages/design-data-spec/components/cards.json
@@ -512,6 +512,7 @@
   "accessibility": {
     "intents": ["select"],
     "focusable": true,
+    "keyboardIntents": ["activate"],
     "wcag": [
       {
         "criterion": "2.1.1",
@@ -523,7 +524,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/cards.json
+++ b/packages/design-data-spec/components/cards.json
@@ -508,5 +508,21 @@
       "token": "horizontal-card-edge-to-content-spacious",
       "context": "Spacing (top/side/bottom edge to content)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["select"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/cards.json
+++ b/packages/design-data-spec/components/cards.json
@@ -523,6 +523,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["activate"]
   }
 }

--- a/packages/design-data-spec/components/checkbox-group.json
+++ b/packages/design-data-spec/components/checkbox-group.json
@@ -50,5 +50,21 @@
   "lifecycle": {
     "introduced": "1.0.0-draft"
   },
-  "tokenBindings": []
+  "tokenBindings": [],
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/checkbox.json
+++ b/packages/design-data-spec/components/checkbox.json
@@ -299,5 +299,28 @@
       "token": "cjk-line-height-100",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "checkbox",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/close-button.json
+++ b/packages/design-data-spec/components/close-button.json
@@ -166,5 +166,23 @@
       "token": "transparent-black-100",
       "context": "Background (static black)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "button",
+    "intents": ["dismiss"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/coach-indicator.json
+++ b/packages/design-data-spec/components/coach-indicator.json
@@ -72,5 +72,8 @@
       "token": "white",
       "context": "Indicator (Static white)"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/coach-mark.json
+++ b/packages/design-data-spec/components/coach-mark.json
@@ -153,5 +153,16 @@
       "token": "coach-mark-pagination-color",
       "context": "Color"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["dismiss"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/coach-mark.json
+++ b/packages/design-data-spec/components/coach-mark.json
@@ -157,13 +157,13 @@
   "accessibility": {
     "intents": ["dismiss"],
     "focusable": true,
+    "keyboardIntents": ["dismiss"],
     "wcag": [
       {
         "criterion": "4.1.2",
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["dismiss"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/coach-mark.json
+++ b/packages/design-data-spec/components/coach-mark.json
@@ -163,6 +163,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["dismiss"]
   }
 }

--- a/packages/design-data-spec/components/code.json
+++ b/packages/design-data-spec/components/code.json
@@ -21,5 +21,8 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "focusable": false
   }
 }

--- a/packages/design-data-spec/components/color-area.json
+++ b/packages/design-data-spec/components/color-area.json
@@ -111,5 +111,28 @@
       "token": "disabled-background-color",
       "context": "Disabled"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "slider",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/color-handle.json
+++ b/packages/design-data-spec/components/color-handle.json
@@ -91,6 +91,7 @@
         "level": "A",
         "title": "Keyboard"
       }
-    ]
+    ],
+    "keyboardIntents": ["increment", "decrement"]
   }
 }

--- a/packages/design-data-spec/components/color-handle.json
+++ b/packages/design-data-spec/components/color-handle.json
@@ -85,13 +85,13 @@
   "accessibility": {
     "intents": ["choose"],
     "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
     "wcag": [
       {
         "criterion": "2.1.1",
         "level": "A",
         "title": "Keyboard"
       }
-    ],
-    "keyboardIntents": ["increment", "decrement"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/color-handle.json
+++ b/packages/design-data-spec/components/color-handle.json
@@ -81,5 +81,16 @@
       "token": "disabled-background-color",
       "context": "Border (disabled)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/color-loupe.json
+++ b/packages/design-data-spec/components/color-loupe.json
@@ -70,5 +70,8 @@
       "token": "color-loupe-drop-shadow-color",
       "context": "S1 Shadows"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/color-slider.json
+++ b/packages/design-data-spec/components/color-slider.json
@@ -117,5 +117,28 @@
       "token": "disabled-background-color",
       "context": "Disabled"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "slider",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/color-wheel.json
+++ b/packages/design-data-spec/components/color-wheel.json
@@ -90,5 +90,28 @@
       "token": "disabled-background-color",
       "context": "Disabled"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "slider",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/combo-box.json
+++ b/packages/design-data-spec/components/combo-box.json
@@ -476,5 +476,28 @@
       "token": "gray-600",
       "context": "Label (populated true/false)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "combobox",
+    "intents": ["input", "select", "expand"],
+    "focusable": true,
+    "keyboardIntents": ["expand", "collapse", "navigate-options"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/contextual-help.json
+++ b/packages/design-data-spec/components/contextual-help.json
@@ -173,6 +173,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["activate"]
   }
 }

--- a/packages/design-data-spec/components/contextual-help.json
+++ b/packages/design-data-spec/components/contextual-help.json
@@ -162,6 +162,7 @@
   "accessibility": {
     "intents": ["trigger"],
     "focusable": true,
+    "keyboardIntents": ["activate"],
     "wcag": [
       {
         "criterion": "2.1.1",
@@ -173,7 +174,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/contextual-help.json
+++ b/packages/design-data-spec/components/contextual-help.json
@@ -158,5 +158,21 @@
       "token": "body-color",
       "context": "Color"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["trigger"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/date-picker.json
+++ b/packages/design-data-spec/components/date-picker.json
@@ -435,5 +435,27 @@
       "token": "spacing-500",
       "context": "Popover minimum width"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["input", "choose"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/detail.json
+++ b/packages/design-data-spec/components/detail.json
@@ -26,5 +26,8 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "focusable": false
   }
 }

--- a/packages/design-data-spec/components/divider.json
+++ b/packages/design-data-spec/components/divider.json
@@ -69,5 +69,8 @@
       "token": "transparent-black-800",
       "context": "Fill (black)"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/drop-zone.json
+++ b/packages/design-data-spec/components/drop-zone.json
@@ -207,5 +207,21 @@
       "token": "white",
       "context": "Border, background, and text area color (filled, hover)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["input"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/drop-zone.json
+++ b/packages/design-data-spec/components/drop-zone.json
@@ -211,6 +211,7 @@
   "accessibility": {
     "intents": ["input"],
     "focusable": true,
+    "keyboardIntents": ["activate"],
     "wcag": [
       {
         "criterion": "2.1.1",
@@ -222,7 +223,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/drop-zone.json
+++ b/packages/design-data-spec/components/drop-zone.json
@@ -222,6 +222,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["activate"]
   }
 }

--- a/packages/design-data-spec/components/field-label.json
+++ b/packages/design-data-spec/components/field-label.json
@@ -185,5 +185,8 @@
       "token": "cjk-line-height-100",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/heading.json
+++ b/packages/design-data-spec/components/heading.json
@@ -29,5 +29,8 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "focusable": false
   }
 }

--- a/packages/design-data-spec/components/help-text.json
+++ b/packages/design-data-spec/components/help-text.json
@@ -4,7 +4,7 @@
   "specVersion": "1.0.0-draft",
   "name": "help-text",
   "displayName": "Help text",
-  "description": "Help text provides either an informative description or an error message that gives more context about what a user needs to input. It’s commonly used in forms.",
+  "description": "Help text provides either an informative description or an error message that gives more context about what a user needs to input. It\u2019s commonly used in forms.",
   "meta": {
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/page/help-text/"
@@ -182,5 +182,8 @@
       "token": "cjk-line-height-100",
       "context": "Text"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/illustrated-message.json
+++ b/packages/design-data-spec/components/illustrated-message.json
@@ -151,5 +151,8 @@
       "token": "body-color",
       "context": "Description color"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/in-field-progress-button.json
+++ b/packages/design-data-spec/components/in-field-progress-button.json
@@ -40,5 +40,23 @@
   ],
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "role": "button",
+    "intents": ["trigger"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
   }
 }

--- a/packages/design-data-spec/components/in-field-progress-circle.json
+++ b/packages/design-data-spec/components/in-field-progress-circle.json
@@ -76,5 +76,8 @@
       "token": "progress-circle-thickness-large",
       "context": "S1 Thickness"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/in-line-alert.json
+++ b/packages/design-data-spec/components/in-line-alert.json
@@ -197,5 +197,15 @@
       "token": "body-line-height",
       "context": "Title and Description"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.3",
+        "level": "AA",
+        "title": "Status Messages"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/link.json
+++ b/packages/design-data-spec/components/link.json
@@ -131,5 +131,23 @@
       "token": "focus-indicator-gap",
       "context": "Focus ring"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "link",
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/list-view.json
+++ b/packages/design-data-spec/components/list-view.json
@@ -351,5 +351,22 @@
       "token": "bold-font-weight",
       "context": "Text (List view title)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["select", "navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate", "select-all"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/menu.json
+++ b/packages/design-data-spec/components/menu.json
@@ -538,5 +538,23 @@
       "token": "font-size-50",
       "context": "Descriptions (section header and item)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "menu",
+    "intents": ["select"],
+    "focusable": false,
+    "keyboardIntents": ["navigate-options", "activate", "dismiss"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/meter.json
+++ b/packages/design-data-spec/components/meter.json
@@ -158,5 +158,8 @@
       "token": "static-white-track-indicator-color",
       "context": "Track and indicator (white)"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/number-field.json
+++ b/packages/design-data-spec/components/number-field.json
@@ -464,5 +464,28 @@
       "token": "positive-visual-color",
       "context": "Positive icon"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "spinbutton",
+    "intents": ["choose", "input"],
+    "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/opacity-checkerboard.json
+++ b/packages/design-data-spec/components/opacity-checkerboard.json
@@ -39,5 +39,8 @@
       "token": "opacity-checkerboard-square-dark",
       "context": "Square"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/picker.json
+++ b/packages/design-data-spec/components/picker.json
@@ -518,5 +518,28 @@
       "token": "component-xl-medium",
       "context": "Prefix"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "combobox",
+    "intents": ["select", "expand"],
+    "focusable": true,
+    "keyboardIntents": ["expand", "collapse", "navigate-options"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/popover.json
+++ b/packages/design-data-spec/components/popover.json
@@ -115,5 +115,16 @@
       "token": "drop-shadow-elevated-blur",
       "context": "Drop shadow"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["dismiss"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/progress-bar.json
+++ b/packages/design-data-spec/components/progress-bar.json
@@ -178,5 +178,8 @@
       "token": "static-white-track-indicator-color",
       "context": "Track and indicator (white)"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/progress-circle.json
+++ b/packages/design-data-spec/components/progress-circle.json
@@ -95,5 +95,8 @@
       "token": "static-black-track-indicator-color",
       "context": "Track and fill (black)"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/radio-button.json
+++ b/packages/design-data-spec/components/radio-button.json
@@ -281,5 +281,28 @@
       "token": "cjk-line-height-100",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "radio",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/radio-group.json
+++ b/packages/design-data-spec/components/radio-group.json
@@ -59,5 +59,21 @@
   "lifecycle": {
     "introduced": "1.0.0-draft"
   },
-  "tokenBindings": []
+  "tokenBindings": [],
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/rating.json
+++ b/packages/design-data-spec/components/rating.json
@@ -141,5 +141,28 @@
       "token": "disabled-content-color",
       "context": "Disabled"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "slider",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/scroll-zoom-bar.json
+++ b/packages/design-data-spec/components/scroll-zoom-bar.json
@@ -49,5 +49,16 @@
   ],
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      }
+    ]
   }
 }

--- a/packages/design-data-spec/components/scroll-zoom-bar.json
+++ b/packages/design-data-spec/components/scroll-zoom-bar.json
@@ -53,13 +53,13 @@
   "accessibility": {
     "intents": ["choose"],
     "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
     "wcag": [
       {
         "criterion": "2.1.1",
         "level": "A",
         "title": "Keyboard"
       }
-    ],
-    "keyboardIntents": ["increment", "decrement"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/scroll-zoom-bar.json
+++ b/packages/design-data-spec/components/scroll-zoom-bar.json
@@ -59,6 +59,7 @@
         "level": "A",
         "title": "Keyboard"
       }
-    ]
+    ],
+    "keyboardIntents": ["increment", "decrement"]
   }
 }

--- a/packages/design-data-spec/components/search-field.json
+++ b/packages/design-data-spec/components/search-field.json
@@ -307,7 +307,6 @@
     "role": "textbox",
     "intents": ["input"],
     "focusable": true,
-    "keyboardIntents": [],
     "wcag": [
       {
         "criterion": "1.3.1",

--- a/packages/design-data-spec/components/search-field.json
+++ b/packages/design-data-spec/components/search-field.json
@@ -302,5 +302,33 @@
       "token": "focus-indicator-color",
       "context": "Focus ring"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "textbox",
+    "intents": ["input"],
+    "focusable": true,
+    "keyboardIntents": [],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "1.3.5",
+        "level": "AA",
+        "title": "Identify Input Purpose"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/segmented-control.json
+++ b/packages/design-data-spec/components/segmented-control.json
@@ -206,5 +206,22 @@
       "token": "line-height-100",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/select-box.json
+++ b/packages/design-data-spec/components/select-box.json
@@ -244,5 +244,22 @@
       "token": "drop-shadow-elevated-color",
       "context": "Focus"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["select"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/side-navigation.json
+++ b/packages/design-data-spec/components/side-navigation.json
@@ -289,5 +289,22 @@
       "token": "font-size-75",
       "context": "Text (Side navigation title)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/slider.json
+++ b/packages/design-data-spec/components/slider.json
@@ -366,5 +366,28 @@
       "token": "cjk-line-height-100",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "slider",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["increment", "decrement"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/standard-dialog.json
+++ b/packages/design-data-spec/components/standard-dialog.json
@@ -147,5 +147,23 @@
       "token": "body-color",
       "context": "Description"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "dialog",
+    "intents": ["dismiss"],
+    "focusable": false,
+    "keyboardIntents": ["dismiss"],
+    "wcag": [
+      {
+        "criterion": "2.4.3",
+        "level": "A",
+        "title": "Focus Order"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/standard-panel.json
+++ b/packages/design-data-spec/components/standard-panel.json
@@ -49,5 +49,8 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "focusable": false
   }
 }

--- a/packages/design-data-spec/components/status-light.json
+++ b/packages/design-data-spec/components/status-light.json
@@ -268,5 +268,8 @@
       "token": "neutral-content-color-default",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/steplist.json
+++ b/packages/design-data-spec/components/steplist.json
@@ -266,5 +266,22 @@
       "token": "cjk-line-height-100",
       "context": "Label"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/swatch-group.json
+++ b/packages/design-data-spec/components/swatch-group.json
@@ -58,5 +58,16 @@
       "token": "swatch-group-border-opacity",
       "context": "Border"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/swatch.json
+++ b/packages/design-data-spec/components/swatch.json
@@ -193,6 +193,7 @@
   "accessibility": {
     "intents": ["choose"],
     "focusable": true,
+    "keyboardIntents": ["activate"],
     "wcag": [
       {
         "criterion": "2.1.1",
@@ -204,7 +205,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/swatch.json
+++ b/packages/design-data-spec/components/swatch.json
@@ -189,5 +189,21 @@
       "token": "spacing-100",
       "context": "Spacing (spacious)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["choose"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/swatch.json
+++ b/packages/design-data-spec/components/swatch.json
@@ -204,6 +204,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["activate"]
   }
 }

--- a/packages/design-data-spec/components/switch.json
+++ b/packages/design-data-spec/components/switch.json
@@ -301,5 +301,23 @@
       "token": "focus-indicator-color",
       "context": "Focus indicator"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "switch",
+    "intents": ["choose"],
+    "focusable": true,
+    "keyboardIntents": ["activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tab-bar-ios.json
+++ b/packages/design-data-spec/components/tab-bar-ios.json
@@ -37,5 +37,22 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
   }
 }

--- a/packages/design-data-spec/components/table.json
+++ b/packages/design-data-spec/components/table.json
@@ -388,5 +388,27 @@
       "token": "table-selected-row-background-opacity-hover",
       "context": "S1 Selected row background (highlight selection, hover)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["select", "navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate", "select-all"],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tabs.json
+++ b/packages/design-data-spec/components/tabs.json
@@ -225,5 +225,22 @@
     {
       "token": "line-height-100"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["navigate"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tag-field.json
+++ b/packages/design-data-spec/components/tag-field.json
@@ -199,5 +199,21 @@
       "token": "focus-indicator-color",
       "context": "Focus ring"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["input", "select"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tag-field.json
+++ b/packages/design-data-spec/components/tag-field.json
@@ -214,6 +214,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["navigate-items", "activate"]
   }
 }

--- a/packages/design-data-spec/components/tag-field.json
+++ b/packages/design-data-spec/components/tag-field.json
@@ -203,6 +203,7 @@
   "accessibility": {
     "intents": ["input", "select"],
     "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
     "wcag": [
       {
         "criterion": "1.3.1",
@@ -214,7 +215,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["navigate-items", "activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/tag-group.json
+++ b/packages/design-data-spec/components/tag-group.json
@@ -49,5 +49,21 @@
       "token": "help-text-to-component",
       "context": "Spacing (Text area to Help text)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["select"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tag-group.json
+++ b/packages/design-data-spec/components/tag-group.json
@@ -53,6 +53,7 @@
   "accessibility": {
     "intents": ["select"],
     "focusable": true,
+    "keyboardIntents": ["navigate-items", "activate"],
     "wcag": [
       {
         "criterion": "1.3.1",
@@ -64,7 +65,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["navigate-items", "activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/tag-group.json
+++ b/packages/design-data-spec/components/tag-group.json
@@ -64,6 +64,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["navigate-items", "activate"]
   }
 }

--- a/packages/design-data-spec/components/tag.json
+++ b/packages/design-data-spec/components/tag.json
@@ -372,5 +372,21 @@
       "token": "focus-indicator-color",
       "context": "Focus indicator"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["dismiss"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tag.json
+++ b/packages/design-data-spec/components/tag.json
@@ -376,6 +376,7 @@
   "accessibility": {
     "intents": ["dismiss"],
     "focusable": true,
+    "keyboardIntents": ["activate"],
     "wcag": [
       {
         "criterion": "2.1.1",
@@ -387,7 +388,6 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ],
-    "keyboardIntents": ["activate"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/tag.json
+++ b/packages/design-data-spec/components/tag.json
@@ -387,6 +387,7 @@
         "level": "A",
         "title": "Name, Role, Value"
       }
-    ]
+    ],
+    "keyboardIntents": ["activate"]
   }
 }

--- a/packages/design-data-spec/components/takeover-dialog.json
+++ b/packages/design-data-spec/components/takeover-dialog.json
@@ -88,5 +88,23 @@
       "token": "heading-color",
       "context": "Title"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "dialog",
+    "intents": ["dismiss"],
+    "focusable": false,
+    "keyboardIntents": ["dismiss"],
+    "wcag": [
+      {
+        "criterion": "2.4.3",
+        "level": "A",
+        "title": "Focus Order"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/text-area.json
+++ b/packages/design-data-spec/components/text-area.json
@@ -481,5 +481,33 @@
       "token": "component-padding-vertical-300",
       "context": "S2 Spacing (top/bottom edge to text: inline)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "textbox",
+    "intents": ["input"],
+    "focusable": true,
+    "keyboardIntents": [],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "1.3.5",
+        "level": "AA",
+        "title": "Identify Input Purpose"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/text-area.json
+++ b/packages/design-data-spec/components/text-area.json
@@ -486,7 +486,6 @@
     "role": "textbox",
     "intents": ["input"],
     "focusable": true,
-    "keyboardIntents": [],
     "wcag": [
       {
         "criterion": "1.3.1",

--- a/packages/design-data-spec/components/text-field.json
+++ b/packages/design-data-spec/components/text-field.json
@@ -502,7 +502,6 @@
     "role": "textbox",
     "intents": ["input"],
     "focusable": true,
-    "keyboardIntents": [],
     "wcag": [
       {
         "criterion": "1.3.1",

--- a/packages/design-data-spec/components/text-field.json
+++ b/packages/design-data-spec/components/text-field.json
@@ -497,5 +497,33 @@
       "token": "field-label-top-to-asterisk-extra-large",
       "context": "Spacing (top/bottom edge to required)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "textbox",
+    "intents": ["input"],
+    "focusable": true,
+    "keyboardIntents": [],
+    "wcag": [
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "1.3.5",
+        "level": "AA",
+        "title": "Identify Input Purpose"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/thumbnail.json
+++ b/packages/design-data-spec/components/thumbnail.json
@@ -105,5 +105,8 @@
       "token": "thumbnail-opacity-disabled",
       "context": "Disabled"
     }
-  ]
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/title.json
+++ b/packages/design-data-spec/components/title.json
@@ -26,14 +26,44 @@
     "introduced": "1.0.0-draft"
   },
   "tokenBindings": [
-    { "token": "font-family", "context": "Title-XXXL" },
-    { "token": "font-weight", "context": "Title-XXXL" },
-    { "token": "font-size", "context": "Title-XXXL" },
-    { "token": "line-height", "context": "Title-XXXL" },
-    { "token": "letter-spacing", "context": "Title-XXXL" },
-    { "token": "font-style", "context": "Title-XXXL" },
-    { "token": "title-margin-top-multiplier", "context": "Margins" },
-    { "token": "title-margin-bottom-multiplier", "context": "Margins" },
-    { "token": "title-color", "context": "Color" }
-  ]
+    {
+      "token": "font-family",
+      "context": "Title-XXXL"
+    },
+    {
+      "token": "font-weight",
+      "context": "Title-XXXL"
+    },
+    {
+      "token": "font-size",
+      "context": "Title-XXXL"
+    },
+    {
+      "token": "line-height",
+      "context": "Title-XXXL"
+    },
+    {
+      "token": "letter-spacing",
+      "context": "Title-XXXL"
+    },
+    {
+      "token": "font-style",
+      "context": "Title-XXXL"
+    },
+    {
+      "token": "title-margin-top-multiplier",
+      "context": "Margins"
+    },
+    {
+      "token": "title-margin-bottom-multiplier",
+      "context": "Margins"
+    },
+    {
+      "token": "title-color",
+      "context": "Color"
+    }
+  ],
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data-spec/components/toast.json
+++ b/packages/design-data-spec/components/toast.json
@@ -137,6 +137,7 @@
         "level": "AA",
         "title": "Status Messages"
       }
-    ]
+    ],
+    "keyboardIntents": ["dismiss"]
   }
 }

--- a/packages/design-data-spec/components/toast.json
+++ b/packages/design-data-spec/components/toast.json
@@ -131,13 +131,13 @@
   "accessibility": {
     "intents": ["dismiss"],
     "focusable": true,
+    "keyboardIntents": ["dismiss"],
     "wcag": [
       {
         "criterion": "4.1.3",
         "level": "AA",
         "title": "Status Messages"
       }
-    ],
-    "keyboardIntents": ["dismiss"]
+    ]
   }
 }

--- a/packages/design-data-spec/components/toast.json
+++ b/packages/design-data-spec/components/toast.json
@@ -127,5 +127,16 @@
       "token": "neutral-background-color-default",
       "context": "Toast token changes (Jan 2025)"
     }
-  ]
+  ],
+  "accessibility": {
+    "intents": ["dismiss"],
+    "focusable": true,
+    "wcag": [
+      {
+        "criterion": "4.1.3",
+        "level": "AA",
+        "title": "Status Messages"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tooltip.json
+++ b/packages/design-data-spec/components/tooltip.json
@@ -136,5 +136,23 @@
       "token": "negative-background-color-default",
       "context": "Background (Negative)"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "tooltip",
+    "intents": [],
+    "focusable": false,
+    "keyboardIntents": [],
+    "wcag": [
+      {
+        "criterion": "1.4.13",
+        "level": "AA",
+        "title": "Content on Hover or Focus"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }

--- a/packages/design-data-spec/components/tooltip.json
+++ b/packages/design-data-spec/components/tooltip.json
@@ -140,7 +140,6 @@
   "accessibility": {
     "role": "tooltip",
     "focusable": false,
-    "keyboardIntents": [],
     "wcag": [
       {
         "criterion": "1.4.13",

--- a/packages/design-data-spec/components/tooltip.json
+++ b/packages/design-data-spec/components/tooltip.json
@@ -139,7 +139,6 @@
   ],
   "accessibility": {
     "role": "tooltip",
-    "intents": [],
     "focusable": false,
     "keyboardIntents": [],
     "wcag": [

--- a/packages/design-data-spec/components/tray.json
+++ b/packages/design-data-spec/components/tray.json
@@ -17,5 +17,16 @@
   },
   "lifecycle": {
     "introduced": "1.0.0-draft"
+  },
+  "accessibility": {
+    "intents": ["dismiss"],
+    "focusable": false,
+    "wcag": [
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
   }
 }

--- a/packages/design-data-spec/components/tree-view.json
+++ b/packages/design-data-spec/components/tree-view.json
@@ -337,5 +337,23 @@
       "token": "thumbnail-opacity-disabled",
       "context": "Disabled"
     }
-  ]
+  ],
+  "accessibility": {
+    "role": "tree",
+    "intents": ["navigate", "select", "expand"],
+    "focusable": true,
+    "keyboardIntents": ["navigate-items", "expand", "collapse", "activate"],
+    "wcag": [
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Description

Adds `accessibility` declarations to all 81 component files in `packages/design-data-spec/components/`, completing the final deliverable of #829 (Phase 7: Foundation Accessibility).

**Coverage:** Every component file now has an `accessibility` field. No component was left unaddressed.

**Three tiers of declaration:**

- **Tier 1 — Canonical role (full declaration):** Components with a direct mapping to the 16-value canonical role vocabulary (`button`, `link`, `checkbox`, `radio`, `switch`, `slider`, `spinbutton`, `textbox`, `combobox`, `menu`, `tooltip`, `dialog`, `tree`). Full `role` + `intents` + `focusable` + `keyboardIntents` + `wcag`.

- **Tier 2 — Composite / no canonical role:** Interactive components without a single canonical role (accordion, tabs, segmented-control, calendar, list-view, etc.). `intents` + `focusable` + `keyboardIntents` + `wcag` — no `role` field.

- **Tier 3 — Decorative / non-interactive:** `{ "focusable": false }` only. Signals explicit consideration. Includes progress indicators (which have ARIA `progressbar`/`meter` roles in practice, but those aren't in the current 16-value canonical vocab — expanding the vocabulary is deferred to a follow-on issue).

**Commits organized by category for reviewability:** actions → inputs → navigation → feedback+containers+data-viz → status+typography.

## Related Issue

Closes #829 (Phase 7: Foundation Accessibility)

## Motivation and Context

The four Phase 7 sub-issues (7.1–7.4) delivered the spec chapter, adapter contracts, JSON schema, and Rust validation rules. This PR delivers the remaining explicit scope item from #829: "Per-component accessibility declarations across the foundation."

## How Has This Been Tested?

- All 81 component files validated against `component.schema.json` via AJV: `2 tests passed`
- SPEC-030/031 Rust rules verified against the updated component set: `187 tests passed`
- All 81 files confirmed to have `accessibility` field via Node.js check

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.