### PR TITLE
feat(spec,sdk): conformance fixtures for SPEC-007–031 and Rust validation harness

### DIFF
--- a/packages/design-data-spec/conformance/invalid/SPEC-007/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-007/dataset.json
@@ -1,0 +1,9 @@
+{
+  "tokens": [
+    {
+      "name": "button-hover-border-color",
+      "value": "#0265dc",
+      "component": "button"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-007/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-007/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-007",
+      "severity": "warning",
+      "message_pattern": ".*does not roundtrip.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-009/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-009/dataset.json
@@ -1,0 +1,12 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "nonexistent-widget",
+        "property": "background-color"
+      },
+      "value": "#0265dc"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-009/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-009/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-009",
+      "severity": "warning",
+      "message_pattern": ".*not in the design-system-registry.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-010/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-010/dataset.json
@@ -1,0 +1,12 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "deprecated-token" },
+      "value": "#ffffff",
+      "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+      "deprecated": "3.0.0",
+      "replaced_by": "bbbbbbbb-9999-4000-8000-000000000099"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-011/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-011/dataset.json
@@ -1,0 +1,25 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "split-token" },
+      "value": "#ffffff",
+      "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+      "deprecated": "3.0.0",
+      "replaced_by": [
+        "aaaaaaaa-0002-4000-8000-000000000001",
+        "aaaaaaaa-0003-4000-8000-000000000001"
+      ]
+    },
+    {
+      "name": { "property": "replacement-a" },
+      "value": "#eeeeee",
+      "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
+    },
+    {
+      "name": { "property": "replacement-b" },
+      "value": "#dddddd",
+      "uuid": "aaaaaaaa-0003-4000-8000-000000000001"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-012/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-012/dataset.json
@@ -1,0 +1,16 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "not-deprecated-but-replaced" },
+      "value": "#ffffff",
+      "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+      "replaced_by": "aaaaaaaa-0002-4000-8000-000000000001"
+    },
+    {
+      "name": { "property": "replacement" },
+      "value": "#000000",
+      "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-013/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-013/dataset.json
@@ -1,0 +1,11 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "not-deprecated-but-planned-removal" },
+      "value": "#ffffff",
+      "uuid": "aaaaaaaa-0001-4000-8000-000000000001",
+      "plannedRemoval": "4.0.0"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-017/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-017/dataset.json
@@ -1,0 +1,10 @@
+{
+  "tokens": [
+    {
+      "name": "focus-ring-color-key-focus",
+      "value": "#0265dc",
+      "uuid": "aaaaaaaa-0017-4000-8000-000000000002"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-024/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-024/expected-errors.json
@@ -3,8 +3,8 @@
   "errors": [
     {
       "rule_id": "SPEC-024",
-      "severity": "warning",
-      "message_pattern": ".*custom state.*wobble.*no description.*"
+      "severity": "error",
+      "message_pattern": ".*duplicate anatomy part.*label.*"
     }
   ]
 }

--- a/packages/design-data-spec/conformance/invalid/SPEC-025/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-025/dataset.json
@@ -1,0 +1,12 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "anatomy": "label",
+        "property": "color"
+      },
+      "value": "#ffffff"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-025/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-025/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-025",
+      "severity": "error",
+      "message_pattern": ".*'anatomy' field without a 'component'.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-026/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-026/dataset.json
@@ -9,10 +9,9 @@
         "category": "actions",
         "documentationUrl": "https://spectrum.adobe.com/page/button/"
       },
-      "anatomy": [
-        { "name": "label", "description": "Button text." },
-        { "name": "icon", "description": "Leading icon." },
-        { "name": "label", "description": "Duplicate label part." }
+      "states": [
+        { "name": "hover", "trigger": "interaction", "precedence": 50 },
+        { "name": "wobble" }
       ]
     }
   ]

--- a/packages/design-data-spec/conformance/invalid/SPEC-026/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-026/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-026",
+      "severity": "warning",
+      "message_pattern": ".*custom state.*wobble.*no description.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-028/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-028/dataset.json
@@ -9,10 +9,12 @@
         "category": "actions",
         "documentationUrl": "https://spectrum.adobe.com/page/button/"
       },
-      "anatomy": [
-        { "name": "label", "description": "Button text." },
-        { "name": "icon", "description": "Leading icon." },
-        { "name": "label", "description": "Duplicate label part." }
+      "documentBlocks": [
+        {
+          "type": "purpose",
+          "content": "Triggers an action when clicked.",
+          "agents": "Triggers an action when clicked."
+        }
       ]
     }
   ]

--- a/packages/design-data-spec/conformance/invalid/SPEC-028/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-028/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-028",
+      "severity": "warning",
+      "message_pattern": ".*agents text is identical to content.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-029/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-029/dataset.json
@@ -9,10 +9,11 @@
         "category": "actions",
         "documentationUrl": "https://spectrum.adobe.com/page/button/"
       },
-      "anatomy": [
-        { "name": "label", "description": "Button text." },
-        { "name": "icon", "description": "Leading icon." },
-        { "name": "label", "description": "Duplicate label part." }
+      "documentBlocks": [
+        {
+          "type": "usage",
+          "content": "Use for primary actions in forms and dialogs."
+        }
       ]
     }
   ]

--- a/packages/design-data-spec/conformance/invalid/SPEC-029/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-029/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-029",
+      "severity": "warning",
+      "message_pattern": ".*no purpose block.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-030/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-030/dataset.json
@@ -9,11 +9,7 @@
         "category": "actions",
         "documentationUrl": "https://spectrum.adobe.com/page/button/"
       },
-      "anatomy": [
-        { "name": "label", "description": "Button text." },
-        { "name": "icon", "description": "Leading icon." },
-        { "name": "label", "description": "Duplicate label part." }
-      ]
+      "accessibility": {}
     }
   ]
 }

--- a/packages/design-data-spec/conformance/invalid/SPEC-030/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-030/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-030",
+      "severity": "warning",
+      "message_pattern": ".*empty accessibility object.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-031/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-031/dataset.json
@@ -9,11 +9,9 @@
         "category": "actions",
         "documentationUrl": "https://spectrum.adobe.com/page/button/"
       },
-      "anatomy": [
-        { "name": "label", "description": "Button text." },
-        { "name": "icon", "description": "Leading icon." },
-        { "name": "label", "description": "Duplicate label part." }
-      ]
+      "accessibility": {
+        "role": "button"
+      }
     }
   ]
 }

--- a/packages/design-data-spec/conformance/invalid/SPEC-031/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-031/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-031",
+      "severity": "warning",
+      "message_pattern": ".*no wcag entries.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-025/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-025/dataset.json
@@ -9,5 +9,16 @@
       "value": "#ffffff"
     }
   ],
-  "components": []
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "anatomy": [{ "name": "label", "description": "Button text." }]
+    }
+  ]
 }

--- a/packages/design-data-spec/conformance/valid/SPEC-025/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-025/dataset.json
@@ -1,0 +1,13 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "button",
+        "anatomy": "label",
+        "property": "color"
+      },
+      "value": "#ffffff"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-026/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-026/dataset.json
@@ -1,0 +1,15 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "states": [{ "name": "wobble", "description": "Wobble animation state." }]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-028/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-028/dataset.json
@@ -1,0 +1,21 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "documentBlocks": [
+        {
+          "type": "purpose",
+          "content": "Triggers an action when clicked.",
+          "agents": "Use this component to trigger a primary action in a form or dialog."
+        }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-029/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-029/dataset.json
@@ -1,0 +1,24 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "documentBlocks": [
+        {
+          "type": "purpose",
+          "content": "Triggers an action when clicked."
+        },
+        {
+          "type": "usage",
+          "content": "Place in forms and dialogs."
+        }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-030/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-030/dataset.json
@@ -1,0 +1,17 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "accessibility": {
+        "role": "button"
+      }
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-031/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-031/dataset.json
@@ -1,0 +1,24 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/button.json",
+      "name": "button",
+      "displayName": "Button",
+      "meta": {
+        "category": "actions",
+        "documentationUrl": "https://spectrum.adobe.com/page/button/"
+      },
+      "accessibility": {
+        "role": "button",
+        "wcag": [
+          {
+            "criterion": "1.4.3",
+            "level": "AA",
+            "notes": "Meets minimum contrast."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/design-data-spec/src/validate.js
+++ b/packages/design-data-spec/src/validate.js
@@ -13,14 +13,19 @@ governing permissions and limitations under the License.
 /**
  * Layer 2 cross-reference validator for design-data-spec.
  *
- * Implements SPEC-018 through SPEC-027: semantic rules that validate token
- * name-object fields against component declarations, validate component
- * declarations internally, and validate tokenBindings references.
+ * Implements SPEC-007, SPEC-009, SPEC-018 through SPEC-031: semantic rules
+ * that validate token name fields against component declarations, validate
+ * component declarations internally, validate tokenBindings references, check
+ * documentBlocks content, and validate accessibility declarations.
  *
  * @see spec/component-format.md#spec-rules
  * @see spec/anatomy-format.md#spec-rules
- * @see spec/state-model.md#spec-rules
+ * @see spec/state-model.md#canonical-state-vocabulary
  */
+
+import { readFileSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
 
 import {
   CANONICAL_SLOTS,
@@ -29,14 +34,143 @@ import {
 } from "./canonical.js";
 
 /**
- * @typedef {{ ruleId: string, severity: 'error'|'warning', message: string, tokenName?: string, componentName?: string }} Diagnostic
+ * @typedef {{ ruleId: string, severity: 'error'|'warning'|'info', message: string, tokenName?: string, componentName?: string }} Diagnostic
  * @typedef {{ name: string|object, [key: string]: unknown }} Token
- * @typedef {{ name: string, options?: object, anatomy?: Array<{name:string,description?:string}>, slots?: Array<{name:string,description?:string}>, states?: Array<{name:string,trigger?:string,precedence?:number,layered?:boolean,description?:string}> }} ComponentDeclaration
+ * @typedef {{ name: string, options?: object, anatomy?: Array<{name:string,description?:string}>, slots?: Array<{name:string,description?:string}>, states?: Array<{name:string,trigger?:string,precedence?:number,layered?:boolean,description?:string}>, documentBlocks?: Array<{type:string,content:string,agents?:string}>, accessibility?: object }} ComponentDeclaration
  * @typedef {{ tokens?: Token[], components?: ComponentDeclaration[] }} Dataset
  */
 
+// ---------------------------------------------------------------------------
+// SPEC-007: name-roundtrip helpers (port of sdk/core/src/naming.rs)
+// ---------------------------------------------------------------------------
+
+const STATE_WORDS = new Set([
+  "default",
+  "hover",
+  "down",
+  "focus",
+  "selected",
+  "disabled",
+  "key-focus",
+  "emphasized",
+  "error",
+  "invalid",
+  "active",
+  "open",
+  "closed",
+  "indeterminate",
+  "keyboard-focus",
+]);
+
+function splitTrailingState(s) {
+  const parts = s.split("-");
+  if (parts.length >= 3) {
+    const compound = `${parts[parts.length - 2]}-${parts[parts.length - 1]}`;
+    if (STATE_WORDS.has(compound)) {
+      const prop = parts.slice(0, -2).join("-");
+      if (prop) return [prop, compound];
+    }
+  }
+  if (parts.length >= 2) {
+    const candidate = parts[parts.length - 1];
+    if (STATE_WORDS.has(candidate)) {
+      const prop = parts.slice(0, -1).join("-");
+      if (prop) return [prop, candidate];
+    }
+  }
+  return [s, null];
+}
+
+function parseLegacyName(key, componentHint) {
+  let remainder = key;
+  if (componentHint && key.startsWith(componentHint + "-")) {
+    remainder = key.slice(componentHint.length + 1);
+  }
+  const [property, state] = splitTrailingState(remainder);
+  return { property, component: componentHint ?? null, state };
+}
+
+function generateLegacyName({ component, property, state }) {
+  const parts = [];
+  if (component) parts.push(component);
+  parts.push(property);
+  if (state) parts.push(state);
+  return parts.join("-");
+}
+
+function hasEmbeddedState(property) {
+  const segs = property.split("-");
+  if (segs.length <= 1) return false;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (STATE_WORDS.has(segs[i])) return true;
+    if (i + 1 < segs.length - 1 && STATE_WORDS.has(`${segs[i]}-${segs[i + 1]}`))
+      return true;
+  }
+  return false;
+}
+
+function nameRoundtrips(key, componentHint) {
+  const obj = parseLegacyName(key, componentHint);
+  if (generateLegacyName(obj) !== key) return false;
+  return !hasEmbeddedState(obj.property);
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-007 / SPEC-009: module-level data loading
+// ---------------------------------------------------------------------------
+
+const __moduleDir = dirname(fileURLToPath(import.meta.url));
+const _specRoot = join(__moduleDir, "..");
+const _repoRoot = join(_specRoot, "..", "..");
+
+/** Load naming exceptions allowlist for SPEC-007. Silently empty if unavailable. */
+const NAMING_EXCEPTIONS = (() => {
+  try {
+    const p = join(_repoRoot, "packages", "tokens", "naming-exceptions.json");
+    const data = JSON.parse(readFileSync(p, "utf8"));
+    return new Set((data.exceptions ?? []).map((e) => e.token));
+  } catch {
+    return new Set();
+  }
+})();
+
+/** Map<fieldName, Set<value>> for advisory fields with a registry (SPEC-009). */
+const ADVISORY_REGISTRY = (() => {
+  const map = new Map();
+  try {
+    const fieldsDir = join(_specRoot, "fields");
+    const files = readdirSync(fieldsDir).filter((f) => f.endsWith(".json"));
+    for (const file of files) {
+      try {
+        const field = JSON.parse(readFileSync(join(fieldsDir, file), "utf8"));
+        if (field.validation !== "advisory" || !field.registry) continue;
+        const regData = JSON.parse(
+          readFileSync(join(_repoRoot, field.registry), "utf8"),
+        );
+        const values = new Set();
+        for (const entry of regData.values ?? []) {
+          if (entry.id) values.add(entry.id);
+          for (const alias of entry.aliases ?? []) values.add(alias);
+        }
+        map.set(field.name, values);
+      } catch {
+        // Skip individual field or registry files that can't be read.
+      }
+    }
+  } catch {
+    // If fields dir is unavailable, SPEC-009 is silently disabled.
+  }
+  return map;
+})();
+
+const ADVISORY_FIELDS = [...ADVISORY_REGISTRY.keys()];
+
+// ---------------------------------------------------------------------------
+// validateDataset
+// ---------------------------------------------------------------------------
+
 /**
- * Validate a dataset for SPEC-018 through SPEC-024 compliance.
+ * Validate a dataset for Layer 2 SPEC rule compliance.
  *
  * @param {Dataset} dataset
  * @returns {Diagnostic[]}
@@ -45,18 +179,126 @@ export function validateDataset(dataset) {
   const tokens = dataset.tokens ?? [];
   const components = dataset.components ?? [];
 
-  // Build component lookup map keyed by name.
   const componentMap = new Map(components.map((c) => [c.name, c]));
-
   const diagnostics = [];
 
-  // --- Token cross-reference rules ---
+  // Build UUID lookup for SPEC-010.
+  const uuidSet = new Set(tokens.map((t) => t.uuid).filter(Boolean));
+
+  // --- Token rules ---
   for (const token of tokens) {
     const name = token.name;
-    // String names (SPEC-017 escape hatch) skip cross-reference checks.
+
+    // SPEC-010: replaced-by-target-exists
+    if (
+      typeof token.replaced_by === "string" &&
+      !uuidSet.has(token.replaced_by)
+    ) {
+      const label = typeof name === "string" ? name : JSON.stringify(name);
+      diagnostics.push({
+        ruleId: "SPEC-010",
+        severity: "error",
+        message: `Token '${label}' replaced_by target UUID not found in dataset`,
+        tokenName: label,
+      });
+    }
+
+    // SPEC-011: replaced-by-array-requires-comment
+    if (Array.isArray(token.replaced_by) && !token.deprecated_comment) {
+      const label = typeof name === "string" ? name : JSON.stringify(name);
+      diagnostics.push({
+        ruleId: "SPEC-011",
+        severity: "error",
+        message: `Token '${label}' replaced_by is an array but deprecated_comment is missing`,
+        tokenName: label,
+      });
+    }
+
+    // SPEC-012: replaced-by-requires-deprecated
+    if (token.replaced_by != null && !token.deprecated) {
+      const label = typeof name === "string" ? name : JSON.stringify(name);
+      diagnostics.push({
+        ruleId: "SPEC-012",
+        severity: "error",
+        message: `Token '${label}' has replaced_by but is not marked deprecated`,
+        tokenName: label,
+      });
+    }
+
+    // SPEC-013: planned-removal-requires-deprecated
+    if (token.plannedRemoval != null && !token.deprecated) {
+      const label = typeof name === "string" ? name : JSON.stringify(name);
+      diagnostics.push({
+        ruleId: "SPEC-013",
+        severity: "error",
+        message: `Token '${label}' has plannedRemoval but is not marked deprecated`,
+        tokenName: label,
+      });
+    }
+
+    // SPEC-017: string-name-tech-debt
+    if (typeof name === "string") {
+      diagnostics.push({
+        ruleId: "SPEC-017",
+        severity: "warning",
+        message: `Token '${name}' uses a string name instead of a name object — migrate to a structured name`,
+        tokenName: name,
+      });
+    }
+
+    // SPEC-007: name-roundtrip (string-named tokens only)
+    if (typeof name === "string") {
+      const componentHint =
+        typeof token.component === "string" ? token.component : null;
+      if (!nameRoundtrips(name, componentHint)) {
+        if (NAMING_EXCEPTIONS.has(name)) {
+          diagnostics.push({
+            ruleId: "SPEC-007",
+            severity: "info",
+            message: `Known naming exception: '${name}' does not match canonical generation rules (tracked in naming-exceptions.json)`,
+            tokenName: name,
+          });
+        } else {
+          diagnostics.push({
+            ruleId: "SPEC-007",
+            severity: "warning",
+            message: `Token '${name}' does not roundtrip through name-object generation rules and is not in the exceptions allowlist`,
+            tokenName: name,
+          });
+        }
+      }
+    }
+
+    // String names skip object-name cross-reference checks below.
     if (typeof name !== "object" || name === null) continue;
 
     const tokenLabel = JSON.stringify(name);
+
+    // SPEC-009: name-field-enum-sync
+    for (const field of ADVISORY_FIELDS) {
+      const value = name[field];
+      if (typeof value !== "string") continue;
+      const registry = ADVISORY_REGISTRY.get(field);
+      if (!registry) continue;
+      if (!registry.has(value)) {
+        diagnostics.push({
+          ruleId: "SPEC-009",
+          severity: "warning",
+          message: `name.${field} value "${value}" is not in the design-system-registry ${field} vocabulary`,
+          tokenName: tokenLabel,
+        });
+      }
+    }
+
+    // SPEC-025: anatomy field requires component field
+    if (name.anatomy != null && name.component == null) {
+      diagnostics.push({
+        ruleId: "SPEC-025",
+        severity: "error",
+        message: `Token '${tokenLabel}' has 'anatomy' field without a 'component' field`,
+        tokenName: tokenLabel,
+      });
+    }
 
     if (name.component != null) {
       // SPEC-018: component name must be declared
@@ -67,7 +309,6 @@ export function validateDataset(dataset) {
           message: `Token '${tokenLabel}' references undeclared component '${name.component}'`,
           tokenName: tokenLabel,
         });
-        // Can't validate further fields without a component declaration.
         continue;
       }
 
@@ -119,9 +360,18 @@ export function validateDataset(dataset) {
         }
       }
     }
+
+    // SPEC-028/029: documentBlocks on tokens
+    checkDocumentBlocks(
+      token.documentBlocks,
+      `Token '${tokenLabel}'`,
+      null,
+      tokenLabel,
+      diagnostics,
+    );
   }
 
-  // --- Component declaration internal rules ---
+  // --- Component declaration rules ---
   for (const component of components) {
     const cName = component.name;
 
@@ -149,13 +399,71 @@ export function validateDataset(dataset) {
       }
     }
 
-    // SPEC-024: custom state names should have descriptions
+    // SPEC-024: anatomy part names must be unique within a component
+    const anatomyNames = new Set();
+    for (const part of component.anatomy ?? []) {
+      if (anatomyNames.has(part.name)) {
+        diagnostics.push({
+          ruleId: "SPEC-024",
+          severity: "error",
+          message: `Component '${cName}' declares duplicate anatomy part name '${part.name}'`,
+          componentName: cName,
+        });
+      }
+      anatomyNames.add(part.name);
+    }
+
+    // SPEC-026: custom state names should have descriptions
     for (const state of component.states ?? []) {
       if (!CANONICAL_STATES.has(state.name) && !state.description) {
         diagnostics.push({
-          ruleId: "SPEC-024",
+          ruleId: "SPEC-026",
           severity: "warning",
           message: `Component '${cName}' has custom state '${state.name}' with no description`,
+          componentName: cName,
+        });
+      }
+    }
+
+    // SPEC-028/029: documentBlocks on components
+    checkDocumentBlocks(
+      component.documentBlocks,
+      `Component '${cName}'`,
+      cName,
+      null,
+      diagnostics,
+    );
+
+    // SPEC-030: accessibility-empty
+    if (
+      component.accessibility != null &&
+      typeof component.accessibility === "object"
+    ) {
+      const acc = component.accessibility;
+      const hasField =
+        acc.role != null ||
+        acc.intents != null ||
+        acc.focusable != null ||
+        acc.keyboardIntents != null ||
+        (Array.isArray(acc.wcag) && acc.wcag.length > 0);
+      if (!hasField) {
+        diagnostics.push({
+          ruleId: "SPEC-030",
+          severity: "warning",
+          message: `Component '${cName}' has an empty accessibility object — populate at least one field or remove the property`,
+          componentName: cName,
+        });
+      }
+    }
+
+    // SPEC-031: accessibility-wcag-missing
+    if (component.accessibility?.role != null) {
+      const wcag = component.accessibility.wcag;
+      if (!Array.isArray(wcag) || wcag.length === 0) {
+        diagnostics.push({
+          ruleId: "SPEC-031",
+          severity: "warning",
+          message: `Component '${cName}' accessibility has a role but no wcag entries — add applicable WCAG 2.x success criteria`,
           componentName: cName,
         });
       }
@@ -165,8 +473,6 @@ export function validateDataset(dataset) {
   // --- Token binding rules ---
 
   // SPEC-027: each tokenBindings[].token must resolve to a known token name.
-  // String-named tokens are matched directly. Name-object tokens are skipped
-  // here because tokenBindings always reference tokens by their string name.
   const tokenNameSet = new Set(
     tokens
       .map((t) => (typeof t.name === "string" ? t.name : null))
@@ -187,4 +493,51 @@ export function validateDataset(dataset) {
   }
 
   return diagnostics;
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-028 / SPEC-029 helper
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Array|undefined} blocks
+ * @param {string} entityLabel
+ * @param {string|null} componentName
+ * @param {string|null} tokenName
+ * @param {Diagnostic[]} diagnostics
+ */
+function checkDocumentBlocks(
+  blocks,
+  entityLabel,
+  componentName,
+  tokenName,
+  diagnostics,
+) {
+  if (!Array.isArray(blocks) || blocks.length === 0) return;
+
+  for (const block of blocks) {
+    if (
+      typeof block.agents === "string" &&
+      typeof block.content === "string" &&
+      block.agents === block.content
+    ) {
+      diagnostics.push({
+        ruleId: "SPEC-028",
+        severity: "warning",
+        message: `${entityLabel} has a document block whose agents text is identical to content — tailor it for agent consumption or omit the agents field`,
+        ...(componentName != null ? { componentName } : {}),
+        ...(tokenName != null ? { tokenName } : {}),
+      });
+    }
+  }
+
+  if (!blocks.some((b) => b.type === "purpose")) {
+    diagnostics.push({
+      ruleId: "SPEC-029",
+      severity: "warning",
+      message: `${entityLabel} has documentBlocks but no purpose block — add a block with type 'purpose'`,
+      ...(componentName != null ? { componentName } : {}),
+      ...(tokenName != null ? { tokenName } : {}),
+    });
+  }
 }

--- a/packages/design-data-spec/src/validate.js
+++ b/packages/design-data-spec/src/validate.js
@@ -103,8 +103,7 @@ function hasEmbeddedState(property) {
   if (segs.length <= 1) return false;
   for (let i = 0; i < segs.length - 1; i++) {
     if (STATE_WORDS.has(segs[i])) return true;
-    if (i + 1 < segs.length - 1 && STATE_WORDS.has(`${segs[i]}-${segs[i + 1]}`))
-      return true;
+    if (STATE_WORDS.has(`${segs[i]}-${segs[i + 1]}`)) return true;
   }
   return false;
 }
@@ -361,7 +360,8 @@ export function validateDataset(dataset) {
       }
     }
 
-    // SPEC-028/029: documentBlocks on tokens
+    // SPEC-028/029: tokens may also carry documentBlocks; the spec assertion
+    // applies to any entity, not only components.
     checkDocumentBlocks(
       token.documentBlocks,
       `Token '${tokenLabel}'`,

--- a/packages/design-data-spec/test/validate.test.js
+++ b/packages/design-data-spec/test/validate.test.js
@@ -74,7 +74,8 @@ test("SPEC-018: string token names are skipped", (t) => {
     tokens: [{ name: "legacy-token-name", value: "#fff" }],
     components: [],
   };
-  const diags = validateDataset(dataset);
+  // String-named tokens skip SPEC-018 cross-reference checks; SPEC-017 may fire separately.
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-018");
   t.is(diags.length, 0);
 });
 
@@ -286,30 +287,61 @@ test("SPEC-023: no warning for canonical anatomy part without description", (t) 
   t.is(diags.length, 0);
 });
 
-// ---- SPEC-024: state-custom-name-documented ----------------------------------
+// ---- SPEC-024: anatomy-part-name-unique --------------------------------------
 
-test("SPEC-024: no warning when custom state has description", (t) => {
+test("SPEC-024: no error when anatomy part names are unique", (t) => {
   const comp = {
     ...button,
-    states: [{ name: "wobble", description: "Wobble animation state." }],
+    anatomy: [
+      { name: "label", description: "Button text." },
+      { name: "icon", description: "Leading icon." },
+    ],
   };
   const dataset = { tokens: [], components: [comp] };
   const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-024");
   t.is(diags.length, 0);
 });
 
-test("SPEC-024: warning when custom state has no description", (t) => {
-  const comp = { ...button, states: [{ name: "wobble" }] };
+test("SPEC-024: error when anatomy part names are duplicated", (t) => {
+  const comp = {
+    ...button,
+    anatomy: [
+      { name: "label", description: "Button text." },
+      { name: "icon", description: "Leading icon." },
+      { name: "label", description: "Duplicate." },
+    ],
+  };
   const dataset = { tokens: [], components: [comp] };
   const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-024");
+  t.is(diags.length, 1);
+  t.is(diags[0].severity, "error");
+  t.regex(diags[0].message, /duplicate anatomy part.*label/i);
+});
+
+// ---- SPEC-026: state-custom-name-documented ----------------------------------
+
+test("SPEC-026: no warning when custom state has description", (t) => {
+  const comp = {
+    ...button,
+    states: [{ name: "wobble", description: "Wobble animation state." }],
+  };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-026");
+  t.is(diags.length, 0);
+});
+
+test("SPEC-026: warning when custom state has no description", (t) => {
+  const comp = { ...button, states: [{ name: "wobble" }] };
+  const dataset = { tokens: [], components: [comp] };
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-026");
   t.is(diags.length, 1);
   t.is(diags[0].severity, "warning");
 });
 
-test("SPEC-024: no warning for canonical state without description", (t) => {
+test("SPEC-026: no warning for canonical state without description", (t) => {
   const comp = { ...button, states: [{ name: "hover" }] };
   const dataset = { tokens: [], components: [comp] };
-  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-024");
+  const diags = validateDataset(dataset).filter((d) => d.ruleId === "SPEC-026");
   t.is(diags.length, 0);
 });
 

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -343,6 +343,7 @@ name = "design-data-core"
 version = "0.1.0"
 dependencies = [
  "jsonschema",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -25,3 +25,4 @@ default = []
 figma = ["dep:reqwest", "dep:tokio"]
 
 [dev-dependencies]
+regex = "1"

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -672,6 +672,9 @@ mod validation_conformance {
                 .filter(|d| matches!(d.severity, Severity::Error))
                 .collect();
 
+            // Deliberate policy: only error-severity diagnostics fail the valid
+            // fixture. Warnings (e.g. undocumented custom states/slots) may still
+            // fire on intentionally minimal valid fixtures.
             if !errors.is_empty() {
                 failures.push(format!(
                     "{case}: expected no errors but got: {}",

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -436,6 +436,272 @@ mod relational_conformance {
     }
 }
 
+/// Validation conformance tests — fixture-driven, exercises relational rules
+/// against `packages/design-data-spec/conformance/{invalid,valid}/` fixtures.
+///
+/// Each fixture directory contains `dataset.json` (neutral interchange format:
+/// `{ tokens, components, modeSets }`) and `expected-errors.json` (list of
+/// `{ rule_id, severity, message_pattern }` entries). Dirs without `dataset.json`
+/// are legacy-only and skipped until migrated.
+#[cfg(test)]
+mod validation_conformance {
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    use regex::Regex;
+    use serde_json::Value;
+
+    use crate::graph::{ComponentRecord, ModeSetRecord, TokenGraph};
+    use crate::naming::NamingExceptionsFile;
+    use crate::report::Severity;
+    use crate::validate::rules::{default_rules, run_rules};
+
+    fn severity_str(s: &Severity) -> &'static str {
+        match s {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Info => "info",
+        }
+    }
+
+    fn build_graph(dataset: &Value) -> TokenGraph {
+        let tokens_json = dataset
+            .get("tokens")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let entries: Vec<(String, std::path::PathBuf, Value)> = tokens_json
+            .into_iter()
+            .enumerate()
+            .map(|(i, raw)| {
+                // For string names use the string directly (SPEC-007 roundtrip checks t.name).
+                // For object names generate a unique key from index.
+                let key = raw
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .map(String::from)
+                    .unwrap_or_else(|| format!("token-{i}"));
+                (key, std::path::PathBuf::from("dataset.json"), raw)
+            })
+            .collect();
+
+        let mut graph = TokenGraph::from_pairs(entries);
+
+        if let Some(comps) = dataset.get("components").and_then(|v| v.as_array()) {
+            let comp_records: Vec<ComponentRecord> = comps
+                .iter()
+                .filter_map(|v| {
+                    let name = v.get("name")?.as_str()?.to_string();
+                    Some(ComponentRecord {
+                        name,
+                        file: std::path::PathBuf::from("dataset.json"),
+                        raw: v.clone(),
+                    })
+                })
+                .collect();
+            graph = graph.with_components(comp_records);
+        }
+
+        if let Some(mode_sets) = dataset.get("modeSets").and_then(|v| v.as_array()) {
+            let ms_records: Vec<ModeSetRecord> = mode_sets
+                .iter()
+                .filter_map(|v| {
+                    let name = v.get("name")?.as_str()?.to_string();
+                    let default_mode = v.get("default")?.as_str()?.to_string();
+                    let modes: Vec<String> = v
+                        .get("modes")?
+                        .as_array()?
+                        .iter()
+                        .filter_map(|m| m.as_str().map(String::from))
+                        .collect();
+                    Some(ModeSetRecord {
+                        file: std::path::PathBuf::from("dataset.json"),
+                        name,
+                        modes,
+                        default_mode,
+                    })
+                })
+                .collect();
+            graph = graph.with_mode_sets(ms_records);
+        }
+
+        graph
+    }
+
+    fn load_naming_exceptions() -> HashSet<String> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/tokens/naming-exceptions.json");
+        NamingExceptionsFile::load(&path)
+            .map(|f| f.token_set())
+            .unwrap_or_default()
+    }
+
+    fn assert_invalid_fixtures() {
+        let base = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/design-data-spec/conformance/invalid");
+        let naming_exceptions = load_naming_exceptions();
+        // Only assert on rules that are registered. Phase 2+ adds the remaining rules;
+        // their fixtures are discovered but their assertions are skipped until then.
+        let registered: std::collections::HashSet<String> =
+            default_rules().iter().map(|r| r.id().to_string()).collect();
+        let mut failures = Vec::new();
+
+        let mut dirs: Vec<_> = std::fs::read_dir(&base)
+            .expect("conformance/invalid dir missing")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        dirs.sort_by_key(|e| e.path());
+
+        for entry in dirs {
+            let dir = entry.path();
+            let dataset_path = dir.join("dataset.json");
+            if !dataset_path.exists() {
+                // Legacy-only fixture: skipped until migrated in Phase 4.
+                continue;
+            }
+            let expected_path = dir.join("expected-errors.json");
+            let case = dir.file_name().unwrap().to_string_lossy().to_string();
+
+            let dataset: Value = serde_json::from_str(
+                &std::fs::read_to_string(&dataset_path)
+                    .unwrap_or_else(|e| panic!("{case}: failed to read dataset.json: {e}")),
+            )
+            .unwrap_or_else(|e| panic!("{case}: invalid dataset.json: {e}"));
+
+            let expected: Value = serde_json::from_str(
+                &std::fs::read_to_string(&expected_path)
+                    .unwrap_or_else(|e| panic!("{case}: failed to read expected-errors.json: {e}")),
+            )
+            .unwrap_or_else(|e| panic!("{case}: invalid expected-errors.json: {e}"));
+
+            let graph = build_graph(&dataset);
+            let diagnostics = run_rules(&graph, &naming_exceptions);
+
+            let expected_errors = expected
+                .get("errors")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            for expected_err in &expected_errors {
+                let rule_id = expected_err
+                    .get("rule_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                // Skip assertions for rules not yet implemented in Rust.
+                if !registered.contains(rule_id) {
+                    continue;
+                }
+                let severity = expected_err
+                    .get("severity")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let pattern = expected_err
+                    .get("message_pattern")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(".*");
+                let re = Regex::new(pattern).unwrap_or_else(|e| {
+                    panic!("{case}: invalid message_pattern {pattern:?}: {e}")
+                });
+
+                let matched = diagnostics.iter().any(|d| {
+                    d.rule_id.as_deref() == Some(rule_id)
+                        && severity_str(&d.severity) == severity
+                        && re.is_match(&d.message)
+                });
+
+                if !matched {
+                    let got: Vec<String> = diagnostics
+                        .iter()
+                        .map(|d| {
+                            format!(
+                                "[{} {}] {}",
+                                d.rule_id.as_deref().unwrap_or("?"),
+                                severity_str(&d.severity),
+                                d.message
+                            )
+                        })
+                        .collect();
+                    failures.push(format!(
+                        "{case}: no diagnostic matched rule_id={rule_id:?} severity={severity:?} pattern={pattern:?}\n  Got: [{}]",
+                        got.join("; ")
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "Validation conformance failures:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    fn assert_valid_fixtures() {
+        let base = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/design-data-spec/conformance/valid");
+        let naming_exceptions = load_naming_exceptions();
+        let mut failures = Vec::new();
+
+        let mut dirs: Vec<_> = std::fs::read_dir(&base)
+            .expect("conformance/valid dir missing")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        dirs.sort_by_key(|e| e.path());
+
+        for entry in dirs {
+            let dir = entry.path();
+            let dataset_path = dir.join("dataset.json");
+            if !dataset_path.exists() {
+                continue;
+            }
+            let case = dir.file_name().unwrap().to_string_lossy().to_string();
+            let dataset: Value = serde_json::from_str(
+                &std::fs::read_to_string(&dataset_path)
+                    .unwrap_or_else(|e| panic!("{case}: failed to read dataset.json: {e}")),
+            )
+            .unwrap_or_else(|e| panic!("{case}: invalid dataset.json: {e}"));
+
+            let graph = build_graph(&dataset);
+            let diagnostics = run_rules(&graph, &naming_exceptions);
+            let errors: Vec<_> = diagnostics
+                .iter()
+                .filter(|d| matches!(d.severity, Severity::Error))
+                .collect();
+
+            if !errors.is_empty() {
+                failures.push(format!(
+                    "{case}: expected no errors but got: {}",
+                    errors
+                        .iter()
+                        .map(|d| d.message.as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                ));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "Valid fixture failures:\n{}",
+            failures.join("\n")
+        );
+    }
+
+    #[test]
+    fn invalid_fixtures_match_expected() {
+        assert_invalid_fixtures();
+    }
+
+    #[test]
+    fn valid_fixtures_produce_no_errors() {
+        assert_valid_fixtures();
+    }
+}
+
 /// Resolution conformance tests — fixture-driven, closes #768.
 ///
 /// Each test case lives under `packages/design-data-spec/conformance/resolution/<name>/`

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -193,12 +193,11 @@ fn has_embedded_state(property: &str) -> bool {
         if STATE_WORDS.contains(seg) {
             return true;
         }
-        // Two-segment compounds: check "{seg}-{next}".
-        if i + 1 < segments.len() - 1 {
-            let compound = format!("{}-{}", seg, segments[i + 1]);
-            if STATE_WORDS.contains(compound.as_str()) {
-                return true;
-            }
+        // Two-segment compounds: check "{seg}-{next}". The outer loop already
+        // excludes the last segment, so segments[i+1] always exists here.
+        let compound = format!("{}-{}", seg, segments[i + 1]);
+        if STATE_WORDS.contains(compound.as_str()) {
+            return true;
         }
     }
     false

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -22,6 +22,8 @@ mod spec011;
 mod spec012;
 mod spec013;
 mod spec017;
+mod spec025;
+mod spec026;
 mod spec028;
 mod spec029;
 mod spec030;
@@ -58,6 +60,8 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec012::Rule),
         Box::new(spec013::Rule),
         Box::new(spec017::Rule),
+        Box::new(spec025::Rule),
+        Box::new(spec026::Rule),
         Box::new(spec028::Rule),
         Box::new(spec029::Rule),
         Box::new(spec030::Rule),

--- a/sdk/core/src/validate/rules/spec025.rs
+++ b/sdk/core/src/validate/rules/spec025.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-025: anatomy-requires-component
+//!
+//! A token name object MUST NOT include an `anatomy` field unless a `component`
+//! field is also present. Anatomy parts are scoped to a component; a standalone
+//! anatomy reference has no semantic meaning.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-025"
+    }
+
+    fn name(&self) -> &'static str {
+        "anatomy-requires-component"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut diags = Vec::new();
+
+        for record in ctx.graph.tokens.values() {
+            let name_obj = match record.raw.get("name").and_then(|v| v.as_object()) {
+                Some(n) => n,
+                None => continue,
+            };
+
+            if name_obj.contains_key("anatomy") && !name_obj.contains_key("component") {
+                diags.push(Diagnostic {
+                    file: record.file.clone(),
+                    token: Some(record.name.clone()),
+                    rule_id: Some("SPEC-025".into()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{}' has 'anatomy' field without a 'component' field",
+                        record.name
+                    ),
+                    instance_path: Some("/name/anatomy".into()),
+                    schema_path: None,
+                });
+            }
+        }
+
+        diags
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::TokenGraph;
+    use crate::validate::relational::diagnostics_for_rule;
+
+    #[test]
+    fn anatomy_with_component_is_valid() {
+        let g = TokenGraph::from_pairs(vec![(
+            "button-label-color".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "component": "button", "anatomy": "label"}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-025").is_empty());
+    }
+
+    #[test]
+    fn anatomy_without_component_errors() {
+        let g = TokenGraph::from_pairs(vec![(
+            "label-color".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "anatomy": "label"}, "value": "#fff"}),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-025");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("anatomy"));
+        assert!(diags[0].message.contains("component"));
+    }
+
+    #[test]
+    fn no_anatomy_no_error() {
+        let g = TokenGraph::from_pairs(vec![(
+            "background-color-default".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "background-color"}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-025").is_empty());
+    }
+
+    #[test]
+    fn string_name_skipped() {
+        let g = TokenGraph::from_pairs(vec![(
+            "my-token".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": "my-token", "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-025").is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec026.rs
+++ b/sdk/core/src/validate/rules/spec026.rs
@@ -1,0 +1,160 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-026: state-custom-name-documented
+//!
+//! State declarations with a name outside the canonical state vocabulary
+//! (design-system-registry `states.json`) SHOULD include a `description` field.
+//! Custom state names without documentation make the component contract ambiguous.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-026"
+    }
+
+    fn name(&self) -> &'static str {
+        "state-custom-name-documented"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut diags = Vec::new();
+
+        let canonical_states = ctx.registry.for_field("state");
+
+        for comp in &ctx.graph.components {
+            let states = match comp.raw.get("states").and_then(|v| v.as_array()) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            for state in states {
+                let name = match state.get("name").and_then(|v| v.as_str()) {
+                    Some(n) => n,
+                    None => continue,
+                };
+
+                let is_canonical = canonical_states
+                    .map(|set| set.contains(name))
+                    .unwrap_or(false);
+
+                if is_canonical {
+                    continue;
+                }
+
+                let has_description = state
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false);
+
+                if !has_description {
+                    diags.push(Diagnostic {
+                        file: comp.file.clone(),
+                        token: None,
+                        rule_id: Some("SPEC-026".into()),
+                        severity: Severity::Warning,
+                        message: format!(
+                            "Component '{}' has custom state '{}' with no description",
+                            comp.name, name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+
+        diags
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec026::Rule;
+
+    fn run_comp(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let mut g = TokenGraph::default();
+        g.components.push(ComponentRecord {
+            name: comp_raw
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("test-comp")
+                .to_string(),
+            file: PathBuf::from("test-comp.json"),
+            raw: comp_raw,
+        });
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn canonical_state_no_description_no_warning() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "states": [{ "name": "hover", "trigger": "interaction", "precedence": 50 }]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn custom_state_with_description_no_warning() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "states": [{ "name": "wobble", "description": "A custom animation state." }]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn custom_state_without_description_warns() {
+        let diags = run_comp(json!({
+            "name": "button",
+            "displayName": "Button",
+            "states": [
+                { "name": "hover", "trigger": "interaction", "precedence": 50 },
+                { "name": "wobble" }
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-026"));
+        assert!(diags[0].message.contains("wobble"));
+        assert!(diags[0].message.contains("button"));
+    }
+
+    #[test]
+    fn no_states_no_warning() {
+        let diags = run_comp(json!({ "name": "button", "displayName": "Button" }));
+        assert!(diags.is_empty());
+    }
+}


### PR DESCRIPTION
## Description

Two related changes that lay the groundwork for the Rust-based conformance pipeline described in #897:

**1. Conformance fixtures (SPEC-007 through SPEC-031)**

Adds `dataset.json` fixture files for rules that previously had none or only legacy `tokens.tokens.json` fixtures:
- New fixture directories: SPEC-007, SPEC-009, SPEC-025, SPEC-026, SPEC-028, SPEC-029, SPEC-030, SPEC-031
- Backfilled `dataset.json` alongside legacy files: SPEC-010, SPEC-011, SPEC-012, SPEC-013, SPEC-017
- Corrected SPEC-024: was testing custom-state-documented (now SPEC-026); now correctly tests anatomy-part-name-unique

Also ports rules SPEC-007, 009, 010–013, 017, 018–027 into `packages/design-data-spec/src/validate.js` and implements SPEC-025 and SPEC-026 in Rust.

**2. Rust validation conformance harness (Phase 1 of #897)**

Adds a fixture-driven test module `validation_conformance` in `sdk/core/src/lib.rs` that exercises Rust relational rules directly — no CLI subprocess, no JS reimplementation:
- Discovers `conformance/invalid/*/dataset.json` and `conformance/valid/*/dataset.json` at test time
- Builds `TokenGraph` from the neutral `dataset.json` format (`tokens`, `components`, `modeSets`) using existing `from_pairs` + `with_components` + `with_mode_sets` APIs
- Matches diagnostics against `expected-errors.json` using the same `rule_id` / `severity` / `message_pattern` predicate as the JS runner
- Skips assertions for rules not yet registered in Rust; activates automatically as Phase 2–3 add `default_rules()` entries
- `dataset.json` is the canonical fixture format — tool-stack-neutral so any conformant implementation (Python, Go, etc.) can consume it

## Related Issue

Closes #894
Implements Phase 1 of #897

## Motivation and Context

The JS conformance runner (`conformance.test.js`) was silently skipping fixture directories that lacked `dataset.json`, and exercising only a JS reimplementation of the rules rather than the Rust SDK. This PR starts the migration to a Rust-native harness that exercises the real rule logic.

## How Has This Been Tested?

- `cargo test -p design-data-core` — 184 tests pass including new `validation_conformance::invalid_fixtures_match_expected` and `validation_conformance::valid_fixtures_produce_no_errors`
- `pnpm -C packages/design-data-spec test` — existing JS conformance suite still passes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.