### PR TITLE
feat(sdk): implement SPEC-018–024 and SPEC-027 component cross-reference rules in Rust

### DIFF
--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -22,8 +22,16 @@ mod spec011;
 mod spec012;
 mod spec013;
 mod spec017;
+mod spec018;
+mod spec019;
+mod spec020;
+mod spec021;
+mod spec022;
+mod spec023;
+mod spec024;
 mod spec025;
 mod spec026;
+mod spec027;
 mod spec028;
 mod spec029;
 mod spec030;
@@ -60,8 +68,16 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec012::Rule),
         Box::new(spec013::Rule),
         Box::new(spec017::Rule),
+        Box::new(spec018::Rule),
+        Box::new(spec019::Rule),
+        Box::new(spec020::Rule),
+        Box::new(spec021::Rule),
+        Box::new(spec022::Rule),
+        Box::new(spec023::Rule),
+        Box::new(spec024::Rule),
         Box::new(spec025::Rule),
         Box::new(spec026::Rule),
+        Box::new(spec027::Rule),
         Box::new(spec028::Rule),
         Box::new(spec029::Rule),
         Box::new(spec030::Rule),

--- a/sdk/core/src/validate/rules/spec018.rs
+++ b/sdk/core/src/validate/rules/spec018.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-018: component-name-declared
+//!
+//! Token name-object `component` field MUST reference a declared component.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-018"
+    }
+
+    fn name(&self) -> &'static str {
+        "component-name-declared"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        let component_names: std::collections::HashSet<&str> = ctx
+            .graph
+            .components
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+
+        for t in ctx.graph.tokens.values() {
+            let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            let Some(component) = name_obj.get("component").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if !component_names.contains(component) {
+                let token_label = serde_json::to_string(name_obj).unwrap_or_default();
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{token_label}' references undeclared component '{component}'"
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec018::Rule;
+
+    fn make_graph(tokens: Vec<serde_json::Value>, components: Vec<serde_json::Value>) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        for (i, raw) in tokens.into_iter().enumerate() {
+            g.tokens.insert(
+                format!("token-{i}"),
+                TokenRecord {
+                    name: format!("token-{i}"),
+                    file: PathBuf::from("dataset.json"),
+                    index: i,
+                    schema_url: None,
+                    uuid: None,
+                    alias_target: None,
+                    raw,
+                },
+            );
+        }
+        for raw in components {
+            let name = raw
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("comp")
+                .to_string();
+            g.components.push(ComponentRecord {
+                name,
+                file: PathBuf::from("dataset.json"),
+                raw,
+            });
+        }
+        g
+    }
+
+    fn run(tokens: Vec<serde_json::Value>, components: Vec<serde_json::Value>) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(tokens, components);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn declared_component_no_error() {
+        let diags = run(
+            vec![json!({"name": {"property": "color", "component": "button"}, "value": "#fff"})],
+            vec![json!({"name": "button"})],
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn undeclared_component_error() {
+        let diags = run(
+            vec![json!({"name": {"property": "color", "component": "ghost"}, "value": "#fff"})],
+            vec![],
+        );
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-018"));
+        assert!(diags[0].message.contains("ghost"));
+    }
+
+    #[test]
+    fn string_name_skipped() {
+        let diags = run(
+            vec![json!({"name": "plain-string-token", "value": "#fff"})],
+            vec![],
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn no_component_field_skipped() {
+        let diags = run(
+            vec![json!({"name": {"property": "color"}, "value": "#fff"})],
+            vec![],
+        );
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec019.rs
+++ b/sdk/core/src/validate/rules/spec019.rs
@@ -61,12 +61,12 @@ impl ValidationRule for Rule {
                 continue; // no enum declared — any variant is allowed
             };
 
-            let declared: Vec<&str> = variant_enum
+            let declared: std::collections::HashSet<&str> = variant_enum
                 .iter()
                 .filter_map(|v| v.as_str())
                 .collect();
 
-            if !declared.contains(&variant) {
+            if !declared.contains(variant) {
                 let token_label = serde_json::to_string(name_obj).unwrap_or_default();
                 out.push(Diagnostic {
                     file: t.file.clone(),

--- a/sdk/core/src/validate/rules/spec019.rs
+++ b/sdk/core/src/validate/rules/spec019.rs
@@ -1,0 +1,166 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-019: component-variant-valid
+//!
+//! Token name-object `variant` field MUST be a value in the component's
+//! `options.variant.enum` when that enum is declared.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-019"
+    }
+
+    fn name(&self) -> &'static str {
+        "component-variant-valid"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        let comp_map: std::collections::HashMap<&str, &crate::graph::ComponentRecord> = ctx
+            .graph
+            .components
+            .iter()
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+
+        for t in ctx.graph.tokens.values() {
+            let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            let Some(component) = name_obj.get("component").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(variant) = name_obj.get("variant").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(comp) = comp_map.get(component) else {
+                continue; // SPEC-018 covers undeclared component
+            };
+
+            let Some(variant_enum) = comp
+                .raw
+                .get("options")
+                .and_then(|o| o.get("variant"))
+                .and_then(|v| v.get("enum"))
+                .and_then(|e| e.as_array())
+            else {
+                continue; // no enum declared — any variant is allowed
+            };
+
+            let declared: Vec<&str> = variant_enum
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect();
+
+            if !declared.contains(&variant) {
+                let token_label = serde_json::to_string(name_obj).unwrap_or_default();
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{token_label}' has variant '{variant}' which is not declared on component '{component}'"
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec019::Rule;
+
+    fn make_graph(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.tokens.insert(
+            "t".into(),
+            TokenRecord {
+                name: "t".into(),
+                file: PathBuf::from("dataset.json"),
+                index: 0,
+                schema_url: None,
+                uuid: None,
+                alias_target: None,
+                raw: token_raw,
+            },
+        );
+        let comp_name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("button")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name: comp_name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(token_raw, comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn valid_variant_no_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "variant": "primary"}, "value": "#fff"}),
+            json!({"name": "button", "options": {"variant": {"enum": ["primary", "secondary"]}}}),
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn invalid_variant_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "variant": "electric"}, "value": "#fff"}),
+            json!({"name": "button", "options": {"variant": {"enum": ["primary", "secondary"]}}}),
+        );
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-019"));
+        assert!(diags[0].message.contains("electric"));
+        assert!(diags[0].message.contains("button"));
+    }
+
+    #[test]
+    fn no_enum_declared_no_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "variant": "anything"}, "value": "#fff"}),
+            json!({"name": "button"}),
+        );
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec020.rs
+++ b/sdk/core/src/validate/rules/spec020.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-020: component-anatomy-valid
+//!
+//! Token name-object `anatomy` field MUST match a declared anatomy part on the
+//! referenced component (when anatomy parts are declared).
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-020"
+    }
+
+    fn name(&self) -> &'static str {
+        "component-anatomy-valid"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        let comp_map: std::collections::HashMap<&str, &crate::graph::ComponentRecord> = ctx
+            .graph
+            .components
+            .iter()
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+
+        for t in ctx.graph.tokens.values() {
+            let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            let Some(component) = name_obj.get("component").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(anatomy) = name_obj.get("anatomy").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(comp) = comp_map.get(component) else {
+                continue; // SPEC-018 covers undeclared component
+            };
+
+            let declared_parts: std::collections::HashSet<&str> = comp
+                .raw
+                .get("anatomy")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|p| p.get("name").and_then(|n| n.as_str()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if !declared_parts.is_empty() && !declared_parts.contains(anatomy) {
+                let token_label = serde_json::to_string(name_obj).unwrap_or_default();
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{token_label}' references undeclared anatomy part '{anatomy}' on component '{component}'"
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec020::Rule;
+
+    fn make_graph(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.tokens.insert(
+            "t".into(),
+            TokenRecord {
+                name: "t".into(),
+                file: PathBuf::from("dataset.json"),
+                index: 0,
+                schema_url: None,
+                uuid: None,
+                alias_target: None,
+                raw: token_raw,
+            },
+        );
+        let comp_name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("button")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name: comp_name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(token_raw, comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn declared_anatomy_no_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "anatomy": "label"}, "value": "#fff"}),
+            json!({"name": "button", "anatomy": [{"name": "label", "description": "Button text."}]}),
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn undeclared_anatomy_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "anatomy": "capsule"}, "value": "#fff"}),
+            json!({"name": "button", "anatomy": [{"name": "label", "description": "Button text."}]}),
+        );
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-020"));
+        assert!(diags[0].message.contains("capsule"));
+    }
+
+    #[test]
+    fn no_anatomy_declared_no_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "anatomy": "anything"}, "value": "#fff"}),
+            json!({"name": "button"}),
+        );
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec021.rs
+++ b/sdk/core/src/validate/rules/spec021.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-021: component-slot-vocabulary
+//!
+//! Component slot declarations with a name outside the canonical slot vocabulary
+//! SHOULD include a description.
+
+use std::sync::LazyLock;
+use std::collections::HashSet;
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+static CANONICAL_SLOTS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "default",
+        "icon",
+        "label",
+        "help-text",
+        "negative-help-text",
+        "action",
+        "heading",
+        "description",
+        "hero",
+        "footer",
+        "tooltip",
+    ]
+    .into_iter()
+    .collect()
+});
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-021"
+    }
+
+    fn name(&self) -> &'static str {
+        "component-slot-vocabulary"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        for comp in &ctx.graph.components {
+            let Some(slots) = comp.raw.get("slots").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for slot in slots {
+                let Some(name) = slot.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if CANONICAL_SLOTS.contains(name) {
+                    continue;
+                }
+                let has_description = slot
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false);
+                if !has_description {
+                    out.push(Diagnostic {
+                        file: comp.file.clone(),
+                        token: None,
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Warning,
+                        message: format!(
+                            "Component '{}' has custom slot '{name}' with no description — add a description or use a canonical slot name",
+                            comp.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec021::Rule;
+
+    fn make_graph(comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        let name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("comp")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn canonical_slot_no_warning() {
+        let diags = run(json!({"name": "button", "slots": [{"name": "icon"}]}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn custom_slot_with_description_no_warning() {
+        let diags = run(json!({
+            "name": "button",
+            "slots": [{"name": "badge", "description": "Notification badge overlay."}]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn custom_slot_no_description_warning() {
+        let diags = run(json!({
+            "name": "button",
+            "slots": [{"name": "badge"}]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-021"));
+        assert!(diags[0].message.contains("badge"));
+    }
+}

--- a/sdk/core/src/validate/rules/spec022.rs
+++ b/sdk/core/src/validate/rules/spec022.rs
@@ -1,0 +1,161 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-022: component-state-valid
+//!
+//! Token name-object `state` field MUST match a declared state on the referenced
+//! component when state declarations are present.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-022"
+    }
+
+    fn name(&self) -> &'static str {
+        "component-state-valid"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        let comp_map: std::collections::HashMap<&str, &crate::graph::ComponentRecord> = ctx
+            .graph
+            .components
+            .iter()
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+
+        for t in ctx.graph.tokens.values() {
+            let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            let Some(component) = name_obj.get("component").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(state) = name_obj.get("state").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(comp) = comp_map.get(component) else {
+                continue; // SPEC-018 covers undeclared component
+            };
+
+            let declared_states: std::collections::HashSet<&str> = comp
+                .raw
+                .get("states")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| s.get("name").and_then(|n| n.as_str()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if !declared_states.is_empty() && !declared_states.contains(state) {
+                let token_label = serde_json::to_string(name_obj).unwrap_or_default();
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{token_label}' references undeclared state '{state}' on component '{component}'"
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec022::Rule;
+
+    fn make_graph(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        g.tokens.insert(
+            "t".into(),
+            TokenRecord {
+                name: "t".into(),
+                file: PathBuf::from("dataset.json"),
+                index: 0,
+                schema_url: None,
+                uuid: None,
+                alias_target: None,
+                raw: token_raw,
+            },
+        );
+        let comp_name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("button")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name: comp_name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(token_raw, comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn declared_state_no_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "state": "hover"}, "value": "#fff"}),
+            json!({"name": "button", "states": [{"name": "hover"}]}),
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn undeclared_state_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "state": "jello"}, "value": "#fff"}),
+            json!({"name": "button", "states": [{"name": "hover"}]}),
+        );
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-022"));
+        assert!(diags[0].message.contains("jello"));
+    }
+
+    #[test]
+    fn no_states_declared_no_error() {
+        let diags = run(
+            json!({"name": {"property": "color", "component": "button", "state": "anything"}, "value": "#fff"}),
+            json!({"name": "button"}),
+        );
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec023.rs
+++ b/sdk/core/src/validate/rules/spec023.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-023: anatomy-custom-part-documented
+//!
+//! Anatomy part declarations with a name outside the canonical anatomy vocabulary
+//! SHOULD include a description.
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+static CANONICAL_ANATOMY_PARTS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "body",
+        "checkmark",
+        "disclosure-triangle",
+        "field",
+        "handle",
+        "header",
+        "icon",
+        "label",
+        "picker",
+        "progress-bar",
+        "swatch",
+        "thumbnail",
+        "track",
+        "value",
+    ]
+    .into_iter()
+    .collect()
+});
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-023"
+    }
+
+    fn name(&self) -> &'static str {
+        "anatomy-custom-part-documented"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        for comp in &ctx.graph.components {
+            let Some(anatomy) = comp.raw.get("anatomy").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for part in anatomy {
+                let Some(name) = part.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if CANONICAL_ANATOMY_PARTS.contains(name) {
+                    continue;
+                }
+                let has_description = part
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false);
+                if !has_description {
+                    out.push(Diagnostic {
+                        file: comp.file.clone(),
+                        token: None,
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Warning,
+                        message: format!(
+                            "Component '{}' has custom anatomy part '{name}' with no description",
+                            comp.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec023::Rule;
+
+    fn make_graph(comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        let name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("comp")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn canonical_part_no_warning() {
+        let diags = run(json!({"name": "button", "anatomy": [{"name": "label"}]}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn custom_part_with_description_no_warning() {
+        let diags = run(json!({
+            "name": "button",
+            "anatomy": [{"name": "shimmer", "description": "Loading shimmer overlay."}]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn custom_part_no_description_warning() {
+        let diags = run(json!({
+            "name": "button",
+            "anatomy": [{"name": "shimmer"}]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-023"));
+        assert!(diags[0].message.contains("shimmer"));
+    }
+}

--- a/sdk/core/src/validate/rules/spec024.rs
+++ b/sdk/core/src/validate/rules/spec024.rs
@@ -1,0 +1,133 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-024: anatomy-part-name-unique
+//!
+//! Anatomy part names within a single component's anatomy array MUST be unique.
+
+use std::collections::HashSet;
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-024"
+    }
+
+    fn name(&self) -> &'static str {
+        "anatomy-part-name-unique"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        for comp in &ctx.graph.components {
+            let Some(anatomy) = comp.raw.get("anatomy").and_then(|v| v.as_array()) else {
+                continue;
+            };
+
+            let mut seen: HashSet<&str> = HashSet::new();
+            for part in anatomy {
+                let Some(name) = part.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if !seen.insert(name) {
+                    out.push(Diagnostic {
+                        file: comp.file.clone(),
+                        token: None,
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!(
+                            "Component '{}' declares duplicate anatomy part name '{name}'",
+                            comp.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec024::Rule;
+
+    fn make_graph(comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        let name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("comp")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn unique_parts_no_error() {
+        let diags = run(json!({
+            "name": "button",
+            "anatomy": [
+                {"name": "label", "description": "Button text."},
+                {"name": "icon", "description": "Leading icon."}
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn duplicate_part_error() {
+        let diags = run(json!({
+            "name": "button",
+            "anatomy": [
+                {"name": "label", "description": "Button text."},
+                {"name": "icon", "description": "Leading icon."},
+                {"name": "label", "description": "Duplicate."}
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-024"));
+        assert!(diags[0].message.contains("label"));
+    }
+
+    #[test]
+    fn no_anatomy_no_error() {
+        let diags = run(json!({"name": "button"}));
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec027.rs
+++ b/sdk/core/src/validate/rules/spec027.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-027: token-binding-token-exists
+//!
+//! Each `tokenBindings[].token` value in a component declaration MUST match the
+//! name of a declared token in the dataset.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-027"
+    }
+
+    fn name(&self) -> &'static str {
+        "token-binding-token-exists"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        // Only string-named tokens are referenceable via tokenBindings.
+        let token_names: std::collections::HashSet<&str> = ctx
+            .graph
+            .tokens
+            .values()
+            .filter_map(|t| {
+                t.raw
+                    .get("name")
+                    .and_then(|n| n.as_str())
+            })
+            .collect();
+
+        for comp in &ctx.graph.components {
+            let Some(bindings) = comp.raw.get("tokenBindings").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for binding in bindings {
+                let Some(token_ref) = binding.get("token").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if !token_names.contains(token_ref) {
+                    out.push(Diagnostic {
+                        file: comp.file.clone(),
+                        token: None,
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!(
+                            "Component '{}' tokenBindings references unknown token '{token_ref}'",
+                            comp.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph, TokenRecord};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec027::Rule;
+
+    fn make_graph(tokens: Vec<serde_json::Value>, comp_raw: serde_json::Value) -> TokenGraph {
+        let mut g = TokenGraph::default();
+        for (i, raw) in tokens.into_iter().enumerate() {
+            g.tokens.insert(
+                format!("token-{i}"),
+                TokenRecord {
+                    name: format!("token-{i}"),
+                    file: PathBuf::from("dataset.json"),
+                    index: i,
+                    schema_url: None,
+                    uuid: None,
+                    alias_target: None,
+                    raw,
+                },
+            );
+        }
+        let comp_name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("comp")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name: comp_name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        g
+    }
+
+    fn run(tokens: Vec<serde_json::Value>, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(tokens, comp_raw);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn known_token_no_error() {
+        let diags = run(
+            vec![json!({"name": "button-background-color", "value": "#fff"})],
+            json!({
+                "name": "button",
+                "tokenBindings": [{"token": "button-background-color", "slot": "default"}]
+            }),
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn unknown_token_error() {
+        let diags = run(
+            vec![],
+            json!({
+                "name": "button",
+                "tokenBindings": [{"token": "ghost-token", "slot": "default"}]
+            }),
+        );
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-027"));
+        assert!(diags[0].message.contains("ghost-token"));
+    }
+
+    #[test]
+    fn no_bindings_no_error() {
+        let diags = run(vec![], json!({"name": "button"}));
+        assert!(diags.is_empty());
+    }
+}


### PR DESCRIPTION
## Description

Implements 8 missing relational validation rules in `sdk/core`, completing all component reference-integrity and contract checks defined in the spec catalog (Phase 2 of #897):

- **SPEC-018** (`component-name-declared`, error): token `name.component` must reference a declared component
- **SPEC-019** (`component-variant-valid`, error): token `name.variant` must be in component `options.variant.enum` (when declared)
- **SPEC-020** (`component-anatomy-valid`, error): token `name.anatomy` must match a declared anatomy part (when parts exist)
- **SPEC-021** (`component-slot-vocabulary`, warning): custom slot names should have a description
- **SPEC-022** (`component-state-valid`, error): token `name.state` must match a declared component state (when states exist)
- **SPEC-023** (`anatomy-custom-part-documented`, warning): custom anatomy part names should have a description
- **SPEC-024** (`anatomy-part-name-unique`, error): anatomy part names must be unique within a component
- **SPEC-027** (`token-binding-token-exists`, error): `tokenBindings[].token` must reference a declared string-named token

Each rule is in its own `spec0NN.rs` file following the established pattern, with co-located unit tests. All 8 are registered in `default_rules()`.

## Related Issue

Implements Phase 2 of #897

## Motivation and Context

Phase 1 (#904) established the Rust conformance harness and showed the fixture-level assertions were skipped for unregistered rules. This PR activates the remaining 8 component cross-reference rules so the harness covers SPEC-018 through SPEC-027 in full.

## How Has This Been Tested?

- `cargo test -p design-data-core` — 209 tests pass, including all unit tests for the 8 new rules and `validation_conformance::invalid_fixtures_match_expected` / `valid_fixtures_produce_no_errors` (which now exercise SPEC-018–024 and SPEC-027 fixture dirs)
- Conformance fixtures for these rules were established in Phase 1 (PR #904)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.