### PR TITLE
feat(spec): migrate legacy SPEC-001–006 and SPEC-008 fixtures to dataset.json

### DIFF
--- a/packages/design-data-spec/conformance/invalid/SPEC-001/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-001/dataset.json
@@ -1,0 +1,10 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "alias-missing-target" },
+      "$ref": "nonexistent-token",
+      "uuid": "aaaaaaaa-0001-4000-8000-000000000001"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-001/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-001/expected-errors.json
@@ -1,5 +1,5 @@
 {
-  "layer": 2,
+  "layer": 1,
   "errors": [
     {
       "rule_id": "SPEC-001",

--- a/packages/design-data-spec/conformance/invalid/SPEC-002/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-002/dataset.json
@@ -1,0 +1,16 @@
+{
+  "tokens": [
+    {
+      "name": "spacing-alias",
+      "$ref": "base-color",
+      "uuid": "bbbbbbbb-0002-4000-8000-000000000001"
+    },
+    {
+      "name": "base-color",
+      "$schema": "https://opensource.adobe.com/spectrum-tokens/schemas/token-types/color.json",
+      "value": "rgb(0, 128, 255)",
+      "uuid": "aaaaaaaa-0002-4000-8000-000000000002"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-002/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-002/expected-errors.json
@@ -1,5 +1,5 @@
 {
-  "layer": 2,
+  "layer": 1,
   "errors": [
     {
       "rule_id": "SPEC-002",

--- a/packages/design-data-spec/conformance/invalid/SPEC-003/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-003/dataset.json
@@ -1,0 +1,15 @@
+{
+  "tokens": [
+    {
+      "name": "cycle-a",
+      "$ref": "cycle-b",
+      "uuid": "cccccccc-0003-4000-8000-000000000001"
+    },
+    {
+      "name": "cycle-b",
+      "$ref": "cycle-a",
+      "uuid": "dddddddd-0003-4000-8000-000000000002"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-003/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-003/expected-errors.json
@@ -1,5 +1,5 @@
 {
-  "layer": 2,
+  "layer": 1,
   "errors": [
     {
       "rule_id": "SPEC-003",

--- a/packages/design-data-spec/conformance/invalid/SPEC-004/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-004/dataset.json
@@ -1,0 +1,15 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "first" },
+      "value": "rgb(1, 2, 3)",
+      "uuid": "eeeeeeee-0004-4000-8000-000000000001"
+    },
+    {
+      "name": { "property": "second" },
+      "value": "rgb(4, 5, 6)",
+      "uuid": "eeeeeeee-0004-4000-8000-000000000001"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-004/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-004/expected-errors.json
@@ -1,5 +1,5 @@
 {
-  "layer": 2,
+  "layer": 1,
   "errors": [
     {
       "rule_id": "SPEC-004",

--- a/packages/design-data-spec/conformance/invalid/SPEC-005/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-005/dataset.json
@@ -1,0 +1,11 @@
+{
+  "tokens": [],
+  "components": [],
+  "modeSets": [
+    {
+      "name": "scale",
+      "modes": ["medium", "large"],
+      "default": "xlarge"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-005/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-005/expected-errors.json
@@ -1,5 +1,5 @@
 {
-  "layer": 2,
+  "layer": 1,
   "errors": [
     {
       "rule_id": "SPEC-005",

--- a/packages/design-data-spec/conformance/invalid/SPEC-006/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-006/dataset.json
@@ -1,0 +1,15 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "ambiguous", "colorScheme": "dark" },
+      "value": "rgb(20, 20, 20)",
+      "uuid": "11111111-0006-4000-8000-000000000001"
+    },
+    {
+      "name": { "property": "ambiguous", "colorScheme": "dark" },
+      "value": "rgb(10, 10, 10)",
+      "uuid": "ffffffff-0006-4000-8000-000000000002"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-006/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-006/expected-errors.json
@@ -1,5 +1,5 @@
 {
-  "layer": 2,
+  "layer": 1,
   "errors": [
     {
       "rule_id": "SPEC-006",

--- a/packages/design-data-spec/conformance/invalid/SPEC-008/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-008/dataset.json
@@ -1,0 +1,25 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "background-color-default", "colorScheme": "dark" },
+      "value": "#000000",
+      "uuid": "spec0008-dark-4000-8000-000000000001"
+    },
+    {
+      "name": {
+        "property": "background-color-default",
+        "colorScheme": "wireframe"
+      },
+      "value": "#f5f5f5",
+      "uuid": "spec0008-wire-4000-8000-000000000002"
+    }
+  ],
+  "components": [],
+  "modeSets": [
+    {
+      "name": "colorScheme",
+      "modes": ["light", "dark", "wireframe"],
+      "default": "light"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-008/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-008/expected-errors.json
@@ -1,4 +1,5 @@
 {
+  "layer": 1,
   "description": "A cascade token property that has non-default colorScheme variants (dark, wireframe) but no base/default variant (mode-set-agnostic or explicit light) MUST trigger SPEC-008.",
   "errors": [
     {


### PR DESCRIPTION
## Description

Phase 4 of #897 — adds `dataset.json` to every remaining legacy-only conformance fixture directory, making all implemented rules discoverable by the Rust harness.

**Fixtures migrated:**

| Rule | Legacy source(s) | dataset.json approach |
|---|---|---|
| SPEC-001 | `fixture.json` | Token with `$ref` to nonexistent target |
| SPEC-002 | `token-bad-alias.json` + `token-color.json` | String-named alias token + color target with `$schema` |
| SPEC-003 | `token-a.json` + `token-b.json` | Two string-named tokens with circular `$ref` |
| SPEC-004 | `token-one.json` + `token-two.json` | Two tokens sharing the same UUID |
| SPEC-005 | `dimension.json` | `modeSets` entry with `default` not in `modes` |
| SPEC-006 | `token-high.json` + `token-low.json` | Two tokens with identical name objects |
| SPEC-008 | `dimension.json` + `tokens.tokens.json` | Tokens + `modeSets`; only non-default `colorScheme` variants present |

**Layer field corrections:**

All seven fixtures are correctly marked `"layer": 1` — these are structural/cascade rules not implemented in the JS `validateDataset` function. The JS conformance runner (added in #906) filters to `layer: 2` only, so these fixtures are now exercised exclusively by the Rust harness.

SPEC-008's `expected-errors.json` previously had no `layer` field at all; one is added.

## Related Issue

Implements Phase 4 of #897

## Motivation and Context

Before this PR every `conformance/invalid/SPEC-001..006` and `SPEC-008` directory was invisible to the Rust conformance harness (no `dataset.json`). The harness skips legacy-only dirs, so those rules had zero fixture-level integration coverage in Rust.

## How Has This Been Tested?

- `cargo test -p design-data-core` — 218 tests pass, including `validation_conformance::invalid_fixtures_match_expected` which now exercises all 7 newly migrated fixture dirs
- `pnpm -C packages/design-data-spec test` — 51 JS tests pass; newly layer-1 fixtures are correctly excluded from the JS runner

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.