### PR TITLE
feat(sdk,spec): implement SPEC-032 product-layer cascade enforcement

### DIFF
--- a/packages/design-data-spec/conformance/invalid/SPEC-032/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-032/dataset.json
@@ -10,6 +10,17 @@
       "value": { "r": 0, "g": 0, "b": 0 },
       "uuid": "dddddddd-0032-4000-8000-000000000002",
       "$layer": "product"
+    },
+    {
+      "name": { "property": "spacing-default" },
+      "value": "8px",
+      "uuid": "dddddddd-0032-4000-8000-000000000004"
+    },
+    {
+      "name": { "property": "spacing-default" },
+      "value": 8,
+      "uuid": "dddddddd-0032-4000-8000-000000000004",
+      "$layer": "platform"
     }
   ],
   "components": []

--- a/packages/design-data-spec/conformance/invalid/SPEC-032/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-032/dataset.json
@@ -1,0 +1,16 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "color-default" },
+      "value": "#ffffff",
+      "uuid": "dddddddd-0032-4000-8000-000000000002"
+    },
+    {
+      "name": { "property": "color-default" },
+      "value": { "r": 0, "g": 0, "b": 0 },
+      "uuid": "dddddddd-0032-4000-8000-000000000002",
+      "$layer": "product"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-032/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-032/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 1,
+  "errors": [
+    {
+      "rule_id": "SPEC-032",
+      "severity": "error",
+      "message_pattern": "override changes value type from 'string' to 'object'"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-032/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-032/expected-errors.json
@@ -5,6 +5,11 @@
       "rule_id": "SPEC-032",
       "severity": "error",
       "message_pattern": "override changes value type from 'string' to 'object'"
+    },
+    {
+      "rule_id": "SPEC-032",
+      "severity": "error",
+      "message_pattern": "override changes value type from 'string' to 'number'"
     }
   ]
 }

--- a/packages/design-data-spec/conformance/resolution/product-layer-wins/expected.json
+++ b/packages/design-data-spec/conformance/resolution/product-layer-wins/expected.json
@@ -1,0 +1,5 @@
+{
+  "description": "When a Product-layer override shares a UUID with a Foundation token, the Product layer MUST win and its value MUST be used.",
+  "resolved": true,
+  "expected_value": "#product"
+}

--- a/packages/design-data-spec/conformance/resolution/product-layer-wins/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/resolution/product-layer-wins/input/tokens.tokens.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": { "property": "background-color-default" },
+    "value": "#foundation",
+    "uuid": "cccccccc-0001-4000-8000-000000000001"
+  }
+]

--- a/packages/design-data-spec/conformance/resolution/product-layer-wins/product-context.json
+++ b/packages/design-data-spec/conformance/resolution/product-layer-wins/product-context.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../schemas/product-context.schema.json",
+  "layer": "product",
+  "overrides": [
+    {
+      "uuid": "cccccccc-0001-4000-8000-000000000001",
+      "value": "#product",
+      "rationale": "Product brand override for background color"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/resolution/product-layer-wins/query.json
+++ b/packages/design-data-spec/conformance/resolution/product-layer-wins/query.json
@@ -1,0 +1,4 @@
+{
+  "property": "background-color-default",
+  "context": {}
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-032/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-032/dataset.json
@@ -1,0 +1,16 @@
+{
+  "tokens": [
+    {
+      "name": { "property": "background-color-default" },
+      "value": "#ffffff",
+      "uuid": "dddddddd-0032-4000-8000-000000000001"
+    },
+    {
+      "name": { "property": "border-color-default" },
+      "value": "#cccccc",
+      "uuid": "dddddddd-0032-4000-8000-000000000003",
+      "$layer": "product"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-032/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-032/dataset.json
@@ -6,9 +6,9 @@
       "uuid": "dddddddd-0032-4000-8000-000000000001"
     },
     {
-      "name": { "property": "border-color-default" },
-      "value": "#cccccc",
-      "uuid": "dddddddd-0032-4000-8000-000000000003",
+      "name": { "property": "background-color-default" },
+      "value": "#eeeeee",
+      "uuid": "dddddddd-0032-4000-8000-000000000001",
       "$layer": "product"
     }
   ],

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -292,3 +292,15 @@ rules:
     message: "Component '{entity}' accessibility has a role but no wcag entries — add applicable WCAG 2.x success criteria"
     spec_ref: spec/accessibility.md
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-032
+    name: product-layer-override-type-compat
+    severity: error
+    category: cascade
+    assert: >
+      A Platform- or Product-layer token that overrides a Foundation token (matched by UUID)
+      MUST NOT change the JSON value type of the `value` field. Overrides may change the value
+      but must preserve its JSON kind (string, number, object, array, boolean).
+    message: "Token '{entity}' override changes value type from '{foundationType}' to '{overrideType}' — overrides MUST NOT change the resolved token's value type"
+    spec_ref: spec/cascade.md
+    introduced_in: "1.0.0-draft"

--- a/sdk/core/src/cascade.rs
+++ b/sdk/core/src/cascade.rs
@@ -12,7 +12,7 @@
 //!
 //! Implements the algorithm defined in `spec/cascade.md`:
 //! 1. Filter candidates by context match (mode set values).
-//! 2. Select by layer precedence (Foundation < Platform < Product).
+//! 2. Select by layer precedence: highest layer wins (Product > Platform > Foundation).
 //! 3. Within a layer, select by specificity (non-default mode set count).
 //! 4. Tie-break by document order (file path lexicographic, then array index).
 //! 5. Resolve alias chain on the winner.
@@ -104,15 +104,12 @@ pub fn matches_context(
 
 /// Resolve the winning token for a given context.
 ///
-/// Applies the full cascade algorithm:
+/// Applies the full cascade algorithm from `spec/cascade.md`:
 /// 1. Filter to tokens whose name object matches `context`.
-/// 2. Select maximum specificity among candidates.
-/// 3. Tie-break by document order: lexicographically earlier file path wins;
+/// 2. Sort by layer descending (Product > Platform > Foundation).
+/// 3. Within a layer, sort by specificity descending.
+/// 4. Tie-break by document order: lexicographically earlier file path wins;
 ///    within the same file, lower `index` wins.
-///
-/// Layer precedence (Foundation < Platform < Product) is not yet enforced
-/// because the current dataset is single-layer (Foundation). Layer support
-/// will be added when multi-layer datasets are introduced.
 ///
 /// Returns `None` when no candidate matches the context.
 pub fn resolve<'a>(graph: &'a TokenGraph, context: &ResolutionContext) -> Option<&'a TokenRecord> {
@@ -132,7 +129,7 @@ pub fn resolve<'a>(graph: &'a TokenGraph, context: &ResolutionContext) -> Option
         return None;
     }
 
-    // 2. Sort: highest specificity first; tie-break by (file path, index).
+    // 2. Sort: layer descending, then specificity descending, then document order.
     candidates.sort_by(|a, b| {
         let spec_a = a
             .raw
@@ -146,8 +143,9 @@ pub fn resolve<'a>(graph: &'a TokenGraph, context: &ResolutionContext) -> Option
             .and_then(|v| v.as_object())
             .map(|n| specificity(n, &graph.mode_sets))
             .unwrap_or(0);
-        spec_b
-            .cmp(&spec_a) // descending specificity
+        b.layer
+            .cmp(&a.layer) // descending layer: Product > Platform > Foundation
+            .then_with(|| spec_b.cmp(&spec_a)) // descending specificity
             .then_with(|| a.file.cmp(&b.file)) // lex file path
             .then_with(|| a.index.cmp(&b.index)) // document order within file
     });
@@ -164,7 +162,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::graph::{ModeSetRecord, TokenGraph};
+    use crate::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
 
     fn color_scheme_mode_set() -> ModeSetRecord {
         ModeSetRecord {
@@ -312,5 +310,39 @@ mod tests {
         let winner = resolve(&g, &ctx).expect("should find a winner");
         // a.tokens.json comes before b.tokens.json lexicographically
         assert_eq!(winner.file, PathBuf::from("a.tokens.json"));
+    }
+
+    #[test]
+    fn product_layer_beats_foundation_layer() {
+        // Foundation token with same name-object as the Product override.
+        let foundation = TokenRecord {
+            name: "foundation-bg".into(),
+            file: PathBuf::from("foundation.tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some("uuid-bg".into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "bg"}, "uuid": "uuid-bg", "value": "#foundation"}),
+            layer: Layer::Foundation,
+        };
+        // Product override: same name-object, overrides value.
+        let product = TokenRecord {
+            name: "product-context:uuid-bg:0".into(),
+            file: PathBuf::from("product-context.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some("uuid-bg".into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "bg"}, "uuid": "uuid-bg", "value": "#product"}),
+            layer: Layer::Product,
+        };
+        let g = TokenGraph::from_records(vec![foundation, product]);
+        let ctx = ResolutionContext::new();
+        let winner = resolve(&g, &ctx).expect("should find a winner");
+        assert_eq!(winner.layer, Layer::Product);
+        assert_eq!(
+            winner.raw.get("value").and_then(|v| v.as_str()),
+            Some("#product")
+        );
     }
 }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -30,13 +30,15 @@ pub enum Layer {
     Product = 3,
 }
 
-impl Layer {
-    pub fn from_str(s: &str) -> Option<Self> {
+impl std::str::FromStr for Layer {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "foundation" => Some(Layer::Foundation),
-            "platform" => Some(Layer::Platform),
-            "product" => Some(Layer::Product),
-            _ => None,
+            "foundation" => Ok(Layer::Foundation),
+            "platform" => Ok(Layer::Platform),
+            "product" => Ok(Layer::Product),
+            _ => Err(()),
         }
     }
 }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -18,6 +18,29 @@ use serde_json::Value;
 use crate::discovery::discover_json_files;
 use crate::CoreError;
 
+/// Cascade layer (Foundation < Platform < Product).
+///
+/// Layer ordering is encoded in the discriminant so `Ord` gives correct
+/// precedence: `Foundation < Platform < Product`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Layer {
+    #[default]
+    Foundation = 1,
+    Platform = 2,
+    Product = 3,
+}
+
+impl Layer {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "foundation" => Some(Layer::Foundation),
+            "platform" => Some(Layer::Platform),
+            "product" => Some(Layer::Product),
+            _ => None,
+        }
+    }
+}
+
 /// One component declaration (spec-format JSON), loaded for relational rules.
 #[derive(Debug, Clone)]
 pub struct ComponentRecord {
@@ -47,6 +70,8 @@ pub struct TokenRecord {
     /// Resolved alias target id when applicable.
     pub alias_target: Option<String>,
     pub raw: Value,
+    /// Cascade layer this token belongs to.
+    pub layer: Layer,
 }
 
 /// Token graph across files.
@@ -110,6 +135,7 @@ impl TokenGraph {
                             uuid,
                             alias_target,
                             raw: token_val.clone(),
+                            layer: Layer::Foundation,
                         },
                     );
                 }
@@ -154,6 +180,7 @@ impl TokenGraph {
                         uuid,
                         alias_target,
                         raw: token_val.clone(),
+                        layer: Layer::Foundation,
                     },
                 );
             }
@@ -208,6 +235,7 @@ impl TokenGraph {
                     uuid,
                     alias_target,
                     raw,
+                    layer: Layer::Foundation,
                 },
             );
         }
@@ -217,6 +245,122 @@ impl TokenGraph {
             components: Vec::new(),
             uuid_index,
         }
+    }
+
+    /// Build a graph from full `TokenRecord`s, preserving each record's `layer`.
+    ///
+    /// Use instead of `from_pairs` when layer information must be retained
+    /// (e.g. after loading a product-context overlay).
+    pub fn from_records(records: Vec<TokenRecord>) -> Self {
+        let mut tokens = HashMap::new();
+        let mut uuid_index = HashMap::new();
+        for record in records {
+            if let Some(u) = &record.uuid {
+                uuid_index.entry(u.clone()).or_insert_with(|| record.name.clone());
+            }
+            tokens.insert(record.name.clone(), record);
+        }
+        Self {
+            tokens,
+            mode_sets: Vec::new(),
+            components: Vec::new(),
+            uuid_index,
+        }
+    }
+
+    /// Load a `product-context.json` and insert Product-layer tokens into the graph.
+    ///
+    /// For each override `{uuid, value}` in the document, the corresponding Foundation
+    /// token is looked up by UUID; a synthetic Product-layer `TokenRecord` is created
+    /// that inherits the Foundation token's `name` object but carries the override value.
+    /// Net-new tokens in `extensions.tokens` are inserted directly at Product layer.
+    pub fn load_product_context(&mut self, path: &Path) -> Result<(), CoreError> {
+        let text = std::fs::read_to_string(path)?;
+        let doc: Value = serde_json::from_str(&text)?;
+
+        // Process overrides: each must reference an existing Foundation token by UUID.
+        if let Some(overrides) = doc.get("overrides").and_then(|v| v.as_array()) {
+            for (idx, entry) in overrides.iter().enumerate() {
+                let Some(uuid_str) = entry.get("uuid").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let Some(override_value) = entry.get("value") else {
+                    continue;
+                };
+
+                // Find the Foundation token's name object via uuid_index.
+                let foundation_raw = self
+                    .uuid_index
+                    .get(uuid_str)
+                    .and_then(|k| self.tokens.get(k))
+                    .map(|t| t.raw.clone());
+
+                let name_obj = foundation_raw
+                    .as_ref()
+                    .and_then(|r| r.get("name"))
+                    .cloned()
+                    .unwrap_or(Value::Null);
+
+                // Synthesize a Product-layer token with the same name object and override value.
+                let mut synthetic_raw = serde_json::json!({
+                    "name": name_obj,
+                    "value": override_value,
+                    "uuid": uuid_str,
+                });
+                if let Some(rationale) = entry.get("rationale") {
+                    synthetic_raw["rationale"] = rationale.clone();
+                }
+
+                let key = format!("product-context:{}:{}", uuid_str, idx);
+                self.tokens.insert(
+                    key.clone(),
+                    TokenRecord {
+                        name: key,
+                        file: path.to_path_buf(),
+                        index: idx,
+                        schema_url: None,
+                        uuid: Some(uuid_str.to_string()),
+                        alias_target: None,
+                        raw: synthetic_raw,
+                        layer: Layer::Product,
+                    },
+                );
+            }
+        }
+
+        // Process extensions.tokens: insert each as a Product-layer token.
+        if let Some(ext_tokens) = doc
+            .get("extensions")
+            .and_then(|v| v.get("tokens"))
+            .and_then(|v| v.as_array())
+        {
+            for (idx, token_val) in ext_tokens.iter().enumerate() {
+                let Some(tok_obj) = token_val.as_object() else {
+                    continue;
+                };
+                let uuid = tok_obj.get("uuid").and_then(|v| v.as_str()).map(str::to_string);
+                let alias_target = extract_alias_target(tok_obj);
+                let key = format!("product-context-ext:{}:{}", path.display(), idx);
+                if let Some(u) = &uuid {
+                    self.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                }
+                self.tokens.insert(
+                    key.clone(),
+                    TokenRecord {
+                        name: key,
+                        file: path.to_path_buf(),
+                        index: idx,
+                        schema_url: None,
+                        uuid,
+                        alias_target,
+                        raw: token_val.clone(),
+                        layer: Layer::Product,
+                    },
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Attach mode set records (e.g. from conformance fixtures).
@@ -288,7 +432,7 @@ fn parse_mode_set(path: &Path, obj: &serde_json::Map<String, Value>) -> Option<M
     })
 }
 
-fn extract_alias_target(obj: &serde_json::Map<String, Value>) -> Option<String> {
+pub(crate) fn extract_alias_target(obj: &serde_json::Map<String, Value>) -> Option<String> {
     if let Some(r) = obj.get("$ref").and_then(|v| v.as_str()) {
         return Some(normalize_ref_target(r));
     }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -22,7 +22,7 @@ use crate::CoreError;
 ///
 /// Layer ordering is encoded in the discriminant so `Ord` gives correct
 /// precedence: `Foundation < Platform < Product`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub enum Layer {
     #[default]
     Foundation = 1,
@@ -291,17 +291,17 @@ impl TokenGraph {
                 };
 
                 // Find the Foundation token's name object via uuid_index.
-                let foundation_raw = self
+                // Skip overrides that reference an unknown UUID — inserting a synthetic
+                // token with "name": null would silently corrupt downstream validation.
+                let Some(name_obj) = self
                     .uuid_index
                     .get(uuid_str)
                     .and_then(|k| self.tokens.get(k))
-                    .map(|t| t.raw.clone());
-
-                let name_obj = foundation_raw
-                    .as_ref()
-                    .and_then(|r| r.get("name"))
+                    .and_then(|t| t.raw.get("name"))
                     .cloned()
-                    .unwrap_or(Value::Null);
+                else {
+                    continue;
+                };
 
                 // Synthesize a Product-layer token with the same name object and override value.
                 let mut synthetic_raw = serde_json::json!({

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -465,13 +465,15 @@ mod validation_conformance {
     }
 
     fn build_graph(dataset: &Value) -> TokenGraph {
+        use crate::graph::{extract_alias_target, Layer, TokenRecord};
+
         let tokens_json = dataset
             .get("tokens")
             .and_then(|v| v.as_array())
             .cloned()
             .unwrap_or_default();
 
-        let entries: Vec<(String, std::path::PathBuf, Value)> = tokens_json
+        let records: Vec<TokenRecord> = tokens_json
             .into_iter()
             .enumerate()
             .map(|(i, raw)| {
@@ -482,11 +484,36 @@ mod validation_conformance {
                     .and_then(|n| n.as_str())
                     .map(String::from)
                     .unwrap_or_else(|| format!("token-{i}"));
-                (key, std::path::PathBuf::from("dataset.json"), raw)
+                // Optional "$layer" field lets fixtures exercise multi-layer rules (e.g. SPEC-032).
+                let layer = raw
+                    .get("$layer")
+                    .and_then(|v| v.as_str())
+                    .and_then(Layer::from_str)
+                    .unwrap_or(Layer::Foundation);
+                let tok_obj = raw.as_object();
+                let schema_url = tok_obj
+                    .and_then(|o| o.get("$schema"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let uuid = tok_obj
+                    .and_then(|o| o.get("uuid"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let alias_target = tok_obj.and_then(extract_alias_target);
+                TokenRecord {
+                    name: key,
+                    file: std::path::PathBuf::from("dataset.json"),
+                    index: i,
+                    schema_url,
+                    uuid,
+                    alias_target,
+                    raw,
+                    layer,
+                }
             })
             .collect();
 
-        let mut graph = TokenGraph::from_pairs(entries);
+        let mut graph = TokenGraph::from_records(records);
 
         if let Some(comps) = dataset.get("components").and_then(|v| v.as_array()) {
             let comp_records: Vec<ComponentRecord> = comps
@@ -763,7 +790,15 @@ mod resolution_conformance {
             graph = graph.with_mode_sets(mode_sets);
         }
 
-        // Filter to property.
+        // Optionally load a product-context.json to test multi-layer resolution.
+        let product_context_path = base.join("product-context.json");
+        if product_context_path.is_file() {
+            graph
+                .load_product_context(&product_context_path)
+                .unwrap_or_else(|e| panic!("{case}: failed to load product-context.json: {e}"));
+        }
+
+        // Filter to property, preserving layer info via from_records.
         let candidates: Vec<_> = graph
             .tokens
             .values()
@@ -775,15 +810,11 @@ mod resolution_conformance {
                     .and_then(|v| v.as_str())
                     == Some(property)
             })
+            .cloned()
             .collect();
 
-        let filtered = TokenGraph::from_pairs(
-            candidates
-                .iter()
-                .map(|t| (t.name.clone(), t.file.clone(), t.raw.clone()))
-                .collect(),
-        )
-        .with_mode_sets(graph.mode_sets.clone());
+        let filtered = TokenGraph::from_records(candidates)
+            .with_mode_sets(graph.mode_sets.clone());
 
         let should_resolve = expected["resolved"].as_bool().unwrap_or(true);
         let winner = resolve(&filtered, &ctx);
@@ -798,6 +829,14 @@ mod resolution_conformance {
                     actual_uuid,
                     Some(expected_uuid),
                     "{case}: wrong token selected (uuid mismatch)"
+                );
+            }
+            if let Some(expected_value) = expected.get("expected_value") {
+                let actual_value = winner.raw.get("value");
+                assert_eq!(
+                    actual_value,
+                    Some(expected_value),
+                    "{case}: wrong value resolved"
                 );
             }
         } else {
@@ -821,6 +860,11 @@ mod resolution_conformance {
     #[test]
     fn alias_resolved_after_cascade() {
         run_fixture("alias-resolved-after-cascade");
+    }
+
+    #[test]
+    fn product_layer_wins() {
+        run_fixture("product-layer-wins");
     }
 }
 

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -488,7 +488,7 @@ mod validation_conformance {
                 let layer = raw
                     .get("$layer")
                     .and_then(|v| v.as_str())
-                    .and_then(Layer::from_str)
+                    .and_then(|s| s.parse().ok())
                     .unwrap_or(Layer::Foundation);
                 let tok_obj = raw.as_object();
                 let schema_url = tok_obj

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -39,6 +39,7 @@ mod spec028;
 mod spec029;
 mod spec030;
 mod spec031;
+mod spec032;
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
@@ -88,6 +89,7 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec029::Rule),
         Box::new(spec030::Rule),
         Box::new(spec031::Rule),
+        Box::new(spec032::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec004.rs
+++ b/sdk/core/src/validate/rules/spec004.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashMap;
 
+use crate::graph::Layer;
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
 
@@ -25,16 +26,20 @@ impl ValidationRule for Rule {
     }
 
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
-        let mut by_uuid: HashMap<&str, Vec<&crate::graph::TokenRecord>> = HashMap::new();
+        // Group by (uuid, layer): duplicate UUIDs across layers are intentional
+        // (product overrides reference the Foundation token by its UUID), so only
+        // flag duplicates within the same layer.
+        let mut by_uuid_layer: HashMap<(&str, Layer), Vec<&crate::graph::TokenRecord>> =
+            HashMap::new();
         for t in ctx.graph.tokens.values() {
             let Some(u) = t.uuid.as_deref() else {
                 continue;
             };
-            by_uuid.entry(u).or_default().push(t);
+            by_uuid_layer.entry((u, t.layer)).or_default().push(t);
         }
 
         let mut out = Vec::new();
-        for (uuid, group) in by_uuid {
+        for ((uuid, _layer), group) in by_uuid_layer {
             if group.len() < 2 {
                 continue;
             }

--- a/sdk/core/src/validate/rules/spec015.rs
+++ b/sdk/core/src/validate/rules/spec015.rs
@@ -248,6 +248,7 @@ mod tests {
                     uuid: None,
                     alias_target,
                     raw,
+                    layer: crate::graph::Layer::Foundation,
                 },
             );
         }

--- a/sdk/core/src/validate/rules/spec016.rs
+++ b/sdk/core/src/validate/rules/spec016.rs
@@ -130,6 +130,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                 raw,
             },
         );

--- a/sdk/core/src/validate/rules/spec016.rs
+++ b/sdk/core/src/validate/rules/spec016.rs
@@ -130,7 +130,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
-                    layer: crate::graph::Layer::Foundation,
+                layer: crate::graph::Layer::Foundation,
                 raw,
             },
         );
@@ -141,7 +141,11 @@ mod tests {
         let g = make_graph(raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec018.rs
+++ b/sdk/core/src/validate/rules/spec018.rs
@@ -87,6 +87,7 @@ mod tests {
                     schema_url: None,
                     uuid: None,
                     alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                     raw,
                 },
             );

--- a/sdk/core/src/validate/rules/spec019.rs
+++ b/sdk/core/src/validate/rules/spec019.rs
@@ -109,6 +109,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                 raw: token_raw,
             },
         );

--- a/sdk/core/src/validate/rules/spec019.rs
+++ b/sdk/core/src/validate/rules/spec019.rs
@@ -61,10 +61,8 @@ impl ValidationRule for Rule {
                 continue; // no enum declared — any variant is allowed
             };
 
-            let declared: std::collections::HashSet<&str> = variant_enum
-                .iter()
-                .filter_map(|v| v.as_str())
-                .collect();
+            let declared: std::collections::HashSet<&str> =
+                variant_enum.iter().filter_map(|v| v.as_str()).collect();
 
             if !declared.contains(variant) {
                 let token_label = serde_json::to_string(name_obj).unwrap_or_default();
@@ -109,7 +107,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
-                    layer: crate::graph::Layer::Foundation,
+                layer: crate::graph::Layer::Foundation,
                 raw: token_raw,
             },
         );
@@ -126,11 +124,18 @@ mod tests {
         g
     }
 
-    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        token_raw: serde_json::Value,
+        comp_raw: serde_json::Value,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(token_raw, comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec020.rs
+++ b/sdk/core/src/validate/rules/spec020.rs
@@ -105,7 +105,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
-                    layer: crate::graph::Layer::Foundation,
+                layer: crate::graph::Layer::Foundation,
                 raw: token_raw,
             },
         );
@@ -122,11 +122,18 @@ mod tests {
         g
     }
 
-    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        token_raw: serde_json::Value,
+        comp_raw: serde_json::Value,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(token_raw, comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec020.rs
+++ b/sdk/core/src/validate/rules/spec020.rs
@@ -105,6 +105,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                 raw: token_raw,
             },
         );

--- a/sdk/core/src/validate/rules/spec022.rs
+++ b/sdk/core/src/validate/rules/spec022.rs
@@ -105,7 +105,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
-                    layer: crate::graph::Layer::Foundation,
+                layer: crate::graph::Layer::Foundation,
                 raw: token_raw,
             },
         );
@@ -122,11 +122,18 @@ mod tests {
         g
     }
 
-    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        token_raw: serde_json::Value,
+        comp_raw: serde_json::Value,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(token_raw, comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec022.rs
+++ b/sdk/core/src/validate/rules/spec022.rs
@@ -105,6 +105,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                 raw: token_raw,
             },
         );

--- a/sdk/core/src/validate/rules/spec027.rs
+++ b/sdk/core/src/validate/rules/spec027.rs
@@ -95,6 +95,7 @@ mod tests {
                     schema_url: None,
                     uuid: None,
                     alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                     raw,
                 },
             );

--- a/sdk/core/src/validate/rules/spec028.rs
+++ b/sdk/core/src/validate/rules/spec028.rs
@@ -109,6 +109,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                 raw,
             },
         );

--- a/sdk/core/src/validate/rules/spec028.rs
+++ b/sdk/core/src/validate/rules/spec028.rs
@@ -109,7 +109,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
-                    layer: crate::graph::Layer::Foundation,
+                layer: crate::graph::Layer::Foundation,
                 raw,
             },
         );
@@ -134,7 +134,11 @@ mod tests {
         let g = make_graph(raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 
@@ -142,7 +146,11 @@ mod tests {
         let g = make_graph_with_component(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec029.rs
+++ b/sdk/core/src/validate/rules/spec029.rs
@@ -106,6 +106,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
+                    layer: crate::graph::Layer::Foundation,
                 raw,
             },
         );

--- a/sdk/core/src/validate/rules/spec029.rs
+++ b/sdk/core/src/validate/rules/spec029.rs
@@ -106,7 +106,7 @@ mod tests {
                 schema_url: None,
                 uuid: None,
                 alias_target: None,
-                    layer: crate::graph::Layer::Foundation,
+                layer: crate::graph::Layer::Foundation,
                 raw,
             },
         );
@@ -131,7 +131,11 @@ mod tests {
         let g = make_graph(raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 
@@ -139,7 +143,11 @@ mod tests {
         let g = make_graph_with_component(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec032.rs
+++ b/sdk/core/src/validate/rules/spec032.rs
@@ -201,4 +201,41 @@ mod tests {
         let diags = run(vec![foundation("uuid-5", json!("#abc"))]);
         assert!(diags.is_empty());
     }
+
+    #[test]
+    fn platform_layer_type_change_is_error() {
+        // Per spec/cascade.md, Platform layer MUST also remain type-compatible.
+        let platform = TokenRecord {
+            name: "platform:uuid-6:0".into(),
+            file: PathBuf::from("platform-context.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some("uuid-6".into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "spacing"}, "uuid": "uuid-6", "value": 8}),
+            layer: Layer::Platform,
+        };
+        let diags = run(vec![foundation("uuid-6", json!("8px")), platform]);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-032"));
+        assert!(diags[0].message.contains("string"));
+        assert!(diags[0].message.contains("number"));
+    }
+
+    #[test]
+    fn platform_layer_same_type_no_error() {
+        let platform = TokenRecord {
+            name: "platform:uuid-7:0".into(),
+            file: PathBuf::from("platform-context.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some("uuid-7".into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "spacing"}, "uuid": "uuid-7", "value": "12px"}),
+            layer: Layer::Platform,
+        };
+        let diags = run(vec![foundation("uuid-7", json!("8px")), platform]);
+        assert!(diags.is_empty());
+    }
 }

--- a/sdk/core/src/validate/rules/spec032.rs
+++ b/sdk/core/src/validate/rules/spec032.rs
@@ -37,6 +37,8 @@ impl ValidationRule for Rule {
         let mut out = Vec::new();
 
         // Build a map: UUID → Foundation-layer token value type.
+        // If two Foundation tokens share a UUID, HashMap insertion is non-deterministic;
+        // SPEC-004 catches that data error before this rule runs, so it's acceptable here.
         let foundation_value_types: HashMap<&str, &str> = ctx
             .graph
             .tokens

--- a/sdk/core/src/validate/rules/spec032.rs
+++ b/sdk/core/src/validate/rules/spec032.rs
@@ -1,0 +1,204 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-032: product-layer-override-type-compat
+//!
+//! A Product-layer (or Platform-layer) token that overrides a Foundation token by UUID
+//! MUST NOT change the JSON value type of the `value` field.
+//! Per spec/cascade.md: "Overrides MUST NOT change the resolved token's value type."
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::graph::Layer;
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-032"
+    }
+
+    fn name(&self) -> &'static str {
+        "product-layer-override-type-compat"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        // Build a map: UUID → Foundation-layer token value type.
+        let foundation_value_types: HashMap<&str, &str> = ctx
+            .graph
+            .tokens
+            .values()
+            .filter(|t| t.layer == Layer::Foundation)
+            .filter_map(|t| {
+                let uuid = t.uuid.as_deref()?;
+                let value = t.raw.get("value")?;
+                Some((uuid, json_type_name(value)))
+            })
+            .collect();
+
+        // Check every non-Foundation token against the Foundation type for its UUID.
+        for t in ctx.graph.tokens.values().filter(|t| t.layer > Layer::Foundation) {
+            let Some(uuid) = t.uuid.as_deref() else {
+                continue;
+            };
+            let Some(override_value) = t.raw.get("value") else {
+                continue;
+            };
+            let Some(&foundation_type) = foundation_value_types.get(uuid) else {
+                // No Foundation token with this UUID — not a type-compat violation.
+                continue;
+            };
+            let override_type = json_type_name(override_value);
+            if override_type != foundation_type {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{}' override changes value type from '{}' to '{}' — overrides MUST NOT change the resolved token's value type",
+                        t.name, foundation_type, override_type
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+            }
+        }
+
+        out
+    }
+}
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{Layer, TokenGraph, TokenRecord};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec032::Rule;
+
+    fn make_graph(records: Vec<TokenRecord>) -> TokenGraph {
+        TokenGraph::from_records(records)
+    }
+
+    fn run(records: Vec<TokenRecord>) -> Vec<crate::report::Diagnostic> {
+        let g = make_graph(records);
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+        };
+        Rule.validate(&ctx)
+    }
+
+    fn foundation(uuid: &str, value: serde_json::Value) -> TokenRecord {
+        TokenRecord {
+            name: format!("foundation-{uuid}"),
+            file: PathBuf::from("foundation.tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some(uuid.into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "p"}, "uuid": uuid, "value": value}),
+            layer: Layer::Foundation,
+        }
+    }
+
+    fn product_override(uuid: &str, value: serde_json::Value) -> TokenRecord {
+        TokenRecord {
+            name: format!("product-context:{uuid}:0"),
+            file: PathBuf::from("product-context.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some(uuid.into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "p"}, "uuid": uuid, "value": value}),
+            layer: Layer::Product,
+        }
+    }
+
+    #[test]
+    fn same_type_no_error() {
+        let diags = run(vec![
+            foundation("uuid-1", json!("#abc")),
+            product_override("uuid-1", json!("#fff")),
+        ]);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn type_change_string_to_object_is_error() {
+        let diags = run(vec![
+            foundation("uuid-2", json!("#abc")),
+            product_override("uuid-2", json!({"r": 0, "g": 0, "b": 0})),
+        ]);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-032"));
+        assert!(diags[0].message.contains("string"));
+        assert!(diags[0].message.contains("object"));
+    }
+
+    #[test]
+    fn type_change_object_to_string_is_error() {
+        let diags = run(vec![
+            foundation("uuid-3", json!({"fontFamily": "Adobe Clean"})),
+            product_override("uuid-3", json!("some-alias")),
+        ]);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+    }
+
+    #[test]
+    fn product_token_without_foundation_no_error() {
+        // Net-new product token (no Foundation match) should not trigger rule.
+        let net_new = TokenRecord {
+            name: "product-context-ext:p:0".into(),
+            file: PathBuf::from("product-context.json"),
+            index: 0,
+            schema_url: None,
+            uuid: Some("uuid-new".into()),
+            alias_target: None,
+            raw: json!({"name": {"property": "q"}, "uuid": "uuid-new", "value": "#123"}),
+            layer: Layer::Product,
+        };
+        let diags = run(vec![net_new]);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn foundation_only_no_error() {
+        let diags = run(vec![foundation("uuid-5", json!("#abc"))]);
+        assert!(diags.is_empty());
+    }
+}


### PR DESCRIPTION
## Description

Implements three-layer cascade resolution (`Foundation < Platform < Product`) in the SDK core, adds the `SPEC-032` validation rule enforcing override type compatibility, and wires up conformance fixtures.

## Related Issue

Closes #911

## Motivation and Context

RFC #714 identified product-level override enforcement as an open gap. The spec (`spec/cascade.md`) normatively requires that higher layers win in cascade resolution and that overrides must not change the value type, but neither was enforced in the resolver or validator. The `cascade.rs` TODO at the single-layer enforcement point is now resolved.

## How Has This Been Tested?

- All 237 existing `design-data-core` unit + conformance tests continue to pass.
- New `product_layer_beats_foundation_layer` unit test in `cascade.rs` verifies the resolver sort.
- New `product_layer_wins` resolution conformance fixture exercises `product-context.json` loading end-to-end.
- New `SPEC-032` valid + invalid conformance fixtures exercise the type-compat rule.
- CLI integration tests (13/13) continue to pass.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Key changes

| File | Change |
|---|---|
| `sdk/core/src/graph.rs` | `Layer` enum (`Foundation=1, Platform=2, Product=3`) added to `TokenRecord`; `from_records()` and `load_product_context()` methods on `TokenGraph` |
| `sdk/core/src/cascade.rs` | `resolve()` sort order now `layer desc → specificity desc → document order` |
| `sdk/core/src/validate/rules/spec032.rs` | New SPEC-032 rule: product-layer override MUST NOT change `value` JSON type |
| `sdk/core/src/validate/rules/mod.rs` | SPEC-032 registered |
| `sdk/core/src/lib.rs` | `build_graph` reads `"$layer"` from dataset entries; `run_fixture` loads optional `product-context.json` |
| `packages/design-data-spec/rules/rules.yaml` | SPEC-032 catalog entry added |
| `conformance/resolution/product-layer-wins/` | New resolution fixture |
| `conformance/{valid,invalid}/SPEC-032/` | New validation conformance fixtures |