### PR TITLE
fix(registry): add disclosure-triangle, picker, progress-bar to anatomy-terms

### DIFF
--- a/.changeset/anatomy-terms-add-disclosure-picker-progress-bar.md
+++ b/.changeset/anatomy-terms-add-disclosure-picker-progress-bar.md
@@ -1,0 +1,10 @@
+---
+"@adobe/design-system-registry": patch
+---
+
+Add `disclosure-triangle`, `picker`, `progress-bar` to anatomy-terms.json.
+
+Closes the spec/registry divergence surfaced during SPEC-035 implementation
+(#924) — these three names appear in the canonical vocabulary table in
+spec/anatomy-format.md but were missing from the registry, causing SPEC-035
+to advisory-warn on them. Resolves #925.

--- a/packages/design-system-registry/registry/anatomy-terms.json
+++ b/packages/design-system-registry/registry/anatomy-terms.json
@@ -716,6 +716,24 @@
       "label": "Guest Icon",
       "description": "Icon displayed in an avatar representing an unauthenticated guest user",
       "usedIn": ["s2-docs"]
+    },
+    {
+      "id": "disclosure-triangle",
+      "label": "Disclosure Triangle",
+      "description": "Expand/collapse indicator for accordion, tree, or disclosure components",
+      "usedIn": ["tokens", "component-schemas"]
+    },
+    {
+      "id": "picker",
+      "label": "Picker",
+      "description": "Dropdown trigger area — the visible affordance, not the overlay",
+      "usedIn": ["tokens", "component-schemas"]
+    },
+    {
+      "id": "progress-bar",
+      "label": "Progress Bar",
+      "description": "Visual progress fill track indicating completion level",
+      "usedIn": ["tokens", "component-schemas"]
     }
   ]
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1322,6 +1322,24 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "label": "Guest Icon",
       "description": "Icon displayed in an avatar representing an unauthenticated guest user",
       "usedIn": ["s2-docs"]
+    },
+    {
+      "id": "disclosure-triangle",
+      "label": "Disclosure Triangle",
+      "description": "Expand/collapse indicator for accordion, tree, or disclosure components",
+      "usedIn": ["tokens", "component-schemas"]
+    },
+    {
+      "id": "picker",
+      "label": "Picker",
+      "description": "Dropdown trigger area — the visible affordance, not the overlay",
+      "usedIn": ["tokens", "component-schemas"]
+    },
+    {
+      "id": "progress-bar",
+      "label": "Progress Bar",
+      "description": "Visual progress fill track indicating completion level",
+      "usedIn": ["tokens", "component-schemas"]
     }
   ]
 }

--- a/sdk/core/src/validate/rules/spec035.rs
+++ b/sdk/core/src/validate/rules/spec035.rs
@@ -180,17 +180,17 @@ mod tests {
 
     #[test]
     fn all_canonical_anatomy_pass() {
-        // These 11 names appear in the canonical vocabulary table in spec/anatomy-format.md
-        // AND in anatomy-terms.json. The 3 spec-table terms absent from the registry
-        // (disclosure-triangle, picker, progress-bar) are tracked in issue #925.
         for part in &[
             "body",
             "checkmark",
+            "disclosure-triangle",
             "field",
             "handle",
             "header",
             "icon",
             "label",
+            "picker",
+            "progress-bar",
             "swatch",
             "thumbnail",
             "track",


### PR DESCRIPTION
## Description

Adds three anatomy term entries to `anatomy-terms.json` that were missing from the registry but present in the canonical vocabulary table in `spec/anatomy-format.md`:

- `disclosure-triangle` — expand/collapse indicator for accordion, tree, or disclosure components
- `picker` — dropdown trigger area (the visible affordance, not the overlay)
- `progress-bar` — visual progress fill track indicating completion level

Also updates the `all_canonical_anatomy_pass` test in `spec035.rs` to assert all 14 canonical names (was 11, with a comment pointing at this issue).

## Related Issue

Closes #925

## Motivation and Context

PR #924 shipped SPEC-035, which advisory-warns when a component anatomy part's `name` is not in `anatomy-terms.json`. While implementing it, we found that three names blessed by the spec's own canonical vocabulary table were absent from the registry, causing SPEC-035 to warn on valid anatomy part names. This closes that divergence.

## How Has This Been Tested?

- `cargo test -p design-data-core spec035` — all 9 tests pass including `all_canonical_anatomy_pass` now covering 14 names
- `cargo test` — full SDK suite (270 tests) passes with no regressions
- `moon run design-system-registry:test` — all 66 AVA registry tests pass

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.