### PR TITLE
fix(changeset): remove invalid @adobe/design-data-core package reference

### DIFF
--- a/.changeset/spec-038-option-values-array.md
+++ b/.changeset/spec-038-option-values-array.md
@@ -1,6 +1,5 @@
 ---
 "@adobe/design-data-spec": major
-"@adobe/design-data-core": minor
 ---
 
 **Breaking:** Replace `optionDescriptor.enum` + `deprecatedEnumValues` with a


### PR DESCRIPTION
## Description

Remove `"@adobe/design-data-core": minor` from the SPEC-038 changeset frontmatter.

## Related Issue

Fixes the release action failure from PR #932 merge.

## Motivation and Context

`design-data-core` is a Rust crate, not an npm workspace package. The changesets release action rejects changesets that reference packages not present in the npm workspace, causing the release workflow to fail with:

> Found changeset spec-038-option-values-array for package @adobe/design-data-core which is not in the workspace

## How Has This Been Tested?

The changeset linter pre-commit hook ran successfully on the updated file. The release action will re-trigger once this merges.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.