### PR TITLE
feat(tokens): pilot name-object migration for color palette and font-weight tokens

### DIFF
--- a/.changeset/tokens-name-pilot.md
+++ b/.changeset/tokens-name-pilot.md
@@ -8,7 +8,8 @@ font-weight tokens (closes first phase of taxonomy corpus migration).
 
 - **color-palette.json**: 369 tokens gain `name: { property, colorFamily, scaleIndex? }`.
 - **typography.json**: 6 canonical font-weight tokens gain `name: { property, weight }`.
-- **design-system-registry**: export the six new taxonomy registries added in #961.
+- **design-system-registry**: export the six new taxonomy registries added in #961 via
+  the package.json `exports` map; add `propertyTerms` named export to `index.js`.
 - **tools/token-corpus-migrate**: new migration tool for injecting name objects;
   run dry-run with `node tools/token-corpus-migrate/src/cli.js --root <tokens-src>`,
   apply with `--write`.

--- a/.changeset/tokens-name-pilot.md
+++ b/.changeset/tokens-name-pilot.md
@@ -1,0 +1,14 @@
+---
+"@adobe/spectrum-tokens": minor
+"@adobe/design-system-registry": patch
+---
+
+Pilot name-object migration: add structured `name` fields to color palette and
+font-weight tokens (closes first phase of taxonomy corpus migration).
+
+- **color-palette.json**: 369 tokens gain `name: { property, colorFamily, scaleIndex? }`.
+- **typography.json**: 6 canonical font-weight tokens gain `name: { property, weight }`.
+- **design-system-registry**: export the six new taxonomy registries added in #961.
+- **tools/token-corpus-migrate**: new migration tool for injecting name objects;
+  run dry-run with `node tools/token-corpus-migrate/src/cli.js --root <tokens-src>`,
+  apply with `--write`.

--- a/packages/design-system-registry/package.json
+++ b/packages/design-system-registry/package.json
@@ -20,7 +20,13 @@
     "./registry/orientations.json": "./registry/orientations.json",
     "./registry/positions.json": "./registry/positions.json",
     "./registry/densities.json": "./registry/densities.json",
-    "./registry/shapes.json": "./registry/shapes.json"
+    "./registry/shapes.json": "./registry/shapes.json",
+    "./registry/color-families.json": "./registry/color-families.json",
+    "./registry/typography-families.json": "./registry/typography-families.json",
+    "./registry/typography-weights.json": "./registry/typography-weights.json",
+    "./registry/typography-styles.json": "./registry/typography-styles.json",
+    "./registry/motion-roles.json": "./registry/motion-roles.json",
+    "./registry/easing-curves.json": "./registry/easing-curves.json"
   },
   "scripts": {
     "validate": "node scripts/validate-registry.js",

--- a/packages/tokens/src/color-palette.json
+++ b/packages/tokens/src/color-palette.json
@@ -3,7 +3,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
-    "value": "rgb(0, 0, 0)"
+    "value": "rgb(0, 0, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "black"
+    }
   },
   "blue-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -25,7 +29,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "482037db-2e5c-4deb-bfa5-986a46cdcf33"
+    "uuid": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 100
+    }
   },
   "blue-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -47,7 +56,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "de6d785f-3534-4648-950c-e0e22fa9e2e9"
+    "uuid": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1000
+    }
   },
   "blue-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -69,7 +83,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae"
+    "uuid": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1100
+    }
   },
   "blue-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -91,7 +110,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "5c04481e-664e-4e9a-8da9-841e349167f5"
+    "uuid": "5c04481e-664e-4e9a-8da9-841e349167f5",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1200
+    }
   },
   "blue-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -113,7 +137,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4"
+    "uuid": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1300
+    }
   },
   "blue-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -135,7 +164,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "1d86cef1-e309-4b79-89a1-a54008a9efcb"
+    "uuid": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1400
+    }
   },
   "blue-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -157,7 +191,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "be3d8c39-72f3-4134-b009-4aa30fb01883"
+    "uuid": "be3d8c39-72f3-4134-b009-4aa30fb01883",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1500
+    }
   },
   "blue-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -179,7 +218,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "1472f089-6c1d-46ec-b8f4-e20855e65cd6"
+    "uuid": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1600
+    }
   },
   "blue-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -201,7 +245,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "ce69a96f-663b-4922-89a3-4ece7acb6d55"
+    "uuid": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 200
+    }
   },
   "blue-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -223,7 +272,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "d434be86-0614-481b-bf30-6f7494f562d5"
+    "uuid": "d434be86-0614-481b-bf30-6f7494f562d5",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 300
+    }
   },
   "blue-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -245,7 +299,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95"
+    "uuid": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 400
+    }
   },
   "blue-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -267,7 +326,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "1350b184-da3d-4920-bfa1-b42ba88761b2"
+    "uuid": "1350b184-da3d-4920-bfa1-b42ba88761b2",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 500
+    }
   },
   "blue-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -289,7 +353,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "71995b2a-07a1-489c-a17a-bf0d91ac5196"
+    "uuid": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 600
+    }
   },
   "blue-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -311,7 +380,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "1f0cc963-2ecf-4885-9ca1-d718b88aa968"
+    "uuid": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 700
+    }
   },
   "blue-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -333,7 +407,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "85be576c-6810-4971-9748-e558384b903d"
+    "uuid": "85be576c-6810-4971-9748-e558384b903d",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 800
+    }
   },
   "blue-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -355,7 +434,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0"
+    "uuid": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 900
+    }
   },
   "brown-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -377,7 +461,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "143930b9-2cfd-4849-94d2-fe5ade2ef5f0"
+    "uuid": "143930b9-2cfd-4849-94d2-fe5ade2ef5f0",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 100
+    }
   },
   "brown-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -399,7 +488,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9"
+    "uuid": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1000
+    }
   },
   "brown-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -421,7 +515,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "aa6d07ca-147f-49f9-bcad-1e7e3afa4afa"
+    "uuid": "aa6d07ca-147f-49f9-bcad-1e7e3afa4afa",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1100
+    }
   },
   "brown-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -443,7 +542,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "1090f8d4-7629-4515-aabf-9882237b87a9"
+    "uuid": "1090f8d4-7629-4515-aabf-9882237b87a9",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1200
+    }
   },
   "brown-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -465,7 +569,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "683f1d83-e54b-4a14-903e-afd3511748a4"
+    "uuid": "683f1d83-e54b-4a14-903e-afd3511748a4",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1300
+    }
   },
   "brown-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -487,7 +596,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "f6cb0828-54a1-4b21-9231-bd693efbe3b6"
+    "uuid": "f6cb0828-54a1-4b21-9231-bd693efbe3b6",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1400
+    }
   },
   "brown-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -509,7 +623,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "dc0ba9bf-3267-48f5-b349-dfc83f07279f"
+    "uuid": "dc0ba9bf-3267-48f5-b349-dfc83f07279f",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1500
+    }
   },
   "brown-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -531,7 +650,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "68d1119b-f487-4802-a74a-7e4a6cd315b7"
+    "uuid": "68d1119b-f487-4802-a74a-7e4a6cd315b7",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1600
+    }
   },
   "brown-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -553,7 +677,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "ce145d13-f1b1-46a7-9c17-0b7fab97022e"
+    "uuid": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 200
+    }
   },
   "brown-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -575,7 +704,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13"
+    "uuid": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 300
+    }
   },
   "brown-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -597,7 +731,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c"
+    "uuid": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 400
+    }
   },
   "brown-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -619,7 +758,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "6b511f8b-4f2e-4734-b659-50cca2ca6dce"
+    "uuid": "6b511f8b-4f2e-4734-b659-50cca2ca6dce",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 500
+    }
   },
   "brown-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -641,7 +785,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "30176b33-a0e1-447e-bb2b-250f963b2d65"
+    "uuid": "30176b33-a0e1-447e-bb2b-250f963b2d65",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 600
+    }
   },
   "brown-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -663,7 +812,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "6f87ea74-5734-40c1-ab34-b284e0f75b1b"
+    "uuid": "6f87ea74-5734-40c1-ab34-b284e0f75b1b",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 700
+    }
   },
   "brown-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -685,7 +839,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "bfbde25d-e087-444a-b26f-6568325a7d2e"
+    "uuid": "bfbde25d-e087-444a-b26f-6568325a7d2e",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 800
+    }
   },
   "brown-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -707,7 +866,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "6c05dc34-9a1b-4bf7-a476-f093c45275f5"
+    "uuid": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 900
+    }
   },
   "celery-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -729,7 +893,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "cfa877de-79f8-493f-898d-ceb70a12f64e"
+    "uuid": "cfa877de-79f8-493f-898d-ceb70a12f64e",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 100
+    }
   },
   "celery-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -751,7 +920,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "2184d450-2711-4e31-bb52-ee71e4fee3a5"
+    "uuid": "2184d450-2711-4e31-bb52-ee71e4fee3a5",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1000
+    }
   },
   "celery-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -773,7 +947,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "bd5d2127-7c7e-428c-bded-4638ab7094a5"
+    "uuid": "bd5d2127-7c7e-428c-bded-4638ab7094a5",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1100
+    }
   },
   "celery-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -795,7 +974,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "e1f435ac-6232-4289-b5fc-f25b10e882a0"
+    "uuid": "e1f435ac-6232-4289-b5fc-f25b10e882a0",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1200
+    }
   },
   "celery-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -817,7 +1001,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "dcfba07b-4ed9-4dbd-bf70-f0e7bed21711"
+    "uuid": "dcfba07b-4ed9-4dbd-bf70-f0e7bed21711",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1300
+    }
   },
   "celery-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -839,7 +1028,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "0b88acb2-45bb-4ef5-b1e5-54027c4cf70e"
+    "uuid": "0b88acb2-45bb-4ef5-b1e5-54027c4cf70e",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1400
+    }
   },
   "celery-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -861,7 +1055,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "118a3ebb-f3f8-4af6-824d-b1413df5f375"
+    "uuid": "118a3ebb-f3f8-4af6-824d-b1413df5f375",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1500
+    }
   },
   "celery-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -883,7 +1082,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "f02a51a1-8528-4a97-bf79-df228b3dbcdd"
+    "uuid": "f02a51a1-8528-4a97-bf79-df228b3dbcdd",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1600
+    }
   },
   "celery-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -905,7 +1109,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "d22658b0-6638-45f9-8567-a2ad056f7c10"
+    "uuid": "d22658b0-6638-45f9-8567-a2ad056f7c10",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 200
+    }
   },
   "celery-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -927,7 +1136,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "577626d4-7631-4de5-bd71-350b9748a4dd"
+    "uuid": "577626d4-7631-4de5-bd71-350b9748a4dd",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 300
+    }
   },
   "celery-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -949,7 +1163,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "e8b68c0f-5e9f-47c0-b844-35032c46aeee"
+    "uuid": "e8b68c0f-5e9f-47c0-b844-35032c46aeee",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 400
+    }
   },
   "celery-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -971,7 +1190,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "b937bc38-d471-47ee-b416-1bbb91c524ac"
+    "uuid": "b937bc38-d471-47ee-b416-1bbb91c524ac",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 500
+    }
   },
   "celery-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -993,7 +1217,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "b908fb61-f581-4942-9d00-57a828a0660b"
+    "uuid": "b908fb61-f581-4942-9d00-57a828a0660b",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 600
+    }
   },
   "celery-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1015,7 +1244,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "95228111-9945-410f-bd26-ea2bb1f5ddf8"
+    "uuid": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 700
+    }
   },
   "celery-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1037,7 +1271,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338"
+    "uuid": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 800
+    }
   },
   "celery-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1059,7 +1298,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "363508bf-9c3a-4e8e-9865-2b4915d2f097"
+    "uuid": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 900
+    }
   },
   "chartreuse-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1081,7 +1325,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "dac7cf0c-9994-4bba-9d65-41d71f15c470"
+    "uuid": "dac7cf0c-9994-4bba-9d65-41d71f15c470",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 100
+    }
   },
   "chartreuse-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1103,7 +1352,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "e26e1c23-490a-41f6-ba57-dd10bc58e504"
+    "uuid": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1000
+    }
   },
   "chartreuse-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1125,7 +1379,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "20c271df-6e71-4082-b953-d8bf938ff286"
+    "uuid": "20c271df-6e71-4082-b953-d8bf938ff286",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1100
+    }
   },
   "chartreuse-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1147,7 +1406,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb"
+    "uuid": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1200
+    }
   },
   "chartreuse-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1169,7 +1433,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "2e179dee-6bf4-431e-9f0d-1d5300bcca5b"
+    "uuid": "2e179dee-6bf4-431e-9f0d-1d5300bcca5b",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1300
+    }
   },
   "chartreuse-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1191,7 +1460,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "c71243f9-192e-4560-ad45-bcc35d005705"
+    "uuid": "c71243f9-192e-4560-ad45-bcc35d005705",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1400
+    }
   },
   "chartreuse-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1213,7 +1487,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "62a1940c-eeca-4182-b854-fe3c0736772e"
+    "uuid": "62a1940c-eeca-4182-b854-fe3c0736772e",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1500
+    }
   },
   "chartreuse-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1235,7 +1514,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "41eb4e4f-3310-469a-b5f5-cb52e4b47d2a"
+    "uuid": "41eb4e4f-3310-469a-b5f5-cb52e4b47d2a",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1600
+    }
   },
   "chartreuse-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1257,7 +1541,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "af7dfd23-39e4-4e6e-a4b2-992eca33812d"
+    "uuid": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 200
+    }
   },
   "chartreuse-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1279,7 +1568,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "5e69e639-7b35-404f-a144-3e4ab6e16ea7"
+    "uuid": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 300
+    }
   },
   "chartreuse-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1301,7 +1595,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "dba5cb03-a980-48bd-8b35-99dd063763e0"
+    "uuid": "dba5cb03-a980-48bd-8b35-99dd063763e0",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 400
+    }
   },
   "chartreuse-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1323,7 +1622,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "b72ad072-4768-463a-b951-00f1cbe4f657"
+    "uuid": "b72ad072-4768-463a-b951-00f1cbe4f657",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 500
+    }
   },
   "chartreuse-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1345,7 +1649,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb"
+    "uuid": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 600
+    }
   },
   "chartreuse-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1367,7 +1676,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "f50abb60-7047-4e92-a48c-627d98eb85d3"
+    "uuid": "f50abb60-7047-4e92-a48c-627d98eb85d3",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 700
+    }
   },
   "chartreuse-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1389,7 +1703,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "9131b099-6865-4e54-b364-acb3891737f1"
+    "uuid": "9131b099-6865-4e54-b364-acb3891737f1",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 800
+    }
   },
   "chartreuse-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1411,7 +1730,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484"
+    "uuid": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 900
+    }
   },
   "cinnamon-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1433,7 +1757,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "c5b7d7be-3392-4635-9fd0-63045afa893f"
+    "uuid": "c5b7d7be-3392-4635-9fd0-63045afa893f",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 100
+    }
   },
   "cinnamon-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1455,7 +1784,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38"
+    "uuid": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1000
+    }
   },
   "cinnamon-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1477,7 +1811,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "f41f4d00-9e57-4f7c-ad3a-3554bb02bcb0"
+    "uuid": "f41f4d00-9e57-4f7c-ad3a-3554bb02bcb0",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1100
+    }
   },
   "cinnamon-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1499,7 +1838,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "5bc8f9af-1607-466a-8a85-72053519d95f"
+    "uuid": "5bc8f9af-1607-466a-8a85-72053519d95f",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1200
+    }
   },
   "cinnamon-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1521,7 +1865,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "fe8b0be8-2dfd-404b-808e-8d411f1cb168"
+    "uuid": "fe8b0be8-2dfd-404b-808e-8d411f1cb168",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1300
+    }
   },
   "cinnamon-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1543,7 +1892,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "3e8926d1-6cd5-4b52-a856-cb9d1bcb907d"
+    "uuid": "3e8926d1-6cd5-4b52-a856-cb9d1bcb907d",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1400
+    }
   },
   "cinnamon-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1565,7 +1919,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "a6ed40d2-aee1-4458-b8ee-abf21d8fc029"
+    "uuid": "a6ed40d2-aee1-4458-b8ee-abf21d8fc029",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1500
+    }
   },
   "cinnamon-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1587,7 +1946,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "9e233bbb-1685-4fc6-9d27-728d4043387f"
+    "uuid": "9e233bbb-1685-4fc6-9d27-728d4043387f",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1600
+    }
   },
   "cinnamon-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1609,7 +1973,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "322b71ea-2187-4fce-90e7-2db63d037368"
+    "uuid": "322b71ea-2187-4fce-90e7-2db63d037368",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 200
+    }
   },
   "cinnamon-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1631,7 +2000,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "3527fc94-a410-4933-bbb7-bedecd37e477"
+    "uuid": "3527fc94-a410-4933-bbb7-bedecd37e477",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 300
+    }
   },
   "cinnamon-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1653,7 +2027,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "e2246f50-4876-48fe-a56e-e859c9723e89"
+    "uuid": "e2246f50-4876-48fe-a56e-e859c9723e89",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 400
+    }
   },
   "cinnamon-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1675,7 +2054,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "7527ee4f-a4cb-4e10-b0f2-6239bb9eeff3"
+    "uuid": "7527ee4f-a4cb-4e10-b0f2-6239bb9eeff3",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 500
+    }
   },
   "cinnamon-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1697,7 +2081,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "51da608c-3871-48de-8b06-615adbc550ca"
+    "uuid": "51da608c-3871-48de-8b06-615adbc550ca",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 600
+    }
   },
   "cinnamon-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1719,7 +2108,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "09b8c3b9-1887-4bb9-a273-dbe1a01446f7"
+    "uuid": "09b8c3b9-1887-4bb9-a273-dbe1a01446f7",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 700
+    }
   },
   "cinnamon-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1741,7 +2135,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f"
+    "uuid": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 800
+    }
   },
   "cinnamon-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1763,7 +2162,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9"
+    "uuid": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 900
+    }
   },
   "cyan-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1785,7 +2189,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "ba6486c3-b48d-4d4e-952e-c179db5671df"
+    "uuid": "ba6486c3-b48d-4d4e-952e-c179db5671df",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 100
+    }
   },
   "cyan-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1807,7 +2216,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f"
+    "uuid": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1000
+    }
   },
   "cyan-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1829,7 +2243,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "6d22fbe4-8c4e-4aff-8cf9-2061feee46f9"
+    "uuid": "6d22fbe4-8c4e-4aff-8cf9-2061feee46f9",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1100
+    }
   },
   "cyan-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1851,7 +2270,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "ff28bc70-c903-4ee0-85b1-8334d2f7263f"
+    "uuid": "ff28bc70-c903-4ee0-85b1-8334d2f7263f",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1200
+    }
   },
   "cyan-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1873,7 +2297,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "225024f7-20bb-4227-a35f-2cebe558113c"
+    "uuid": "225024f7-20bb-4227-a35f-2cebe558113c",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1300
+    }
   },
   "cyan-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1895,7 +2324,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "3409b02f-7492-474b-8d63-f67efb123522"
+    "uuid": "3409b02f-7492-474b-8d63-f67efb123522",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1400
+    }
   },
   "cyan-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1917,7 +2351,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "c417cbf7-e9e6-4142-8392-08b96fe199e4"
+    "uuid": "c417cbf7-e9e6-4142-8392-08b96fe199e4",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1500
+    }
   },
   "cyan-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1939,7 +2378,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "2702626c-ab55-4b59-b4f0-f964531d11a0"
+    "uuid": "2702626c-ab55-4b59-b4f0-f964531d11a0",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1600
+    }
   },
   "cyan-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1961,7 +2405,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "c7fd6eda-f850-4dec-a883-e970cdfca622"
+    "uuid": "c7fd6eda-f850-4dec-a883-e970cdfca622",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 200
+    }
   },
   "cyan-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1983,7 +2432,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7"
+    "uuid": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 300
+    }
   },
   "cyan-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2005,7 +2459,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "61be07be-d428-4fe9-8e79-96df63980556"
+    "uuid": "61be07be-d428-4fe9-8e79-96df63980556",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 400
+    }
   },
   "cyan-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2027,7 +2486,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "78fb712e-40e4-4026-881a-a71250b35ceb"
+    "uuid": "78fb712e-40e4-4026-881a-a71250b35ceb",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 500
+    }
   },
   "cyan-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2049,7 +2513,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670"
+    "uuid": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 600
+    }
   },
   "cyan-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2071,7 +2540,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "2f04ecb9-b406-4eeb-ba9d-ea8d6d7d850a"
+    "uuid": "2f04ecb9-b406-4eeb-ba9d-ea8d6d7d850a",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 700
+    }
   },
   "cyan-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2093,7 +2567,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "96e75cf8-2f23-47ee-b79b-618a28d2cceb"
+    "uuid": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 800
+    }
   },
   "cyan-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2115,7 +2594,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "ee2ce3c0-207d-4c24-b939-189b9b9e2972"
+    "uuid": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 900
+    }
   },
   "fuchsia-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2137,7 +2621,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "203daf80-39e9-4362-bff4-6a9cc609a987"
+    "uuid": "203daf80-39e9-4362-bff4-6a9cc609a987",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 100
+    }
   },
   "fuchsia-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2159,7 +2648,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "0f412425-de6f-48f1-9d0f-0310d933d244"
+    "uuid": "0f412425-de6f-48f1-9d0f-0310d933d244",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1000
+    }
   },
   "fuchsia-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2181,7 +2675,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "3ffd0b97-3692-400d-b6d6-9147b6028fbe"
+    "uuid": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1100
+    }
   },
   "fuchsia-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2203,7 +2702,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "b66743ea-ab53-4642-b14d-60f61783686e"
+    "uuid": "b66743ea-ab53-4642-b14d-60f61783686e",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1200
+    }
   },
   "fuchsia-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2225,7 +2729,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "64e2235c-ef58-4c57-98f7-2092ae60c1bc"
+    "uuid": "64e2235c-ef58-4c57-98f7-2092ae60c1bc",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1300
+    }
   },
   "fuchsia-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2247,7 +2756,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "63bb89b6-97d3-4b2b-bb18-d5bcb443d7b8"
+    "uuid": "63bb89b6-97d3-4b2b-bb18-d5bcb443d7b8",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1400
+    }
   },
   "fuchsia-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2269,7 +2783,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "4f31cd4a-1aa5-4f68-8999-b0dfbb3a1227"
+    "uuid": "4f31cd4a-1aa5-4f68-8999-b0dfbb3a1227",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1500
+    }
   },
   "fuchsia-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2291,7 +2810,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "7f7a1ea4-5833-48db-8aa5-230808d39cf7"
+    "uuid": "7f7a1ea4-5833-48db-8aa5-230808d39cf7",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1600
+    }
   },
   "fuchsia-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2313,7 +2837,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "078936af-2556-4ee2-a849-e7f19088b0ee"
+    "uuid": "078936af-2556-4ee2-a849-e7f19088b0ee",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 200
+    }
   },
   "fuchsia-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2335,7 +2864,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "09aef364-8827-48fa-9888-b0424ce8981c"
+    "uuid": "09aef364-8827-48fa-9888-b0424ce8981c",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 300
+    }
   },
   "fuchsia-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2357,7 +2891,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "2136078a-adb2-4011-89fc-ef5863f46033"
+    "uuid": "2136078a-adb2-4011-89fc-ef5863f46033",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 400
+    }
   },
   "fuchsia-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2379,7 +2918,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "53fc62b5-9f54-45b7-af63-0d14c72d3d8c"
+    "uuid": "53fc62b5-9f54-45b7-af63-0d14c72d3d8c",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 500
+    }
   },
   "fuchsia-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2401,7 +2945,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "44f05566-476f-407f-b6d6-a211b2754fa5"
+    "uuid": "44f05566-476f-407f-b6d6-a211b2754fa5",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 600
+    }
   },
   "fuchsia-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2423,7 +2972,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "1149f4f6-5cd0-4792-9dad-189c2a75a542"
+    "uuid": "1149f4f6-5cd0-4792-9dad-189c2a75a542",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 700
+    }
   },
   "fuchsia-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2445,7 +2999,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "1bcf666f-165b-4ec9-b360-c891109a2f5c"
+    "uuid": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 800
+    }
   },
   "fuchsia-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2467,7 +3026,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "ad5957c2-2829-450e-973c-bf0075e1fa67"
+    "uuid": "ad5957c2-2829-450e-973c-bf0075e1fa67",
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 900
+    }
   },
   "gradient-stop-1-avatar": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
@@ -2507,7 +3071,12 @@
         "value": "rgb(228, 234, 249)"
       }
     },
-    "uuid": "16d156d1-4af9-4878-9984-643a2c08aff8"
+    "uuid": "16d156d1-4af9-4878-9984-643a2c08aff8",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 100
+    }
   },
   "gray-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2529,7 +3098,12 @@
         "value": "rgb(0, 0, 0)"
       }
     },
-    "uuid": "dbe6ded6-404a-4011-9a64-d2375eca73d3"
+    "uuid": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 1000
+    }
   },
   "gray-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2551,7 +3125,12 @@
         "value": "rgb(214, 224, 246)"
       }
     },
-    "uuid": "8a182a6b-149b-41a6-b608-fc247bcc298f"
+    "uuid": "8a182a6b-149b-41a6-b608-fc247bcc298f",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 200
+    }
   },
   "gray-25": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2573,7 +3152,12 @@
         "value": "rgb(254, 254, 255)"
       }
     },
-    "uuid": "306be0f2-7644-4480-8c83-3bdb1afed54e"
+    "uuid": "306be0f2-7644-4480-8c83-3bdb1afed54e",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 25
+    }
   },
   "gray-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2595,7 +3179,12 @@
         "value": "rgb(207, 219, 245)"
       }
     },
-    "uuid": "dac01571-b26a-4aef-ace7-d0e34e917570"
+    "uuid": "dac01571-b26a-4aef-ace7-d0e34e917570",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 300
+    }
   },
   "gray-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2617,7 +3206,12 @@
         "value": "rgb(180, 199, 239)"
       }
     },
-    "uuid": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f"
+    "uuid": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 400
+    }
   },
   "gray-50": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2639,7 +3233,12 @@
         "value": "rgb(246, 248, 253)"
       }
     },
-    "uuid": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee"
+    "uuid": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 50
+    }
   },
   "gray-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2661,7 +3260,12 @@
         "value": "rgb(108, 142, 217)"
       }
     },
-    "uuid": "60077744-c665-4c80-8f88-dff31a10219e"
+    "uuid": "60077744-c665-4c80-8f88-dff31a10219e",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 500
+    }
   },
   "gray-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2683,7 +3287,12 @@
         "value": "rgb(72, 110, 194)"
       }
     },
-    "uuid": "b49953b7-ef80-4e57-b1e7-546279b36bb4"
+    "uuid": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 600
+    }
   },
   "gray-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2705,7 +3314,12 @@
         "value": "rgb(44, 77, 149)"
       }
     },
-    "uuid": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680"
+    "uuid": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 700
+    }
   },
   "gray-75": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2727,7 +3341,12 @@
         "value": "rgb(241, 244, 251)"
       }
     },
-    "uuid": "5793fc53-b676-4bc8-b5d4-2a2394c853f5"
+    "uuid": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 75
+    }
   },
   "gray-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2749,7 +3368,12 @@
         "value": "rgb(25, 46, 93)"
       }
     },
-    "uuid": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22"
+    "uuid": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 800
+    }
   },
   "gray-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2771,7 +3395,12 @@
         "value": "rgb(10, 19, 39)"
       }
     },
-    "uuid": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a"
+    "uuid": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 900
+    }
   },
   "green-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2793,7 +3422,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "7c7c0136-2623-468d-a12f-678d21973613"
+    "uuid": "7c7c0136-2623-468d-a12f-678d21973613",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 100
+    }
   },
   "green-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2815,7 +3449,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "23d8a797-8f40-4072-868d-6213c3cd6c0a"
+    "uuid": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1000
+    }
   },
   "green-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2837,7 +3476,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc"
+    "uuid": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1100
+    }
   },
   "green-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2859,7 +3503,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "365a47c9-43c8-45a4-8cb8-07c552aca28b"
+    "uuid": "365a47c9-43c8-45a4-8cb8-07c552aca28b",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1200
+    }
   },
   "green-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2881,7 +3530,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "6668c6c5-b66e-4c83-a95a-37fde594296b"
+    "uuid": "6668c6c5-b66e-4c83-a95a-37fde594296b",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1300
+    }
   },
   "green-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2903,7 +3557,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9"
+    "uuid": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1400
+    }
   },
   "green-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2925,7 +3584,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "54ef3b06-ac50-4176-af22-86d0c73d5d13"
+    "uuid": "54ef3b06-ac50-4176-af22-86d0c73d5d13",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1500
+    }
   },
   "green-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2947,7 +3611,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "2d45aad7-eb31-46f9-a73f-69498e466a29"
+    "uuid": "2d45aad7-eb31-46f9-a73f-69498e466a29",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1600
+    }
   },
   "green-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2969,7 +3638,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "4f7df0e3-fed5-4f7a-8783-c367c1457796"
+    "uuid": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 200
+    }
   },
   "green-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2991,7 +3665,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c"
+    "uuid": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 300
+    }
   },
   "green-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3013,7 +3692,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "6673709d-2154-4189-ad4f-e6867ecfe744"
+    "uuid": "6673709d-2154-4189-ad4f-e6867ecfe744",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 400
+    }
   },
   "green-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3035,7 +3719,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "a63a12c8-2526-49b0-a918-543af6deb103"
+    "uuid": "a63a12c8-2526-49b0-a918-543af6deb103",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 500
+    }
   },
   "green-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3057,7 +3746,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "26b0bdde-2ea0-456c-8ade-a521e8799613"
+    "uuid": "26b0bdde-2ea0-456c-8ade-a521e8799613",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 600
+    }
   },
   "green-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3079,7 +3773,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "a2d13cc0-1445-46ca-b941-c50f04127376"
+    "uuid": "a2d13cc0-1445-46ca-b941-c50f04127376",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 700
+    }
   },
   "green-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3101,7 +3800,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "6d8cdeaa-c122-4bba-9867-8634e78e767a"
+    "uuid": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 800
+    }
   },
   "green-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3123,7 +3827,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "c0f6d150-e59f-4ee9-bf85-087c67258767"
+    "uuid": "c0f6d150-e59f-4ee9-bf85-087c67258767",
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 900
+    }
   },
   "indigo-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3145,7 +3854,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e"
+    "uuid": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 100
+    }
   },
   "indigo-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3167,7 +3881,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "7e4d3279-2b61-46f6-8eb3-7636f564f591"
+    "uuid": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1000
+    }
   },
   "indigo-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3189,7 +3908,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb"
+    "uuid": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1100
+    }
   },
   "indigo-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3211,7 +3935,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "027533ce-0ec5-4f37-ac0e-7ca8aa3ef922"
+    "uuid": "027533ce-0ec5-4f37-ac0e-7ca8aa3ef922",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1200
+    }
   },
   "indigo-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3233,7 +3962,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "f48f431b-f811-4f9c-bd10-61c65de8ad40"
+    "uuid": "f48f431b-f811-4f9c-bd10-61c65de8ad40",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1300
+    }
   },
   "indigo-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3255,7 +3989,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "821ebda4-7380-4132-ba50-bddeaaaf1aa0"
+    "uuid": "821ebda4-7380-4132-ba50-bddeaaaf1aa0",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1400
+    }
   },
   "indigo-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3277,7 +4016,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "ad005eac-7b19-4f23-9f50-514fc1b07f8c"
+    "uuid": "ad005eac-7b19-4f23-9f50-514fc1b07f8c",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1500
+    }
   },
   "indigo-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3299,7 +4043,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "64ef5b19-c162-4283-9f5d-1fe46ccf6dd8"
+    "uuid": "64ef5b19-c162-4283-9f5d-1fe46ccf6dd8",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1600
+    }
   },
   "indigo-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3321,7 +4070,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "03acbe76-ab2c-493b-8dbf-624802f4ff1d"
+    "uuid": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 200
+    }
   },
   "indigo-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3343,7 +4097,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "571bb191-0f29-4a11-95a2-831a454b4df1"
+    "uuid": "571bb191-0f29-4a11-95a2-831a454b4df1",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 300
+    }
   },
   "indigo-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3365,7 +4124,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "17d0ac0b-d180-4027-b424-5325e5954cf0"
+    "uuid": "17d0ac0b-d180-4027-b424-5325e5954cf0",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 400
+    }
   },
   "indigo-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3387,7 +4151,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "57800450-9118-40df-aa96-739ef71a0914"
+    "uuid": "57800450-9118-40df-aa96-739ef71a0914",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 500
+    }
   },
   "indigo-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3409,7 +4178,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "906f3a03-47e3-4763-97e6-376cf4545429"
+    "uuid": "906f3a03-47e3-4763-97e6-376cf4545429",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 600
+    }
   },
   "indigo-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3431,7 +4205,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac"
+    "uuid": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 700
+    }
   },
   "indigo-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3453,7 +4232,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "54c17da1-02fe-4b9c-9d07-0d5a3e839310"
+    "uuid": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 800
+    }
   },
   "indigo-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3475,7 +4259,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "f482731c-c07e-4323-bf79-6e45cdce4052"
+    "uuid": "f482731c-c07e-4323-bf79-6e45cdce4052",
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 900
+    }
   },
   "magenta-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3497,7 +4286,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "36840c2e-6b57-484b-911a-f915c8a5c086"
+    "uuid": "36840c2e-6b57-484b-911a-f915c8a5c086",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 100
+    }
   },
   "magenta-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3519,7 +4313,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "66f59c7d-f12b-4b8b-a472-c196deec527c"
+    "uuid": "66f59c7d-f12b-4b8b-a472-c196deec527c",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1000
+    }
   },
   "magenta-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3541,7 +4340,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "03d47c47-99f0-4ed3-a275-7659dee3ca8e"
+    "uuid": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1100
+    }
   },
   "magenta-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3563,7 +4367,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "b98f20e8-32f0-4ca4-80a3-e8a280060b76"
+    "uuid": "b98f20e8-32f0-4ca4-80a3-e8a280060b76",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1200
+    }
   },
   "magenta-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3585,7 +4394,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "1b7b4db7-c2a7-4a3c-a4dc-b7da54eb3dde"
+    "uuid": "1b7b4db7-c2a7-4a3c-a4dc-b7da54eb3dde",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1300
+    }
   },
   "magenta-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3607,7 +4421,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "cf007ff4-06dc-434e-95bb-20f941a1fb78"
+    "uuid": "cf007ff4-06dc-434e-95bb-20f941a1fb78",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1400
+    }
   },
   "magenta-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3629,7 +4448,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "72bd2742-4716-42a3-893a-ee7ae83dfa90"
+    "uuid": "72bd2742-4716-42a3-893a-ee7ae83dfa90",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1500
+    }
   },
   "magenta-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3651,7 +4475,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "14b3aac6-cd51-4591-afca-4da472c4bf1e"
+    "uuid": "14b3aac6-cd51-4591-afca-4da472c4bf1e",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1600
+    }
   },
   "magenta-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3673,7 +4502,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "f7909075-b049-43d4-bae5-bd74c7827174"
+    "uuid": "f7909075-b049-43d4-bae5-bd74c7827174",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 200
+    }
   },
   "magenta-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3695,7 +4529,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856"
+    "uuid": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 300
+    }
   },
   "magenta-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3717,7 +4556,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "cd64bdbd-3a45-4643-a3b7-32aa72a10445"
+    "uuid": "cd64bdbd-3a45-4643-a3b7-32aa72a10445",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 400
+    }
   },
   "magenta-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3739,7 +4583,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "56c78f18-9687-4d7a-8291-22bc12071897"
+    "uuid": "56c78f18-9687-4d7a-8291-22bc12071897",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 500
+    }
   },
   "magenta-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3761,7 +4610,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "33d7cba7-516c-452d-b359-34827edead60"
+    "uuid": "33d7cba7-516c-452d-b359-34827edead60",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 600
+    }
   },
   "magenta-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3783,7 +4637,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9"
+    "uuid": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 700
+    }
   },
   "magenta-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3805,7 +4664,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "ff51c954-677f-4053-8426-b7fbc3d2d155"
+    "uuid": "ff51c954-677f-4053-8426-b7fbc3d2d155",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 800
+    }
   },
   "magenta-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3827,7 +4691,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "d8eb420e-b2d5-4bbe-baad-955009069eff"
+    "uuid": "d8eb420e-b2d5-4bbe-baad-955009069eff",
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 900
+    }
   },
   "orange-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3849,7 +4718,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "b31d8010-6701-4a59-8f7e-3ae680755c17"
+    "uuid": "b31d8010-6701-4a59-8f7e-3ae680755c17",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 100
+    }
   },
   "orange-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3871,7 +4745,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2"
+    "uuid": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1000
+    }
   },
   "orange-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3893,7 +4772,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "a0f0fc25-7be4-4ff7-b756-47b018352a7a"
+    "uuid": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1100
+    }
   },
   "orange-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3915,7 +4799,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "cdffa59a-a440-4e1b-a9f4-c45755f954b8"
+    "uuid": "cdffa59a-a440-4e1b-a9f4-c45755f954b8",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1200
+    }
   },
   "orange-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3937,7 +4826,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "322a161e-bbda-4369-b4ec-6140ccbb01c4"
+    "uuid": "322a161e-bbda-4369-b4ec-6140ccbb01c4",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1300
+    }
   },
   "orange-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3959,7 +4853,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb"
+    "uuid": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1400
+    }
   },
   "orange-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -3981,7 +4880,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "dae987e5-c3ee-405b-83a9-3d9e054f95b1"
+    "uuid": "dae987e5-c3ee-405b-83a9-3d9e054f95b1",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1500
+    }
   },
   "orange-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4003,7 +4907,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3"
+    "uuid": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1600
+    }
   },
   "orange-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4025,7 +4934,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "a4287e01-3b0a-45e2-9118-d2ec157805c3"
+    "uuid": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 200
+    }
   },
   "orange-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4047,7 +4961,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "ec281039-7256-4db9-8261-d0af048d3e6d"
+    "uuid": "ec281039-7256-4db9-8261-d0af048d3e6d",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 300
+    }
   },
   "orange-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4069,7 +4988,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3"
+    "uuid": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 400
+    }
   },
   "orange-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4091,7 +5015,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "9e3e4263-9515-4937-b33f-3af341e57073"
+    "uuid": "9e3e4263-9515-4937-b33f-3af341e57073",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 500
+    }
   },
   "orange-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4113,7 +5042,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "1c185916-6dc9-41df-b01d-24187d7d6fb0"
+    "uuid": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 600
+    }
   },
   "orange-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4135,7 +5069,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "a43502bd-ffae-4544-a3d0-08288cff141d"
+    "uuid": "a43502bd-ffae-4544-a3d0-08288cff141d",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 700
+    }
   },
   "orange-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4157,7 +5096,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "bed559d1-c097-40ad-8d3a-2866198832c2"
+    "uuid": "bed559d1-c097-40ad-8d3a-2866198832c2",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 800
+    }
   },
   "orange-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4179,7 +5123,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "b2e24ca2-6bfb-43c6-ab37-f6107563a371"
+    "uuid": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 900
+    }
   },
   "pink-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4201,7 +5150,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "d74ec156-cd49-484d-9cf3-aef8707fe0b2"
+    "uuid": "d74ec156-cd49-484d-9cf3-aef8707fe0b2",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 100
+    }
   },
   "pink-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4223,7 +5177,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "c937f1fd-146d-4558-a42d-c8aafc5f4589"
+    "uuid": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1000
+    }
   },
   "pink-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4245,7 +5204,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "6e45d7ec-2d6b-4cea-a99e-3e0b60f89579"
+    "uuid": "6e45d7ec-2d6b-4cea-a99e-3e0b60f89579",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1100
+    }
   },
   "pink-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4267,7 +5231,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "6d2d02df-d772-42ef-8b7e-a8443c38513b"
+    "uuid": "6d2d02df-d772-42ef-8b7e-a8443c38513b",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1200
+    }
   },
   "pink-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4289,7 +5258,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "be724277-3ab7-4bfa-877d-e58a0c9df662"
+    "uuid": "be724277-3ab7-4bfa-877d-e58a0c9df662",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1300
+    }
   },
   "pink-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4311,7 +5285,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "9ba11179-dde4-478a-8c04-9d7664b9a438"
+    "uuid": "9ba11179-dde4-478a-8c04-9d7664b9a438",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1400
+    }
   },
   "pink-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4333,7 +5312,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "e1bc1107-0b97-47ff-a7c5-6c5336764d2d"
+    "uuid": "e1bc1107-0b97-47ff-a7c5-6c5336764d2d",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1500
+    }
   },
   "pink-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4355,7 +5339,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "6bb71c0d-2f9b-4ab9-9ad7-5930f559e99b"
+    "uuid": "6bb71c0d-2f9b-4ab9-9ad7-5930f559e99b",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1600
+    }
   },
   "pink-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4377,7 +5366,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "500888e2-48c7-4962-8323-f160cc7a07d6"
+    "uuid": "500888e2-48c7-4962-8323-f160cc7a07d6",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 200
+    }
   },
   "pink-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4399,7 +5393,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "7bb48388-b3bc-47eb-a7ab-b15327996714"
+    "uuid": "7bb48388-b3bc-47eb-a7ab-b15327996714",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 300
+    }
   },
   "pink-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4421,7 +5420,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "7185247f-126a-48ee-9c40-9c5e8bb77838"
+    "uuid": "7185247f-126a-48ee-9c40-9c5e8bb77838",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 400
+    }
   },
   "pink-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4443,7 +5447,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "dec3c71f-42c7-4e91-89a7-db4c88366fd2"
+    "uuid": "dec3c71f-42c7-4e91-89a7-db4c88366fd2",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 500
+    }
   },
   "pink-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4465,7 +5474,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "f36f7f59-44b3-48d7-aed5-32996709c9db"
+    "uuid": "f36f7f59-44b3-48d7-aed5-32996709c9db",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 600
+    }
   },
   "pink-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4487,7 +5501,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9"
+    "uuid": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 700
+    }
   },
   "pink-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4509,7 +5528,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987"
+    "uuid": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 800
+    }
   },
   "pink-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4531,7 +5555,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "242b7614-2f02-4227-a94c-7b7d419e1b4e"
+    "uuid": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 900
+    }
   },
   "purple-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4553,7 +5582,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "7b8cb760-9a04-4274-98bb-66dd657e814b"
+    "uuid": "7b8cb760-9a04-4274-98bb-66dd657e814b",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 100
+    }
   },
   "purple-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4575,7 +5609,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "6f0335da-6c21-4946-9a67-e6e908cc2aaa"
+    "uuid": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1000
+    }
   },
   "purple-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4597,7 +5636,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "bd31f22a-d6c5-4ec6-a40b-cec88d085734"
+    "uuid": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1100
+    }
   },
   "purple-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4619,7 +5663,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "72a305b3-3696-4d92-8f74-46694168c75b"
+    "uuid": "72a305b3-3696-4d92-8f74-46694168c75b",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1200
+    }
   },
   "purple-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4641,7 +5690,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "82adc7f4-119c-407c-923f-3496a76b3a6e"
+    "uuid": "82adc7f4-119c-407c-923f-3496a76b3a6e",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1300
+    }
   },
   "purple-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4663,7 +5717,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "3ea73e1d-91ba-4801-837c-ae908fc74465"
+    "uuid": "3ea73e1d-91ba-4801-837c-ae908fc74465",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1400
+    }
   },
   "purple-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4685,7 +5744,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "ba35d83a-03b8-4e07-9a85-71e61e472818"
+    "uuid": "ba35d83a-03b8-4e07-9a85-71e61e472818",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1500
+    }
   },
   "purple-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4707,7 +5771,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "2eed244c-3803-4922-9d87-8f906a05f619"
+    "uuid": "2eed244c-3803-4922-9d87-8f906a05f619",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1600
+    }
   },
   "purple-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4729,7 +5798,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "745626e1-7c10-4e35-a99f-03c252bd441d"
+    "uuid": "745626e1-7c10-4e35-a99f-03c252bd441d",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 200
+    }
   },
   "purple-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4751,7 +5825,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "61b16d70-8650-4e61-9446-a5f2c4f197b9"
+    "uuid": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 300
+    }
   },
   "purple-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4773,7 +5852,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "8b7aba6a-1ab0-46b0-834d-4aab42892a36"
+    "uuid": "8b7aba6a-1ab0-46b0-834d-4aab42892a36",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 400
+    }
   },
   "purple-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4795,7 +5879,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "e4039631-2769-464d-800c-ad084597761c"
+    "uuid": "e4039631-2769-464d-800c-ad084597761c",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 500
+    }
   },
   "purple-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4817,7 +5906,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "cfc7871e-bb08-4b7e-8fe7-257b9e29c9ee"
+    "uuid": "cfc7871e-bb08-4b7e-8fe7-257b9e29c9ee",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 600
+    }
   },
   "purple-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4839,7 +5933,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e"
+    "uuid": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 700
+    }
   },
   "purple-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4861,7 +5960,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f"
+    "uuid": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 800
+    }
   },
   "purple-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4883,7 +5987,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "630e0415-8751-4a1c-8f1f-96800ff93802"
+    "uuid": "630e0415-8751-4a1c-8f1f-96800ff93802",
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 900
+    }
   },
   "red-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4905,7 +6014,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "921d4bb8-f5b0-4955-a495-294864cf4ca5"
+    "uuid": "921d4bb8-f5b0-4955-a495-294864cf4ca5",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 100
+    }
   },
   "red-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4927,7 +6041,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "07ad3c80-0ca4-4e23-9daa-42c97c558678"
+    "uuid": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1000
+    }
   },
   "red-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4949,7 +6068,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "5485c698-0ea9-47d7-b81d-43f0647c4078"
+    "uuid": "5485c698-0ea9-47d7-b81d-43f0647c4078",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1100
+    }
   },
   "red-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4971,7 +6095,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "403564fd-fda3-4ef5-a68e-96c6f5a93a93"
+    "uuid": "403564fd-fda3-4ef5-a68e-96c6f5a93a93",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1200
+    }
   },
   "red-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -4993,7 +6122,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849"
+    "uuid": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1300
+    }
   },
   "red-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5015,7 +6149,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "590136e1-3127-4540-9689-05b1161bd4c2"
+    "uuid": "590136e1-3127-4540-9689-05b1161bd4c2",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1400
+    }
   },
   "red-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5037,7 +6176,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e"
+    "uuid": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1500
+    }
   },
   "red-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5059,7 +6203,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "e042de3e-9b82-4229-880d-e1e4b1af80b7"
+    "uuid": "e042de3e-9b82-4229-880d-e1e4b1af80b7",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1600
+    }
   },
   "red-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5081,7 +6230,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "ebf4003d-ce93-4026-8e3b-13e128e014e7"
+    "uuid": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 200
+    }
   },
   "red-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5103,7 +6257,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242"
+    "uuid": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 300
+    }
   },
   "red-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5125,7 +6284,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5"
+    "uuid": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 400
+    }
   },
   "red-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5147,7 +6311,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "33e7f73d-be80-4961-bcd7-6088fddadf44"
+    "uuid": "33e7f73d-be80-4961-bcd7-6088fddadf44",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 500
+    }
   },
   "red-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5169,7 +6338,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "2bad908f-065a-45fb-9a75-6f3ae0da19a4"
+    "uuid": "2bad908f-065a-45fb-9a75-6f3ae0da19a4",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 600
+    }
   },
   "red-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5191,7 +6365,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "e96c54da-a4e2-4735-91b4-784d0ce275d0"
+    "uuid": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 700
+    }
   },
   "red-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5213,7 +6392,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "cee84ce0-439b-444c-bb7e-a77777da716d"
+    "uuid": "cee84ce0-439b-444c-bb7e-a77777da716d",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 800
+    }
   },
   "red-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5235,7 +6419,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8"
+    "uuid": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 900
+    }
   },
   "seafoam-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5257,7 +6446,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "68294acd-b557-4990-a326-9b8c724c5d2e"
+    "uuid": "68294acd-b557-4990-a326-9b8c724c5d2e",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 100
+    }
   },
   "seafoam-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5279,7 +6473,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "487ae86b-24c7-4587-87b0-008fca574e84"
+    "uuid": "487ae86b-24c7-4587-87b0-008fca574e84",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1000
+    }
   },
   "seafoam-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5301,7 +6500,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "17f2ffaf-07ad-4cf2-9224-1bee76e4c3ac"
+    "uuid": "17f2ffaf-07ad-4cf2-9224-1bee76e4c3ac",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1100
+    }
   },
   "seafoam-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5323,7 +6527,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "50172156-b818-458f-aae6-d24bcd128272"
+    "uuid": "50172156-b818-458f-aae6-d24bcd128272",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1200
+    }
   },
   "seafoam-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5345,7 +6554,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "838807a0-fae7-4fe6-be9d-c6c2ad0f751c"
+    "uuid": "838807a0-fae7-4fe6-be9d-c6c2ad0f751c",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1300
+    }
   },
   "seafoam-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5367,7 +6581,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "b179c26d-cd65-419e-b4ad-8af2ec3e478f"
+    "uuid": "b179c26d-cd65-419e-b4ad-8af2ec3e478f",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1400
+    }
   },
   "seafoam-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5389,7 +6608,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "1e24bea9-ddb5-4da1-96fe-0523053abedd"
+    "uuid": "1e24bea9-ddb5-4da1-96fe-0523053abedd",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1500
+    }
   },
   "seafoam-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5411,7 +6635,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "4afc4f90-8773-436d-b19c-817b2041ff03"
+    "uuid": "4afc4f90-8773-436d-b19c-817b2041ff03",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1600
+    }
   },
   "seafoam-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5433,7 +6662,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "92b7d64b-e8ae-4261-adf3-55b7435fce69"
+    "uuid": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 200
+    }
   },
   "seafoam-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5455,7 +6689,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9"
+    "uuid": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 300
+    }
   },
   "seafoam-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5477,7 +6716,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "63882463-c739-495b-b164-317ebcf97e35"
+    "uuid": "63882463-c739-495b-b164-317ebcf97e35",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 400
+    }
   },
   "seafoam-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5499,7 +6743,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "455bbf75-71fe-470d-80f9-abe5784270c3"
+    "uuid": "455bbf75-71fe-470d-80f9-abe5784270c3",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 500
+    }
   },
   "seafoam-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5521,7 +6770,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "dbb00476-446d-4243-9e80-291c6ee1602d"
+    "uuid": "dbb00476-446d-4243-9e80-291c6ee1602d",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 600
+    }
   },
   "seafoam-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5543,7 +6797,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "ad52345b-0360-4819-9fe8-b6e07249810d"
+    "uuid": "ad52345b-0360-4819-9fe8-b6e07249810d",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 700
+    }
   },
   "seafoam-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5565,7 +6824,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "472d8ac6-f0ae-4a37-9990-28773c10c959"
+    "uuid": "472d8ac6-f0ae-4a37-9990-28773c10c959",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 800
+    }
   },
   "seafoam-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5587,7 +6851,12 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "de37323c-69e7-476b-a62e-467e104c5d36"
+    "uuid": "de37323c-69e7-476b-a62e-467e104c5d36",
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 900
+    }
   },
   "silver-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5609,7 +6878,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "35feabca-281f-4eab-8f61-8dc672b1f390"
+    "uuid": "35feabca-281f-4eab-8f61-8dc672b1f390",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 100
+    }
   },
   "silver-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5631,7 +6905,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86"
+    "uuid": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1000
+    }
   },
   "silver-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5653,7 +6932,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "b00f5d31-8cc1-4883-ab5d-8ce078b0b147"
+    "uuid": "b00f5d31-8cc1-4883-ab5d-8ce078b0b147",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1100
+    }
   },
   "silver-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5675,7 +6959,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "aea2f725-ee6e-4ca7-b272-6090a8c85c17"
+    "uuid": "aea2f725-ee6e-4ca7-b272-6090a8c85c17",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1200
+    }
   },
   "silver-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5697,7 +6986,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "ba7a5494-8be0-43d5-8523-6314167026c0"
+    "uuid": "ba7a5494-8be0-43d5-8523-6314167026c0",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1300
+    }
   },
   "silver-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5719,7 +7013,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "51d48c84-cc9c-4cce-9fa3-84988492b5a0"
+    "uuid": "51d48c84-cc9c-4cce-9fa3-84988492b5a0",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1400
+    }
   },
   "silver-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5741,7 +7040,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "a73d4598-2974-4efd-a6db-34fac3b649d5"
+    "uuid": "a73d4598-2974-4efd-a6db-34fac3b649d5",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1500
+    }
   },
   "silver-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5763,7 +7067,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "29e4253c-f215-4f5b-aa15-ef8593b70c57"
+    "uuid": "29e4253c-f215-4f5b-aa15-ef8593b70c57",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1600
+    }
   },
   "silver-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5785,7 +7094,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1"
+    "uuid": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 200
+    }
   },
   "silver-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5807,7 +7121,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28"
+    "uuid": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 300
+    }
   },
   "silver-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5829,7 +7148,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "2ac14b55-357e-43a0-85f3-c41a8f3697c8"
+    "uuid": "2ac14b55-357e-43a0-85f3-c41a8f3697c8",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 400
+    }
   },
   "silver-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5851,7 +7175,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "83e5106a-8420-4013-bcb3-58ba8a2b5d08"
+    "uuid": "83e5106a-8420-4013-bcb3-58ba8a2b5d08",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 500
+    }
   },
   "silver-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5873,7 +7202,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "d360e142-a676-4474-89de-a6e478860fbe"
+    "uuid": "d360e142-a676-4474-89de-a6e478860fbe",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 600
+    }
   },
   "silver-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5895,7 +7229,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3"
+    "uuid": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 700
+    }
   },
   "silver-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5917,7 +7256,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "2fe35623-7905-48c1-84f7-b0ad2b362ba1"
+    "uuid": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 800
+    }
   },
   "silver-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -5939,403 +7283,738 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "d522fe05-cad5-4484-89e0-65c524f92e89"
+    "uuid": "d522fe05-cad5-4484-89e0-65c524f92e89",
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 900
+    }
   },
   "static-blue-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "8402b6ad-f3da-4ea2-8b55-174a9794950d",
-    "value": "rgb(39, 77, 234)"
+    "value": "rgb(39, 77, 234)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-blue",
+      "scaleIndex": 1000
+    }
   },
   "static-blue-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "e193b8bb-6a0b-4c23-9851-83634f3797f8",
-    "value": "rgb(59, 99, 251)"
+    "value": "rgb(59, 99, 251)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-blue",
+      "scaleIndex": 900
+    }
   },
   "static-chartreuse-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "956d3239-08e0-4f24-86ed-f9a3c63407a8",
-    "value": "rgb(182, 219, 0)"
+    "value": "rgb(182, 219, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-chartreuse",
+      "scaleIndex": 400
+    }
   },
   "static-chartreuse-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "c1a4bb2c-5823-41fb-abab-02024e601b2e",
-    "value": "rgb(143, 172, 0)"
+    "value": "rgb(143, 172, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-chartreuse",
+      "scaleIndex": 600
+    }
   },
   "static-chartreuse-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "5b878f8b-b097-4bcd-aac7-adde5b8b704f",
-    "value": "rgb(114, 137, 0)"
+    "value": "rgb(114, 137, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-chartreuse",
+      "scaleIndex": 800
+    }
   },
   "static-cyan-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "c83a7db4-4fbe-467b-a6b7-34e37544c8a4",
-    "value": "rgb(138, 213, 255)"
+    "value": "rgb(138, 213, 255)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-cyan",
+      "scaleIndex": 400
+    }
   },
   "static-cyan-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "3d8f857c-09fb-4be9-a557-76b5d3f95439",
-    "value": "rgb(48, 167, 254)"
+    "value": "rgb(48, 167, 254)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-cyan",
+      "scaleIndex": 600
+    }
   },
   "static-cyan-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "341fd624-7f99-4d2e-93b1-5f9b06af6796",
-    "value": "rgb(18, 134, 205)"
+    "value": "rgb(18, 134, 205)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-cyan",
+      "scaleIndex": 800
+    }
   },
   "static-fuchsia-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "0aee9ad6-2d79-4479-bdb6-aafa07a98673",
-    "value": "rgb(156, 40, 175)"
+    "value": "rgb(156, 40, 175)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 1000
+    }
   },
   "static-fuchsia-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "6bf55034-f65e-4ce5-af39-b36c2ef2af0b",
-    "value": "rgb(247, 181, 255)"
+    "value": "rgb(247, 181, 255)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 400
+    }
   },
   "static-fuchsia-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "47d7dca9-deed-4508-aec4-55713e1548ce",
-    "value": "rgb(236, 105, 255)"
+    "value": "rgb(236, 105, 255)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 600
+    }
   },
   "static-fuchsia-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "d4d44881-8175-414b-b707-e94d3f97a983",
-    "value": "rgb(200, 68, 220)"
+    "value": "rgb(200, 68, 220)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 800
+    }
   },
   "static-fuchsia-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "7629af9c-2f91-449e-a82f-c60a771b0e6f",
-    "value": "rgb(181, 57, 200)"
+    "value": "rgb(181, 57, 200)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 900
+    }
   },
   "static-green-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "43ad64e7-95b1-4edf-8a25-3ea6e047a549",
-    "value": "rgb(107, 227, 162)"
+    "value": "rgb(107, 227, 162)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-green",
+      "scaleIndex": 400
+    }
   },
   "static-green-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "a8264c36-acc7-4082-8be7-037016b1e79a",
-    "value": "rgb(18, 184, 103)"
+    "value": "rgb(18, 184, 103)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-green",
+      "scaleIndex": 600
+    }
   },
   "static-green-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "16a05db4-e5e1-48ff-92d2-72fc6d3e1ebe",
-    "value": "rgb(7, 147, 85)"
+    "value": "rgb(7, 147, 85)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-green",
+      "scaleIndex": 800
+    }
   },
   "static-indigo-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "fb3003ec-6793-47b0-947d-a89e642652fc",
-    "value": "rgb(99, 56, 238)"
+    "value": "rgb(99, 56, 238)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 1000
+    }
   },
   "static-indigo-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "61c77769-5598-4509-8ec6-579838e2ca0c",
-    "value": "rgb(192, 201, 255)"
+    "value": "rgb(192, 201, 255)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 400
+    }
   },
   "static-indigo-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "def10fcb-9261-4869-b221-48707c4037fb",
-    "value": "rgb(145, 151, 254)"
+    "value": "rgb(145, 151, 254)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 600
+    }
   },
   "static-indigo-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "f1fb98f5-401c-40ff-88da-b06c97ef8a39",
-    "value": "rgb(122, 106, 253)"
+    "value": "rgb(122, 106, 253)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 800
+    }
   },
   "static-indigo-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "970ddf30-3683-4f48-9ac7-8a9e42902fd3",
-    "value": "rgb(113, 85, 250)"
+    "value": "rgb(113, 85, 250)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 900
+    }
   },
   "static-magenta-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "058a8ff9-740d-4e11-bdb6-7473a77f872b",
-    "value": "rgb(186, 22, 80)"
+    "value": "rgb(186, 22, 80)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 1000
+    }
   },
   "static-magenta-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "d8fc21df-dcf5-4d7e-9366-f1df094c95c2",
-    "value": "rgb(255, 185, 208)"
+    "value": "rgb(255, 185, 208)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 400
+    }
   },
   "static-magenta-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "f743ffcd-019e-4f25-b559-5d563a2d8996",
-    "value": "rgb(255, 112, 159)"
+    "value": "rgb(255, 112, 159)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 600
+    }
   },
   "static-magenta-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "a6fb2dc7-d4b9-497d-af1a-863217a84b2a",
-    "value": "rgb(240, 45, 110)"
+    "value": "rgb(240, 45, 110)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 800
+    }
   },
   "static-magenta-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "5b34bb1d-a23e-4799-ad59-8fa8f51d3726",
-    "value": "rgb(217, 35, 97)"
+    "value": "rgb(217, 35, 97)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 900
+    }
   },
   "static-orange-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "333615da-5ca1-44be-9407-4613fba38999",
-    "value": "rgb(255, 193, 94)"
+    "value": "rgb(255, 193, 94)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-orange",
+      "scaleIndex": 400
+    }
   },
   "static-orange-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "fa30a6d2-df6f-40b0-8877-f826f5f62adb",
-    "value": "rgb(252, 125, 0)"
+    "value": "rgb(252, 125, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-orange",
+      "scaleIndex": 600
+    }
   },
   "static-orange-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "77e8a380-26f9-4b61-8131-421b8ccf2212",
-    "value": "rgb(212, 91, 0)"
+    "value": "rgb(212, 91, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-orange",
+      "scaleIndex": 800
+    }
   },
   "static-purple-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "40c4db9a-eaea-4266-b00f-5793afc95422",
-    "value": "rgb(221, 193, 246)"
+    "value": "rgb(221, 193, 246)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-purple",
+      "scaleIndex": 400
+    }
   },
   "static-purple-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "c1cc646a-21a9-4c3b-bcda-be77e4b2d735",
-    "value": "rgb(191, 138, 238)"
+    "value": "rgb(191, 138, 238)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-purple",
+      "scaleIndex": 600
+    }
   },
   "static-purple-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "a6bfb1a2-9fd6-4247-b615-af1d4fc4c476",
-    "value": "rgb(166, 92, 231)"
+    "value": "rgb(166, 92, 231)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-purple",
+      "scaleIndex": 800
+    }
   },
   "static-red-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "3a65213c-4d36-48ec-8bf9-1b163a81299d",
-    "value": "rgb(183, 40, 24)"
+    "value": "rgb(183, 40, 24)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 1000
+    }
   },
   "static-red-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "59ce78e2-3fbb-4e2a-be17-07afce5ca987",
-    "value": "rgb(255, 188, 180)"
+    "value": "rgb(255, 188, 180)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 400
+    }
   },
   "static-red-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "865349c3-a5e0-4940-b404-918616390195",
-    "value": "rgb(255, 118, 101)"
+    "value": "rgb(255, 118, 101)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 600
+    }
   },
   "static-red-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "341e5068-62cb-4e3f-a0a1-54c107db50cc",
-    "value": "rgb(240, 56, 35)"
+    "value": "rgb(240, 56, 35)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 800
+    }
   },
   "static-red-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "d31011ef-7270-4c83-802d-05701ae9a3c8",
-    "value": "rgb(215, 50, 32)"
+    "value": "rgb(215, 50, 32)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 900
+    }
   },
   "static-turquoise-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "86ef11d6-aacd-470b-9d61-ffd7c5c09b45",
-    "value": "rgb(111, 221, 228)"
+    "value": "rgb(111, 221, 228)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-turquoise",
+      "scaleIndex": 400
+    }
   },
   "static-turquoise-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "60816b84-ee3f-4b17-9bcb-fd26f194dd32",
-    "value": "rgb(15, 177, 192)"
+    "value": "rgb(15, 177, 192)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-turquoise",
+      "scaleIndex": 600
+    }
   },
   "static-turquoise-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "94f1f308-c049-4b5e-ae02-2d609c114e83",
-    "value": "rgb(10, 141, 153)"
+    "value": "rgb(10, 141, 153)",
+    "name": {
+      "property": "color",
+      "colorFamily": "static-turquoise",
+      "scaleIndex": 800
+    }
   },
   "transparent-black-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "7565eb32-d745-4fc3-8779-a717f8ba910a",
-    "value": "rgba(0, 0, 0, 0.09)"
+    "value": "rgba(0, 0, 0, 0.09)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 100
+    }
   },
   "transparent-black-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "098f2f56-e52f-47b1-943a-d1d7218de484",
-    "value": "rgb(0, 0, 0)"
+    "value": "rgb(0, 0, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 1000
+    }
   },
   "transparent-black-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
-    "value": "rgba(0, 0, 0, 0.12)"
+    "value": "rgba(0, 0, 0, 0.12)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 200
+    }
   },
   "transparent-black-25": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "d0867b86-6245-4c02-8617-ea7fd5c80288",
-    "value": "rgba(0, 0, 0, 0)"
+    "value": "rgba(0, 0, 0, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 25
+    }
   },
   "transparent-black-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "16a871e1-d9df-42bb-8889-99059d70e82e",
-    "value": "rgba(0, 0, 0, 0.15)"
+    "value": "rgba(0, 0, 0, 0.15)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 300
+    }
   },
   "transparent-black-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "b769453b-586c-4dd2-b3a1-ddf5964160bc",
-    "value": "rgba(0, 0, 0, 0.22)"
+    "value": "rgba(0, 0, 0, 0.22)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 400
+    }
   },
   "transparent-black-50": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "d6aa176c-30bd-423f-b05f-4360672bd87e",
-    "value": "rgba(0, 0, 0, 0.03)"
+    "value": "rgba(0, 0, 0, 0.03)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 50
+    }
   },
   "transparent-black-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "cebedd9f-9e4b-47cf-addb-45d8ff9c9179",
-    "value": "rgba(0, 0, 0, 0.44)"
+    "value": "rgba(0, 0, 0, 0.44)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 500
+    }
   },
   "transparent-black-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
-    "value": "rgba(0, 0, 0, 0.56)"
+    "value": "rgba(0, 0, 0, 0.56)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 600
+    }
   },
   "transparent-black-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "56da822f-98ea-4ad1-b993-3f052de45f36",
-    "value": "rgba(0, 0, 0, 0.69)"
+    "value": "rgba(0, 0, 0, 0.69)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 700
+    }
   },
   "transparent-black-75": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "d33a66ea-ca60-416f-9e92-967dbbb1e983",
-    "value": "rgba(0, 0, 0, 0.05)"
+    "value": "rgba(0, 0, 0, 0.05)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 75
+    }
   },
   "transparent-black-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "3e89f180-b0f0-4de0-904b-c80f0210a361",
-    "value": "rgba(0, 0, 0, 0.84)"
+    "value": "rgba(0, 0, 0, 0.84)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 800
+    }
   },
   "transparent-black-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "c0a331f9-53e3-4c72-b5e3-139d730a1752",
-    "value": "rgba(0, 0, 0, 0.93)"
+    "value": "rgba(0, 0, 0, 0.93)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 900
+    }
   },
   "transparent-white-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "a1b64a62-7c78-415e-a9be-c86acbf361ca",
-    "value": "rgba(255, 255, 255, 0.11)"
+    "value": "rgba(255, 255, 255, 0.11)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 100
+    }
   },
   "transparent-white-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "1409a50a-9a9d-463d-957f-fa2e4f98a0cd",
-    "value": "rgb(255, 255, 255)"
+    "value": "rgb(255, 255, 255)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 1000
+    }
   },
   "transparent-white-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "936db837-bc5a-40b0-a0e8-8e39b9fc62cb",
-    "value": "rgba(255, 255, 255, 0.14)"
+    "value": "rgba(255, 255, 255, 0.14)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 200
+    }
   },
   "transparent-white-25": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
-    "value": "rgba(255, 255, 255, 0)"
+    "value": "rgba(255, 255, 255, 0)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 25
+    }
   },
   "transparent-white-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
-    "value": "rgba(255, 255, 255, 0.17)"
+    "value": "rgba(255, 255, 255, 0.17)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 300
+    }
   },
   "transparent-white-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "12e610d4-e3dc-4e86-9c09-09d86915b6f1",
-    "value": "rgba(255, 255, 255, 0.21)"
+    "value": "rgba(255, 255, 255, 0.21)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 400
+    }
   },
   "transparent-white-50": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "db1dbf26-fa48-42e1-b724-7953b0a6a543",
-    "value": "rgba(255, 255, 255, 0.04)"
+    "value": "rgba(255, 255, 255, 0.04)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 50
+    }
   },
   "transparent-white-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "89c1380f-3e8e-4895-b025-027cee7ecd5b",
-    "value": "rgba(255, 255, 255, 0.39)"
+    "value": "rgba(255, 255, 255, 0.39)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 500
+    }
   },
   "transparent-white-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
-    "value": "rgba(255, 255, 255, 0.51)"
+    "value": "rgba(255, 255, 255, 0.51)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 600
+    }
   },
   "transparent-white-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "3ecc14ec-a21e-47ba-8225-915509a532af",
-    "value": "rgba(255, 255, 255, 0.66)"
+    "value": "rgba(255, 255, 255, 0.66)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 700
+    }
   },
   "transparent-white-75": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "28d11d38-570d-4d99-b581-855781b972c5",
-    "value": "rgba(255, 255, 255, 0.07)"
+    "value": "rgba(255, 255, 255, 0.07)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 75
+    }
   },
   "transparent-white-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "b85836bf-af47-412a-900a-4ec5ad0733b2",
-    "value": "rgba(255, 255, 255, 0.85)"
+    "value": "rgba(255, 255, 255, 0.85)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 800
+    }
   },
   "transparent-white-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "c5c823c6-1911-4e0e-ba2f-5105f467e108",
-    "value": "rgba(255, 255, 255, 0.94)"
+    "value": "rgba(255, 255, 255, 0.94)",
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 900
+    }
   },
   "turquoise-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6357,7 +8036,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "32dac6f5-6603-4f0a-b85e-1177e1ce23a1"
+    "uuid": "32dac6f5-6603-4f0a-b85e-1177e1ce23a1",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 100
+    }
   },
   "turquoise-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6379,7 +8063,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "eba4bafc-0f66-4dd1-8007-d25121e79a4b"
+    "uuid": "eba4bafc-0f66-4dd1-8007-d25121e79a4b",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1000
+    }
   },
   "turquoise-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6401,7 +8090,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "b179a56d-ff8b-4540-94fa-6ddd415b5841"
+    "uuid": "b179a56d-ff8b-4540-94fa-6ddd415b5841",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1100
+    }
   },
   "turquoise-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6423,7 +8117,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "25950327-72b2-4f1d-97df-b8411e03abcb"
+    "uuid": "25950327-72b2-4f1d-97df-b8411e03abcb",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1200
+    }
   },
   "turquoise-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6445,7 +8144,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "12ccafd6-dd63-4829-b3b4-9d015b9dc0c9"
+    "uuid": "12ccafd6-dd63-4829-b3b4-9d015b9dc0c9",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1300
+    }
   },
   "turquoise-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6467,7 +8171,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "f2fec1aa-b46a-4046-8c5a-ce7360b37f0a"
+    "uuid": "f2fec1aa-b46a-4046-8c5a-ce7360b37f0a",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1400
+    }
   },
   "turquoise-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6489,7 +8198,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "796df5b7-982f-409a-892f-791eaee4d9f5"
+    "uuid": "796df5b7-982f-409a-892f-791eaee4d9f5",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1500
+    }
   },
   "turquoise-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6511,7 +8225,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "b248731f-de4c-4526-983c-cee0ac10b20f"
+    "uuid": "b248731f-de4c-4526-983c-cee0ac10b20f",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1600
+    }
   },
   "turquoise-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6533,7 +8252,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "7720aa32-deea-454b-a593-f1234e638565"
+    "uuid": "7720aa32-deea-454b-a593-f1234e638565",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 200
+    }
   },
   "turquoise-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6555,7 +8279,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "47de7f9a-3e02-4824-b667-ad499729c9ff"
+    "uuid": "47de7f9a-3e02-4824-b667-ad499729c9ff",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 300
+    }
   },
   "turquoise-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6577,7 +8306,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "1327ec82-3f65-4706-a664-11e46294ffd2"
+    "uuid": "1327ec82-3f65-4706-a664-11e46294ffd2",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 400
+    }
   },
   "turquoise-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6599,7 +8333,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "02f0b460-1456-4c41-bea1-d2bf70eeab5d"
+    "uuid": "02f0b460-1456-4c41-bea1-d2bf70eeab5d",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 500
+    }
   },
   "turquoise-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6621,7 +8360,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "4d12dcd0-e3ff-43ef-a742-5a9c74848e04"
+    "uuid": "4d12dcd0-e3ff-43ef-a742-5a9c74848e04",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 600
+    }
   },
   "turquoise-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6643,7 +8387,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "3cf57594-3174-4192-ab62-b854b1562748"
+    "uuid": "3cf57594-3174-4192-ab62-b854b1562748",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 700
+    }
   },
   "turquoise-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6665,7 +8414,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2"
+    "uuid": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 800
+    }
   },
   "turquoise-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6687,13 +8441,22 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c"
+    "uuid": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 900
+    }
   },
   "white": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "private": true,
     "uuid": "9b799da8-2130-417e-b7ee-5e1154a89837",
-    "value": "rgb(255, 255, 255)"
+    "value": "rgb(255, 255, 255)",
+    "name": {
+      "property": "color",
+      "colorFamily": "white"
+    }
   },
   "yellow-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6715,7 +8478,12 @@
         "value": "rgb(246, 248, 252)"
       }
     },
-    "uuid": "34318bf7-de9b-46a0-8bc1-29b154d89cb8"
+    "uuid": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 100
+    }
   },
   "yellow-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6737,7 +8505,12 @@
         "value": "rgb(61, 94, 165)"
       }
     },
-    "uuid": "92f600a8-beb5-427b-990d-f9f486a7f3ab"
+    "uuid": "92f600a8-beb5-427b-990d-f9f486a7f3ab",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1000
+    }
   },
   "yellow-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6759,7 +8532,12 @@
         "value": "rgb(52, 79, 140)"
       }
     },
-    "uuid": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9"
+    "uuid": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1100
+    }
   },
   "yellow-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6781,7 +8559,12 @@
         "value": "rgb(42, 65, 114)"
       }
     },
-    "uuid": "af877bd7-9943-454e-b83e-5597e381190a"
+    "uuid": "af877bd7-9943-454e-b83e-5597e381190a",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1200
+    }
   },
   "yellow-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6803,7 +8586,12 @@
         "value": "rgb(34, 51, 91)"
       }
     },
-    "uuid": "b2558f6d-b45c-4662-a4a9-e34acd060c1d"
+    "uuid": "b2558f6d-b45c-4662-a4a9-e34acd060c1d",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1300
+    }
   },
   "yellow-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6825,7 +8613,12 @@
         "value": "rgb(25, 39, 69)"
       }
     },
-    "uuid": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce"
+    "uuid": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1400
+    }
   },
   "yellow-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6847,7 +8640,12 @@
         "value": "rgb(18, 27, 48)"
       }
     },
-    "uuid": "20f1c823-6340-45db-afa9-f666bdf65f78"
+    "uuid": "20f1c823-6340-45db-afa9-f666bdf65f78",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1500
+    }
   },
   "yellow-1600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6869,7 +8667,12 @@
         "value": "rgb(8, 12, 22)"
       }
     },
-    "uuid": "edc119b5-088e-4099-aa53-da1a8bdd7ba8"
+    "uuid": "edc119b5-088e-4099-aa53-da1a8bdd7ba8",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1600
+    }
   },
   "yellow-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6891,7 +8694,12 @@
         "value": "rgb(235, 239, 248)"
       }
     },
-    "uuid": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1"
+    "uuid": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 200
+    }
   },
   "yellow-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6913,7 +8721,12 @@
         "value": "rgb(216, 224, 242)"
       }
     },
-    "uuid": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98"
+    "uuid": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 300
+    }
   },
   "yellow-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6935,7 +8748,12 @@
         "value": "rgb(192, 205, 234)"
       }
     },
-    "uuid": "0bc3e99e-6f92-47c9-90ae-593363bef6aa"
+    "uuid": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 400
+    }
   },
   "yellow-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6957,7 +8775,12 @@
         "value": "rgb(164, 183, 225)"
       }
     },
-    "uuid": "8f90e008-a466-4477-ab93-1a55a644f52e"
+    "uuid": "8f90e008-a466-4477-ab93-1a55a644f52e",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 500
+    }
   },
   "yellow-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -6979,7 +8802,12 @@
         "value": "rgb(135, 160, 215)"
       }
     },
-    "uuid": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc"
+    "uuid": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 600
+    }
   },
   "yellow-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -7001,7 +8829,12 @@
         "value": "rgb(113, 142, 208)"
       }
     },
-    "uuid": "56ec10af-38c5-46f8-8fcf-634546c1bcc9"
+    "uuid": "56ec10af-38c5-46f8-8fcf-634546c1bcc9",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 700
+    }
   },
   "yellow-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -7023,7 +8856,12 @@
         "value": "rgb(93, 127, 201)"
       }
     },
-    "uuid": "3fa72ad4-4c82-457f-a5f8-eb4593a9701d"
+    "uuid": "3fa72ad4-4c82-457f-a5f8-eb4593a9701d",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 800
+    }
   },
   "yellow-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -7045,6 +8883,11 @@
         "value": "rgb(74, 111, 195)"
       }
     },
-    "uuid": "9c2d18b5-151b-4765-97ea-d1307df3de56"
+    "uuid": "9c2d18b5-151b-4765-97ea-d1307df3de56",
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 900
+    }
   }
 }

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -2,7 +2,11 @@
   "black-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "e2f23ca1-802b-40a2-a211-33090f9a043e",
-    "value": "black"
+    "value": "black",
+    "name": {
+      "property": "font-weight",
+      "weight": "black"
+    }
   },
   "body-cjk-emphasized-font-style": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -280,7 +284,11 @@
   "bold-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
-    "value": "bold"
+    "value": "bold",
+    "name": {
+      "property": "font-weight",
+      "weight": "bold"
+    }
   },
   "cjk-font-family": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
@@ -1077,7 +1085,11 @@
   "extra-bold-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "ccadf44e-5424-4920-979f-ea1ef39687c4",
-    "value": "extra-bold"
+    "value": "extra-bold",
+    "name": {
+      "property": "font-weight",
+      "weight": "extra-bold"
+    }
   },
   "font-size-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1987,7 +1999,11 @@
   "light-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "fd477873-3767-4883-ab3f-5ee2758b923b",
-    "value": "light"
+    "value": "light",
+    "name": {
+      "property": "font-weight",
+      "weight": "light"
+    }
   },
   "line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
@@ -2290,12 +2306,20 @@
   "medium-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
-    "value": "medium"
+    "value": "medium",
+    "name": {
+      "property": "font-weight",
+      "weight": "medium"
+    }
   },
   "regular-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "02a94ddf-1007-4c86-8863-905874e40f95",
-    "value": "regular"
+    "value": "regular",
+    "name": {
+      "property": "font-weight",
+      "weight": "regular"
+    }
   },
   "sans-serif-font-family": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,22 @@ importers:
         specifier: ^6.0.1
         version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
+  tools/token-corpus-migrate:
+    dependencies:
+      "@adobe/design-system-registry":
+        specifier: workspace:*
+        version: link:../../packages/design-system-registry
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.3
+    devDependencies:
+      ava:
+        specifier: ^6.4.0
+        version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
+
   tools/token-manifest-builder: {}
 
   tools/token-mapping-analyzer:

--- a/sdk/core/src/validate/rules/spec043.rs
+++ b/sdk/core/src/validate/rules/spec043.rs
@@ -15,6 +15,9 @@
 //!
 //! Domain detection is based on the token's `$schema` URL suffix:
 //! - Color tokens (color.json, color-set.json) SHOULD have `colorFamily` or `scaleIndex`.
+//!   Either field alone satisfies the check intentionally — a token with only `scaleIndex`
+//!   (ramp step without family context) is still sortable, and a token with only
+//!   `colorFamily` (non-ramp token such as transparent-black) is also valid.
 //! - Typography tokens (font-*.json, typography.json) SHOULD have `family`, `weight`,
 //!   or `style`.
 //! - Motion tokens (duration.json, easing.json, motion.json) SHOULD have

--- a/tools/token-corpus-migrate/README.md
+++ b/tools/token-corpus-migrate/README.md
@@ -1,0 +1,76 @@
+# token-corpus-migrate
+
+CLI tool that injects structured `name` objects into Spectrum token source files.
+Run it as a one-shot transform when extending the corpus to use new taxonomy fields
+(see `packages/design-data-spec/spec/taxonomy.md`).
+
+## Usage
+
+```bash
+# Dry-run (default) — report what would change, no files written
+node tools/token-corpus-migrate/src/cli.js --root packages/tokens/src
+
+# Apply changes to disk
+node tools/token-corpus-migrate/src/cli.js --root packages/tokens/src --write
+
+# Save the report to a file
+node tools/token-corpus-migrate/src/cli.js --root packages/tokens/src --report /tmp/migrate.md
+```
+
+## Pilot scope
+
+By default the tool processes only the files declared in `PILOT_FILES` (currently
+`color-palette.json` and `typography.json`). Pass `--all` to process every
+`*.tokens.json` file under `--root`.
+
+## How classification works
+
+Each token is matched against the rules in `src/transform.js`:
+
+| Token `$schema`                 | Key pattern            | Resulting `name`                                 |
+| ------------------------------- | ---------------------- | ------------------------------------------------ |
+| `color.json` / `color-set.json` | `<family>-<N>`         | `{ property: "color", colorFamily, scaleIndex }` |
+| `color.json` / `color-set.json` | bare family id         | `{ property: "color", colorFamily }`             |
+| `font-weight.json`              | `<weight>-font-weight` | `{ property: "font-weight", weight }`            |
+
+Valid `colorFamily` values are sourced from `@adobe/design-system-registry/registry/color-families.json`.
+Valid `weight` values are sourced from `@adobe/design-system-registry/registry/typography-weights.json`.
+Tokens that already have a `name` field are skipped.
+Alias tokens and other out-of-scope schemas are left untouched.
+
+## Handling unclassified tokens
+
+If a token's `$schema` is in scope but the key doesn't match any rule, the
+dry-run report lists it under **Unclassified**. Add it to `src/overrides.json`:
+
+```json
+{
+  "overrides": {
+    "my-special-token": { "name": { "property": "color", "colorFamily": "gray" } }
+  }
+}
+```
+
+Re-run the dry-run to confirm the override resolves the entry, then apply with `--write`.
+
+## Tests
+
+```bash
+pnpm test   # from tools/token-corpus-migrate/
+```
+
+or
+
+```bash
+moon run token-corpus-migrate:test
+```
+
+## Extending for new domains
+
+To add a new domain (e.g. motion):
+
+1. Add a new classification function in `src/transform.js` (see `fontWeightNameForKey`
+   as a template).
+2. Add the schema suffix and the new function call inside `classifyToken`.
+3. Add unit tests in `test/transform.test.js`.
+4. Add the new token file name to `PILOT_FILES` in `src/cli.js` if appropriate.

--- a/tools/token-corpus-migrate/ava.config.js
+++ b/tools/token-corpus-migrate/ava.config.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export default {
+  files: ["test/**/*.test.js"],
+  verbose: true,
+  environmentVariables: {
+    NODE_ENV: "test",
+  },
+};

--- a/tools/token-corpus-migrate/moon.yml
+++ b/tools/token-corpus-migrate/moon.yml
@@ -1,0 +1,28 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+type: tool
+language: javascript
+platform: node
+
+tasks:
+  test:
+    command: [pnpm, ava, test]
+    inputs:
+      - "src/**/*"
+      - "test/**/*"
+      - "package.json"
+      - "ava.config.js"
+
+  lint:
+    command: [echo, "No linting configured"]
+
+  ci:
+    deps: [test]

--- a/tools/token-corpus-migrate/package.json
+++ b/tools/token-corpus-migrate/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@adobe/token-corpus-migrate",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Migration tool that adds structured name objects to tokens in packages/tokens/src/",
+  "type": "module",
+  "main": "src/index.js",
+  "bin": {
+    "token-corpus-migrate": "src/cli.js"
+  },
+  "scripts": {
+    "test": "ava test/**/*.test.js",
+    "lint": "echo 'No linting configured'"
+  },
+  "keywords": [
+    "spectrum",
+    "tokens",
+    "migration",
+    "taxonomy"
+  ],
+  "author": "Adobe",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@adobe/design-system-registry": "workspace:*",
+    "commander": "^12.1.0",
+    "glob": "^11.0.0"
+  },
+  "devDependencies": {
+    "ava": "^6.4.0"
+  },
+  "engines": {
+    "node": "~20.12"
+  },
+  "packageManager": "pnpm@10.17.1"
+}

--- a/tools/token-corpus-migrate/src/cli.js
+++ b/tools/token-corpus-migrate/src/cli.js
@@ -12,7 +12,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -58,14 +58,7 @@ program
     if (options.all) {
       files = await glob("**/*.tokens.json", { cwd: root, absolute: true });
     } else {
-      files = PILOT_FILES.map((f) => resolve(root, f)).filter((f) => {
-        try {
-          readFileSync(f);
-          return true;
-        } catch {
-          return false;
-        }
-      });
+      files = PILOT_FILES.map((f) => resolve(root, f)).filter(existsSync);
     }
 
     if (files.length === 0) {

--- a/tools/token-corpus-migrate/src/cli.js
+++ b/tools/token-corpus-migrate/src/cli.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Command } from "commander";
+import { glob } from "glob";
+import { transformFile } from "./transform.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+
+const PILOT_FILES = ["color-palette.json", "typography.json"];
+
+const program = new Command();
+
+program
+  .name("token-corpus-migrate")
+  .description(
+    "Inject structured name objects into Spectrum token source files",
+  )
+  .version(version)
+  .option(
+    "--root <dir>",
+    "Directory containing *.json token source files",
+    process.cwd(),
+  )
+  .option("--write", "Apply changes to disk (default: dry-run)", false)
+  .option(
+    "--report <path>",
+    "Write a Markdown summary to this file (default: stdout)",
+  )
+  .option(
+    "--all",
+    "Process all *.tokens.json files (default: pilot scope only)",
+    false,
+  )
+  .action(async (options) => {
+    const root = resolve(options.root);
+    const overridesPath = resolve(__dirname, "overrides.json");
+    const { overrides } = JSON.parse(readFileSync(overridesPath, "utf8"));
+
+    let files;
+    if (options.all) {
+      files = await glob("**/*.tokens.json", { cwd: root, absolute: true });
+    } else {
+      files = PILOT_FILES.map((f) => resolve(root, f)).filter((f) => {
+        try {
+          readFileSync(f);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    }
+
+    if (files.length === 0) {
+      console.error(`No token files found under ${root}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const lines = [
+      `# token-corpus-migrate report\n`,
+      `**Mode:** ${options.write ? "write" : "dry-run"}\n`,
+    ];
+    let totalClassified = 0;
+    let totalUnclassified = 0;
+
+    for (const filePath of files) {
+      const raw = readFileSync(filePath, "utf8");
+      const tokens = JSON.parse(raw);
+      const { transformed, classified, unclassified, skipped } = transformFile(
+        tokens,
+        overrides,
+      );
+
+      totalClassified += classified;
+      totalUnclassified += unclassified.length;
+
+      lines.push(`## ${filePath.replace(root + "/", "")}\n`);
+      lines.push(`- Classified: ${classified}`);
+      lines.push(`- Skipped (out of scope): ${skipped}`);
+      lines.push(
+        `- Unclassified (add to overrides.json): ${unclassified.length}\n`,
+      );
+
+      if (unclassified.length > 0) {
+        lines.push("### Unclassified tokens\n");
+        lines.push("| Token key | $schema |");
+        lines.push("|---|---|");
+        for (const key of unclassified) {
+          const schema = tokens[key]?.["$schema"]?.split("/").pop() ?? "—";
+          lines.push(`| \`${key}\` | ${schema} |`);
+        }
+        lines.push("");
+      }
+
+      if (options.write && classified > 0) {
+        writeFileSync(
+          filePath,
+          JSON.stringify(transformed, null, 2) + "\n",
+          "utf8",
+        );
+        lines.push(`_Written to disk._\n`);
+      }
+    }
+
+    lines.push(`## Summary\n`);
+    lines.push(`- Total classified: ${totalClassified}`);
+    lines.push(`- Total unclassified: ${totalUnclassified}`);
+
+    const report = lines.join("\n");
+
+    if (options.report) {
+      writeFileSync(resolve(options.report), report, "utf8");
+      console.log(`Report written to ${options.report}`);
+    } else {
+      console.log(report);
+    }
+
+    if (totalUnclassified > 0) {
+      process.exitCode = 1;
+    }
+  });
+
+program.parse();

--- a/tools/token-corpus-migrate/src/index.js
+++ b/tools/token-corpus-migrate/src/index.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export {
+  classifyToken,
+  colorNameForKey,
+  fontWeightNameForKey,
+  transformFile,
+} from "./transform.js";

--- a/tools/token-corpus-migrate/src/overrides.json
+++ b/tools/token-corpus-migrate/src/overrides.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Manual overrides for token keys that cannot be classified by the regex rules. Shape: { \"<token-key>\": { \"name\": { … } } }. Add entries here when the dry-run report lists unclassified tokens that are genuinely in scope.",
+  "overrides": {}
+}

--- a/tools/token-corpus-migrate/src/transform.js
+++ b/tools/token-corpus-migrate/src/transform.js
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import colorFamiliesData from "@adobe/design-system-registry/registry/color-families.json" assert { type: "json" };
+import typographyWeightsData from "@adobe/design-system-registry/registry/typography-weights.json" assert { type: "json" };
+
+const COLOR_FAMILIES = new Set(colorFamiliesData.values.map((v) => v.id));
+const TYPOGRAPHY_WEIGHTS = new Set(
+  typographyWeightsData.values.map((v) => v.id),
+);
+
+const COLOR_SCHEMAS = new Set(["color.json", "color-set.json"]);
+const FONT_WEIGHT_SCHEMA = "font-weight.json";
+
+/** Returns true when a $schema URL ends with one of the given suffixes. */
+function schemaEndsWith(schemaUrl, suffix) {
+  return typeof schemaUrl === "string" && schemaUrl.endsWith(suffix);
+}
+
+/**
+ * Derive the name object for a color-palette token, or null if unclassifiable.
+ *
+ * Patterns handled:
+ *   <family>-<integer>          → { property, colorFamily, scaleIndex }
+ *   <family>                    → { property, colorFamily }            (bare family id)
+ *   static-<family>-<integer>   → { property, colorFamily, scaleIndex }
+ */
+export function colorNameForKey(key) {
+  // bare family (black, white, transparent-black, transparent-white, …)
+  if (COLOR_FAMILIES.has(key)) {
+    return { property: "color", colorFamily: key };
+  }
+
+  // <family>-<scaleIndex>  where family is in the registry
+  const rampMatch = key.match(/^(.+?)-(\d+)$/);
+  if (rampMatch) {
+    const [, family, indexStr] = rampMatch;
+    if (COLOR_FAMILIES.has(family)) {
+      return {
+        property: "color",
+        colorFamily: family,
+        scaleIndex: Number(indexStr),
+      };
+    }
+  }
+
+  // static-<family>-<scaleIndex>  (static-blue-100, etc.)
+  const staticRampMatch = key.match(/^(static-.+?)-(\d+)$/);
+  if (staticRampMatch) {
+    const [, family, indexStr] = staticRampMatch;
+    if (COLOR_FAMILIES.has(family)) {
+      return {
+        property: "color",
+        colorFamily: family,
+        scaleIndex: Number(indexStr),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Derive the name object for a font-weight token, or null if unclassifiable.
+ *
+ * Pattern:  <weight>-font-weight  where weight is in the typography-weights registry.
+ */
+export function fontWeightNameForKey(key) {
+  const match = key.match(/^(.+)-font-weight$/);
+  if (match) {
+    const [, weight] = match;
+    if (TYPOGRAPHY_WEIGHTS.has(weight)) {
+      return { property: "font-weight", weight };
+    }
+  }
+  return null;
+}
+
+/**
+ * Classify a single token entry and return a name object, or null to skip.
+ *
+ * @param {string} key            - Token key (e.g. "blue-100")
+ * @param {object} token          - Raw token object
+ * @param {object} overrides      - Manual override map keyed by token key
+ * @returns {{ name: object }|null}
+ */
+export function classifyToken(key, token, overrides = {}) {
+  // Skip if already has a name field (don't overwrite existing structure)
+  if ("name" in token) return null;
+
+  // Manual override wins over all automatic rules
+  if (overrides[key]) return { name: overrides[key].name };
+
+  const schema = token["$schema"] ?? "";
+
+  if (COLOR_SCHEMAS.has(schema.split("/").pop())) {
+    const name = colorNameForKey(key);
+    if (name) return { name };
+    return { name: null }; // in-scope but unclassified
+  }
+
+  if (schemaEndsWith(schema, FONT_WEIGHT_SCHEMA)) {
+    const name = fontWeightNameForKey(key);
+    if (name) return { name };
+    return { name: null }; // in-scope but unclassified
+  }
+
+  return null; // out of scope for this tool
+}
+
+/**
+ * Process a parsed token file object and return:
+ *   - transformed: new file object with name fields injected
+ *   - classified: count of tokens that got a name object
+ *   - unclassified: keys whose schema was in-scope but couldn't be mapped
+ *   - skipped: keys outside this tool's scope
+ */
+export function transformFile(tokens, overrides = {}) {
+  const transformed = {};
+  const unclassified = [];
+  let classified = 0;
+  let skipped = 0;
+
+  for (const [key, token] of Object.entries(tokens)) {
+    const result = classifyToken(key, token, overrides);
+
+    if (result === null) {
+      // out of scope — copy as-is
+      transformed[key] = token;
+      skipped++;
+    } else if (result.name === null) {
+      // in-scope but unclassified
+      transformed[key] = token;
+      unclassified.push(key);
+    } else {
+      // inject name field; keep existing field order then add name
+      transformed[key] = { ...token, name: result.name };
+      classified++;
+    }
+  }
+
+  return { transformed, classified, unclassified, skipped };
+}

--- a/tools/token-corpus-migrate/src/transform.js
+++ b/tools/token-corpus-migrate/src/transform.js
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import colorFamiliesData from "@adobe/design-system-registry/registry/color-families.json" assert { type: "json" };
-import typographyWeightsData from "@adobe/design-system-registry/registry/typography-weights.json" assert { type: "json" };
+import colorFamiliesData from "@adobe/design-system-registry/registry/color-families.json" with { type: "json" };
+import typographyWeightsData from "@adobe/design-system-registry/registry/typography-weights.json" with { type: "json" };
 
 const COLOR_FAMILIES = new Set(colorFamiliesData.values.map((v) => v.id));
 const TYPOGRAPHY_WEIGHTS = new Set(
@@ -21,9 +21,16 @@ const TYPOGRAPHY_WEIGHTS = new Set(
 const COLOR_SCHEMAS = new Set(["color.json", "color-set.json"]);
 const FONT_WEIGHT_SCHEMA = "font-weight.json";
 
-/** Returns true when a $schema URL ends with one of the given suffixes. */
+/** Returns true when a $schema URL ends with the given suffix. */
 function schemaEndsWith(schemaUrl, suffix) {
   return typeof schemaUrl === "string" && schemaUrl.endsWith(suffix);
+}
+
+function isColorSchema(schemaUrl) {
+  return (
+    typeof schemaUrl === "string" &&
+    COLOR_SCHEMAS.has(schemaUrl.split("/").pop())
+  );
 }
 
 /**
@@ -102,7 +109,7 @@ export function classifyToken(key, token, overrides = {}) {
 
   const schema = token["$schema"] ?? "";
 
-  if (COLOR_SCHEMAS.has(schema.split("/").pop())) {
+  if (isColorSchema(schema)) {
     const name = colorNameForKey(key);
     if (name) return { name };
     return { name: null }; // in-scope but unclassified

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import test from "ava";
+import {
+  classifyToken,
+  colorNameForKey,
+  fontWeightNameForKey,
+  transformFile,
+} from "../src/transform.js";
+
+const COLOR_SCHEMA = "https://example.com/schemas/token-types/color.json";
+const COLOR_SET_SCHEMA =
+  "https://example.com/schemas/token-types/color-set.json";
+const FONT_WEIGHT_SCHEMA =
+  "https://example.com/schemas/token-types/font-weight.json";
+const ALIAS_SCHEMA = "https://example.com/schemas/token-types/alias.json";
+
+// ── colorNameForKey ───────────────────────────────────────────────────────────
+
+test("colorNameForKey: ramp token returns colorFamily + scaleIndex", (t) => {
+  const name = colorNameForKey("blue-100");
+  t.deepEqual(name, {
+    property: "color",
+    colorFamily: "blue",
+    scaleIndex: 100,
+  });
+});
+
+test("colorNameForKey: high ramp value", (t) => {
+  const name = colorNameForKey("gray-1600");
+  t.deepEqual(name, {
+    property: "color",
+    colorFamily: "gray",
+    scaleIndex: 1600,
+  });
+});
+
+test("colorNameForKey: bare family id (black)", (t) => {
+  t.deepEqual(colorNameForKey("black"), {
+    property: "color",
+    colorFamily: "black",
+  });
+});
+
+test("colorNameForKey: bare family id (white)", (t) => {
+  t.deepEqual(colorNameForKey("white"), {
+    property: "color",
+    colorFamily: "white",
+  });
+});
+
+test("colorNameForKey: transparent-black", (t) => {
+  t.deepEqual(colorNameForKey("transparent-black"), {
+    property: "color",
+    colorFamily: "transparent-black",
+  });
+});
+
+test("colorNameForKey: transparent-white", (t) => {
+  t.deepEqual(colorNameForKey("transparent-white"), {
+    property: "color",
+    colorFamily: "transparent-white",
+  });
+});
+
+test("colorNameForKey: static ramp token", (t) => {
+  const name = colorNameForKey("static-blue-600");
+  t.deepEqual(name, {
+    property: "color",
+    colorFamily: "static-blue",
+    scaleIndex: 600,
+  });
+});
+
+test("colorNameForKey: unknown key returns null", (t) => {
+  t.is(colorNameForKey("gradient-stop-1-avatar"), null);
+});
+
+test("colorNameForKey: unknown family in ramp returns null", (t) => {
+  t.is(colorNameForKey("mystery-100"), null);
+});
+
+// ── fontWeightNameForKey ──────────────────────────────────────────────────────
+
+test("fontWeightNameForKey: known weight", (t) => {
+  t.deepEqual(fontWeightNameForKey("bold-font-weight"), {
+    property: "font-weight",
+    weight: "bold",
+  });
+});
+
+test("fontWeightNameForKey: black weight", (t) => {
+  t.deepEqual(fontWeightNameForKey("black-font-weight"), {
+    property: "font-weight",
+    weight: "black",
+  });
+});
+
+test("fontWeightNameForKey: extra-bold weight", (t) => {
+  t.deepEqual(fontWeightNameForKey("extra-bold-font-weight"), {
+    property: "font-weight",
+    weight: "extra-bold",
+  });
+});
+
+test("fontWeightNameForKey: unknown weight returns null", (t) => {
+  t.is(fontWeightNameForKey("semibold-font-weight"), null);
+});
+
+test("fontWeightNameForKey: non-weight key returns null", (t) => {
+  t.is(fontWeightNameForKey("body-cjk-emphasized-font-weight"), null);
+});
+
+// ── classifyToken ─────────────────────────────────────────────────────────────
+
+test("classifyToken: color ramp token gets name", (t) => {
+  const token = { $schema: COLOR_SCHEMA, uuid: "abc", value: "#fff" };
+  const result = classifyToken("blue-100", token);
+  t.deepEqual(result, {
+    name: { property: "color", colorFamily: "blue", scaleIndex: 100 },
+  });
+});
+
+test("classifyToken: color-set token gets name", (t) => {
+  const token = { $schema: COLOR_SET_SCHEMA, uuid: "abc" };
+  const result = classifyToken("red-400", token);
+  t.deepEqual(result, {
+    name: { property: "color", colorFamily: "red", scaleIndex: 400 },
+  });
+});
+
+test("classifyToken: token already has name is skipped", (t) => {
+  const token = {
+    $schema: COLOR_SCHEMA,
+    name: { property: "color", colorFamily: "blue", scaleIndex: 100 },
+    uuid: "abc",
+    value: "#fff",
+  };
+  t.is(classifyToken("blue-100", token), null);
+});
+
+test("classifyToken: alias token is out of scope (null)", (t) => {
+  const token = { $schema: ALIAS_SCHEMA, uuid: "abc", value: "{blue-100}" };
+  t.is(classifyToken("body-color", token), null);
+});
+
+test("classifyToken: color token with unclassifiable key returns name:null", (t) => {
+  const token = { $schema: COLOR_SCHEMA, uuid: "abc", value: "0" };
+  const result = classifyToken("gradient-stop-1-avatar", token);
+  t.deepEqual(result, { name: null });
+});
+
+test("classifyToken: font-weight canonical token gets name", (t) => {
+  const token = { $schema: FONT_WEIGHT_SCHEMA, uuid: "abc", value: "bold" };
+  const result = classifyToken("bold-font-weight", token);
+  t.deepEqual(result, { name: { property: "font-weight", weight: "bold" } });
+});
+
+test("classifyToken: font-weight alias is out of scope (null)", (t) => {
+  const token = {
+    $schema: ALIAS_SCHEMA,
+    uuid: "abc",
+    value: "{bold-font-weight}",
+  };
+  t.is(classifyToken("body-cjk-strong-font-weight", token), null);
+});
+
+test("classifyToken: manual override applied", (t) => {
+  const token = { $schema: COLOR_SCHEMA, uuid: "abc", value: "#000" };
+  const overrides = {
+    "my-special-token": { name: { property: "color", colorFamily: "gray" } },
+  };
+  const result = classifyToken("my-special-token", token, overrides);
+  t.deepEqual(result, { name: { property: "color", colorFamily: "gray" } });
+});
+
+// ── transformFile ─────────────────────────────────────────────────────────────
+
+test("transformFile: injects name into color tokens, leaves others untouched", (t) => {
+  const tokens = {
+    "blue-100": { $schema: COLOR_SCHEMA, uuid: "a", value: "#fff" },
+    "body-font": { $schema: ALIAS_SCHEMA, uuid: "b", value: "{sans-serif}" },
+    "bold-font-weight": {
+      $schema: FONT_WEIGHT_SCHEMA,
+      uuid: "c",
+      value: "bold",
+    },
+  };
+  const { transformed, classified, unclassified, skipped } =
+    transformFile(tokens);
+  t.is(classified, 2);
+  t.is(skipped, 1);
+  t.is(unclassified.length, 0);
+  t.deepEqual(transformed["blue-100"].name, {
+    property: "color",
+    colorFamily: "blue",
+    scaleIndex: 100,
+  });
+  t.deepEqual(transformed["bold-font-weight"].name, {
+    property: "font-weight",
+    weight: "bold",
+  });
+  t.false("name" in transformed["body-font"]);
+});
+
+test("transformFile: unclassifiable in-scope token reported, not modified", (t) => {
+  const tokens = {
+    "gradient-stop-1-avatar": { $schema: COLOR_SCHEMA, uuid: "a", value: "0" },
+  };
+  const { unclassified, transformed } = transformFile(tokens);
+  t.is(unclassified.length, 1);
+  t.is(unclassified[0], "gradient-stop-1-avatar");
+  t.false("name" in transformed["gradient-stop-1-avatar"]);
+});

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -222,3 +222,24 @@ test("transformFile: unclassifiable in-scope token reported, not modified", (t) 
   t.is(unclassified[0], "gradient-stop-1-avatar");
   t.false("name" in transformed["gradient-stop-1-avatar"]);
 });
+
+test("transformFile: override is applied via transformFile", (t) => {
+  const tokens = {
+    "gradient-stop-1-avatar": { $schema: COLOR_SCHEMA, uuid: "a", value: "0" },
+  };
+  const overrides = {
+    "gradient-stop-1-avatar": {
+      name: { property: "color", colorFamily: "gray" },
+    },
+  };
+  const { transformed, classified, unclassified } = transformFile(
+    tokens,
+    overrides,
+  );
+  t.is(classified, 1);
+  t.is(unclassified.length, 0);
+  t.deepEqual(transformed["gradient-stop-1-avatar"].name, {
+    property: "color",
+    colorFamily: "gray",
+  });
+});


### PR DESCRIPTION
## Description

Introduces the first structured `name` objects to the Spectrum token corpus as
a pilot for the taxonomy migration kicked off by #961. The migration is driven
by a new reusable CLI tool (`tools/token-corpus-migrate`) so subsequent domains
can be migrated repeatably without hand-editing thousands of JSON files.

**What changed in token data:**
- `color-palette.json`: 369 tokens gain `name: { property: "color", colorFamily, scaleIndex? }`.
  Ramp tokens (e.g. `blue-100`) get both fields; bare family tokens (`black`, `white`,
  `transparent-black`, `transparent-white`) get `colorFamily` only.
  The 3 `gradient-stop-*` tokens are out of scope and untouched.
- `typography.json`: 6 canonical font-weight tokens (light, regular, medium, bold,
  extra-bold, black) gain `name: { property: "font-weight", weight }`.
  The 306 alias font-weight tokens are skipped (different PR).

**What's new in tooling:**
- `tools/token-corpus-migrate`: dry-run by default, `--write` to apply.
  Reads `colorFamily` and `weight` values directly from the registry JSON so it
  stays in sync automatically. Supports an `overrides.json` for edge cases.

**Registry package:** exports added for the 6 new taxonomy registries introduced
in #961 so downstream tools can import them as `@adobe/design-system-registry/registry/color-families.json`, etc.

## Related Issue

Corpus migration phase of #961 / #942 (taxonomy fields pilot).

## Motivation and Context

PR #961 landed `colorFamily`, `weight`, `style`, `motionRole`, `easing`, and
`family` as new structured name-object fields, but no token in the corpus used
them yet. This PR exercises those fields end-to-end against the cleanest,
most-mechanically-classifiable subsets of the corpus.

## How Has This Been Tested?

- `moon run tokens:test` — 20 tests pass, no regressions.
- `moon run sdk:test` — passes.
- `cargo run -p design-data-cli -- validate packages/tokens/src/` — SPEC-042 = 0 diagnostics
  (domain alignment is correct); SPEC-043 = 0 warnings (migrated tokens now have
  `colorFamily`/`weight`); SPEC-017 unchanged.
- Tool unit tests: 24 AVA tests covering all classification branches and edge cases.
- Dry-run report: 369 color classified, 6 typography classified, 0 unclassified.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.