### PR TITLE
feat(tokens): name-object migration for typography canonicals and font-size scale

### DIFF
--- a/.changeset/typography-canonicals-pilot.md
+++ b/.changeset/typography-canonicals-pilot.md
@@ -1,0 +1,16 @@
+---
+"@adobe/spectrum-tokens": minor
+"@adobe/design-system-registry": patch
+---
+
+Typography canonical name-object migration: add `name` fields to remaining
+non-alias typography tokens in `typography.json`.
+
+- **font-family tokens** (4): gain `name: { property: "font-family", family }`.
+- **font-style tokens** (2): gain `name: { property: "font-style", style }`.
+- **font-size scale-set tokens** (18): gain `name: { property: "font-size", scaleIndex }`.
+- **line-height scale-set tokens** (18): gain `name: { property: "line-height", scaleIndex }`.
+- **design-system-registry**: add `font-style` to `property-terms.json`; add
+  `normal` to `typography-styles.json`; update `registry_data.rs`.
+- **token-corpus-migrate**: extend with `fontFamilyNameForKey`, `fontStyleNameForKey`,
+  `fontSizeNameForKey`, `lineHeightNameForKey` classifiers.

--- a/packages/design-system-registry/registry/property-terms.json
+++ b/packages/design-system-registry/registry/property-terms.json
@@ -154,6 +154,11 @@
       "description": "Typeface family name"
     },
     {
+      "id": "font-style",
+      "label": "Font Style",
+      "description": "Typeface style (normal, italic, oblique)"
+    },
+    {
       "id": "line-height",
       "label": "Line Height",
       "description": "Vertical spacing between lines of text"

--- a/packages/design-system-registry/registry/typography-styles.json
+++ b/packages/design-system-registry/registry/typography-styles.json
@@ -4,6 +4,11 @@
   "description": "Typographic style values for typography tokens. Assigned via the `style` name-object field. Corresponds to the CSS font-style axis. The normal/default style is not listed — omit the field when style is normal.",
   "values": [
     {
+      "id": "normal",
+      "label": "Normal",
+      "description": "Default upright font style (font-style: normal)"
+    },
+    {
       "id": "italic",
       "label": "Italic",
       "description": "Italic font style (font-style: italic)"

--- a/packages/design-system-registry/registry/typography-styles.json
+++ b/packages/design-system-registry/registry/typography-styles.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "typography-style",
-  "description": "Typographic style values for typography tokens. Assigned via the `style` name-object field. Corresponds to the CSS font-style axis. The normal/default style is not listed — omit the field when style is normal.",
+  "description": "Typographic style values for typography tokens. Assigned via the `style` name-object field. Corresponds to the CSS font-style axis. All recognized styles are listed; normal represents the default upright style.",
   "values": [
     {
       "id": "normal",

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -293,7 +293,11 @@
   "cjk-font-family": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
     "uuid": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
-    "value": "Adobe Clean Han"
+    "value": "Adobe Clean Han",
+    "name": {
+      "property": "font-family",
+      "family": "cjk"
+    }
   },
   "cjk-letter-spacing": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -392,7 +396,11 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
     "component": "code",
     "uuid": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1",
-    "value": "Source Code Pro"
+    "value": "Source Code Pro",
+    "name": {
+      "property": "font-family",
+      "family": "code"
+    }
   },
   "code-font-style": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -639,7 +647,11 @@
   "default-font-style": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-style.json",
     "uuid": "25668698-bf78-46f4-bc6c-8fea068ddb34",
-    "value": "normal"
+    "value": "normal",
+    "name": {
+      "property": "font-style",
+      "style": "normal"
+    }
   },
   "detail-cjk-emphasized-font-style": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1105,7 +1117,11 @@
         "value": "17px"
       }
     },
-    "uuid": "ee894aad-f166-42eb-b08b-859f73db742a"
+    "uuid": "ee894aad-f166-42eb-b08b-859f73db742a",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 100
+    }
   },
   "font-size-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1121,7 +1137,11 @@
         "value": "49px"
       }
     },
-    "uuid": "200d964e-b6f4-4011-a40d-33b1bfb7aa68"
+    "uuid": "200d964e-b6f4-4011-a40d-33b1bfb7aa68",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 1000
+    }
   },
   "font-size-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1137,7 +1157,11 @@
         "value": "55px"
       }
     },
-    "uuid": "202a2c3e-5bfc-4871-9481-13c771bdc8dc"
+    "uuid": "202a2c3e-5bfc-4871-9481-13c771bdc8dc",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 1100
+    }
   },
   "font-size-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1153,7 +1177,11 @@
         "value": "62px"
       }
     },
-    "uuid": "dbd67b04-f114-4549-8e36-223b7d7007c7"
+    "uuid": "dbd67b04-f114-4549-8e36-223b7d7007c7",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 1200
+    }
   },
   "font-size-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1169,7 +1197,11 @@
         "value": "70px"
       }
     },
-    "uuid": "760d6969-7e0e-4744-b1c6-d89d3a02af8d"
+    "uuid": "760d6969-7e0e-4744-b1c6-d89d3a02af8d",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 1300
+    }
   },
   "font-size-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1185,7 +1217,11 @@
         "value": "79px"
       }
     },
-    "uuid": "21c1f04f-3a63-4bf8-9f60-e9afa0e672a2"
+    "uuid": "21c1f04f-3a63-4bf8-9f60-e9afa0e672a2",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 1400
+    }
   },
   "font-size-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1201,7 +1237,11 @@
         "value": "88px"
       }
     },
-    "uuid": "d59c0cd1-efb8-4f5b-9d5a-7ecbcd79f758"
+    "uuid": "d59c0cd1-efb8-4f5b-9d5a-7ecbcd79f758",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 1500
+    }
   },
   "font-size-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1217,7 +1257,11 @@
         "value": "19px"
       }
     },
-    "uuid": "fe457dd7-582a-4f0a-badc-7850adfd8cb7"
+    "uuid": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 200
+    }
   },
   "font-size-25": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1233,7 +1277,11 @@
         "value": "12px"
       }
     },
-    "uuid": "73ef03ac-5b7b-4182-8991-0bb62006d276"
+    "uuid": "73ef03ac-5b7b-4182-8991-0bb62006d276",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 25
+    }
   },
   "font-size-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1249,7 +1297,11 @@
         "value": "22px"
       }
     },
-    "uuid": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a"
+    "uuid": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 300
+    }
   },
   "font-size-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1265,7 +1317,11 @@
         "value": "24px"
       }
     },
-    "uuid": "7560656c-41c2-4b51-ba29-b04aa3cd386b"
+    "uuid": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 400
+    }
   },
   "font-size-50": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1281,7 +1337,11 @@
         "value": "13px"
       }
     },
-    "uuid": "c6074b73-d460-439d-9401-498f52c88340"
+    "uuid": "c6074b73-d460-439d-9401-498f52c88340",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 50
+    }
   },
   "font-size-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1297,7 +1357,11 @@
         "value": "27px"
       }
     },
-    "uuid": "935af8c5-6f70-49ee-b5ba-5e9650682753"
+    "uuid": "935af8c5-6f70-49ee-b5ba-5e9650682753",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 500
+    }
   },
   "font-size-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1313,7 +1377,11 @@
         "value": "31px"
       }
     },
-    "uuid": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e"
+    "uuid": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 600
+    }
   },
   "font-size-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1329,7 +1397,11 @@
         "value": "34px"
       }
     },
-    "uuid": "c9a3ec61-f116-4298-be2d-6149d6eae889"
+    "uuid": "c9a3ec61-f116-4298-be2d-6149d6eae889",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 700
+    }
   },
   "font-size-75": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1345,7 +1417,11 @@
         "value": "15px"
       }
     },
-    "uuid": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e"
+    "uuid": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 75
+    }
   },
   "font-size-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1361,7 +1437,11 @@
         "value": "39px"
       }
     },
-    "uuid": "d46d987e-44dd-4113-81b3-1b28c0f5cfe6"
+    "uuid": "d46d987e-44dd-4113-81b3-1b28c0f5cfe6",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 800
+    }
   },
   "font-size-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1377,7 +1457,11 @@
         "value": "44px"
       }
     },
-    "uuid": "cf1791b4-dcc2-4620-a508-d95bbd44504b"
+    "uuid": "cf1791b4-dcc2-4620-a508-d95bbd44504b",
+    "name": {
+      "property": "font-size",
+      "scaleIndex": 900
+    }
   },
   "heading-cjk-emphasized-font-style": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1989,7 +2073,11 @@
   "italic-font-style": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-style.json",
     "uuid": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
-    "value": "italic"
+    "value": "italic",
+    "name": {
+      "property": "font-style",
+      "style": "italic"
+    }
   },
   "letter-spacing": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -2029,7 +2117,11 @@
         "value": "22px"
       }
     },
-    "uuid": "65b87e13-5799-43e0-a8d3-7f8288ccc3f7"
+    "uuid": "65b87e13-5799-43e0-a8d3-7f8288ccc3f7",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 100
+    }
   },
   "line-height-font-size-1000": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2045,7 +2137,11 @@
         "value": "56px"
       }
     },
-    "uuid": "9c0a5092-0faa-4f70-bd5e-dfeda66ae286"
+    "uuid": "9c0a5092-0faa-4f70-bd5e-dfeda66ae286",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 1000
+    }
   },
   "line-height-font-size-1100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2061,7 +2157,11 @@
         "value": "64px"
       }
     },
-    "uuid": "55494016-ab3d-475c-99b3-6824e8df227a"
+    "uuid": "55494016-ab3d-475c-99b3-6824e8df227a",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 1100
+    }
   },
   "line-height-font-size-1200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2077,7 +2177,11 @@
         "value": "72px"
       }
     },
-    "uuid": "f94ee04e-f2d7-4cb3-8d5f-f35119766fc8"
+    "uuid": "f94ee04e-f2d7-4cb3-8d5f-f35119766fc8",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 1200
+    }
   },
   "line-height-font-size-1300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2093,7 +2197,11 @@
         "value": "80px"
       }
     },
-    "uuid": "6a5986cd-4bcb-4de2-a474-d5d0fad5187f"
+    "uuid": "6a5986cd-4bcb-4de2-a474-d5d0fad5187f",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 1300
+    }
   },
   "line-height-font-size-1400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2109,7 +2217,11 @@
         "value": "90px"
       }
     },
-    "uuid": "15edb168-9840-4fad-ab60-c1c3423ec855"
+    "uuid": "15edb168-9840-4fad-ab60-c1c3423ec855",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 1400
+    }
   },
   "line-height-font-size-1500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2125,7 +2237,11 @@
         "value": "102px"
       }
     },
-    "uuid": "330c5167-53ef-46cc-8a7c-3cb5b3ee0b2b"
+    "uuid": "330c5167-53ef-46cc-8a7c-3cb5b3ee0b2b",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 1500
+    }
   },
   "line-height-font-size-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2141,7 +2257,11 @@
         "value": "24px"
       }
     },
-    "uuid": "f8763297-f04f-4294-a7ba-376e3b12f1eb"
+    "uuid": "f8763297-f04f-4294-a7ba-376e3b12f1eb",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 200
+    }
   },
   "line-height-font-size-25": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2157,7 +2277,11 @@
         "value": "14px"
       }
     },
-    "uuid": "1894b682-105c-409b-916a-d2e08de4f6a8"
+    "uuid": "1894b682-105c-409b-916a-d2e08de4f6a8",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 25
+    }
   },
   "line-height-font-size-300": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2173,7 +2297,11 @@
         "value": "26px"
       }
     },
-    "uuid": "228d27b4-ff57-4308-9761-3ad5cf7f39d1"
+    "uuid": "228d27b4-ff57-4308-9761-3ad5cf7f39d1",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 300
+    }
   },
   "line-height-font-size-400": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2189,7 +2317,11 @@
         "value": "28px"
       }
     },
-    "uuid": "97f2ab52-9c62-43c3-b7b6-3eeb6c561e87"
+    "uuid": "97f2ab52-9c62-43c3-b7b6-3eeb6c561e87",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 400
+    }
   },
   "line-height-font-size-50": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2205,7 +2337,11 @@
         "value": "16px"
       }
     },
-    "uuid": "1553daaa-14c0-405e-bd80-e04a059b52e2"
+    "uuid": "1553daaa-14c0-405e-bd80-e04a059b52e2",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 50
+    }
   },
   "line-height-font-size-500": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2221,7 +2357,11 @@
         "value": "32px"
       }
     },
-    "uuid": "7f8c6173-2708-4196-b04d-2d5027fface8"
+    "uuid": "7f8c6173-2708-4196-b04d-2d5027fface8",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 500
+    }
   },
   "line-height-font-size-600": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2237,7 +2377,11 @@
         "value": "36px"
       }
     },
-    "uuid": "7d112d28-28c4-4bca-aef7-a7a0af1b7d1d"
+    "uuid": "7d112d28-28c4-4bca-aef7-a7a0af1b7d1d",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 600
+    }
   },
   "line-height-font-size-700": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2253,7 +2397,11 @@
         "value": "40px"
       }
     },
-    "uuid": "cbb416af-7b54-4024-b495-fa87fb9f742f"
+    "uuid": "cbb416af-7b54-4024-b495-fa87fb9f742f",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 700
+    }
   },
   "line-height-font-size-75": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2269,7 +2417,11 @@
         "value": "20px"
       }
     },
-    "uuid": "6214acc2-2130-4b31-857f-0f865673a9ad"
+    "uuid": "6214acc2-2130-4b31-857f-0f865673a9ad",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 75
+    }
   },
   "line-height-font-size-800": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2285,7 +2437,11 @@
         "value": "44px"
       }
     },
-    "uuid": "8bd1d897-56c3-432f-a2c7-d6138e337de6"
+    "uuid": "8bd1d897-56c3-432f-a2c7-d6138e337de6",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 800
+    }
   },
   "line-height-font-size-900": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -2301,7 +2457,11 @@
         "value": "50px"
       }
     },
-    "uuid": "4ff1f344-dad7-4b12-9c38-2d9561d433a7"
+    "uuid": "4ff1f344-dad7-4b12-9c38-2d9561d433a7",
+    "name": {
+      "property": "line-height",
+      "scaleIndex": 900
+    }
   },
   "medium-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
@@ -2324,12 +2484,20 @@
   "sans-serif-font-family": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
     "uuid": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
-    "value": "Adobe Clean Spectrum VF"
+    "value": "Adobe Clean Spectrum VF",
+    "name": {
+      "property": "font-family",
+      "family": "sans-serif"
+    }
   },
   "serif-font-family": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
     "uuid": "7f83198f-26ec-4156-9573-826dd7feb718",
-    "value": "Adobe Clean Serif"
+    "value": "Adobe Clean Serif",
+    "name": {
+      "property": "font-family",
+      "family": "serif"
+    }
   },
   "text-align-center": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -2146,7 +2146,7 @@ const TYPOGRAPHY_WEIGHTS_JSON: &str = r##"{
 const TYPOGRAPHY_STYLES_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "typography-style",
-  "description": "Typographic style values for typography tokens. Assigned via the `style` name-object field. Corresponds to the CSS font-style axis. The normal/default style is not listed — omit the field when style is normal.",
+  "description": "Typographic style values for typography tokens. Assigned via the `style` name-object field. Corresponds to the CSS font-style axis. All recognized styles are listed; normal represents the default upright style.",
   "values": [
     {
       "id": "normal",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1533,6 +1533,11 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "description": "Typeface family name"
     },
     {
+      "id": "font-style",
+      "label": "Font Style",
+      "description": "Typeface style (normal, italic, oblique)"
+    },
+    {
       "id": "line-height",
       "label": "Line Height",
       "description": "Vertical spacing between lines of text"
@@ -2143,6 +2148,11 @@ const TYPOGRAPHY_STYLES_JSON: &str = r##"{
   "type": "typography-style",
   "description": "Typographic style values for typography tokens. Assigned via the `style` name-object field. Corresponds to the CSS font-style axis. The normal/default style is not listed — omit the field when style is normal.",
   "values": [
+    {
+      "id": "normal",
+      "label": "Normal",
+      "description": "Default upright font style (font-style: normal)"
+    },
     {
       "id": "italic",
       "label": "Italic",

--- a/tools/token-corpus-migrate/README.md
+++ b/tools/token-corpus-migrate/README.md
@@ -27,13 +27,20 @@ By default the tool processes only the files declared in `PILOT_FILES` (currentl
 
 Each token is matched against the rules in `src/transform.js`:
 
-| Token `$schema`                 | Key pattern            | Resulting `name`                                 |
-| ------------------------------- | ---------------------- | ------------------------------------------------ |
-| `color.json` / `color-set.json` | `<family>-<N>`         | `{ property: "color", colorFamily, scaleIndex }` |
-| `color.json` / `color-set.json` | bare family id         | `{ property: "color", colorFamily }`             |
-| `font-weight.json`              | `<weight>-font-weight` | `{ property: "font-weight", weight }`            |
+| Token `$schema`                 | Key pattern                    | Resulting `name`                                 |
+| ------------------------------- | ------------------------------ | ------------------------------------------------ |
+| `color.json` / `color-set.json` | `<family>-<N>`                 | `{ property: "color", colorFamily, scaleIndex }` |
+| `color.json` / `color-set.json` | bare family id                 | `{ property: "color", colorFamily }`             |
+| `font-family.json`              | `<family>-font-family`         | `{ property: "font-family", family }`            |
+| `font-style.json`               | `<style>-font-style`           | `{ property: "font-style", style }`              |
+| `font-style.json`               | any key with `value: "normal"` | `{ property: "font-style", style: "normal" }`    |
+| `font-weight.json`              | `<weight>-font-weight`         | `{ property: "font-weight", weight }`            |
+| `scale-set.json`                | `font-size-<N>`                | `{ property: "font-size", scaleIndex }`          |
+| `scale-set.json`                | `line-height-font-size-<N>`    | `{ property: "line-height", scaleIndex }`        |
 
 Valid `colorFamily` values are sourced from `@adobe/design-system-registry/registry/color-families.json`.
+Valid `family` values are sourced from `@adobe/design-system-registry/registry/typography-families.json`.
+Valid `style` values are sourced from `@adobe/design-system-registry/registry/typography-styles.json`.
 Valid `weight` values are sourced from `@adobe/design-system-registry/registry/typography-weights.json`.
 Tokens that already have a `name` field are skipped.
 Alias tokens and other out-of-scope schemas are left untouched.

--- a/tools/token-corpus-migrate/src/transform.js
+++ b/tools/token-corpus-migrate/src/transform.js
@@ -11,15 +11,24 @@ governing permissions and limitations under the License.
 */
 
 import colorFamiliesData from "@adobe/design-system-registry/registry/color-families.json" with { type: "json" };
+import typographyFamiliesData from "@adobe/design-system-registry/registry/typography-families.json" with { type: "json" };
+import typographyStylesData from "@adobe/design-system-registry/registry/typography-styles.json" with { type: "json" };
 import typographyWeightsData from "@adobe/design-system-registry/registry/typography-weights.json" with { type: "json" };
 
 const COLOR_FAMILIES = new Set(colorFamiliesData.values.map((v) => v.id));
+const TYPOGRAPHY_FAMILIES = new Set(
+  typographyFamiliesData.values.map((v) => v.id),
+);
+const TYPOGRAPHY_STYLES = new Set(typographyStylesData.values.map((v) => v.id));
 const TYPOGRAPHY_WEIGHTS = new Set(
   typographyWeightsData.values.map((v) => v.id),
 );
 
 const COLOR_SCHEMAS = new Set(["color.json", "color-set.json"]);
+const FONT_FAMILY_SCHEMA = "font-family.json";
+const FONT_STYLE_SCHEMA = "font-style.json";
 const FONT_WEIGHT_SCHEMA = "font-weight.json";
+const SCALE_SET_SCHEMA = "scale-set.json";
 
 /** Returns true when a $schema URL ends with the given suffix. */
 function schemaEndsWith(schemaUrl, suffix) {
@@ -93,6 +102,72 @@ export function fontWeightNameForKey(key) {
 }
 
 /**
+ * Derive the name object for a font-family token, or null if unclassifiable.
+ *
+ * Pattern:  <family>-font-family  where family is in the typography-families registry.
+ */
+export function fontFamilyNameForKey(key) {
+  const match = key.match(/^(.+)-font-family$/);
+  if (match) {
+    const [, family] = match;
+    if (TYPOGRAPHY_FAMILIES.has(family)) {
+      return { property: "font-family", family };
+    }
+  }
+  return null;
+}
+
+/**
+ * Derive the name object for a font-style token, or null if unclassifiable.
+ *
+ * Patterns:
+ *   <style>-font-style  where <style> is in the typography-styles registry.
+ *   <anything>-font-style  where the token value is a registry style id
+ *   (handles "default-font-style" whose value is "normal").
+ */
+export function fontStyleNameForKey(key, token) {
+  const match = key.match(/^(.+)-font-style$/);
+  if (!match) return null;
+  const [, candidate] = match;
+  if (TYPOGRAPHY_STYLES.has(candidate)) {
+    return { property: "font-style", style: candidate };
+  }
+  // Key prefix isn't a registry id — fall back to the token's value.
+  const value = typeof token?.value === "string" ? token.value : null;
+  if (value && TYPOGRAPHY_STYLES.has(value)) {
+    return { property: "font-style", style: value };
+  }
+  return null;
+}
+
+/**
+ * Derive the name object for a font-size scale-set token, or null if unclassifiable.
+ *
+ * Pattern:  font-size-<N>
+ */
+export function fontSizeNameForKey(key) {
+  const match = key.match(/^font-size-(\d+)$/);
+  if (match) {
+    return { property: "font-size", scaleIndex: Number(match[1]) };
+  }
+  return null;
+}
+
+/**
+ * Derive the name object for a line-height scale-set token expressed in font-size
+ * units, or null if unclassifiable.
+ *
+ * Pattern:  line-height-font-size-<N>
+ */
+export function lineHeightNameForKey(key) {
+  const match = key.match(/^line-height-font-size-(\d+)$/);
+  if (match) {
+    return { property: "line-height", scaleIndex: Number(match[1]) };
+  }
+  return null;
+}
+
+/**
  * Classify a single token entry and return a name object, or null to skip.
  *
  * @param {string} key            - Token key (e.g. "blue-100")
@@ -119,6 +194,24 @@ export function classifyToken(key, token, overrides = {}) {
     const name = fontWeightNameForKey(key);
     if (name) return { name };
     return { name: null }; // in-scope but unclassified
+  }
+
+  if (schemaEndsWith(schema, FONT_FAMILY_SCHEMA)) {
+    const name = fontFamilyNameForKey(key);
+    if (name) return { name };
+    return { name: null }; // in-scope but unclassified
+  }
+
+  if (schemaEndsWith(schema, FONT_STYLE_SCHEMA)) {
+    const name = fontStyleNameForKey(key, token);
+    if (name) return { name };
+    return { name: null }; // in-scope but unclassified
+  }
+
+  if (schemaEndsWith(schema, SCALE_SET_SCHEMA)) {
+    const name = fontSizeNameForKey(key) ?? lineHeightNameForKey(key);
+    if (name) return { name };
+    return null; // other scale-set tokens (layout, etc.) are out of scope
   }
 
   return null; // out of scope for this tool

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -14,15 +14,27 @@ import test from "ava";
 import {
   classifyToken,
   colorNameForKey,
+  fontFamilyNameForKey,
+  fontSizeNameForKey,
+  fontStyleNameForKey,
   fontWeightNameForKey,
+  lineHeightNameForKey,
   transformFile,
 } from "../src/transform.js";
 
 const COLOR_SCHEMA = "https://example.com/schemas/token-types/color.json";
 const COLOR_SET_SCHEMA =
   "https://example.com/schemas/token-types/color-set.json";
+const FONT_FAMILY_SCHEMA =
+  "https://example.com/schemas/token-types/font-family.json";
+const FONT_SIZE_SCHEMA =
+  "https://example.com/schemas/token-types/font-size.json";
+const FONT_STYLE_SCHEMA =
+  "https://example.com/schemas/token-types/font-style.json";
 const FONT_WEIGHT_SCHEMA =
   "https://example.com/schemas/token-types/font-weight.json";
+const SCALE_SET_SCHEMA =
+  "https://example.com/schemas/token-types/scale-set.json";
 const ALIAS_SCHEMA = "https://example.com/schemas/token-types/alias.json";
 
 // ── colorNameForKey ───────────────────────────────────────────────────────────
@@ -242,4 +254,221 @@ test("transformFile: override is applied via transformFile", (t) => {
     property: "color",
     colorFamily: "gray",
   });
+});
+
+// ── fontFamilyNameForKey ──────────────────────────────────────────────────────
+
+test("fontFamilyNameForKey: sans-serif", (t) => {
+  t.deepEqual(fontFamilyNameForKey("sans-serif-font-family"), {
+    property: "font-family",
+    family: "sans-serif",
+  });
+});
+
+test("fontFamilyNameForKey: serif", (t) => {
+  t.deepEqual(fontFamilyNameForKey("serif-font-family"), {
+    property: "font-family",
+    family: "serif",
+  });
+});
+
+test("fontFamilyNameForKey: cjk", (t) => {
+  t.deepEqual(fontFamilyNameForKey("cjk-font-family"), {
+    property: "font-family",
+    family: "cjk",
+  });
+});
+
+test("fontFamilyNameForKey: code", (t) => {
+  t.deepEqual(fontFamilyNameForKey("code-font-family"), {
+    property: "font-family",
+    family: "code",
+  });
+});
+
+test("fontFamilyNameForKey: unknown family returns null", (t) => {
+  t.is(fontFamilyNameForKey("monospace-font-family"), null);
+});
+
+test("fontFamilyNameForKey: non-family key returns null", (t) => {
+  t.is(fontFamilyNameForKey("body-font-size"), null);
+});
+
+// ── fontStyleNameForKey ───────────────────────────────────────────────────────
+
+test("fontStyleNameForKey: italic via key prefix", (t) => {
+  t.deepEqual(fontStyleNameForKey("italic-font-style", { value: "italic" }), {
+    property: "font-style",
+    style: "italic",
+  });
+});
+
+test("fontStyleNameForKey: default key falls back to token value (normal)", (t) => {
+  t.deepEqual(fontStyleNameForKey("default-font-style", { value: "normal" }), {
+    property: "font-style",
+    style: "normal",
+  });
+});
+
+test("fontStyleNameForKey: oblique via key prefix", (t) => {
+  t.deepEqual(fontStyleNameForKey("oblique-font-style", { value: "oblique" }), {
+    property: "font-style",
+    style: "oblique",
+  });
+});
+
+test("fontStyleNameForKey: unknown key and unknown value returns null", (t) => {
+  t.is(fontStyleNameForKey("mystery-font-style", { value: "condensed" }), null);
+});
+
+test("fontStyleNameForKey: non-style key returns null", (t) => {
+  t.is(fontStyleNameForKey("bold-font-weight", {}), null);
+});
+
+// ── fontSizeNameForKey ────────────────────────────────────────────────────────
+
+test("fontSizeNameForKey: font-size-100", (t) => {
+  t.deepEqual(fontSizeNameForKey("font-size-100"), {
+    property: "font-size",
+    scaleIndex: 100,
+  });
+});
+
+test("fontSizeNameForKey: font-size-1500", (t) => {
+  t.deepEqual(fontSizeNameForKey("font-size-1500"), {
+    property: "font-size",
+    scaleIndex: 1500,
+  });
+});
+
+test("fontSizeNameForKey: non-numeric suffix returns null", (t) => {
+  t.is(fontSizeNameForKey("font-size-foo"), null);
+});
+
+test("fontSizeNameForKey: line-height key returns null", (t) => {
+  t.is(fontSizeNameForKey("line-height-font-size-100"), null);
+});
+
+// ── lineHeightNameForKey ──────────────────────────────────────────────────────
+
+test("lineHeightNameForKey: line-height-font-size-75", (t) => {
+  t.deepEqual(lineHeightNameForKey("line-height-font-size-75"), {
+    property: "line-height",
+    scaleIndex: 75,
+  });
+});
+
+test("lineHeightNameForKey: line-height-font-size-900", (t) => {
+  t.deepEqual(lineHeightNameForKey("line-height-font-size-900"), {
+    property: "line-height",
+    scaleIndex: 900,
+  });
+});
+
+test("lineHeightNameForKey: plain font-size key returns null", (t) => {
+  t.is(lineHeightNameForKey("font-size-100"), null);
+});
+
+test("lineHeightNameForKey: non-match returns null", (t) => {
+  t.is(lineHeightNameForKey("body-line-height"), null);
+});
+
+// ── classifyToken (new schema types) ─────────────────────────────────────────
+
+test("classifyToken: font-family token gets name", (t) => {
+  const token = {
+    $schema: FONT_FAMILY_SCHEMA,
+    uuid: "abc",
+    value: "Adobe Clean",
+  };
+  t.deepEqual(classifyToken("sans-serif-font-family", token), {
+    name: { property: "font-family", family: "sans-serif" },
+  });
+});
+
+test("classifyToken: font-style italic token gets name", (t) => {
+  const token = { $schema: FONT_STYLE_SCHEMA, uuid: "abc", value: "italic" };
+  t.deepEqual(classifyToken("italic-font-style", token), {
+    name: { property: "font-style", style: "italic" },
+  });
+});
+
+test("classifyToken: font-style default token gets name with style: normal", (t) => {
+  const token = { $schema: FONT_STYLE_SCHEMA, uuid: "abc", value: "normal" };
+  t.deepEqual(classifyToken("default-font-style", token), {
+    name: { property: "font-style", style: "normal" },
+  });
+});
+
+test("classifyToken: scale-set font-size token gets name", (t) => {
+  const token = { $schema: SCALE_SET_SCHEMA, uuid: "abc" };
+  t.deepEqual(classifyToken("font-size-100", token), {
+    name: { property: "font-size", scaleIndex: 100 },
+  });
+});
+
+test("classifyToken: scale-set line-height token gets name", (t) => {
+  const token = { $schema: SCALE_SET_SCHEMA, uuid: "abc" };
+  t.deepEqual(classifyToken("line-height-font-size-100", token), {
+    name: { property: "line-height", scaleIndex: 100 },
+  });
+});
+
+test("classifyToken: other scale-set tokens are out of scope (null)", (t) => {
+  const token = { $schema: SCALE_SET_SCHEMA, uuid: "abc" };
+  // A layout token keyed as a scale-set — not in scope
+  t.is(classifyToken("spacing-100", token), null);
+});
+
+// ── transformFile (typography round) ─────────────────────────────────────────
+
+test("transformFile: injects name into typography canonical tokens", (t) => {
+  const tokens = {
+    "sans-serif-font-family": {
+      $schema: FONT_FAMILY_SCHEMA,
+      uuid: "a",
+      value: "Adobe Clean",
+    },
+    "italic-font-style": {
+      $schema: FONT_STYLE_SCHEMA,
+      uuid: "b",
+      value: "italic",
+    },
+    "default-font-style": {
+      $schema: FONT_STYLE_SCHEMA,
+      uuid: "c",
+      value: "normal",
+    },
+    "font-size-100": { $schema: SCALE_SET_SCHEMA, uuid: "d" },
+    "line-height-font-size-100": { $schema: SCALE_SET_SCHEMA, uuid: "e" },
+    "body-font-size": {
+      $schema: ALIAS_SCHEMA,
+      uuid: "f",
+      value: "{font-size-100}",
+    },
+  };
+  const { transformed, classified, skipped } = transformFile(tokens);
+  t.is(classified, 5);
+  t.is(skipped, 1); // alias
+  t.deepEqual(transformed["sans-serif-font-family"].name, {
+    property: "font-family",
+    family: "sans-serif",
+  });
+  t.deepEqual(transformed["italic-font-style"].name, {
+    property: "font-style",
+    style: "italic",
+  });
+  t.deepEqual(transformed["default-font-style"].name, {
+    property: "font-style",
+    style: "normal",
+  });
+  t.deepEqual(transformed["font-size-100"].name, {
+    property: "font-size",
+    scaleIndex: 100,
+  });
+  t.deepEqual(transformed["line-height-font-size-100"].name, {
+    property: "line-height",
+    scaleIndex: 100,
+  });
+  t.false("name" in transformed["body-font-size"]);
 });

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -27,8 +27,6 @@ const COLOR_SET_SCHEMA =
   "https://example.com/schemas/token-types/color-set.json";
 const FONT_FAMILY_SCHEMA =
   "https://example.com/schemas/token-types/font-family.json";
-const FONT_SIZE_SCHEMA =
-  "https://example.com/schemas/token-types/font-size.json";
 const FONT_STYLE_SCHEMA =
   "https://example.com/schemas/token-types/font-style.json";
 const FONT_WEIGHT_SCHEMA =


### PR DESCRIPTION
## Description

Extends the `token-corpus-migrate` tool with four new classifiers and applies
them to all canonical (non-alias) typography tokens in `packages/tokens/src/typography.json`:

- **4 font-family tokens** gain `name: { property: "font-family", family }`
- **2 font-style tokens** gain `name: { property: "font-style", style }`
- **18 font-size scale-set tokens** gain `name: { property: "font-size", scaleIndex }`
- **18 line-height scale-set tokens** gain `name: { property: "line-height", scaleIndex }`

Also adds `font-style` to `property-terms.json` (it was missing) and adds `normal`
to `typography-styles.json` to correctly represent the default upright style. Regenerates
`registry_data.rs` accordingly.

## Related Issue

Follow-up to #963 (color palette + font-weight pilot). Continues the taxonomy corpus
migration plan from issue #942.

## Motivation and Context

PR #961 introduced the taxonomy fields (`family`, `style`, `weight`, `scaleIndex`, etc.)
but no tokens in the corpus used them. PR #963 migrated color-palette and font-weight
tokens as a pilot. This PR completes the remaining canonical typography tokens before
moving to alias/semantic tokens (which require a different name shape).

## How Has This Been Tested?

- `pnpm ava test` in `tools/token-corpus-migrate/` — 51 tests pass (26 new tests added)
- `moon run tokens:test` — 20 tests pass
- `moon run sdk:test` — 350 Rust tests pass
- `cargo run --bin design-data -- validate packages/tokens/src/` — SPEC-042: 0, SPEC-043: 0, SPEC-017: 0
- Changeset linter: `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.