### PR TITLE
feat(taxonomy): classify typography multiplier tokens (margin, line-height, cjk)

### DIFF
--- a/.changeset/line-height-multiplier-names.md
+++ b/.changeset/line-height-multiplier-names.md
@@ -1,15 +1,11 @@
 ---
-"@adobe/spectrum-tokens": minor
 "@adobe/design-system-registry": minor
+"@adobe/token-names": minor
 "design-data-core": minor
 ---
 
 Classify line-height multiplier and CJK line-height multiplier tokens.
 
-- **tokens/typography.json**: 4 tokens gain `name` objects — `line-height-{100,200}`
-  → `{ property: "line-height-multiplier", scaleIndex: N }`;
-  `cjk-line-height-{100,200}` → `{ property: "line-height-multiplier", family: "cjk",
-  scaleIndex: N }`
 - **registry/property-terms.json**: add `line-height-multiplier` term (unitless ratio,
   distinct from absolute px line-height paired with a font-size tier).
 - **sdk/validate/rules/mod.rs**: add `multiplier.json` to typography `DOMAIN_SCHEMAS`

--- a/.changeset/line-height-multiplier-names.md
+++ b/.changeset/line-height-multiplier-names.md
@@ -1,0 +1,20 @@
+---
+"@adobe/spectrum-tokens": minor
+"@adobe/design-system-registry": minor
+"design-data-core": minor
+---
+
+Classify line-height multiplier and CJK line-height multiplier tokens.
+
+- **tokens/typography.json**: 4 tokens gain `name` objects — `line-height-{100,200}`
+  → `{ property: "line-height-multiplier", scaleIndex: N }`;
+  `cjk-line-height-{100,200}` → `{ property: "line-height-multiplier", family: "cjk",
+  scaleIndex: N }`
+- **registry/property-terms.json**: add `line-height-multiplier` term (unitless ratio,
+  distinct from absolute px line-height paired with a font-size tier).
+- **sdk/validate/rules/mod.rs**: add `multiplier.json` to typography `DOMAIN_SCHEMAS`
+  so the `family` field is permitted on CJK multiplier tokens (SPEC-042).
+- **sdk/validate/rules/spec043.rs**: extend typography domain-required-fields check to
+  accept `scaleIndex` and `structure` alongside `family`/`weight`/`style`.
+- **token-names/names/typography.json**: sidecar entries for all 4 tokens.
+- Reduces SPEC-017 warning count by 4.

--- a/.changeset/margin-multiplier-names.md
+++ b/.changeset/margin-multiplier-names.md
@@ -1,6 +1,7 @@
 ---
 "@adobe/design-system-registry": minor
 "@adobe/token-names": minor
+"design-data-core": minor
 ---
 
 Classify 5 margin multiplier tokens; add margin property-terms and typography structures.

--- a/.changeset/margin-multiplier-names.md
+++ b/.changeset/margin-multiplier-names.md
@@ -1,0 +1,14 @@
+---
+"@adobe/spectrum-tokens": minor
+"@adobe/design-system-registry": minor
+---
+
+Classify 5 margin multiplier tokens; add margin property-terms and typography structures.
+
+- **tokens/typography.json**: 5 tokens gain `name` objects using `{ structure, property }` shape.
+  `body-margin-multiplier` → `{ structure: "body", property: "margin" }`;
+  `detail/heading-margin-{top,bottom}-multiplier` follow the same pattern.
+- **registry/property-terms.json**: add `margin`, `margin-top`, `margin-bottom`.
+- **registry/structures.json**: add `body`, `detail`, `heading` typography-scale structures.
+- **token-names/names/typography.json**: sidecar entries for all 5 tokens.
+- Reduces SPEC-017 (`string-name-tech-debt`) warning count by 5.

--- a/.changeset/margin-multiplier-names.md
+++ b/.changeset/margin-multiplier-names.md
@@ -1,14 +1,12 @@
 ---
-"@adobe/spectrum-tokens": minor
 "@adobe/design-system-registry": minor
+"@adobe/token-names": minor
 ---
 
 Classify 5 margin multiplier tokens; add margin property-terms and typography structures.
 
-- **tokens/typography.json**: 5 tokens gain `name` objects using `{ structure, property }` shape.
-  `body-margin-multiplier` → `{ structure: "body", property: "margin" }`;
-  `detail/heading-margin-{top,bottom}-multiplier` follow the same pattern.
 - **registry/property-terms.json**: add `margin`, `margin-top`, `margin-bottom`.
 - **registry/structures.json**: add `body`, `detail`, `heading` typography-scale structures.
-- **token-names/names/typography.json**: sidecar entries for all 5 tokens.
+- **token-names/names/typography.json**: sidecar entries for all 5 tokens using
+  `{ structure, property }` shape.
 - Reduces SPEC-017 (`string-name-tech-debt`) warning count by 5.

--- a/packages/design-system-registry/registry/property-terms.json
+++ b/packages/design-system-registry/registry/property-terms.json
@@ -202,6 +202,11 @@
       "id": "margin-bottom",
       "label": "Margin Bottom",
       "description": "External spacing below a block element"
+    },
+    {
+      "id": "line-height-multiplier",
+      "label": "Line Height Multiplier",
+      "description": "Unitless line-height ratio (multiplier), distinct from the absolute px line-height paired with a specific font-size tier"
     }
   ]
 }

--- a/packages/design-system-registry/registry/property-terms.json
+++ b/packages/design-system-registry/registry/property-terms.json
@@ -187,6 +187,21 @@
       "id": "easing",
       "label": "Easing",
       "description": "Animation or transition easing function"
+    },
+    {
+      "id": "margin",
+      "label": "Margin",
+      "description": "External spacing on all sides (used for typography block margin multipliers)"
+    },
+    {
+      "id": "margin-top",
+      "label": "Margin Top",
+      "description": "External spacing above a block element"
+    },
+    {
+      "id": "margin-bottom",
+      "label": "Margin Bottom",
+      "description": "External spacing below a block element"
     }
   ]
 }

--- a/packages/design-system-registry/registry/structures.json
+++ b/packages/design-system-registry/registry/structures.json
@@ -22,6 +22,21 @@
       "id": "accessory",
       "label": "Accessory",
       "description": "Supplementary element attached to a primary structure"
+    },
+    {
+      "id": "body",
+      "label": "Body",
+      "description": "Body text typography scale — used for standard paragraph and UI text"
+    },
+    {
+      "id": "detail",
+      "label": "Detail",
+      "description": "Detail text typography scale — used for captions, labels, and supporting text"
+    },
+    {
+      "id": "heading",
+      "label": "Heading",
+      "description": "Heading text typography scale — used for section and page headings"
     }
   ]
 }

--- a/packages/token-names/names/typography.json
+++ b/packages/token-names/names/typography.json
@@ -11,6 +11,16 @@
     "property": "font-weight",
     "weight": "bold"
   },
+  "cjk-line-height-100": {
+    "property": "line-height-multiplier",
+    "family": "cjk",
+    "scaleIndex": 100
+  },
+  "cjk-line-height-200": {
+    "property": "line-height-multiplier",
+    "family": "cjk",
+    "scaleIndex": 200
+  },
   "cjk-font-family": {
     "property": "font-family",
     "family": "cjk"
@@ -118,6 +128,14 @@
   "italic-font-style": {
     "property": "font-style",
     "style": "italic"
+  },
+  "line-height-100": {
+    "property": "line-height-multiplier",
+    "scaleIndex": 100
+  },
+  "line-height-200": {
+    "property": "line-height-multiplier",
+    "scaleIndex": 200
   },
   "letter-spacing": {
     "property": "letter-spacing"

--- a/packages/token-names/names/typography.json
+++ b/packages/token-names/names/typography.json
@@ -1,4 +1,8 @@
 {
+  "body-margin-multiplier": {
+    "structure": "body",
+    "property": "margin"
+  },
   "black-font-weight": {
     "property": "font-weight",
     "weight": "black"
@@ -14,6 +18,14 @@
   "code-font-family": {
     "property": "font-family",
     "family": "code"
+  },
+  "detail-margin-bottom-multiplier": {
+    "structure": "detail",
+    "property": "margin-bottom"
+  },
+  "detail-margin-top-multiplier": {
+    "structure": "detail",
+    "property": "margin-top"
   },
   "default-font-style": {
     "property": "font-style",
@@ -94,6 +106,14 @@
   "font-size-900": {
     "property": "font-size",
     "scaleIndex": 900
+  },
+  "heading-margin-bottom-multiplier": {
+    "structure": "heading",
+    "property": "margin-bottom"
+  },
+  "heading-margin-top-multiplier": {
+    "structure": "heading",
+    "property": "margin-top"
   },
   "italic-font-style": {
     "property": "font-style",

--- a/packages/tokens/schemas/token-types/multiplier.json
+++ b/packages/tokens/schemas/token-types/multiplier.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
   "title": "Multiplier",
-  "description": "A float used to multiply a value by a given amount. Also used as a line-height multiplier.",
+  "description": "A float used to multiply a value by a given amount. Used for line-height and margin multipliers.",
   "type": "object",
   "allOf": [
     {

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -119,10 +119,6 @@
   "body-margin-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "body",
-    "name": {
-      "structure": "body",
-      "property": "margin"
-    },
     "uuid": "8f2e9283-4cbc-4374-9757-ed8d68542c89",
     "value": 0.75
   },
@@ -298,21 +294,11 @@
   },
   "cjk-line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
-    "name": {
-      "property": "line-height-multiplier",
-      "family": "cjk",
-      "scaleIndex": 100
-    },
     "uuid": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
     "value": 1.5
   },
   "cjk-line-height-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
-    "name": {
-      "property": "line-height-multiplier",
-      "family": "cjk",
-      "scaleIndex": 200
-    },
     "uuid": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
     "value": 1.7
   },
@@ -815,20 +801,12 @@
   "detail-margin-bottom-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "detail",
-    "name": {
-      "structure": "detail",
-      "property": "margin-bottom"
-    },
     "uuid": "35ac24a4-0338-44c6-b780-120a0af0fc51",
     "value": 0.25
   },
   "detail-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "detail",
-    "name": {
-      "structure": "detail",
-      "property": "margin-top"
-    },
     "uuid": "5d34c3b5-fddd-420b-bfe4-0dee4e07701c",
     "value": 0.88888889
   },
@@ -1621,20 +1599,12 @@
   "heading-margin-bottom-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "heading",
-    "name": {
-      "structure": "heading",
-      "property": "margin-bottom"
-    },
     "uuid": "dd2035b4-506f-41ab-a656-de3668d44e0f",
     "value": 0.25
   },
   "heading-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "heading",
-    "name": {
-      "structure": "heading",
-      "property": "margin-top"
-    },
     "uuid": "008fa04b-6d74-416b-a6ae-ceec90f08642",
     "value": 0.88888889
   },
@@ -2021,19 +1991,11 @@
   },
   "line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
-    "name": {
-      "property": "line-height-multiplier",
-      "scaleIndex": 100
-    },
     "uuid": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
     "value": 1.3
   },
   "line-height-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
-    "name": {
-      "property": "line-height-multiplier",
-      "scaleIndex": 200
-    },
     "uuid": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97",
     "value": 1.5
   },

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -119,6 +119,10 @@
   "body-margin-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "body",
+    "name": {
+      "structure": "body",
+      "property": "margin"
+    },
     "uuid": "8f2e9283-4cbc-4374-9757-ed8d68542c89",
     "value": 0.75
   },
@@ -801,12 +805,20 @@
   "detail-margin-bottom-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "detail",
+    "name": {
+      "structure": "detail",
+      "property": "margin-bottom"
+    },
     "uuid": "35ac24a4-0338-44c6-b780-120a0af0fc51",
     "value": 0.25
   },
   "detail-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "detail",
+    "name": {
+      "structure": "detail",
+      "property": "margin-top"
+    },
     "uuid": "5d34c3b5-fddd-420b-bfe4-0dee4e07701c",
     "value": 0.88888889
   },
@@ -1599,12 +1611,20 @@
   "heading-margin-bottom-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "heading",
+    "name": {
+      "structure": "heading",
+      "property": "margin-bottom"
+    },
     "uuid": "dd2035b4-506f-41ab-a656-de3668d44e0f",
     "value": 0.25
   },
   "heading-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "heading",
+    "name": {
+      "structure": "heading",
+      "property": "margin-top"
+    },
     "uuid": "008fa04b-6d74-416b-a6ae-ceec90f08642",
     "value": 0.88888889
   },

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -298,11 +298,21 @@
   },
   "cjk-line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "name": {
+      "property": "line-height-multiplier",
+      "family": "cjk",
+      "scaleIndex": 100
+    },
     "uuid": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
     "value": 1.5
   },
   "cjk-line-height-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "name": {
+      "property": "line-height-multiplier",
+      "family": "cjk",
+      "scaleIndex": 200
+    },
     "uuid": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
     "value": 1.7
   },
@@ -2011,11 +2021,19 @@
   },
   "line-height-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "name": {
+      "property": "line-height-multiplier",
+      "scaleIndex": 100
+    },
     "uuid": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
     "value": 1.3
   },
   "line-height-200": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "name": {
+      "property": "line-height-multiplier",
+      "scaleIndex": 200
+    },
     "uuid": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97",
     "value": 1.5
   },

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1596,6 +1596,11 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "margin-bottom",
       "label": "Margin Bottom",
       "description": "External spacing below a block element"
+    },
+    {
+      "id": "line-height-multiplier",
+      "label": "Line Height Multiplier",
+      "description": "Unitless line-height ratio (multiplier), distinct from the absolute px line-height paired with a specific font-size tier"
     }
   ]
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -587,6 +587,21 @@ const STRUCTURES_JSON: &str = r##"{
       "id": "accessory",
       "label": "Accessory",
       "description": "Supplementary element attached to a primary structure"
+    },
+    {
+      "id": "body",
+      "label": "Body",
+      "description": "Body text typography scale — used for standard paragraph and UI text"
+    },
+    {
+      "id": "detail",
+      "label": "Detail",
+      "description": "Detail text typography scale — used for captions, labels, and supporting text"
+    },
+    {
+      "id": "heading",
+      "label": "Heading",
+      "description": "Heading text typography scale — used for section and page headings"
     }
   ]
 }
@@ -1566,6 +1581,21 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "easing",
       "label": "Easing",
       "description": "Animation or transition easing function"
+    },
+    {
+      "id": "margin",
+      "label": "Margin",
+      "description": "External spacing on all sides (used for typography block margin multipliers)"
+    },
+    {
+      "id": "margin-top",
+      "label": "Margin Top",
+      "description": "External spacing above a block element"
+    },
+    {
+      "id": "margin-bottom",
+      "label": "Margin Bottom",
+      "description": "External spacing below a block element"
     }
   ]
 }

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -68,6 +68,7 @@ pub(super) const DOMAIN_SCHEMAS: &[(&str, &[&str])] = &[
             "font-style.json",
             "font-size.json",
             "typography.json",
+            "multiplier.json",
         ],
     ),
     (

--- a/sdk/core/src/validate/rules/spec043.rs
+++ b/sdk/core/src/validate/rules/spec043.rs
@@ -18,8 +18,11 @@
 //!   Either field alone satisfies the check intentionally — a token with only `scaleIndex`
 //!   (ramp step without family context) is still sortable, and a token with only
 //!   `colorFamily` (non-ramp token such as transparent-black) is also valid.
-//! - Typography tokens (font-*.json, typography.json) SHOULD have `family`, `weight`,
-//!   or `style`.
+//! - Typography tokens (font-*.json, typography.json, multiplier.json) SHOULD have
+//!   `family`, `weight`, `style`, `scaleIndex`, or `structure`. The last two cover
+//!   typography-domain multiplier tokens (line-height ratios, margin multipliers)
+//!   which are identified by scale position or typography-scale category rather than
+//!   typeface attributes.
 //! - Motion tokens (duration.json, easing.json, motion.json) SHOULD have
 //!   `motionRole` or `easing`.
 //!
@@ -47,6 +50,8 @@ fn has_required_fields(
             name_obj.contains_key("family")
                 || name_obj.contains_key("weight")
                 || name_obj.contains_key("style")
+                || name_obj.contains_key("scaleIndex")
+                || name_obj.contains_key("structure")
         }
         "motion" => {
             name_obj.contains_key("motionRole") || name_obj.contains_key("easing")
@@ -106,7 +111,7 @@ impl ValidationRule for Rule {
 fn required_fields_description(domain: &str) -> &'static str {
     match domain {
         "color" => "colorFamily, scaleIndex",
-        "typography" => "family, weight, style",
+        "typography" => "family, weight, style, scaleIndex, structure",
         "motion" => "motionRole, easing",
         _ => "(unknown)",
     }
@@ -248,6 +253,42 @@ mod tests {
             json!({ "property": "easing", "motionRole": "enter" }),
         );
         assert!(diagnostics_for_rule(&g, "SPEC-043").is_empty());
+    }
+
+    #[test]
+    fn typography_multiplier_with_scale_index_no_warning() {
+        // multiplier.json is in the typography domain; scaleIndex satisfies the check.
+        const MULTIPLIER_SCHEMA: &str =
+            "https://example.com/schemas/token-types/multiplier.json";
+        let g = make_token(
+            MULTIPLIER_SCHEMA,
+            json!({ "property": "line-height-multiplier", "scaleIndex": 100 }),
+        );
+        assert!(diagnostics_for_rule(&g, "SPEC-043").is_empty());
+    }
+
+    #[test]
+    fn typography_multiplier_with_structure_no_warning() {
+        const MULTIPLIER_SCHEMA: &str =
+            "https://example.com/schemas/token-types/multiplier.json";
+        let g = make_token(
+            MULTIPLIER_SCHEMA,
+            json!({ "structure": "body", "property": "margin" }),
+        );
+        assert!(diagnostics_for_rule(&g, "SPEC-043").is_empty());
+    }
+
+    #[test]
+    fn typography_multiplier_missing_domain_fields_warns() {
+        const MULTIPLIER_SCHEMA: &str =
+            "https://example.com/schemas/token-types/multiplier.json";
+        let g = make_token(
+            MULTIPLIER_SCHEMA,
+            json!({ "property": "some-multiplier" }),
+        );
+        let diags = diagnostics_for_rule(&g, "SPEC-043");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("family"));
     }
 
     #[test]

--- a/tools/token-corpus-migrate/src/transform.js
+++ b/tools/token-corpus-migrate/src/transform.js
@@ -295,17 +295,32 @@ export function marginMultiplierNameForKey(key) {
 /**
  * Derive the name object for a line-height multiplier token, or null if unclassifiable.
  *
- * Pattern:  line-height-<N>  → { property, scaleIndex }
+ * Patterns handled:
+ *   line-height-<N>       → { property: "line-height-multiplier", scaleIndex: N }
+ *   cjk-line-height-<N>   → { property: "line-height-multiplier", family: "cjk", scaleIndex: N }
  *
- * cjk-line-height-<N> is deferred: SPEC-042 prohibits the `family` field on
- * multiplier.json tokens (not in the typography domain schema set).
+ * Uses "line-height-multiplier" (not "line-height") to avoid SPEC-006 collision with
+ * line-height-font-size-<N> scale-set tokens, which are absolute px values paired with
+ * specific font-size tiers. multiplier.json is in the typography DOMAIN_SCHEMAS so the
+ * `family` field is permitted on cjk tokens.
  *
  * Distinct from lineHeightNameForKey which handles line-height-font-size-<N> / scale-set.json.
  */
 export function lineHeightMultiplierNameForKey(key) {
   const plainMatch = key.match(/^line-height-(\d+)$/);
   if (plainMatch) {
-    return { property: "line-height", scaleIndex: Number(plainMatch[1]) };
+    return {
+      property: "line-height-multiplier",
+      scaleIndex: Number(plainMatch[1]),
+    };
+  }
+  const cjkMatch = key.match(/^cjk-line-height-(\d+)$/);
+  if (cjkMatch) {
+    return {
+      property: "line-height-multiplier",
+      family: "cjk",
+      scaleIndex: Number(cjkMatch[1]),
+    };
   }
   return null;
 }
@@ -383,12 +398,9 @@ export function classifyToken(key, token, overrides = {}) {
   }
 
   if (schemaEndsWith(schema, MULTIPLIER_SCHEMA)) {
-    const name = marginMultiplierNameForKey(key);
+    const name =
+      marginMultiplierNameForKey(key) ?? lineHeightMultiplierNameForKey(key);
     if (name) return { name };
-    // line-height multipliers (line-height-100, cjk-line-height-100) are deferred:
-    // - line-height-N collides with line-height-font-size-N (SPEC-006 specificity tie)
-    // - cjk-line-height-N would need `family` field, prohibited on multiplier.json (SPEC-042)
-    // When SPEC-006 is resolved, use lineHeightMultiplierNameForKey(key) here.
     return null; // other multipliers out of scope
   }
 

--- a/tools/token-corpus-migrate/src/transform.js
+++ b/tools/token-corpus-migrate/src/transform.js
@@ -276,9 +276,9 @@ export function alignmentNameForKey(key) {
  * Derive the name object for a margin multiplier token, or null if unclassifiable.
  *
  * Patterns handled:
- *   <component>-margin-multiplier             → { component, property: "margin" }
- *   <component>-margin-top-multiplier         → { component, property: "margin-top" }
- *   <component>-margin-bottom-multiplier      → { component, property: "margin-bottom" }
+ *   <structure>-margin-multiplier             → { structure, property: "margin" }
+ *   <structure>-margin-top-multiplier         → { structure, property: "margin-top" }
+ *   <structure>-margin-bottom-multiplier      → { structure, property: "margin-bottom" }
  *
  * Known structures: body, detail, heading.
  */

--- a/tools/token-corpus-migrate/src/transform.js
+++ b/tools/token-corpus-migrate/src/transform.js
@@ -273,6 +273,26 @@ export function alignmentNameForKey(key) {
 }
 
 /**
+ * Derive the name object for a margin multiplier token, or null if unclassifiable.
+ *
+ * Patterns handled:
+ *   <component>-margin-multiplier             → { component, property: "margin" }
+ *   <component>-margin-top-multiplier         → { component, property: "margin-top" }
+ *   <component>-margin-bottom-multiplier      → { component, property: "margin-bottom" }
+ *
+ * Known structures: body, detail, heading.
+ */
+export function marginMultiplierNameForKey(key) {
+  const match = key.match(
+    /^(body|detail|heading)-margin(-top|-bottom)?-multiplier$/,
+  );
+  if (!match) return null;
+  const [, structure, dir] = match;
+  const property = dir ? `margin${dir}` : "margin";
+  return { structure, property };
+}
+
+/**
  * Derive the name object for a line-height multiplier token, or null if unclassifiable.
  *
  * Pattern:  line-height-<N>  → { property, scaleIndex }
@@ -363,11 +383,13 @@ export function classifyToken(key, token, overrides = {}) {
   }
 
   if (schemaEndsWith(schema, MULTIPLIER_SCHEMA)) {
+    const name = marginMultiplierNameForKey(key);
+    if (name) return { name };
     // line-height multipliers (line-height-100, cjk-line-height-100) are deferred:
     // - line-height-N collides with line-height-font-size-N (SPEC-006 specificity tie)
     // - cjk-line-height-N would need `family` field, prohibited on multiplier.json (SPEC-042)
     // When SPEC-006 is resolved, use lineHeightMultiplierNameForKey(key) here.
-    return null; // out of scope
+    return null; // other multipliers out of scope
   }
 
   if (schemaEndsWith(schema, DIMENSION_SCHEMA)) {

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -790,13 +790,30 @@ test("classifyToken: cjk-line-height multiplier is out of scope (SPEC-042: famil
   t.is(classifyToken("cjk-line-height-100", token), null);
 });
 
-test("classifyToken: margin multiplier is out of scope (null)", (t) => {
+test("classifyToken: margin multiplier classifies with component and property", (t) => {
   const token = {
     $schema: MULTIPLIER_SCHEMA_URL,
     uuid: "abc",
     value: 0.75,
   };
-  t.is(classifyToken("body-margin-multiplier", token), null);
+  t.deepEqual(classifyToken("body-margin-multiplier", token), {
+    name: { structure: "body", property: "margin" },
+  });
+  t.deepEqual(
+    classifyToken("detail-margin-top-multiplier", { ...token, value: 0.89 }),
+    {
+      name: { structure: "detail", property: "margin-top" },
+    },
+  );
+  t.deepEqual(
+    classifyToken("heading-margin-bottom-multiplier", {
+      ...token,
+      value: 0.25,
+    }),
+    {
+      name: { structure: "heading", property: "margin-bottom" },
+    },
+  );
 });
 
 test("classifyToken: bare letter-spacing dimension classifies", (t) => {
@@ -861,8 +878,8 @@ test("transformFile: classifies text-align, line-height multipliers, and letter-
     },
   };
   const { nameMap, classified, unclassified, skipped } = transformFile(tokens);
-  t.is(classified, 4);
-  t.is(skipped, 4); // line-height-100 + cjk-line-height-100 + body-margin-multiplier + detail-letter-spacing
+  t.is(classified, 5); // text-align-{start,center,end} + letter-spacing + body-margin-multiplier
+  t.is(skipped, 3); // line-height-100 + cjk-line-height-100 + detail-letter-spacing
   t.deepEqual(unclassified, []);
   t.deepEqual(nameMap["text-align-start"], {
     property: "text-align",
@@ -881,6 +898,9 @@ test("transformFile: classifies text-align, line-height multipliers, and letter-
   t.deepEqual(nameMap["letter-spacing"], {
     property: "letter-spacing",
   });
-  t.falsy(nameMap["body-margin-multiplier"]);
+  t.deepEqual(nameMap["body-margin-multiplier"], {
+    structure: "body",
+    property: "margin",
+  });
   t.falsy(nameMap["detail-letter-spacing"]);
 });

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -714,21 +714,29 @@ test("alignmentNameForKey: non-alignment key returns null", (t) => {
 
 test("lineHeightMultiplierNameForKey: line-height-100", (t) => {
   t.deepEqual(lineHeightMultiplierNameForKey("line-height-100"), {
-    property: "line-height",
+    property: "line-height-multiplier",
     scaleIndex: 100,
   });
 });
 
 test("lineHeightMultiplierNameForKey: line-height-200", (t) => {
   t.deepEqual(lineHeightMultiplierNameForKey("line-height-200"), {
-    property: "line-height",
+    property: "line-height-multiplier",
     scaleIndex: 200,
   });
 });
 
-test("lineHeightMultiplierNameForKey: cjk-line-height deferred (SPEC-042: family not allowed on multiplier.json)", (t) => {
-  t.is(lineHeightMultiplierNameForKey("cjk-line-height-100"), null);
-  t.is(lineHeightMultiplierNameForKey("cjk-line-height-200"), null);
+test("lineHeightMultiplierNameForKey: cjk-line-height classifies with family", (t) => {
+  t.deepEqual(lineHeightMultiplierNameForKey("cjk-line-height-100"), {
+    property: "line-height-multiplier",
+    family: "cjk",
+    scaleIndex: 100,
+  });
+  t.deepEqual(lineHeightMultiplierNameForKey("cjk-line-height-200"), {
+    property: "line-height-multiplier",
+    family: "cjk",
+    scaleIndex: 200,
+  });
 });
 
 test("lineHeightMultiplierNameForKey: margin multiplier is out of scope", (t) => {
@@ -780,14 +788,22 @@ test("classifyToken: alignment token with unknown value is in-scope but unclassi
   t.deepEqual(classifyToken("text-align-justify", token), { name: null });
 });
 
-test("classifyToken: line-height multiplier is out of scope (SPEC-006: collides with scale-set line-height-font-size-N)", (t) => {
+test("classifyToken: line-height multiplier classifies as line-height-multiplier", (t) => {
   const token = { $schema: MULTIPLIER_SCHEMA_URL, uuid: "abc", value: 1.3 };
-  t.is(classifyToken("line-height-100", token), null);
+  t.deepEqual(classifyToken("line-height-100", token), {
+    name: { property: "line-height-multiplier", scaleIndex: 100 },
+  });
 });
 
-test("classifyToken: cjk-line-height multiplier is out of scope (SPEC-042: family not allowed on multiplier.json)", (t) => {
+test("classifyToken: cjk-line-height multiplier classifies with family", (t) => {
   const token = { $schema: MULTIPLIER_SCHEMA_URL, uuid: "abc", value: 1.5 };
-  t.is(classifyToken("cjk-line-height-100", token), null);
+  t.deepEqual(classifyToken("cjk-line-height-100", token), {
+    name: {
+      property: "line-height-multiplier",
+      family: "cjk",
+      scaleIndex: 100,
+    },
+  });
 });
 
 test("classifyToken: margin multiplier classifies with component and property", (t) => {
@@ -878,8 +894,8 @@ test("transformFile: classifies text-align, line-height multipliers, and letter-
     },
   };
   const { nameMap, classified, unclassified, skipped } = transformFile(tokens);
-  t.is(classified, 5); // text-align-{start,center,end} + letter-spacing + body-margin-multiplier
-  t.is(skipped, 3); // line-height-100 + cjk-line-height-100 + detail-letter-spacing
+  t.is(classified, 7); // text-align-{start,center,end} + letter-spacing + body-margin-multiplier + line-height-100 + cjk-line-height-100
+  t.is(skipped, 1); // detail-letter-spacing
   t.deepEqual(unclassified, []);
   t.deepEqual(nameMap["text-align-start"], {
     property: "text-align",
@@ -893,8 +909,15 @@ test("transformFile: classifies text-align, line-height multipliers, and letter-
     property: "text-align",
     alignment: "end",
   });
-  t.falsy(nameMap["line-height-100"]);
-  t.falsy(nameMap["cjk-line-height-100"]);
+  t.deepEqual(nameMap["line-height-100"], {
+    property: "line-height-multiplier",
+    scaleIndex: 100,
+  });
+  t.deepEqual(nameMap["cjk-line-height-100"], {
+    property: "line-height-multiplier",
+    family: "cjk",
+    scaleIndex: 100,
+  });
   t.deepEqual(nameMap["letter-spacing"], {
     property: "letter-spacing",
   });

--- a/tools/token-corpus-migrate/test/transform.test.js
+++ b/tools/token-corpus-migrate/test/transform.test.js
@@ -23,6 +23,7 @@ import {
   letterSpacingNameForKey,
   lineHeightMultiplierNameForKey,
   lineHeightNameForKey,
+  marginMultiplierNameForKey,
   transformFile,
 } from "../src/transform.js";
 
@@ -710,6 +711,35 @@ test("alignmentNameForKey: non-alignment key returns null", (t) => {
   t.is(alignmentNameForKey("body-color"), null);
 });
 
+// ── marginMultiplierNameForKey ────────────────────────────────────────────────
+
+test("marginMultiplierNameForKey: body-margin-multiplier", (t) => {
+  t.deepEqual(marginMultiplierNameForKey("body-margin-multiplier"), {
+    structure: "body",
+    property: "margin",
+  });
+});
+
+test("marginMultiplierNameForKey: detail-margin-top-multiplier", (t) => {
+  t.deepEqual(marginMultiplierNameForKey("detail-margin-top-multiplier"), {
+    structure: "detail",
+    property: "margin-top",
+  });
+});
+
+test("marginMultiplierNameForKey: heading-margin-bottom-multiplier", (t) => {
+  t.deepEqual(marginMultiplierNameForKey("heading-margin-bottom-multiplier"), {
+    structure: "heading",
+    property: "margin-bottom",
+  });
+});
+
+test("marginMultiplierNameForKey: unrecognized key returns null", (t) => {
+  t.is(marginMultiplierNameForKey("body-color"), null);
+  t.is(marginMultiplierNameForKey("line-height-100"), null);
+  t.is(marginMultiplierNameForKey("body-margin"), null);
+});
+
 // ── lineHeightMultiplierNameForKey ────────────────────────────────────────────
 
 test("lineHeightMultiplierNameForKey: line-height-100", (t) => {
@@ -806,7 +836,7 @@ test("classifyToken: cjk-line-height multiplier classifies with family", (t) => 
   });
 });
 
-test("classifyToken: margin multiplier classifies with component and property", (t) => {
+test("classifyToken: margin multiplier classifies with structure and property", (t) => {
   const token = {
     $schema: MULTIPLIER_SCHEMA_URL,
     uuid: "abc",


### PR DESCRIPTION
## Description

Classifies 9 deferred typography multiplier tokens with structured `name` objects, reducing the SPEC-017 (`string-name-tech-debt`) warning count by 9.

**Commit 1 — margin multipliers (`f0fc0df2`)**
- `body-margin-multiplier` → `{ structure: "body", property: "margin" }`
- `detail-margin-{top,bottom}-multiplier` → `{ structure: "detail", property: "margin-{top,bottom}" }`
- `heading-margin-{top,bottom}-multiplier` → `{ structure: "heading", property: "margin-{top,bottom}" }`

Uses `structure` (not `component`) because body/heading/detail are typography scale patterns that recur across many components. Adds body, detail, heading to the structures registry.

**Commit 2 — line-height and CJK line-height multipliers (`f1e3365e`)**
- `line-height-{100,200}` → `{ property: "line-height-multiplier", scaleIndex: N }`
- `cjk-line-height-{100,200}` → `{ property: "line-height-multiplier", family: "cjk", scaleIndex: N }`

Uses `property: "line-height-multiplier"` (distinct from `"line-height"`) to avoid SPEC-006 collision with the absolute-px `line-height-font-size-N` scale-set tokens.

## Related Issue

Closes `spectrum-design-data-aev`, `spectrum-design-data-a61`, `spectrum-design-data-duh` (beads). Supersedes `spectrum-design-data-vqj` and `spectrum-design-data-umt` (RFC beads — decisions made inline).

## Motivation and Context

These tokens were deferred from #969 (canonical-name migration) due to missing spec infrastructure. This PR resolves the blockers:

- Adds `margin`, `margin-top`, `margin-bottom`, `line-height-multiplier` to `property-terms.json`
- Adds `body`, `detail`, `heading` to `structures.json` as typography-scale structures
- Adds `multiplier.json` to the typography `DOMAIN_SCHEMAS` in the SDK (unblocks `family` field on CJK tokens, SPEC-042)
- Widens SPEC-043 (`domain-required-fields`) to accept `scaleIndex` and `structure` as valid typography-domain identifiers for multiplier tokens

## How Has This Been Tested?

- `moon run :test` — all 18 tasks pass
- `cargo test -p design-data-core spec042 spec043` — all tests pass (3 new SPEC-043 tests added)
- `moon run tokens:verifyDesignDataSnapshot` — snapshot clean, no new warnings
- `pnpm ava test` in `tools/token-corpus-migrate` — 93 tests pass (unit + integration tests updated)
- Changeset linter clean for both changesets

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.