### PR TITLE
feat(sdk): scaffold sdk/tui crate (M0 of RFC #973)

### DIFF
--- a/.changeset/tui-scaffold.md
+++ b/.changeset/tui-scaffold.md
@@ -1,0 +1,7 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Scaffold `sdk/tui/` crate — M0 of RFC #973 (Interactive TUI & Token Authoring Wizard).
+
+- **sdk/tui/**: new `design-data-tui` binary crate (Ratatui + crossterm) with primer header, empty active view, and palette prompt; `:` opens command mode, `/` opens fuzzy-find mode, `Esc` closes, `q` quits.

--- a/.changeset/tui-scaffold.md
+++ b/.changeset/tui-scaffold.md
@@ -4,4 +4,5 @@
 
 Scaffold `sdk/tui/` crate — M0 of RFC #973 (Interactive TUI & Token Authoring Wizard).
 
-- **sdk/tui/**: new `design-data-tui` binary crate (Ratatui + crossterm) with primer header, empty active view, and palette prompt; `:` opens command mode, `/` opens fuzzy-find mode, `Esc` closes, `q` quits.
+- **sdk/tui/**: new `design-data-tui` binary crate (Ratatui + crossterm) with primer header,
+  empty active view, and palette prompt (`:` command mode, `/` fuzzy-find, `Esc` closes, `q` quits).

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +225,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +319,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +357,82 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "design-data-cli"
@@ -356,6 +467,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "design-data-tui"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "crossterm 0.27.0",
+ "design-data-core",
+ "miette",
+ "ratatui",
+ "thiserror",
+ "tui-input",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +495,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "email_address"
@@ -615,6 +745,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -861,6 +993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +1032,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1080,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -982,6 +1151,12 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1006,6 +1181,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1066,11 +1250,24 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1278,6 +1475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1677,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1843,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1626,7 +1863,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1793,6 +2030,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "mio 1.1.1",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,10 +2090,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1914,7 +2211,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1924,7 +2221,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1941,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "unicode-linebreak",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1997,7 +2294,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -2119,6 +2416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-input"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b02e86628a225c39b2602863f244a01668184149928ceb410e47a8022d7597e"
+dependencies = [
+ "crossterm 0.27.0",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2438,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,9 +2462,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -2393,6 +2717,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2740,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2473,6 +2819,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2496,6 +2851,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2533,6 +2903,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2545,6 +2921,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2554,6 +2936,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2581,6 +2969,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2590,6 +2984,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2605,6 +3005,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2614,6 +3020,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -360,29 +360,13 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "mio 1.1.1",
+ "mio",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -471,7 +455,7 @@ name = "design-data-tui"
 version = "0.1.0"
 dependencies = [
  "clap",
- "crossterm 0.27.0",
+ "crossterm",
  "design-data-core",
  "miette",
  "ratatui",
@@ -1250,18 +1234,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1685,7 +1657,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
- "crossterm 0.28.1",
+ "crossterm",
  "instability",
  "itertools",
  "lru",
@@ -2046,8 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.1.1",
+ "mio",
  "signal-hook",
 ]
 
@@ -2294,7 +2265,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -2417,11 +2388,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-input"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b02e86628a225c39b2602863f244a01668184149928ceb410e47a8022d7597e"
+checksum = "bd137780d743c103a391e06fe952487f914b299a4fe2c3626677f6a6339a7c6b"
 dependencies = [
- "crossterm 0.27.0",
+ "ratatui",
  "unicode-width 0.1.14",
 ]
 
@@ -2819,15 +2790,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2851,21 +2813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2903,12 +2850,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2921,12 +2862,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2936,12 +2871,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2969,12 +2898,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2984,12 +2907,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3005,12 +2922,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3020,12 +2931,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "cli"]
+members = ["core", "cli", "tui"]
 
 [workspace.package]
 edition = "2021"

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -589,6 +589,21 @@ const STRUCTURES_JSON: &str = r##"{
       "description": "Supplementary element attached to a primary structure"
     },
     {
+      "id": "group",
+      "label": "Group",
+      "description": "Collection of similar UI elements or related controls"
+    },
+    {
+      "id": "banner",
+      "label": "Banner",
+      "description": "Prominent element for displaying non-permanent information or actions"
+    },
+    {
+      "id": "table",
+      "label": "Table",
+      "description": "Tabular layout of rows and columns for structured data"
+    },
+    {
       "id": "body",
       "label": "Body",
       "description": "Body text typography scale — used for standard paragraph and UI text"

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -14,8 +14,10 @@ fileGroups:
   sources:
     - "core/src/**/*.rs"
     - "cli/src/**/*.rs"
+    - "tui/src/**/*.rs"
     - "core/Cargo.toml"
     - "cli/Cargo.toml"
+    - "tui/Cargo.toml"
     - "Cargo.toml"
     - "rust-toolchain.toml"
 tasks:
@@ -73,6 +75,8 @@ tasks:
       - scripts/sync-cargo-version.mjs
     inputs:
       - "cli/package.json"
+      - "tui/package.json"
     outputs:
       - "cli/Cargo.toml"
+      - "tui/Cargo.toml"
     platform: node

--- a/sdk/scripts/sync-cargo-version.mjs
+++ b/sdk/scripts/sync-cargo-version.mjs
@@ -8,25 +8,28 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-// Syncs the version from sdk/cli/package.json into sdk/cli/Cargo.toml.
-// Run after `changeset version` to keep Cargo.toml in step with the npm stub.
+// Syncs the version from each crate's package.json into its Cargo.toml.
+// Run after `changeset version` to keep Cargo.toml files in step with their npm stubs.
 
 import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { resolve, dirname } from 'path';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const pkg = JSON.parse(readFileSync(resolve(root, 'cli/package.json'), 'utf8'));
-const { version } = pkg;
 
-const cargoPath = resolve(root, 'cli/Cargo.toml');
-const cargo = readFileSync(cargoPath, 'utf8');
+for (const crate of ['cli', 'tui']) {
+  const pkg = JSON.parse(readFileSync(resolve(root, `${crate}/package.json`), 'utf8'));
+  const { version } = pkg;
 
-const updated = cargo.replace(/^version\s*=\s*"[^"]+"/m, `version = "${version}"`);
+  const cargoPath = resolve(root, `${crate}/Cargo.toml`);
+  const cargo = readFileSync(cargoPath, 'utf8');
 
-if (updated === cargo) {
-  console.log(`sdk/cli/Cargo.toml already at ${version}`);
-} else {
-  writeFileSync(cargoPath, updated);
-  console.log(`Updated sdk/cli/Cargo.toml to ${version}`);
+  const updated = cargo.replace(/^version\s*=\s*"[^"]+"/m, `version = "${version}"`);
+
+  if (updated === cargo) {
+    console.log(`sdk/${crate}/Cargo.toml already at ${version}`);
+  } else {
+    writeFileSync(cargoPath, updated);
+    console.log(`Updated sdk/${crate}/Cargo.toml to ${version}`);
+  }
 }

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "design-data-tui"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Interactive TUI for Spectrum design data authoring and inspection"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "design-data-tui"
+path = "src/main.rs"
+
+[dependencies]
+design-data-core = { path = "../core" }
+ratatui = "0.28"
+crossterm = "0.27"
+tui-input = "0.9"
+clap = { version = "4.5", features = ["derive"] }
+miette = { version = "7.4", features = ["fancy"] }
+thiserror = "2.0"

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/main.rs"
 [dependencies]
 design-data-core = { path = "../core" }
 ratatui = "0.28"
-crossterm = "0.27"
-tui-input = "0.9"
+crossterm = "0.28"
+tui-input = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 miette = { version = "7.4", features = ["fancy"] }
 thiserror = "2.0"

--- a/sdk/tui/package.json
+++ b/sdk/tui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@adobe/design-data-tui",
+  "version": "0.1.0",
+  "description": "Interactive TUI for Spectrum design data authoring and inspection",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-design-data.git",
+    "directory": "sdk/tui"
+  },
+  "author": "Garth Braithwaite <garthdb@gmail.com> (https://garthdb.com/)",
+  "license": "Apache-2.0"
+}

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -1,0 +1,98 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
+
+/// Which prefix the palette was opened with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaletteMode {
+    /// `:` — explicit command mode.
+    Command,
+    /// `/` — fuzzy-find mode.
+    FuzzyFind,
+}
+
+/// Top-level application state.
+pub struct App {
+    /// Whether the palette is currently open.
+    pub palette_open: bool,
+    /// The mode the palette was opened in.
+    pub palette_mode: PaletteMode,
+    /// The text buffer for the palette prompt.
+    pub palette_input: Input,
+    /// Set to true when the application should exit.
+    pub quit: bool,
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self {
+            palette_open: false,
+            palette_mode: PaletteMode::Command,
+            palette_input: Input::default(),
+            quit: false,
+        }
+    }
+
+    /// Process a key event and update state accordingly.
+    pub fn handle_key(&mut self, key: KeyEvent) {
+        // Ctrl-C always exits.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.quit = true;
+            return;
+        }
+
+        if self.palette_open {
+            match key.code {
+                KeyCode::Esc => {
+                    self.palette_open = false;
+                    self.palette_input = Input::default();
+                }
+                // All other keys are forwarded to the input buffer.
+                _ => {
+                    self.palette_input.handle_event(&crossterm::event::Event::Key(key));
+                }
+            }
+        } else {
+            match key.code {
+                KeyCode::Char(':') => {
+                    self.palette_open = true;
+                    self.palette_mode = PaletteMode::Command;
+                    self.palette_input = Input::default();
+                }
+                KeyCode::Char('/') => {
+                    self.palette_open = true;
+                    self.palette_mode = PaletteMode::FuzzyFind;
+                    self.palette_input = Input::default();
+                }
+                KeyCode::Char('q') => {
+                    self.quit = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// The prompt prefix to display when the palette is open.
+    pub fn palette_prefix(&self) -> &'static str {
+        match self.palette_mode {
+            PaletteMode::Command => ":",
+            PaletteMode::FuzzyFind => "/",
+        }
+    }
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+pub mod app;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -13,6 +13,7 @@
 //! M0 surface: primer header + empty active view + palette prompt.
 //! The palette opens on `:` (command) or `/` (fuzzy-find) and closes on `Esc`.
 
+use std::io::stderr;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -34,13 +35,17 @@ use ratatui::{
 
 use design_data_tui::app::App;
 
-/// Dataset loaded once at startup.
-struct DatasetHandle {
+/// Token count and path summary loaded once at startup.
+///
+/// Stores only the information needed to render the primer header.
+/// The `TokenGraph` itself is not retained after loading — it is only
+/// used to extract `token_count` before being dropped.
+struct PrimerData {
     token_count: usize,
     dataset_path: PathBuf,
 }
 
-impl DatasetHandle {
+impl PrimerData {
     fn load(path: PathBuf) -> Result<Self> {
         let graph = TokenGraph::from_json_dir(&path)
             .into_diagnostic()
@@ -70,7 +75,15 @@ struct Cli {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let dataset = DatasetHandle::load(cli.dataset)?;
+    let primer = PrimerData::load(cli.dataset)?;
+
+    // Restore terminal on panic so the shell is not left in a broken state.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(stderr(), LeaveAlternateScreen);
+        original_hook(info);
+    }));
 
     enable_raw_mode().into_diagnostic()?;
     let mut stdout = std::io::stdout();
@@ -79,16 +92,18 @@ fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).into_diagnostic()?;
 
-    let result = run(&mut terminal, &dataset);
+    let result = run(&mut terminal, &primer);
 
-    disable_raw_mode().into_diagnostic()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen).into_diagnostic()?;
-    terminal.show_cursor().into_diagnostic()?;
+    // Best-effort cleanup — continue even if individual steps fail so the
+    // caller always gets the original result rather than a cleanup error.
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
 
     result
 }
 
-fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, dataset: &DatasetHandle) -> Result<()> {
+fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, primer: &PrimerData) -> Result<()> {
     let mut app = App::new();
 
     loop {
@@ -107,7 +122,7 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, dataset: &Datas
             // Primer header.
             let primer_text = Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(Color::Green)),
-                Span::raw(dataset.primer_line()),
+                Span::raw(primer.primer_line()),
             ]);
             f.render_widget(Paragraph::new(primer_text), chunks[0]);
 

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Interactive TUI for Spectrum design data authoring and inspection.
+//!
+//! M0 surface: primer header + empty active view + palette prompt.
+//! The palette opens on `:` (command) or `/` (fuzzy-find) and closes on `Esc`.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use crossterm::{
+    event::{self, Event, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use design_data_core::graph::TokenGraph;
+use miette::{IntoDiagnostic, Result, WrapErr};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+
+use design_data_tui::app::App;
+
+/// Dataset loaded once at startup.
+struct DatasetHandle {
+    token_count: usize,
+    dataset_path: PathBuf,
+}
+
+impl DatasetHandle {
+    fn load(path: PathBuf) -> Result<Self> {
+        let graph = TokenGraph::from_json_dir(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+        Ok(Self {
+            token_count: graph.tokens.len(),
+            dataset_path: path,
+        })
+    }
+
+    /// One-line summary for the primer header.
+    fn primer_line(&self) -> String {
+        format!(
+            " {} tokens  ·  {}",
+            self.token_count,
+            self.dataset_path.display()
+        )
+    }
+}
+
+#[derive(Parser)]
+#[command(name = "design-data-tui", about = "Interactive Spectrum design data TUI")]
+struct Cli {
+    /// Path to the token dataset directory.
+    dataset: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let dataset = DatasetHandle::load(cli.dataset)?;
+
+    enable_raw_mode().into_diagnostic()?;
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen).into_diagnostic()?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).into_diagnostic()?;
+
+    let result = run(&mut terminal, &dataset);
+
+    disable_raw_mode().into_diagnostic()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).into_diagnostic()?;
+    terminal.show_cursor().into_diagnostic()?;
+
+    result
+}
+
+fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, dataset: &DatasetHandle) -> Result<()> {
+    let mut app = App::new();
+
+    loop {
+        terminal.draw(|f| {
+            let size = f.area();
+
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1), // primer header
+                    Constraint::Min(0),    // active view
+                    Constraint::Length(1), // palette prompt
+                ])
+                .split(size);
+
+            // Primer header.
+            let primer_text = Line::from(vec![
+                Span::styled("▶ ", Style::default().fg(Color::Green)),
+                Span::raw(dataset.primer_line()),
+            ]);
+            f.render_widget(Paragraph::new(primer_text), chunks[0]);
+
+            // Active view (empty for M0).
+            let active_block = Block::default()
+                .borders(Borders::ALL)
+                .title(" Active View ");
+            f.render_widget(active_block, chunks[1]);
+
+            // Palette prompt.
+            let palette_text = if app.palette_open {
+                format!("{}{}", app.palette_prefix(), app.palette_input.value())
+            } else {
+                String::new()
+            };
+            f.render_widget(Paragraph::new(palette_text), chunks[2]);
+        }).into_diagnostic()?;
+
+        if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
+            if let Event::Key(key) = event::read().into_diagnostic()? {
+                // Ignore key-release events (Windows sends them; crossterm surfaces them).
+                if key.kind == KeyEventKind::Press {
+                    app.handle_key(key);
+                }
+            }
+        }
+
+        if app.quit {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/sdk/tui/tests/palette.rs
+++ b/sdk/tui/tests/palette.rs
@@ -1,0 +1,96 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_tui::app::{App, PaletteMode};
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn ctrl(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+}
+
+#[test]
+fn colon_opens_palette_in_command_mode() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    assert!(app.palette_open);
+    assert_eq!(app.palette_mode, PaletteMode::Command);
+}
+
+#[test]
+fn slash_opens_palette_in_fuzzy_find_mode() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('/')));
+    assert!(app.palette_open);
+    assert_eq!(app.palette_mode, PaletteMode::FuzzyFind);
+}
+
+#[test]
+fn esc_closes_palette() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    assert!(app.palette_open);
+    app.handle_key(key(KeyCode::Esc));
+    assert!(!app.palette_open);
+}
+
+#[test]
+fn q_quits_when_palette_closed() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('q')));
+    assert!(app.quit);
+}
+
+#[test]
+fn q_does_not_quit_when_palette_open() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    app.handle_key(key(KeyCode::Char('q')));
+    assert!(!app.quit);
+    assert!(app.palette_open);
+}
+
+#[test]
+fn ctrl_c_always_quits() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    assert!(app.palette_open);
+    app.handle_key(ctrl('c'));
+    assert!(app.quit);
+}
+
+#[test]
+fn esc_clears_palette_input() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    app.handle_key(key(KeyCode::Char('f')));
+    app.handle_key(key(KeyCode::Char('o')));
+    app.handle_key(key(KeyCode::Char('o')));
+    app.handle_key(key(KeyCode::Esc));
+    assert!(!app.palette_open);
+    assert!(app.palette_input.value().is_empty());
+}
+
+#[test]
+fn palette_prefix_command() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    assert_eq!(app.palette_prefix(), ":");
+}
+
+#[test]
+fn palette_prefix_fuzzy_find() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('/')));
+    assert_eq!(app.palette_prefix(), "/");
+}

--- a/sdk/tui/tests/palette.rs
+++ b/sdk/tui/tests/palette.rs
@@ -94,3 +94,12 @@ fn palette_prefix_fuzzy_find() {
     app.handle_key(key(KeyCode::Char('/')));
     assert_eq!(app.palette_prefix(), "/");
 }
+
+#[test]
+fn colon_while_palette_open_goes_to_input_buffer() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':'))); // open palette
+    app.handle_key(key(KeyCode::Char(':'))); // forwarded to input, not re-open
+    assert!(app.palette_open);
+    assert_eq!(app.palette_input.value(), ":");
+}


### PR DESCRIPTION
## Description

Scaffolds the `sdk/tui/` crate — M0 of [RFC #973 — Interactive TUI & Token Authoring Wizard](https://github.com/adobe/spectrum-design-data/discussions/973).

Delivers the three-region Ratatui layout (primer header / active view / palette prompt) and the palette state machine that all later milestones build on.

## Related Issue

Closes #981 (M0 sub-issue under epic #980)

## Motivation and Context

RFC #973 was adopted after `write_token` (#976) and `suggest_token` (#975) landed. M0 establishes the `sdk/tui/` crate in the workspace so M1–M5 have a tracked home.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — 9 palette state machine tests pass (pure-logic, no terminal)
- `cargo test -p design-data-core` — 366 + 1 doc-test green (no core changes)
- `cargo clippy --workspace -- -D warnings` — clean
- Manual: `cargo run -p design-data-tui packages/tokens/src` renders primer header + empty active view; `:` / `/` opens palette; `Esc` closes; `q` quits; `Ctrl-C` exits from any state

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.