### PR TITLE
feat(sdk): wire :query into TUI — M1 of RFC #973

### DIFF
--- a/.changeset/tui-query.md
+++ b/.changeset/tui-query.md
@@ -1,0 +1,9 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Wire `:query` into the TUI — M1 of RFC #973.
+
+- **sdk/tui/**: typing `:query property=<expr>` renders a filtered table
+  (Name/Value/File/Layer), up/down and j/k navigate, `y` yanks the
+  selected row's name to the system clipboard.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "design-data-core",
  "miette",
  "ratatui",
+ "serde_json",
  "thiserror",
  "tui-input",
 ]

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -21,3 +21,5 @@ tui-input = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 miette = { version = "7.4", features = ["fancy"] }
 thiserror = "2.0"
+[dev-dependencies]
+serde_json = "1"

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -25,6 +25,29 @@ pub enum PaletteMode {
     FuzzyFind,
 }
 
+/// Severity of a status bar message; controls render colour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusKind {
+    Info,
+    Error,
+}
+
+/// A status bar message with its display kind.
+#[derive(Debug, Clone)]
+pub struct StatusMessage {
+    pub text: String,
+    pub kind: StatusKind,
+}
+
+impl StatusMessage {
+    pub fn info(text: impl Into<String>) -> Self {
+        Self { text: text.into(), kind: StatusKind::Info }
+    }
+    pub fn error(text: impl Into<String>) -> Self {
+        Self { text: text.into(), kind: StatusKind::Error }
+    }
+}
+
 /// One row in the query results table.
 #[derive(Debug, Clone)]
 pub struct QueryRow {
@@ -113,12 +136,10 @@ pub struct App {
     pub quit: bool,
     /// The currently active view.
     pub active_view: ActiveView,
-    /// One-line status/error shown above the palette.
-    pub status_message: Option<String>,
-    /// The last yanked string, waiting to be written to the clipboard.
-    pub last_yank: Option<String>,
-    /// Set by `y` key; cleared by main.rs after copying to the clipboard.
-    pub yank_pending: bool,
+    /// One-line status message shown above the palette; `None` when hidden.
+    pub status_message: Option<StatusMessage>,
+    /// Non-None while a yank is pending clipboard write; cleared by main.rs.
+    pub pending_yank: Option<String>,
 }
 
 impl App {
@@ -130,8 +151,7 @@ impl App {
             quit: false,
             active_view: ActiveView::Empty,
             status_message: None,
-            last_yank: None,
-            yank_pending: false,
+            pending_yank: None,
         }
     }
 
@@ -174,8 +194,7 @@ impl App {
                     KeyCode::Char('y') => {
                         if let ActiveView::Query(ref qv) = self.active_view {
                             if let Some(row) = qv.selected_row() {
-                                self.last_yank = Some(row.name.clone());
-                                self.yank_pending = true;
+                                self.pending_yank = Some(row.name.clone());
                             }
                         }
                     }
@@ -241,7 +260,7 @@ impl App {
         match cmd.as_str() {
             "query" => {
                 if rest.is_empty() {
-                    self.status_message = Some("query: expression required".to_string());
+                    self.status_message = Some(StatusMessage::error("query: expression required"));
                     return;
                 }
                 match query::parse(&rest) {
@@ -250,22 +269,25 @@ impl App {
                         let rows: Vec<QueryRow> = records.iter().map(|r| QueryRow::from_record(r)).collect();
                         let count = rows.len();
                         self.active_view = ActiveView::Query(QueryView::new(rest.clone(), rows));
-                        self.status_message = Some(format!("{count} token(s) matched"));
+                        self.status_message = Some(StatusMessage::info(format!("{count} token(s) matched")));
                     }
                     Err(e) => {
-                        self.status_message = Some(format!("query error: {e}"));
+                        self.status_message = Some(StatusMessage::error(format!("query error: {e}")));
                     }
                 }
             }
             other => {
-                self.status_message = Some(format!("unknown command: {other}"));
+                self.status_message = Some(StatusMessage::error(format!("unknown command: {other}")));
             }
         }
     }
 
-    /// Clear the pending yank flag after main.rs has written to the clipboard.
-    pub fn clear_yank(&mut self) {
-        self.yank_pending = false;
+    /// Take the pending yank string, clearing it from app state.
+    ///
+    /// Returns `Some(text)` when a yank is pending; `None` otherwise.
+    /// main.rs calls this after writing to the clipboard.
+    pub fn take_pending_yank(&mut self) -> Option<String> {
+        self.pending_yank.take()
     }
 
     /// The prompt prefix to display when the palette is open.

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -9,8 +9,12 @@
 // governing permissions and limitations under the License.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use tui_input::backend::crossterm::EventHandler;
+use design_data_core::diff::display_name;
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_core::query;
+use ratatui::widgets::TableState;
 use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
 
 /// Which prefix the palette was opened with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,6 +23,82 @@ pub enum PaletteMode {
     Command,
     /// `/` — fuzzy-find mode.
     FuzzyFind,
+}
+
+/// One row in the query results table.
+#[derive(Debug, Clone)]
+pub struct QueryRow {
+    pub name: String,
+    pub value: String,
+    pub file: String,
+    pub layer: String,
+}
+
+impl QueryRow {
+    fn from_record(t: &TokenRecord) -> Self {
+        let value = t
+            .raw
+            .get("value")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    v.to_string()
+                }
+            })
+            .or_else(|| t.alias_target.clone())
+            .unwrap_or_default();
+        let file = t.file.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or_default();
+        let layer = match t.layer {
+            Layer::Foundation => "foundation",
+            Layer::Platform => "platform",
+            Layer::Product => "product",
+        }
+        .to_string();
+        Self {
+            name: display_name(t),
+            value,
+            file,
+            layer,
+        }
+    }
+}
+
+/// State for an active query view.
+pub struct QueryView {
+    pub expr_text: String,
+    pub rows: Vec<QueryRow>,
+    pub table_state: TableState,
+}
+
+impl QueryView {
+    fn new(expr_text: String, rows: Vec<QueryRow>) -> Self {
+        let mut table_state = TableState::default();
+        if !rows.is_empty() {
+            table_state.select(Some(0));
+        }
+        Self { expr_text, rows, table_state }
+    }
+
+    fn selected_row(&self) -> Option<&QueryRow> {
+        self.table_state.selected().and_then(|i| self.rows.get(i))
+    }
+
+    fn move_selection(&mut self, delta: i64) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let len = self.rows.len() as i64;
+        let current = self.table_state.selected().unwrap_or(0) as i64;
+        let next = (current + delta).clamp(0, len - 1) as usize;
+        self.table_state.select(Some(next));
+    }
+}
+
+/// Which view the active area is showing.
+pub enum ActiveView {
+    Empty,
+    Query(QueryView),
 }
 
 /// Top-level application state.
@@ -31,6 +111,14 @@ pub struct App {
     pub palette_input: Input,
     /// Set to true when the application should exit.
     pub quit: bool,
+    /// The currently active view.
+    pub active_view: ActiveView,
+    /// One-line status/error shown above the palette.
+    pub status_message: Option<String>,
+    /// The last yanked string, waiting to be written to the clipboard.
+    pub last_yank: Option<String>,
+    /// Set by `y` key; cleared by main.rs after copying to the clipboard.
+    pub yank_pending: bool,
 }
 
 impl App {
@@ -40,6 +128,10 @@ impl App {
             palette_mode: PaletteMode::Command,
             palette_input: Input::default(),
             quit: false,
+            active_view: ActiveView::Empty,
+            status_message: None,
+            last_yank: None,
+            yank_pending: false,
         }
     }
 
@@ -57,29 +149,123 @@ impl App {
                     self.palette_open = false;
                     self.palette_input = Input::default();
                 }
-                // All other keys are forwarded to the input buffer.
+                // Enter closes the palette; main.rs detects the closed state and
+                // calls submit_palette with the graph.
+                KeyCode::Enter => {
+                    self.palette_open = false;
+                }
                 _ => {
                     self.palette_input.handle_event(&crossterm::event::Event::Key(key));
                 }
             }
         } else {
-            match key.code {
-                KeyCode::Char(':') => {
-                    self.palette_open = true;
-                    self.palette_mode = PaletteMode::Command;
-                    self.palette_input = Input::default();
-                }
-                KeyCode::Char('/') => {
-                    self.palette_open = true;
-                    self.palette_mode = PaletteMode::FuzzyFind;
-                    self.palette_input = Input::default();
-                }
-                KeyCode::Char('q') => {
-                    self.quit = true;
-                }
-                _ => {}
+            match &self.active_view {
+                ActiveView::Query(_) => match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        if let ActiveView::Query(ref mut qv) = self.active_view {
+                            qv.move_selection(-1);
+                        }
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if let ActiveView::Query(ref mut qv) = self.active_view {
+                            qv.move_selection(1);
+                        }
+                    }
+                    KeyCode::Char('y') => {
+                        if let ActiveView::Query(ref qv) = self.active_view {
+                            if let Some(row) = qv.selected_row() {
+                                self.last_yank = Some(row.name.clone());
+                                self.yank_pending = true;
+                            }
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.active_view = ActiveView::Empty;
+                        self.status_message = None;
+                    }
+                    KeyCode::Char(':') => {
+                        self.palette_open = true;
+                        self.palette_mode = PaletteMode::Command;
+                        self.palette_input = Input::default();
+                    }
+                    KeyCode::Char('/') => {
+                        self.palette_open = true;
+                        self.palette_mode = PaletteMode::FuzzyFind;
+                        self.palette_input = Input::default();
+                    }
+                    KeyCode::Char('q') => {
+                        self.quit = true;
+                    }
+                    _ => {}
+                },
+                ActiveView::Empty => match key.code {
+                    KeyCode::Char(':') => {
+                        self.palette_open = true;
+                        self.palette_mode = PaletteMode::Command;
+                        self.palette_input = Input::default();
+                    }
+                    KeyCode::Char('/') => {
+                        self.palette_open = true;
+                        self.palette_mode = PaletteMode::FuzzyFind;
+                        self.palette_input = Input::default();
+                    }
+                    KeyCode::Char('q') => {
+                        self.quit = true;
+                    }
+                    _ => {}
+                },
             }
         }
+    }
+
+    /// Dispatch a committed palette command against the graph.
+    ///
+    /// Called by main.rs after Enter is pressed in Command mode, passing the
+    /// loaded graph. Fuzzy-find mode (M2+) is a no-op here.
+    pub fn submit_palette(&mut self, graph: &TokenGraph) {
+        if self.palette_mode != PaletteMode::Command {
+            self.palette_open = false;
+            self.palette_input = Input::default();
+            return;
+        }
+
+        let raw = self.palette_input.value().trim().to_string();
+        self.palette_open = false;
+        self.palette_input = Input::default();
+
+        let (cmd, rest) = match raw.split_once(' ') {
+            Some((c, r)) => (c.to_lowercase(), r.trim().to_string()),
+            None => (raw.to_lowercase(), String::new()),
+        };
+
+        match cmd.as_str() {
+            "query" => {
+                if rest.is_empty() {
+                    self.status_message = Some("query: expression required".to_string());
+                    return;
+                }
+                match query::parse(&rest) {
+                    Ok(expr) => {
+                        let records = query::filter(graph, &expr);
+                        let rows: Vec<QueryRow> = records.iter().map(|r| QueryRow::from_record(r)).collect();
+                        let count = rows.len();
+                        self.active_view = ActiveView::Query(QueryView::new(rest.clone(), rows));
+                        self.status_message = Some(format!("{count} token(s) matched"));
+                    }
+                    Err(e) => {
+                        self.status_message = Some(format!("query error: {e}"));
+                    }
+                }
+            }
+            other => {
+                self.status_message = Some(format!("unknown command: {other}"));
+            }
+        }
+    }
+
+    /// Clear the pending yank flag after main.rs has written to the clipboard.
+    pub fn clear_yank(&mut self) {
+        self.yank_pending = false;
     }
 
     /// The prompt prefix to display when the palette is open.

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -10,15 +10,24 @@
 
 //! Interactive TUI for Spectrum design data authoring and inspection.
 //!
-//! M0 surface: primer header + empty active view + palette prompt.
-//! The palette opens on `:` (command) or `/` (fuzzy-find) and closes on `Esc`.
+//! Three-region layout (RFC #973 §3.1):
+//! - Primer header (1 line): token count + dataset path.
+//! - Active view (flex): empty, or a query-results table.
+//! - Status + palette (2 lines at bottom): optional status message, then palette prompt.
+//!
+//! Key bindings (M1):
+//! - `:` opens palette in command mode; `/` opens in fuzzy-find mode.
+//! - In palette, Enter dispatches the command; Esc cancels.
+//! - In query view: Up/k and Down/j navigate; `y` yanks selected name; Esc returns to empty.
+//! - `q` quits when palette is closed; Ctrl-C always quits.
 
-use std::io::stderr;
+use std::io::{Write, stderr};
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 use clap::Parser;
 use crossterm::{
-    event::{self, Event, KeyEventKind},
+    event::{self, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -28,24 +37,21 @@ use ratatui::{
     Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
 };
 
-use design_data_tui::app::App;
+use design_data_tui::app::{ActiveView, App};
 
-/// Token count and path summary loaded once at startup.
-///
-/// Stores only the information needed to render the primer header.
-/// The `TokenGraph` itself is not retained after loading — it is only
-/// used to extract `token_count` before being dropped.
-struct PrimerData {
+/// Token dataset loaded once at startup and held for the full session.
+struct DatasetHandle {
     token_count: usize,
     dataset_path: PathBuf,
+    graph: TokenGraph,
 }
 
-impl PrimerData {
+impl DatasetHandle {
     fn load(path: PathBuf) -> Result<Self> {
         let graph = TokenGraph::from_json_dir(&path)
             .into_diagnostic()
@@ -53,10 +59,10 @@ impl PrimerData {
         Ok(Self {
             token_count: graph.tokens.len(),
             dataset_path: path,
+            graph,
         })
     }
 
-    /// One-line summary for the primer header.
     fn primer_line(&self) -> String {
         format!(
             " {} tokens  ·  {}",
@@ -73,9 +79,26 @@ struct Cli {
     dataset: PathBuf,
 }
 
+/// Write `text` to the system clipboard via pbcopy (macOS) or xclip (Linux).
+fn write_clipboard(text: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    let mut child = Command::new("pbcopy").stdin(Stdio::piped()).spawn()?;
+    #[cfg(not(target_os = "macos"))]
+    let mut child = Command::new("xclip")
+        .args(["-selection", "clipboard"])
+        .stdin(Stdio::piped())
+        .spawn()?;
+    if let Some(stdin) = child.stdin.take() {
+        let mut stdin = stdin;
+        stdin.write_all(text.as_bytes())?;
+    }
+    child.wait()?;
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let primer = PrimerData::load(cli.dataset)?;
+    let handle = DatasetHandle::load(cli.dataset)?;
 
     // Restore terminal on panic so the shell is not left in a broken state.
     let original_hook = std::panic::take_hook();
@@ -92,10 +115,9 @@ fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).into_diagnostic()?;
 
-    let result = run(&mut terminal, &primer);
+    let result = run(&mut terminal, &handle);
 
-    // Best-effort cleanup — continue even if individual steps fail so the
-    // caller always gets the original result rather than a cleanup error.
+    // Best-effort cleanup — continue even if individual steps fail.
     let _ = disable_raw_mode();
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
     let _ = terminal.show_cursor();
@@ -103,34 +125,83 @@ fn main() -> Result<()> {
     result
 }
 
-fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, primer: &PrimerData) -> Result<()> {
+fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &DatasetHandle) -> Result<()> {
     let mut app = App::new();
 
     loop {
         terminal.draw(|f| {
             let size = f.area();
 
+            // Bottom area: status line (when present) + palette prompt.
+            let status_height = if app.status_message.is_some() { 1 } else { 0 };
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(1), // primer header
-                    Constraint::Min(0),    // active view
-                    Constraint::Length(1), // palette prompt
+                    Constraint::Length(1),                    // primer header
+                    Constraint::Min(0),                       // active view
+                    Constraint::Length(status_height),        // status message
+                    Constraint::Length(1),                    // palette prompt
                 ])
                 .split(size);
 
             // Primer header.
             let primer_text = Line::from(vec![
                 Span::styled("▶ ", Style::default().fg(Color::Green)),
-                Span::raw(primer.primer_line()),
+                Span::raw(handle.primer_line()),
             ]);
             f.render_widget(Paragraph::new(primer_text), chunks[0]);
 
-            // Active view (empty for M0).
-            let active_block = Block::default()
-                .borders(Borders::ALL)
-                .title(" Active View ");
-            f.render_widget(active_block, chunks[1]);
+            // Active view.
+            match &mut app.active_view {
+                ActiveView::Empty => {
+                    let block = Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Active View ");
+                    f.render_widget(block, chunks[1]);
+                }
+                ActiveView::Query(ref mut qv) => {
+                    let header = Row::new(vec![
+                        Cell::from("Name").style(Style::default().add_modifier(Modifier::BOLD)),
+                        Cell::from("Value").style(Style::default().add_modifier(Modifier::BOLD)),
+                        Cell::from("File").style(Style::default().add_modifier(Modifier::BOLD)),
+                        Cell::from("Layer").style(Style::default().add_modifier(Modifier::BOLD)),
+                    ]);
+                    let rows: Vec<Row> = qv
+                        .rows
+                        .iter()
+                        .map(|r| {
+                            Row::new(vec![
+                                Cell::from(r.name.as_str()),
+                                Cell::from(r.value.as_str()),
+                                Cell::from(r.file.as_str()),
+                                Cell::from(r.layer.as_str()),
+                            ])
+                        })
+                        .collect();
+                    let widths = [
+                        Constraint::Percentage(40),
+                        Constraint::Percentage(30),
+                        Constraint::Percentage(20),
+                        Constraint::Percentage(10),
+                    ];
+                    let table = Table::new(rows, widths)
+                        .header(header)
+                        .block(
+                            Block::default()
+                                .borders(Borders::ALL)
+                                .title(format!(" Query: {} ", qv.expr_text)),
+                        )
+                        .highlight_style(Style::default().bg(Color::DarkGray));
+                    f.render_stateful_widget(table, chunks[1], &mut qv.table_state);
+                }
+            }
+
+            // Status message.
+            if let Some(ref msg) = app.status_message {
+                let status = Paragraph::new(msg.as_str())
+                    .style(Style::default().fg(Color::Red));
+                f.render_widget(status, chunks[2]);
+            }
 
             // Palette prompt.
             let palette_text = if app.palette_open {
@@ -138,14 +209,35 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, primer: &Primer
             } else {
                 String::new()
             };
-            f.render_widget(Paragraph::new(palette_text), chunks[2]);
+            f.render_widget(Paragraph::new(palette_text), chunks[3]);
         }).into_diagnostic()?;
+
+        // Copy to clipboard outside the draw closure (needs mutable app).
+        if app.yank_pending {
+            let text = app.last_yank.clone().unwrap_or_default();
+            // Use pbcopy (macOS) or xclip/xsel (Linux) via stdin pipe.
+            let result = write_clipboard(&text);
+            if let Err(e) = result {
+                app.status_message = Some(format!("clipboard unavailable: {e}"));
+            }
+            app.clear_yank();
+        }
 
         if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
             if let Event::Key(key) = event::read().into_diagnostic()? {
-                // Ignore key-release events (Windows sends them; crossterm surfaces them).
                 if key.kind == KeyEventKind::Press {
+                    let was_open = app.palette_open;
                     app.handle_key(key);
+                    // Palette just closed via Enter (not Esc) — dispatch command.
+                    if was_open
+                        && !app.palette_open
+                        && key.code == KeyCode::Enter
+                    {
+                        // handle_key forwarded Enter to the input buffer; undo that
+                        // and dispatch. The input value already has the text without
+                        // the Enter character because tui-input appends nothing for Enter.
+                        app.submit_palette(&handle.graph);
+                    }
                 }
             }
         }

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -42,7 +42,7 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
 };
 
-use design_data_tui::app::{ActiveView, App};
+use design_data_tui::app::{ActiveView, App, StatusKind, StatusMessage};
 
 /// Token dataset loaded once at startup and held for the full session.
 struct DatasetHandle {
@@ -79,21 +79,35 @@ struct Cli {
     dataset: PathBuf,
 }
 
-/// Write `text` to the system clipboard via pbcopy (macOS) or xclip (Linux).
+/// Write `text` to the system clipboard.
+///
+/// - macOS: `pbcopy`
+/// - Linux: `xclip -selection clipboard`
+/// - Windows: not supported; returns an error that main.rs surfaces in the status bar.
 fn write_clipboard(text: &str) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
     let mut child = Command::new("pbcopy").stdin(Stdio::piped()).spawn()?;
-    #[cfg(not(target_os = "macos"))]
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     let mut child = Command::new("xclip")
         .args(["-selection", "clipboard"])
         .stdin(Stdio::piped())
         .spawn()?;
-    if let Some(stdin) = child.stdin.take() {
-        let mut stdin = stdin;
-        stdin.write_all(text.as_bytes())?;
+
+    #[cfg(target_os = "windows")]
+    return Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "clipboard yank is not supported on Windows (coming in M5)",
+    ));
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(text.as_bytes())?;
+        }
+        child.wait()?;
+        Ok(())
     }
-    child.wait()?;
-    Ok(())
 }
 
 fn main() -> Result<()> {
@@ -137,10 +151,10 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(1),                    // primer header
-                    Constraint::Min(0),                       // active view
-                    Constraint::Length(status_height),        // status message
-                    Constraint::Length(1),                    // palette prompt
+                    Constraint::Length(1),             // primer header
+                    Constraint::Min(0),                // active view
+                    Constraint::Length(status_height), // status message
+                    Constraint::Length(1),             // palette prompt
                 ])
                 .split(size);
 
@@ -196,10 +210,14 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                 }
             }
 
-            // Status message.
+            // Status message — green for info, red for errors.
             if let Some(ref msg) = app.status_message {
-                let status = Paragraph::new(msg.as_str())
-                    .style(Style::default().fg(Color::Red));
+                let color = match msg.kind {
+                    StatusKind::Info => Color::Green,
+                    StatusKind::Error => Color::Red,
+                };
+                let status = Paragraph::new(msg.text.as_str())
+                    .style(Style::default().fg(color));
                 f.render_widget(status, chunks[2]);
             }
 
@@ -213,14 +231,10 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
         }).into_diagnostic()?;
 
         // Copy to clipboard outside the draw closure (needs mutable app).
-        if app.yank_pending {
-            let text = app.last_yank.clone().unwrap_or_default();
-            // Use pbcopy (macOS) or xclip/xsel (Linux) via stdin pipe.
-            let result = write_clipboard(&text);
-            if let Err(e) = result {
-                app.status_message = Some(format!("clipboard unavailable: {e}"));
+        if let Some(text) = app.take_pending_yank() {
+            if let Err(e) = write_clipboard(&text) {
+                app.status_message = Some(StatusMessage::error(format!("clipboard unavailable: {e}")));
             }
-            app.clear_yank();
         }
 
         if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
@@ -228,14 +242,8 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                 if key.kind == KeyEventKind::Press {
                     let was_open = app.palette_open;
                     app.handle_key(key);
-                    // Palette just closed via Enter (not Esc) — dispatch command.
-                    if was_open
-                        && !app.palette_open
-                        && key.code == KeyCode::Enter
-                    {
-                        // handle_key forwarded Enter to the input buffer; undo that
-                        // and dispatch. The input value already has the text without
-                        // the Enter character because tui-input appends nothing for Enter.
+                    // Palette just closed via Enter — dispatch command.
+                    if was_open && !app.palette_open && key.code == KeyCode::Enter {
                         app.submit_palette(&handle.graph);
                     }
                 }

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -87,8 +87,7 @@ fn submit_invalid_query_sets_status_message() {
     app.submit_palette(&graph);
     assert!(!app.palette_open);
     assert!(matches!(app.active_view, ActiveView::Empty));
-    assert!(app.status_message.is_some());
-    let msg = app.status_message.as_deref().unwrap_or("");
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("query error") || msg.contains("error"), "expected error message, got: {msg}");
 }
 
@@ -101,7 +100,8 @@ fn submit_unknown_command_sets_status_message() {
         app.handle_key(key(KeyCode::Char(c)));
     }
     app.submit_palette(&graph);
-    assert!(app.status_message.as_deref().unwrap_or("").contains("unknown command"));
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("unknown command"), "expected 'unknown command' in: {msg}");
 }
 
 #[test]
@@ -176,8 +176,7 @@ fn y_sets_yank_pending_with_selected_name() {
     }
     app.submit_palette(&graph);
     app.handle_key(key(KeyCode::Char('y')));
-    assert!(app.yank_pending);
-    assert!(app.last_yank.is_some());
+    assert!(app.pending_yank.is_some());
 }
 
 #[test]

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -1,0 +1,219 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_tui::app::{ActiveView, App};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn make_graph_with_tokens(names: &[&str]) -> TokenGraph {
+    let records: Vec<TokenRecord> = names
+        .iter()
+        .enumerate()
+        .map(|(i, &name)| TokenRecord {
+            name: name.to_string(),
+            file: PathBuf::from("test.json"),
+            index: i,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            // Include name.property so property=* queries match.
+            raw: json!({
+                "value": "red",
+                "$schema": "https://example.com",
+                "name": { "property": name }
+            }),
+            layer: Layer::Foundation,
+        })
+        .collect();
+    TokenGraph::from_records(records)
+}
+
+fn empty_graph() -> TokenGraph {
+    make_graph_with_tokens(&[])
+}
+
+#[test]
+fn submit_valid_query_populates_query_view() {
+    let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
+    let mut app = App::new();
+    // Simulate opening palette, typing, and submitting.
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=accent-color".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    // Palette is still open; submit_palette is called by main.rs after Enter.
+    app.submit_palette(&graph);
+    assert!(!app.palette_open);
+    assert!(matches!(app.active_view, ActiveView::Query(_)));
+}
+
+#[test]
+fn submit_query_resets_selection_to_zero() {
+    let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(0));
+    } else {
+        panic!("expected Query view");
+    }
+}
+
+#[test]
+fn submit_invalid_query_sets_status_message() {
+    let graph = empty_graph();
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query ===bad===".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    assert!(!app.palette_open);
+    assert!(matches!(app.active_view, ActiveView::Empty));
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(msg.contains("query error") || msg.contains("error"), "expected error message, got: {msg}");
+}
+
+#[test]
+fn submit_unknown_command_sets_status_message() {
+    let graph = empty_graph();
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "foobar".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    assert!(app.status_message.as_deref().unwrap_or("").contains("unknown command"));
+}
+
+#[test]
+fn down_j_moves_selection() {
+    let graph = make_graph_with_tokens(&["a", "b", "c"]);
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    // Selection starts at 0.
+    app.handle_key(key(KeyCode::Char('j')));
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(1));
+    } else {
+        panic!("expected Query view");
+    }
+}
+
+#[test]
+fn up_k_moves_selection() {
+    let graph = make_graph_with_tokens(&["a", "b", "c"]);
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    app.handle_key(key(KeyCode::Char('j')));
+    app.handle_key(key(KeyCode::Char('k')));
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(0));
+    } else {
+        panic!("expected Query view");
+    }
+}
+
+#[test]
+fn selection_clamps_at_bounds() {
+    let graph = make_graph_with_tokens(&["a", "b"]);
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    // Try to go above 0.
+    app.handle_key(key(KeyCode::Up));
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(0));
+    } else {
+        panic!("expected Query view");
+    }
+    // Go to last, then try to go past.
+    app.handle_key(key(KeyCode::Down));
+    app.handle_key(key(KeyCode::Down));
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(1));
+    } else {
+        panic!("expected Query view");
+    }
+}
+
+#[test]
+fn y_sets_yank_pending_with_selected_name() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    app.handle_key(key(KeyCode::Char('y')));
+    assert!(app.yank_pending);
+    assert!(app.last_yank.is_some());
+}
+
+#[test]
+fn esc_from_query_view_returns_to_empty() {
+    let graph = make_graph_with_tokens(&["a"]);
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    assert!(matches!(app.active_view, ActiveView::Query(_)));
+    app.handle_key(key(KeyCode::Esc));
+    assert!(matches!(app.active_view, ActiveView::Empty));
+}
+
+#[test]
+fn re_query_replaces_results_and_resets_selection() {
+    let graph = make_graph_with_tokens(&["a", "b", "c"]);
+    let mut app = App::new();
+    // First query.
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    app.handle_key(key(KeyCode::Char('j')));
+    // Second query from within query view — `:` opens palette.
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "query property=*".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&graph);
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(0));
+    } else {
+        panic!("expected Query view");
+    }
+}


### PR DESCRIPTION
## Description

Wires the `:query` command end-to-end in the `sdk/tui` crate — M1 of the [TUI & Token Authoring Wizard RFC (#973)](https://github.com/adobe/spectrum-design-data/discussions/973).

### What's in this PR

- **`sdk/tui/src/app.rs`** — adds `ActiveView` enum (`Empty` | `Query`), `QueryView` with `TableState` for navigation, `QueryRow` with owned name/value/file/layer strings, `submit_palette()` dispatch, and key handling for Up/Down/j/k navigation, `y` yank, and `Esc` to return to empty view.
- **`sdk/tui/src/main.rs`** — renames `PrimerData` → `DatasetHandle` (retains `TokenGraph` for M1+ filtering), renders `ActiveView::Query` as a Ratatui `Table`, shows `status_message` in red above the palette, writes the yank string via `pbcopy`/`xclip` on Enter+`y`.
- **`sdk/tui/tests/query.rs`** — 10 integration tests covering submit/navigate/yank/esc state machine (pure logic, no terminal required).
- **`.changeset/tui-query.md`** — `minor` bump for `@adobe/design-data-tui`.

### M1 exit criterion (RFC #973 §4)

> Typing `:query property=background-color/*` returns a filtered table; up/down navigates; `y` yanks selected row.

The query notation requires `key=value` pairs (per `packages/design-data-spec/spec/query.md`); `property=background-color/*` uses the glob wildcard to match all tokens with that property prefix.

## Related Issue

Closes #983 (M1 sub-issue under epic #980).

## Motivation and Context

M0 landed in #982 and gave us the TUI scaffold. M1 wires the existing `design_data_core::query` engine (already powering `design-data-cli query`) into the TUI's palette, adding the first interactive view.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — 20 tests pass (10 palette + 10 query state machine).
- `cargo test -p design-data-core` — 360+ tests unchanged.
- `cargo clippy --workspace -- -D warnings` — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean (pre-commit hook passed).

Manual smoke test: `cargo run -p design-data-tui packages/tokens/src` → primer header renders; `:` → `query property=background-color*` → Enter → filtered table; Up/Down/j/k move selection; `y` copies selected name to clipboard; `Esc` returns to empty view.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.