### PR TITLE
feat(sdk/tui): wizard modal — 4 screens + diff preview (M3 of RFC #973)

### DIFF
--- a/.changeset/tui-m3.md
+++ b/.changeset/tui-m3.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Add wizard modal (M3 of RFC #973): four-screen token authoring flow ending in diff preview.
+
+- **sdk/tui/src/wizard.rs**: `WizardState`; Intent/Classification/Values/Confirm screens.
+- **sdk/tui/src/app.rs**: `:new`/`:create` palette command opens the wizard modal; Esc cancels.
+- **sdk/tui/src/main.rs**: centered overlay render via `Clear` widget; modal captures all input.
+- **sdk/tui/Cargo.toml**: add `similar` dep for unified diff preview on Screen 4.
+- **sdk/tui/tests/wizard.rs**: 15 new tests covering all screens and screen transitions.
+- M3 stops at diff preview; `write_token` integration is M4 (no disk writes in this milestone).

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "ratatui",
  "serde_json",
  "similar",
+ "tempfile",
  "thiserror",
  "tui-input",
 ]

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "miette",
  "ratatui",
  "serde_json",
+ "similar",
  "thiserror",
  "tui-input",
 ]
@@ -2032,6 +2033,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -25,3 +25,4 @@ serde_json = "1"
 similar = "2"
 
 [dev-dependencies]
+tempfile = "3"

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -22,5 +22,6 @@ clap = { version = "4.5", features = ["derive"] }
 miette = { version = "7.4", features = ["fancy"] }
 thiserror = "2.0"
 serde_json = "1"
+similar = "2"
 
 [dev-dependencies]

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -22,8 +22,10 @@ use ratatui::widgets::TableState;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
+use crate::wizard::{WizardCtx, WizardEvent, WizardState};
+
 /// Command names for Tab autocomplete.
-const KNOWN_COMMANDS: &[&str] = &["query", "resolve", "describe", "validate"];
+const KNOWN_COMMANDS: &[&str] = &["new", "query", "resolve", "describe", "validate"];
 
 /// Which prefix the palette was opened with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -185,6 +187,11 @@ pub enum ActiveView {
     Validate(ValidateView),
 }
 
+/// An overlay modal that temporarily captures all keyboard input.
+pub enum Modal {
+    Wizard(WizardState),
+}
+
 /// Context passed to `submit_palette`; carries the graph plus optional paths for
 /// describe and validate commands.
 pub struct SubmitContext<'a> {
@@ -226,6 +233,8 @@ pub struct App {
     pub status_message: Option<StatusMessage>,
     /// Non-None while a yank is pending clipboard write; cleared by main.rs.
     pub pending_yank: Option<String>,
+    /// Overlay modal; when present, all key events are routed here by main.rs.
+    pub modal: Option<Modal>,
 }
 
 impl App {
@@ -238,6 +247,7 @@ impl App {
             active_view: ActiveView::Empty,
             status_message: None,
             pending_yank: None,
+            modal: None,
         }
     }
 
@@ -312,6 +322,43 @@ impl App {
                 }
                 _ => {}
             }
+        }
+    }
+
+    /// Route a key event into the active modal, closing it on Cancel or Submit.
+    ///
+    /// Called by `main.rs` instead of `handle_key` when `app.modal.is_some()`.
+    pub fn handle_modal_key(&mut self, key: KeyEvent, ctx: &WizardCtx<'_>) {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.quit = true;
+            return;
+        }
+        let event = match &mut self.modal {
+            Some(Modal::Wizard(ws)) => {
+                // Special case: Screen 3 Enter needs dataset_path from ctx.
+                if matches!(ws.screen, crate::wizard::WizardScreen::Values)
+                    && key.code == KeyCode::Enter
+                    && !ws.values.editing
+                {
+                    ws.advance_to_confirm(ctx.dataset_path);
+                    return;
+                }
+                ws.handle_key(key, ctx)
+            }
+            None => return,
+        };
+        match event {
+            WizardEvent::Cancel => {
+                self.modal = None;
+                self.status_message = Some(StatusMessage::info("wizard cancelled"));
+            }
+            WizardEvent::Submit => {
+                self.modal = None;
+                self.status_message = Some(StatusMessage::info(
+                    "wizard preview ready — write disabled (M4)",
+                ));
+            }
+            WizardEvent::Continue => {}
         }
     }
 
@@ -670,6 +717,12 @@ impl App {
                             Some(StatusMessage::error(format!("validate: {e}")));
                     }
                 }
+            }
+            "new" | "create" => {
+                let mut ws = WizardState::new_with_intent(rest.trim());
+                ws.refresh_suggestions(ctx.graph);
+                self.modal = Some(Modal::Wizard(ws));
+                self.status_message = None;
             }
             other => {
                 self.status_message =

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -334,17 +334,7 @@ impl App {
             return;
         }
         let event = match &mut self.modal {
-            Some(Modal::Wizard(ws)) => {
-                // Special case: Screen 3 Enter needs dataset_path from ctx.
-                if matches!(ws.screen, crate::wizard::WizardScreen::Values)
-                    && key.code == KeyCode::Enter
-                    && !ws.values.editing
-                {
-                    ws.advance_to_confirm(ctx.dataset_path);
-                    return;
-                }
-                ws.handle_key(key, ctx)
-            }
+            Some(Modal::Wizard(ws)) => ws.handle_key(key, ctx),
             None => return,
         };
         match event {

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -9,3 +9,4 @@
 // governing permissions and limitations under the License.
 
 pub mod app;
+pub mod wizard;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -36,15 +36,16 @@ use design_data_core::graph::TokenGraph;
 use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use ratatui::{
-    Terminal,
+    Frame, Terminal,
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table},
 };
 
-use design_data_tui::app::{ActiveView, App, StatusKind, StatusMessage, SubmitContext};
+use design_data_tui::app::{ActiveView, App, Modal, StatusKind, StatusMessage, SubmitContext};
+use design_data_tui::wizard::{ValueKind, WizardCtx, WizardScreen, WizardState};
 
 /// Token dataset loaded once at startup and held for the full session.
 struct DatasetHandle {
@@ -123,6 +124,10 @@ impl DatasetHandle {
             mode_sets_dir: self.mode_sets_dir.as_deref(),
         }
     }
+
+    fn wizard_ctx(&self) -> WizardCtx<'_> {
+        WizardCtx { graph: &self.graph, dataset_path: Some(&self.dataset_path) }
+    }
 }
 
 fn default_schema_path() -> Option<PathBuf> {
@@ -196,6 +201,26 @@ fn write_clipboard(text: &str) -> std::io::Result<()> {
     }
 }
 
+/// Return a centered `Rect` covering `percent_x` × `percent_y` of `area`.
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vert = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vert[1])[1]
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let handle = DatasetHandle::load(cli.dataset, cli.components, cli.mode_sets)?;
@@ -223,6 +248,199 @@ fn main() -> Result<()> {
     let _ = terminal.show_cursor();
 
     result
+}
+
+fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect) {
+    let screen_num = ws.screen.number();
+    let screen_name = ws.screen.name();
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Wizard · {screen_num}/4 · {screen_name} "));
+    let inner_area = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner_area);
+
+    let footer_text = match ws.screen {
+        WizardScreen::Intent => {
+            "Enter: continue  Tab: reuse selected  ↑↓: select suggestion  Esc: cancel"
+        }
+        WizardScreen::Classification => {
+            "Tab/Shift-Tab: next/prev field  ←→: cycle layer  +: add name field  Enter: continue  Esc: cancel"
+        }
+        WizardScreen::Values => {
+            "a: alias  l: literal  e: edit value  ↑↓: select row  Enter: continue  Esc: cancel"
+        }
+        WizardScreen::Confirm => {
+            "Type rationale, then Enter to preview (no write)  Esc: cancel"
+        }
+    };
+    f.render_widget(
+        Paragraph::new(footer_text).style(Style::default().fg(Color::DarkGray)),
+        inner_chunks[1],
+    );
+
+    match ws.screen {
+        WizardScreen::Intent => render_intent_screen(f, ws, inner_chunks[0]),
+        WizardScreen::Classification => render_classification_screen(f, ws, inner_chunks[0]),
+        WizardScreen::Values => render_values_screen(f, ws, inner_chunks[0]),
+        WizardScreen::Confirm => render_confirm_screen(f, ws, inner_chunks[0]),
+    }
+}
+
+fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(area);
+
+    // Input line.
+    let intent_line = format!("Intent: {}", ws.intent.value());
+    f.render_widget(Paragraph::new(intent_line), chunks[0]);
+
+    // Suggestions list.
+    if ws.suggestions.is_empty() {
+        if !ws.intent.value().is_empty() {
+            f.render_widget(
+                Paragraph::new("  (no suggestions — will create new token)"),
+                chunks[1],
+            );
+        } else {
+            f.render_widget(Paragraph::new("  Type to search for existing tokens…"), chunks[1]);
+        }
+    } else {
+        let rows: Vec<Row> = ws
+            .suggestions
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let marker = if i == ws.selected_suggestion { "▶" } else { " " };
+                let conf = format!("{:.0}%", s.confidence * 100.0);
+                Row::new(vec![
+                    Cell::from(marker),
+                    Cell::from(s.token_name.as_str()),
+                    Cell::from(conf),
+                ])
+            })
+            .collect();
+        let widths = [Constraint::Length(2), Constraint::Min(0), Constraint::Length(5)];
+        let table = Table::new(rows, widths).highlight_style(Style::default().bg(Color::DarkGray));
+        f.render_widget(table, chunks[1]);
+    }
+}
+
+fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+    let layer_str = match ws.classification.layer {
+        design_data_core::graph::Layer::Foundation => "Foundation",
+        design_data_core::graph::Layer::Platform => "Platform",
+        design_data_core::graph::Layer::Product => "Product",
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    let focused = ws.classification.focused_field;
+
+    let layer_label = if focused == 0 {
+        format!("▶ Layer:    ← {layer_str} →")
+    } else {
+        format!("  Layer:      {layer_str}")
+    };
+    lines.push(Line::from(layer_label));
+
+    let prop_label = if focused == 1 {
+        format!("▶ Property: {}", ws.classification.property.value())
+    } else {
+        format!("  Property: {}", ws.classification.property.value())
+    };
+    lines.push(Line::from(prop_label));
+
+    for (i, field) in ws.classification.name_fields.iter().enumerate() {
+        let marker = if focused == i + 2 { "▶" } else { " " };
+        lines.push(Line::from(format!("{marker} {}: {}", field.key, field.value.value())));
+    }
+
+    lines.push(Line::from(""));
+    let name = ws.assembled_name();
+    lines.push(Line::from(format!("  Preview: {name}")));
+
+    f.render_widget(Paragraph::new(lines), area);
+}
+
+fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+    if ws.values.rows.is_empty() {
+        f.render_widget(Paragraph::new("  (no mode combinations — graph has no mode sets)"), area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("Mode combo").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Kind").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Value / Alias target").style(Style::default().add_modifier(Modifier::BOLD)),
+    ]);
+    let rows: Vec<Row> = ws
+        .values
+        .rows
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let combo = row.combo_label();
+            let kind = match row.kind {
+                ValueKind::Alias => "alias",
+                ValueKind::Literal => "literal",
+            };
+            let value = match row.kind {
+                ValueKind::Alias => row.alias_target.value().to_string(),
+                ValueKind::Literal => row.literal.value().to_string(),
+            };
+            let style = if i == ws.values.selected {
+                Style::default().bg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            Row::new(vec![Cell::from(combo), Cell::from(kind), Cell::from(value)]).style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Percentage(30),
+        Constraint::Percentage(10),
+        Constraint::Percentage(60),
+    ];
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default().borders(Borders::NONE),
+    );
+    f.render_widget(table, area);
+}
+
+fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+    let rationale_height = 3u16;
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(rationale_height), Constraint::Min(0)])
+        .split(area);
+
+    // Rationale input.
+    let rationale_block = Block::default().borders(Borders::ALL).title(" Rationale (required) ");
+    let rationale_text = ws.rationale.value();
+    let warn = if rationale_text.len() > 280 {
+        " ⚠ >280 chars"
+    } else {
+        ""
+    };
+    f.render_widget(
+        Paragraph::new(format!("{rationale_text}{warn}")).block(rationale_block),
+        chunks[0],
+    );
+
+    // Diff preview.
+    let diff_text = ws.diff_preview.as_deref().unwrap_or("(diff will appear here once rationale is added and Enter pressed)");
+    let diff_para = Paragraph::new(diff_text)
+        .block(Block::default().borders(Borders::ALL).title(" Diff preview "))
+        .scroll((ws.diff_scroll, 0));
+    f.render_widget(diff_para, chunks[1]);
 }
 
 fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &DatasetHandle) -> Result<()> {
@@ -393,13 +611,20 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                 f.render_widget(status, chunks[2]);
             }
 
-            // Palette prompt.
-            let palette_text = if app.palette_open {
+            // Palette prompt (hidden while a modal is open).
+            let palette_text = if app.modal.is_none() && app.palette_open {
                 format!("{}{}", app.palette_prefix(), app.palette_input.value())
             } else {
                 String::new()
             };
             f.render_widget(Paragraph::new(palette_text), chunks[3]);
+
+            // Overlay modal (rendered last so it appears on top).
+            if let Some(Modal::Wizard(ref mut ws)) = app.modal {
+                let popup_area = centered_rect(82, 85, size);
+                f.render_widget(Clear, popup_area);
+                render_wizard(f, ws, popup_area);
+            }
         }).into_diagnostic()?;
 
         // Copy to clipboard outside the draw closure (needs mutable app).
@@ -412,11 +637,16 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
         if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
             if let Event::Key(key) = event::read().into_diagnostic()? {
                 if key.kind == KeyEventKind::Press {
-                    let was_open = app.palette_open;
-                    app.handle_key(key);
-                    // Palette just closed via Enter — dispatch command.
-                    if was_open && !app.palette_open && key.code == KeyCode::Enter {
-                        app.submit_palette(&handle.submit_context());
+                    if app.modal.is_some() {
+                        // Modal captures all input; palette is suppressed.
+                        app.handle_modal_key(key, &handle.wizard_ctx());
+                    } else {
+                        let was_open = app.palette_open;
+                        app.handle_key(key);
+                        // Palette just closed via Enter — dispatch command.
+                        if was_open && !app.palette_open && key.code == KeyCode::Enter {
+                            app.submit_palette(&handle.submit_context());
+                        }
                     }
                 }
             }

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -425,15 +425,15 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
     // Rationale input.
     let rationale_block = Block::default().borders(Borders::ALL).title(" Rationale (required) ");
     let rationale_text = ws.rationale.value();
-    let warn = if rationale_text.len() > 280 {
-        " ⚠ >280 chars"
+    let rationale_line = if rationale_text.len() > 280 {
+        Line::from(vec![
+            Span::raw(rationale_text),
+            Span::styled(" ⚠ >280 chars", Style::default().fg(Color::Yellow)),
+        ])
     } else {
-        ""
+        Line::from(Span::raw(rationale_text))
     };
-    f.render_widget(
-        Paragraph::new(format!("{rationale_text}{warn}")).block(rationale_block),
-        chunks[0],
-    );
+    f.render_widget(Paragraph::new(rationale_line).block(rationale_block), chunks[0]);
 
     // Diff preview.
     let diff_text = ws.diff_preview.as_deref().unwrap_or("(diff will appear here once rationale is added and Enter pressed)");

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -1,0 +1,618 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Four-screen token authoring wizard (RFC #973 §3.10–§3.15).
+//!
+//! Screens: Intent → Classification → Values → Confirm (diff preview).
+//! M3 ends at preview; no real disk writes (M4).
+
+use std::path::Path;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
+use design_data_core::suggest::{self, SuggestionResult};
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+/// Minimal graph context passed to wizard key handlers.
+pub struct WizardCtx<'a> {
+    pub graph: &'a TokenGraph,
+    pub dataset_path: Option<&'a Path>,
+}
+
+// ── Screen & path enums ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WizardScreen {
+    Intent,
+    Classification,
+    Values,
+    Confirm,
+}
+
+impl WizardScreen {
+    pub fn number(self) -> u8 {
+        match self {
+            WizardScreen::Intent => 1,
+            WizardScreen::Classification => 2,
+            WizardScreen::Values => 3,
+            WizardScreen::Confirm => 4,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            WizardScreen::Intent => "Intent",
+            WizardScreen::Classification => "Classification",
+            WizardScreen::Values => "Values",
+            WizardScreen::Confirm => "Confirm",
+        }
+    }
+}
+
+/// Whether the user is creating a new token or aliasing an existing one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WizardPath {
+    CreateNew,
+    AliasToExisting(String), // token name of the reuse target
+}
+
+// ── Draft types ──────────────────────────────────────────────────────────────
+
+/// An additional name-object field (key + editable value).
+pub struct NameField {
+    pub key: String,
+    pub value: Input,
+}
+
+/// State for Screen 2 (Classification).
+///
+/// `focused_field` index:  0 = layer selector, 1 = property, 2..= name_fields[i-2].
+pub struct ClassificationDraft {
+    pub layer: Layer,
+    pub property: Input,
+    pub name_fields: Vec<NameField>,
+    pub focused_field: usize,
+}
+
+impl ClassificationDraft {
+    fn new() -> Self {
+        Self {
+            layer: Layer::Foundation,
+            property: Input::default(),
+            name_fields: Vec::new(),
+            focused_field: 0,
+        }
+    }
+
+    fn field_count(&self) -> usize {
+        2 + self.name_fields.len() // layer + property + name_fields
+    }
+}
+
+/// Whether a value row uses an alias (reference) or a literal value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueKind {
+    Alias,
+    Literal,
+}
+
+/// One row in Screen 3's values table.
+pub struct ValueRow {
+    /// Mode-set conditions for this row, e.g. `[("colorScheme", "dark")]`.
+    pub mode_combo: Vec<(String, String)>,
+    pub kind: ValueKind,
+    /// Target token name when `kind = Alias`.
+    pub alias_target: Input,
+    /// Literal value string when `kind = Literal`.
+    pub literal: Input,
+}
+
+impl ValueRow {
+    fn label(&self) -> String {
+        if self.mode_combo.is_empty() {
+            "default".to_string()
+        } else {
+            self.mode_combo.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join(", ")
+        }
+    }
+}
+
+/// State for Screen 3 (Values).
+pub struct ValuesDraft {
+    pub rows: Vec<ValueRow>,
+    pub selected: usize,
+    /// True when keyboard input is being routed into the selected row's active field.
+    pub editing: bool,
+}
+
+impl ValuesDraft {
+    fn new() -> Self {
+        Self { rows: Vec::new(), selected: 0, editing: false }
+    }
+}
+
+// ── Main wizard state ────────────────────────────────────────────────────────
+
+/// All state for the four-screen wizard.
+pub struct WizardState {
+    pub screen: WizardScreen,
+    pub intent: Input,
+    pub suggestions: Vec<SuggestionResult>,
+    pub selected_suggestion: usize,
+    pub chosen_path: WizardPath,
+    pub classification: ClassificationDraft,
+    pub values: ValuesDraft,
+    pub rationale: Input,
+    pub diff_preview: Option<String>,
+    pub diff_scroll: u16,
+}
+
+/// Outcome of a single key event inside the wizard.
+pub enum WizardEvent {
+    /// Normal key handling; no state change visible to App.
+    Continue,
+    /// User pressed Esc — App should close the modal.
+    Cancel,
+    /// User confirmed on Screen 4 — App should close the modal and show the preview status.
+    Submit,
+}
+
+impl WizardState {
+    pub fn new() -> Self {
+        Self {
+            screen: WizardScreen::Intent,
+            intent: Input::default(),
+            suggestions: Vec::new(),
+            selected_suggestion: 0,
+            chosen_path: WizardPath::CreateNew,
+            classification: ClassificationDraft::new(),
+            values: ValuesDraft::new(),
+            rationale: Input::default(),
+            diff_preview: None,
+            diff_scroll: 0,
+        }
+    }
+
+    /// Create a wizard with `intent` pre-seeded from a palette `:new <intent>` command.
+    pub fn new_with_intent(intent: &str) -> Self {
+        let mut s = Self::new();
+        if !intent.is_empty() {
+            s.intent = Input::from(intent.to_string());
+        }
+        s
+    }
+
+    // ── Dispatch ─────────────────────────────────────────────────────────────
+
+    /// Route a key event through the appropriate screen handler.
+    pub fn handle_key(&mut self, key: KeyEvent, ctx: &WizardCtx<'_>) -> WizardEvent {
+        // Ctrl-C should not be consumed here — App handles it above us.
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            return WizardEvent::Continue;
+        }
+        if key.code == KeyCode::Esc {
+            return WizardEvent::Cancel;
+        }
+        let event = match self.screen {
+            WizardScreen::Intent => self.handle_intent_key(key, ctx),
+            WizardScreen::Classification => self.handle_classification_key(key),
+            WizardScreen::Values => self.handle_values_key(key),
+            WizardScreen::Confirm => self.handle_confirm_key(key),
+        };
+        // Refresh suggestions on every Screen 1 key.
+        if matches!(self.screen, WizardScreen::Intent) {
+            self.refresh_suggestions(ctx.graph);
+        }
+        event
+    }
+
+    // ── Screen 1: Intent ─────────────────────────────────────────────────────
+
+    fn handle_intent_key(&mut self, key: KeyEvent, ctx: &WizardCtx<'_>) -> WizardEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.chosen_path = WizardPath::CreateNew;
+                self.advance_to_classification(ctx.graph);
+                WizardEvent::Continue
+            }
+            KeyCode::Tab => {
+                if !self.suggestions.is_empty() {
+                    let name = self.suggestions[self.selected_suggestion].token_name.clone();
+                    self.chosen_path = WizardPath::AliasToExisting(name);
+                    self.build_diff(ctx.dataset_path);
+                    self.screen = WizardScreen::Confirm;
+                }
+                WizardEvent::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.selected_suggestion > 0 {
+                    self.selected_suggestion -= 1;
+                }
+                WizardEvent::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.suggestions.is_empty()
+                    && self.selected_suggestion < self.suggestions.len() - 1
+                {
+                    self.selected_suggestion += 1;
+                }
+                WizardEvent::Continue
+            }
+            _ => {
+                self.intent.handle_event(&crossterm::event::Event::Key(key));
+                WizardEvent::Continue
+            }
+        }
+    }
+
+    fn advance_to_classification(&mut self, graph: &TokenGraph) {
+        // Pre-populate property from the intent hint.
+        let intent = self.intent.value().to_string();
+        if !intent.is_empty() && self.classification.property.value().is_empty() {
+            // Seed property from the top suggestion's name.property if available.
+            if let Some(top) = self.suggestions.first() {
+                if let Some(prop) = top
+                    .name_object
+                    .as_ref()
+                    .and_then(|n| n.get("property"))
+                    .and_then(|v| v.as_str())
+                {
+                    self.classification.property = Input::from(prop.to_string());
+                }
+            }
+        }
+        // Build value rows based on graph mode sets.
+        self.values.rows = build_value_rows(&graph.mode_sets, graph, &intent);
+        self.screen = WizardScreen::Classification;
+    }
+
+    // ── Screen 2: Classification ─────────────────────────────────────────────
+
+    fn handle_classification_key(&mut self, key: KeyEvent) -> WizardEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.screen = WizardScreen::Values;
+                WizardEvent::Continue
+            }
+            KeyCode::Tab => {
+                let count = self.classification.field_count();
+                self.classification.focused_field =
+                    (self.classification.focused_field + 1) % count;
+                WizardEvent::Continue
+            }
+            KeyCode::BackTab => {
+                let count = self.classification.field_count();
+                let f = self.classification.focused_field;
+                self.classification.focused_field = if f == 0 { count - 1 } else { f - 1 };
+                WizardEvent::Continue
+            }
+            KeyCode::Left | KeyCode::Char('h') if self.classification.focused_field == 0 => {
+                self.classification.layer = cycle_layer_backward(self.classification.layer);
+                WizardEvent::Continue
+            }
+            KeyCode::Right | KeyCode::Char('l') if self.classification.focused_field == 0 => {
+                self.classification.layer = cycle_layer_forward(self.classification.layer);
+                WizardEvent::Continue
+            }
+            KeyCode::Char('+') => {
+                // Add a new name field.
+                self.classification.name_fields.push(NameField {
+                    key: "key".to_string(),
+                    value: Input::default(),
+                });
+                WizardEvent::Continue
+            }
+            _ => {
+                let focused = self.classification.focused_field;
+                if focused == 1 {
+                    self.classification.property.handle_event(&crossterm::event::Event::Key(key));
+                } else if focused >= 2 {
+                    let idx = focused - 2;
+                    if let Some(field) = self.classification.name_fields.get_mut(idx) {
+                        field.value.handle_event(&crossterm::event::Event::Key(key));
+                    }
+                }
+                WizardEvent::Continue
+            }
+        }
+    }
+
+    // ── Screen 3: Values ─────────────────────────────────────────────────────
+
+    fn handle_values_key(&mut self, key: KeyEvent) -> WizardEvent {
+        if self.values.editing {
+            // Route keys into the active row input; Esc or Enter exits edit mode.
+            match key.code {
+                KeyCode::Esc | KeyCode::Enter => {
+                    self.values.editing = false;
+                }
+                _ => {
+                    if let Some(row) = self.values.rows.get_mut(self.values.selected) {
+                        let input = match row.kind {
+                            ValueKind::Alias => &mut row.alias_target,
+                            ValueKind::Literal => &mut row.literal,
+                        };
+                        input.handle_event(&crossterm::event::Event::Key(key));
+                    }
+                }
+            }
+            return WizardEvent::Continue;
+        }
+
+        match key.code {
+            KeyCode::Enter => {
+                // Advance to Screen 4, computing the diff.
+                WizardEvent::Continue // dataset_path not available here; caller handles via ctx
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.values.selected > 0 {
+                    self.values.selected -= 1;
+                }
+                WizardEvent::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.values.rows.is_empty()
+                    && self.values.selected < self.values.rows.len() - 1
+                {
+                    self.values.selected += 1;
+                }
+                WizardEvent::Continue
+            }
+            KeyCode::Char('a') => {
+                if let Some(row) = self.values.rows.get_mut(self.values.selected) {
+                    row.kind = ValueKind::Alias;
+                }
+                WizardEvent::Continue
+            }
+            KeyCode::Char('l') => {
+                if let Some(row) = self.values.rows.get_mut(self.values.selected) {
+                    row.kind = ValueKind::Literal;
+                }
+                WizardEvent::Continue
+            }
+            KeyCode::Char('e') => {
+                if !self.values.rows.is_empty() {
+                    self.values.editing = true;
+                }
+                WizardEvent::Continue
+            }
+            _ => WizardEvent::Continue,
+        }
+    }
+
+    // ── Screen 4: Confirm ────────────────────────────────────────────────────
+
+    fn handle_confirm_key(&mut self, key: KeyEvent) -> WizardEvent {
+        match key.code {
+            KeyCode::Enter => {
+                if !self.rationale.value().is_empty() {
+                    WizardEvent::Submit
+                } else {
+                    WizardEvent::Continue
+                }
+            }
+            KeyCode::Up => {
+                self.diff_scroll = self.diff_scroll.saturating_sub(1);
+                WizardEvent::Continue
+            }
+            KeyCode::Down => {
+                self.diff_scroll = self.diff_scroll.saturating_add(1);
+                WizardEvent::Continue
+            }
+            _ => {
+                self.rationale.handle_event(&crossterm::event::Event::Key(key));
+                WizardEvent::Continue
+            }
+        }
+    }
+
+    // ── Public helpers ───────────────────────────────────────────────────────
+
+    /// Recompute `suggestions` from the current intent string.  Cheap; safe to call on
+    /// every key event.
+    pub fn refresh_suggestions(&mut self, graph: &TokenGraph) {
+        let intent = self.intent.value().to_string();
+        self.suggestions = suggest::suggest(graph, &intent, None, 5);
+        // Clamp selection.
+        if !self.suggestions.is_empty() && self.selected_suggestion >= self.suggestions.len() {
+            self.selected_suggestion = self.suggestions.len() - 1;
+        }
+    }
+
+    /// Advance Screen 3 → Screen 4 with a pre-computed diff.
+    ///
+    /// Called by `App::handle_modal_key` when it detects that the wizard is on Screen 3
+    /// and Enter was pressed (so `dataset_path` from `WizardCtx` is available).
+    pub fn advance_to_confirm(&mut self, dataset_path: Option<&Path>) {
+        self.build_diff(dataset_path);
+        self.screen = WizardScreen::Confirm;
+    }
+
+    /// The assembled token name derived from classification fields (property + name fields).
+    pub fn assembled_name(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        let prop = self.classification.property.value().trim().to_string();
+        if !prop.is_empty() {
+            parts.push(prop);
+        }
+        for field in &self.classification.name_fields {
+            let v = field.value.value().trim().to_string();
+            if !v.is_empty() {
+                parts.push(v);
+            }
+        }
+        parts.join("-")
+    }
+
+    /// Build a unified diff between the current and predicted post-write state of the
+    /// target file.  Populates `self.diff_preview`.  No files are written.
+    pub fn build_diff(&mut self, dataset_path: Option<&Path>) {
+        let Some(path) = dataset_path else {
+            self.diff_preview = None;
+            return;
+        };
+
+        let target = path.join("tokens.json");
+
+        // "before" — existing file content, or empty object.
+        let before_raw = if target.exists() {
+            std::fs::read_to_string(&target).unwrap_or_else(|_| "{}".to_string())
+        } else {
+            "{}".to_string()
+        };
+        let before = if before_raw.ends_with('\n') {
+            before_raw.clone()
+        } else {
+            format!("{before_raw}\n")
+        };
+
+        // Build the new token object.
+        let key = self.assembled_name();
+        let key = if key.is_empty() { "new-token".to_string() } else { key };
+
+        let token_value = match self.values.rows.first() {
+            Some(row) => match row.kind {
+                ValueKind::Alias => {
+                    let t = row.alias_target.value();
+                    if t.is_empty() {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::json!({ "$alias": t })
+                    }
+                }
+                ValueKind::Literal => {
+                    let v = row.literal.value().to_string();
+                    serde_json::Value::String(v)
+                }
+            },
+            None => serde_json::Value::Null,
+        };
+
+        let mut token_obj = serde_json::json!({ "value": token_value });
+        let rationale = self.rationale.value().trim().to_string();
+        if !rationale.is_empty() {
+            token_obj["rationale"] = serde_json::Value::String(rationale);
+        }
+
+        // Merge into the existing file map.
+        let mut map: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(&before_raw).unwrap_or_default();
+        map.insert(key, token_obj);
+        let after_body = serde_json::to_string_pretty(&serde_json::Value::Object(map))
+            .unwrap_or_else(|_| "{}".to_string());
+        let after = format!("{after_body}\n");
+
+        // Build unified diff.
+        let diff_text = similar::TextDiff::from_lines(before.as_str(), after.as_str())
+            .unified_diff()
+            .header("a/tokens.json", "b/tokens.json")
+            .to_string();
+
+        // Cap at 200 lines.
+        let capped: String = diff_text.lines().take(200).collect::<Vec<&str>>().join("\n");
+        self.diff_preview = Some(capped);
+    }
+}
+
+impl Default for WizardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn cycle_layer_forward(layer: Layer) -> Layer {
+    match layer {
+        Layer::Foundation => Layer::Platform,
+        Layer::Platform => Layer::Product,
+        Layer::Product => Layer::Foundation,
+    }
+}
+
+fn cycle_layer_backward(layer: Layer) -> Layer {
+    match layer {
+        Layer::Foundation => Layer::Product,
+        Layer::Platform => Layer::Foundation,
+        Layer::Product => Layer::Platform,
+    }
+}
+
+/// Build Screen 3 value rows from a graph's mode sets.
+///
+/// Produces the Cartesian product of all mode values.  If the graph has no
+/// mode sets, a single "default" row is returned.
+fn build_value_rows(
+    mode_sets: &[ModeSetRecord],
+    graph: &TokenGraph,
+    intent: &str,
+) -> Vec<ValueRow> {
+    let combos = cartesian_product(mode_sets);
+    if combos.is_empty() {
+        return vec![ValueRow {
+            mode_combo: vec![],
+            kind: ValueKind::Alias,
+            alias_target: seed_alias(graph, intent, None),
+            literal: Input::default(),
+        }];
+    }
+    combos
+        .into_iter()
+        .map(|combo| {
+            let property_hint: Option<String> = None; // refined in M4 with primer
+            ValueRow {
+                mode_combo: combo,
+                kind: ValueKind::Alias,
+                alias_target: seed_alias(
+                    graph,
+                    intent,
+                    property_hint.as_deref(),
+                ),
+                literal: Input::default(),
+            }
+        })
+        .collect()
+}
+
+fn seed_alias(graph: &TokenGraph, intent: &str, property_hint: Option<&str>) -> Input {
+    let suggestions = suggest::suggest(graph, intent, property_hint, 1);
+    if let Some(top) = suggestions.into_iter().next() {
+        Input::from(top.token_name)
+    } else {
+        Input::default()
+    }
+}
+
+/// Cartesian product of mode sets → list of mode-combo vectors.
+fn cartesian_product(mode_sets: &[ModeSetRecord]) -> Vec<Vec<(String, String)>> {
+    let mut result: Vec<Vec<(String, String)>> = vec![vec![]];
+    for ms in mode_sets {
+        let mut next = Vec::new();
+        for combo in &result {
+            for mode in &ms.modes {
+                let mut new_combo = combo.clone();
+                new_combo.push((ms.name.clone(), mode.clone()));
+                next.push(new_combo);
+            }
+        }
+        result = next;
+    }
+    result
+}
+
+// ── Re-export row label helper for tests ─────────────────────────────────────
+
+impl ValueRow {
+    /// Human-readable label for the mode combo.
+    pub fn combo_label(&self) -> String {
+        self.label()
+    }
+}

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -116,7 +116,8 @@ pub struct ValueRow {
 }
 
 impl ValueRow {
-    fn label(&self) -> String {
+    /// Human-readable label for the mode combo.
+    pub fn combo_label(&self) -> String {
         if self.mode_combo.is_empty() {
             "default".to_string()
         } else {
@@ -204,8 +205,8 @@ impl WizardState {
         let event = match self.screen {
             WizardScreen::Intent => self.handle_intent_key(key, ctx),
             WizardScreen::Classification => self.handle_classification_key(key),
-            WizardScreen::Values => self.handle_values_key(key),
-            WizardScreen::Confirm => self.handle_confirm_key(key),
+            WizardScreen::Values => self.handle_values_key(key, ctx),
+            WizardScreen::Confirm => self.handle_confirm_key(key, ctx),
         };
         // Refresh suggestions on every Screen 1 key.
         if matches!(self.screen, WizardScreen::Intent) {
@@ -327,7 +328,7 @@ impl WizardState {
 
     // ── Screen 3: Values ─────────────────────────────────────────────────────
 
-    fn handle_values_key(&mut self, key: KeyEvent) -> WizardEvent {
+    fn handle_values_key(&mut self, key: KeyEvent, ctx: &WizardCtx<'_>) -> WizardEvent {
         if self.values.editing {
             // Route keys into the active row input; Esc or Enter exits edit mode.
             match key.code {
@@ -349,8 +350,8 @@ impl WizardState {
 
         match key.code {
             KeyCode::Enter => {
-                // Advance to Screen 4, computing the diff.
-                WizardEvent::Continue // dataset_path not available here; caller handles via ctx
+                self.advance_to_confirm(ctx.dataset_path);
+                WizardEvent::Continue
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 if self.values.selected > 0 {
@@ -390,10 +391,12 @@ impl WizardState {
 
     // ── Screen 4: Confirm ────────────────────────────────────────────────────
 
-    fn handle_confirm_key(&mut self, key: KeyEvent) -> WizardEvent {
+    fn handle_confirm_key(&mut self, key: KeyEvent, ctx: &WizardCtx<'_>) -> WizardEvent {
         match key.code {
             KeyCode::Enter => {
                 if !self.rationale.value().is_empty() {
+                    // Regenerate so the final diff includes the rationale field.
+                    self.build_diff(ctx.dataset_path);
                     WizardEvent::Submit
                 } else {
                     WizardEvent::Continue
@@ -409,6 +412,9 @@ impl WizardState {
             }
             _ => {
                 self.rationale.handle_event(&crossterm::event::Event::Key(key));
+                // Regenerate the diff on each keystroke so the rationale field
+                // is reflected immediately in the preview panel.
+                self.build_diff(ctx.dataset_path);
                 WizardEvent::Continue
             }
         }
@@ -427,10 +433,7 @@ impl WizardState {
         }
     }
 
-    /// Advance Screen 3 → Screen 4 with a pre-computed diff.
-    ///
-    /// Called by `App::handle_modal_key` when it detects that the wizard is on Screen 3
-    /// and Enter was pressed (so `dataset_path` from `WizardCtx` is available).
+    /// Advance Screen 3 → Screen 4, computing an initial diff preview.
     pub fn advance_to_confirm(&mut self, dataset_path: Option<&Path>) {
         self.build_diff(dataset_path);
         self.screen = WizardScreen::Confirm;
@@ -478,6 +481,7 @@ impl WizardState {
         let key = self.assembled_name();
         let key = if key.is_empty() { "new-token".to_string() } else { key };
 
+        // M3: preview uses only the first value row. Full per-mode diff is M4.
         let token_value = match self.values.rows.first() {
             Some(row) => match row.kind {
                 ValueKind::Alias => {
@@ -608,11 +612,3 @@ fn cartesian_product(mode_sets: &[ModeSetRecord]) -> Vec<Vec<(String, String)>> 
     result
 }
 
-// ── Re-export row label helper for tests ─────────────────────────────────────
-
-impl ValueRow {
-    /// Human-readable label for the mode combo.
-    pub fn combo_label(&self) -> String {
-        self.label()
-    }
-}

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -1,0 +1,337 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
+use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::wizard::{ValueKind, WizardCtx, WizardPath, WizardScreen};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+/// Simple graph with a few color tokens.
+fn make_graph() -> TokenGraph {
+    let records: Vec<TokenRecord> = vec![
+        TokenRecord {
+            name: "accent-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": { "property": "background-color", "variant": "accent" }
+            }),
+            layer: Layer::Foundation,
+        },
+        TokenRecord {
+            name: "neutral-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 1,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#F5F5F5",
+                "name": { "property": "background-color", "variant": "neutral" }
+            }),
+            layer: Layer::Foundation,
+        },
+    ];
+    TokenGraph::from_records(records)
+}
+
+/// Graph with a colorScheme mode set — used for Screen 3 tests.
+fn make_graph_with_modes() -> TokenGraph {
+    let ms = ModeSetRecord {
+        file: PathBuf::from("mode-sets/color-scheme.json"),
+        name: "colorScheme".into(),
+        modes: vec!["light".into(), "dark".into()],
+        default_mode: "light".into(),
+    };
+    make_graph().with_mode_sets(vec![ms])
+}
+
+/// Open the wizard via `:new <intent>`.
+fn open_wizard(app: &mut App, graph: &TokenGraph, intent: &str) {
+    let cmd = format!("new {intent}");
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in cmd.chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&SubmitContext::new(graph));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn new_command_opens_wizard() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "accent background");
+    assert!(app.modal.is_some(), "modal should be open after :new");
+}
+
+#[test]
+fn esc_cancels_wizard() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "accent background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    app.handle_modal_key(key(KeyCode::Esc), &ctx);
+    assert!(app.modal.is_none(), "modal should close on Esc");
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("cancelled"), "status should say cancelled: {msg}");
+}
+
+#[test]
+fn intent_populates_suggestions_on_open() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "accent background");
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert!(
+            !ws.suggestions.is_empty(),
+            "suggestions should be populated from intent"
+        );
+    } else {
+        panic!("expected wizard modal");
+    }
+}
+
+#[test]
+fn enter_on_screen_1_advances_to_screen_2() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "accent background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.screen, WizardScreen::Classification, "should advance to Screen 2");
+    } else {
+        panic!("expected wizard modal after Enter on Screen 1");
+    }
+}
+
+#[test]
+fn tab_with_suggestion_sets_alias_path_and_jumps_to_confirm() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "accent background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    // Tab should reuse the top suggestion and skip to Screen 4.
+    app.handle_modal_key(key(KeyCode::Tab), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.screen, WizardScreen::Confirm, "should jump to Confirm after Tab reuse");
+        assert!(
+            matches!(ws.chosen_path, WizardPath::AliasToExisting(_)),
+            "chosen_path should be AliasToExisting"
+        );
+    } else {
+        panic!("expected wizard modal after Tab");
+    }
+}
+
+#[test]
+fn screen_2_layer_cycles_with_arrow_keys() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    // Advance to Screen 2.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // focused_field = 0 (layer); Right cycles forward.
+    app.handle_modal_key(key(KeyCode::Right), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.classification.layer, Layer::Platform, "Right should advance layer");
+    } else {
+        panic!("expected wizard modal");
+    }
+    // Left cycles back.
+    app.handle_modal_key(key(KeyCode::Left), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.classification.layer, Layer::Foundation, "Left should reverse layer");
+    }
+}
+
+#[test]
+fn screen_2_enter_advances_to_screen_3() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.screen, WizardScreen::Values, "should advance to Screen 3");
+    } else {
+        panic!("expected wizard modal");
+    }
+}
+
+#[test]
+fn screen_3_mode_rows_match_cartesian_product() {
+    let graph = make_graph_with_modes();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        // colorScheme has 2 modes → 2 rows.
+        assert_eq!(ws.values.rows.len(), 2, "should have one row per mode combo");
+    } else {
+        panic!("expected wizard modal");
+    }
+}
+
+#[test]
+fn screen_3_a_l_toggle_value_kind() {
+    let graph = make_graph_with_modes();
+    let mut app = App::new();
+    open_wizard(&mut app, &graph, "background");
+    let ctx = WizardCtx { graph: &graph, dataset_path: None };
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    // Default is Alias; 'l' should switch to Literal.
+    app.handle_modal_key(key(KeyCode::Char('l')), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.values.rows[0].kind, ValueKind::Literal, "'l' should set Literal");
+    }
+    // 'a' should switch back.
+    app.handle_modal_key(key(KeyCode::Char('a')), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.values.rows[0].kind, ValueKind::Alias, "'a' should restore Alias");
+    }
+}
+
+#[test]
+fn screen_3_enter_advances_to_screen_4() {
+    let graph = make_graph();
+    let mut app = App::new();
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures) };
+    open_wizard(&mut app, &graph, "background");
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.screen, WizardScreen::Confirm, "should advance to Screen 4");
+    } else {
+        panic!("expected wizard modal");
+    }
+}
+
+#[test]
+fn screen_4_empty_rationale_blocks_submit() {
+    let graph = make_graph();
+    let mut app = App::new();
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures) };
+    open_wizard(&mut app, &graph, "background");
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4
+    // Rationale is empty; Enter should NOT close the modal.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    assert!(app.modal.is_some(), "modal should stay open when rationale is empty");
+}
+
+#[test]
+fn screen_4_diff_preview_is_populated_on_enter() {
+    let graph = make_graph();
+    let mut app = App::new();
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures) };
+    open_wizard(&mut app, &graph, "background");
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    // Tab once: layer (0) → property (1).
+    app.handle_modal_key(key(KeyCode::Tab), &ctx);
+    for c in "background-color".chars() {
+        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+    }
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4 (triggers build_diff)
+    if let Some(Modal::Wizard(ref ws)) = app.modal {
+        assert_eq!(ws.screen, WizardScreen::Confirm);
+        let diff = ws.diff_preview.as_ref().expect("diff_preview should be populated");
+        assert!(diff.contains('+'), "diff should contain '+' lines for the new token");
+    } else {
+        panic!("expected wizard modal");
+    }
+}
+
+#[test]
+fn screen_4_submit_closes_modal_and_sets_status() {
+    let graph = make_graph();
+    let mut app = App::new();
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures) };
+    open_wizard(&mut app, &graph, "background");
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4
+    // Type a rationale.
+    for c in "Needed for the checkout redesign".chars() {
+        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+    }
+    // Submit.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    assert!(app.modal.is_none(), "modal should close after submit");
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(
+        msg.contains("write disabled") || msg.contains("preview"),
+        "status should mention preview/write disabled: {msg}"
+    );
+}
+
+#[test]
+fn submit_does_not_create_tokens_json_in_fixture_dir() {
+    let graph = make_graph();
+    let mut app = App::new();
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let tokens_file = fixtures.join("tokens.json");
+    // Ensure the file doesn't exist before the test.
+    assert!(
+        !tokens_file.exists(),
+        "tokens.json should not exist in fixtures dir (it would make this test meaningless)"
+    );
+    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures) };
+    open_wizard(&mut app, &graph, "background");
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    for c in "Rationale text here".chars() {
+        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+    }
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    assert!(
+        !tokens_file.exists(),
+        "M3 wizard submit must NOT write tokens.json to the dataset"
+    );
+}
+
+#[test]
+fn assembled_name_joins_property_and_fields() {
+    use design_data_tui::wizard::WizardState;
+    let mut ws = WizardState::new();
+    // Set property via Classification input.
+    use tui_input::Input;
+    ws.classification.property = Input::from("background-color".to_string());
+    ws.classification.name_fields.push(design_data_tui::wizard::NameField {
+        key: "variant".into(),
+        value: Input::from("hover".to_string()),
+    });
+    assert_eq!(ws.assembled_name(), "background-color-hover");
+}

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -297,17 +297,13 @@ fn screen_4_submit_closes_modal_and_sets_status() {
 }
 
 #[test]
-fn submit_does_not_create_tokens_json_in_fixture_dir() {
+fn submit_does_not_create_tokens_json_in_dataset() {
     let graph = make_graph();
     let mut app = App::new();
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
-    let tokens_file = fixtures.join("tokens.json");
-    // Ensure the file doesn't exist before the test.
-    assert!(
-        !tokens_file.exists(),
-        "tokens.json should not exist in fixtures dir (it would make this test meaningless)"
-    );
-    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures) };
+    // Use a fresh tempdir so there's no pre-existing tokens.json to confuse us.
+    let tmpdir = tempfile::TempDir::new().expect("tempdir");
+    let tokens_file = tmpdir.path().join("tokens.json");
+    let ctx = WizardCtx { graph: &graph, dataset_path: Some(tmpdir.path()) };
     open_wizard(&mut app, &graph, "background");
     app.handle_modal_key(key(KeyCode::Enter), &ctx);
     app.handle_modal_key(key(KeyCode::Enter), &ctx);


### PR DESCRIPTION
## Description

Implements the M3 milestone of the interactive TUI (RFC #973): a four-screen token
authoring wizard rendered as a centered overlay modal.

Screens:
1. **Intent** — free-form text; `suggest_token` surfaces reuse candidates; `Tab` aliases to
   a suggestion and skips straight to Confirm.
2. **Classification** — Layer radio (← →), Property text input, free-form name fields (+),
   live assembled-name preview.
3. **Values** — one row per mode-set Cartesian combination; `a`/`l` toggle Alias/Literal;
   `e` edits the active row.
4. **Confirm** — required rationale input; unified diff preview via `similar`; final Enter
   closes the modal with `"wizard preview ready — write disabled (M4)"` status.

**No real disk writes** — M4 wires `write_token` behind `--allow-write`.

New palette command: `:new <intent>` (alias `:create`). Tab autocomplete covers `new`.

## Related Issue

Closes #987 (sub-issue of epic #980).

## Motivation and Context

RFC #973 §4 M3 exit criterion: "all four wizard screens work against a fixture dataset,
end with diff-preview confirm."

## How Has This Been Tested?

- 15 new tests in `sdk/tui/tests/wizard.rs` covering all four screens, screen transitions,
  Alias/Literal toggling, diff preview population, empty-rationale guard, and the
  M3 no-write guarantee.
- All 67 `cargo test -p design-data-tui` tests pass.
- `cargo clippy --workspace -- -D warnings` clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` green.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)