### PR TITLE
feat(sdk/tui): m5 polish — mouse, help overlay, history, theming

### DIFF
--- a/.changeset/tui-m5.md
+++ b/.changeset/tui-m5.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+TUI polish (M5 of RFC #973): mouse capture, `?` help overlay, persisted
+palette history, and `--theme {terminal,spectrum}` opt-in (closes #991).
+
+- **sdk/tui/src/main.rs**: mouse capture in init/teardown; `--theme` CLI
+  flag; `Event::Mouse` arm; inline colors replaced with central Theme;
+  `render_help_modal`; hit region computation after draw.
+- **sdk/tui/src/app.rs**: `Modal::Help`, palette history load/save/recall,
+  `handle_mouse`, `scroll_active`, `click_at`, `v`-toggled drag-select,
+  `Modal::Wizard` boxed to reduce enum size.
+- **sdk/tui/src/help.rs** (new): static `HELP_TEXT` for all screens.
+- **sdk/tui/src/theme.rs** (new): `Theme` with `terminal()` + `spectrum()`.
+- **sdk/tui/tests/m5.rs** (new): 17 tests for mouse, help, history, theming.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
  "walkdir",
@@ -457,12 +457,13 @@ dependencies = [
  "clap",
  "crossterm",
  "design-data-core",
+ "dirs",
  "miette",
  "ratatui",
  "serde_json",
  "similar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tui-input",
  "uuid",
 ]
@@ -472,6 +473,27 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1138,6 +1160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,7 +1598,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1582,7 +1619,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1680,6 +1717,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2224,11 +2272,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2800,6 +2868,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2823,6 +2900,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2860,6 +2952,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2872,6 +2970,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2881,6 +2985,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2908,6 +3018,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2917,6 +3033,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2932,6 +3054,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2941,6 +3069,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "2.0"
 serde_json = "1"
 similar = "2"
 uuid = { version = "1", features = ["v4"] }
+dirs = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -377,6 +377,9 @@ impl App {
                     }
                 }
                 _ => {
+                    // Any character input resets the history position so the next ↑ starts
+                    // from the head again (mirrors bash/zsh behavior).
+                    self.palette_history_cursor = None;
                     self.palette_input.handle_event(&crossterm::event::Event::Key(key));
                 }
             }
@@ -557,11 +560,11 @@ impl App {
         }
         match &mut self.active_view {
             ActiveView::Describe(dv) => {
+                let amount = delta.unsigned_abs() as u16 * 3;
                 if delta > 0 {
-                    dv.scroll = dv.scroll.saturating_add(delta.unsigned_abs() as u16 * 3);
+                    dv.scroll = dv.scroll.saturating_add(amount);
                 } else {
-                    dv.scroll =
-                        dv.scroll.saturating_sub((-delta).unsigned_abs() as u16 * 3);
+                    dv.scroll = dv.scroll.saturating_sub(amount);
                 }
             }
             ActiveView::Query(qv) => {

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -9,15 +9,16 @@
 // governing permissions and limitations under the License.
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use design_data_core::cascade::{self, ResolutionContext, specificity};
 use design_data_core::diff::display_name;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_core::query;
 use design_data_core::schema::SchemaRegistry;
 use design_data_core::validate;
+use ratatui::layout::Rect;
 use ratatui::widgets::TableState;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
@@ -26,6 +27,9 @@ use crate::wizard::{WizardCtx, WizardEvent, WizardState};
 
 /// Command names for Tab autocomplete.
 const KNOWN_COMMANDS: &[&str] = &["new", "query", "resolve", "describe", "validate"];
+
+/// Max palette history entries persisted to disk.
+const HISTORY_CAP: usize = 200;
 
 /// Which prefix the palette was opened with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,7 +101,7 @@ pub struct QueryView {
 }
 
 impl QueryView {
-    fn new(expr_text: String, rows: Vec<QueryRow>) -> Self {
+    pub fn new(expr_text: String, rows: Vec<QueryRow>) -> Self {
         let mut table_state = TableState::default();
         if !rows.is_empty() {
             table_state.select(Some(0));
@@ -187,10 +191,36 @@ pub enum ActiveView {
     Validate(ValidateView),
 }
 
+// ── Modals ────────────────────────────────────────────────────────────────────
+
+/// State for the `?` help overlay.
+pub struct HelpModal {
+    pub scroll: u16,
+}
+
 /// An overlay modal that temporarily captures all keyboard input.
 pub enum Modal {
-    Wizard(WizardState),
+    Wizard(Box<WizardState>),
+    Help(HelpModal),
 }
+
+// ── Hit regions (mouse support) ───────────────────────────────────────────────
+
+/// What clicking a region does.
+pub enum HitAction {
+    /// Selects a row in the active list or table view.
+    SelectListRow(usize),
+}
+
+/// A rectangular region on screen with an associated action and text content.
+pub struct HitRegion {
+    pub rect: Rect,
+    pub action: HitAction,
+    /// Text representation of this element, used for drag-select copy.
+    pub text: String,
+}
+
+// ── Submit context ────────────────────────────────────────────────────────────
 
 /// Context passed to `submit_palette`; carries the graph plus optional paths for
 /// describe and validate commands.
@@ -235,6 +265,22 @@ pub struct App {
     pub pending_yank: Option<String>,
     /// Overlay modal; when present, all key events are routed here by main.rs.
     pub modal: Option<Modal>,
+
+    // ── History (palette command recall) ─────────────────────────────────────
+    /// Previously submitted palette commands, newest first.
+    pub palette_history: Vec<String>,
+    /// Index into `palette_history` being navigated; `None` = fresh input.
+    pub palette_history_cursor: Option<usize>,
+
+    // ── Mouse / selection ────────────────────────────────────────────────────
+    /// Hit regions from the most recent frame, used to handle click events.
+    pub hit_regions: Vec<HitRegion>,
+    /// When true, mouse drags record a selection instead of scrolling.
+    pub selection_mode: bool,
+    /// Drag start position (row, col) in selection mode.
+    pub sel_start: Option<(u16, u16)>,
+    /// Drag current/end position (row, col) in selection mode.
+    pub sel_end: Option<(u16, u16)>,
 }
 
 impl App {
@@ -248,8 +294,16 @@ impl App {
             status_message: None,
             pending_yank: None,
             modal: None,
+            palette_history: load_palette_history(),
+            palette_history_cursor: None,
+            hit_regions: Vec::new(),
+            selection_mode: false,
+            sel_start: None,
+            sel_end: None,
         }
     }
+
+    // ── Key handling ─────────────────────────────────────────────────────────
 
     /// Process a key event and update state accordingly.
     pub fn handle_key(&mut self, key: KeyEvent) {
@@ -264,16 +318,14 @@ impl App {
                 KeyCode::Esc => {
                     self.palette_open = false;
                     self.palette_input = Input::default();
+                    self.palette_history_cursor = None;
                 }
-                // Enter closes the palette; main.rs detects the closed state and
-                // calls submit_palette with the graph.
                 KeyCode::Enter => {
                     self.palette_open = false;
                 }
                 KeyCode::Tab => {
                     if self.palette_mode == PaletteMode::Command {
                         let current = self.palette_input.value().to_string();
-                        // Only autocomplete while the user is still typing the command word.
                         if !current.contains(' ') {
                             let matches: Vec<&str> = KNOWN_COMMANDS
                                 .iter()
@@ -294,6 +346,36 @@ impl App {
                         }
                     }
                 }
+                // History recall (↑ = older, ↓ = newer).
+                KeyCode::Up if self.palette_mode == PaletteMode::Command => {
+                    let next = match self.palette_history_cursor {
+                        None if !self.palette_history.is_empty() => Some(0),
+                        Some(i) if i + 1 < self.palette_history.len() => Some(i + 1),
+                        other => other,
+                    };
+                    self.palette_history_cursor = next;
+                    if let Some(i) = next {
+                        if let Some(entry) = self.palette_history.get(i) {
+                            self.palette_input = Input::from(entry.clone());
+                        }
+                    }
+                }
+                KeyCode::Down if self.palette_mode == PaletteMode::Command => {
+                    let next = self.palette_history_cursor.and_then(|i| {
+                        if i == 0 { None } else { Some(i - 1) }
+                    });
+                    self.palette_history_cursor = next;
+                    match next {
+                        Some(i) => {
+                            if let Some(entry) = self.palette_history.get(i) {
+                                self.palette_input = Input::from(entry.clone());
+                            }
+                        }
+                        None => {
+                            self.palette_input = Input::default();
+                        }
+                    }
+                }
                 _ => {
                     self.palette_input.handle_event(&crossterm::event::Event::Key(key));
                 }
@@ -301,21 +383,37 @@ impl App {
             return;
         }
 
-        // View-specific keys.  Returns true when the key was consumed so the
-        // shared fallback (palette open / quit) is skipped.
         let consumed = self.handle_view_key(key.code);
 
         if !consumed {
             match key.code {
+                // Help overlay.
+                KeyCode::Char('?') if self.modal.is_none() => {
+                    self.modal = Some(Modal::Help(HelpModal { scroll: 0 }));
+                }
+                // Text selection mode toggle.
+                KeyCode::Char('v') if self.modal.is_none() => {
+                    self.selection_mode = !self.selection_mode;
+                    if !self.selection_mode {
+                        self.sel_start = None;
+                        self.sel_end = None;
+                    }
+                    let label = if self.selection_mode { "on" } else { "off" };
+                    self.status_message = Some(StatusMessage::info(
+                        format!("selection mode {label}  (drag to select, release to copy)"),
+                    ));
+                }
                 KeyCode::Char(':') => {
                     self.palette_open = true;
                     self.palette_mode = PaletteMode::Command;
                     self.palette_input = Input::default();
+                    self.palette_history_cursor = None;
                 }
                 KeyCode::Char('/') => {
                     self.palette_open = true;
                     self.palette_mode = PaletteMode::FuzzyFind;
                     self.palette_input = Input::default();
+                    self.palette_history_cursor = None;
                 }
                 KeyCode::Char('q') => {
                     self.quit = true;
@@ -333,9 +431,33 @@ impl App {
             self.quit = true;
             return;
         }
+
+        // Help modal: closed by Esc or ?.
+        if let Some(Modal::Help(ref mut hm)) = self.modal {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('?') => {
+                    self.modal = None;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    hm.scroll = hm.scroll.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    hm.scroll = hm.scroll.saturating_add(1);
+                }
+                KeyCode::PageUp => {
+                    hm.scroll = hm.scroll.saturating_sub(10);
+                }
+                KeyCode::PageDown => {
+                    hm.scroll = hm.scroll.saturating_add(10);
+                }
+                _ => {}
+            }
+            return;
+        }
+
         let event = match &mut self.modal {
             Some(Modal::Wizard(ws)) => ws.handle_key(key, ctx),
-            None => return,
+            _ => return,
         };
         match event {
             WizardEvent::Cancel => {
@@ -349,14 +471,12 @@ impl App {
                         "wizard preview ready — pass --allow-write to enable writes",
                     ));
                 } else {
-                    // Phase 1: borrow ws immutably to run perform_write.
                     let (assembled_name, write_result) =
                         if let Some(Modal::Wizard(ref ws)) = self.modal {
                             (ws.assembled_name(), Some(ws.perform_write(ctx)))
                         } else {
                             (String::new(), None)
                         };
-                    // Phase 2: handle result (borrow on self.modal released).
                     match write_result {
                         Some(Ok(written_path)) => {
                             self.modal = None;
@@ -376,6 +496,135 @@ impl App {
             WizardEvent::Continue => {}
         }
     }
+
+    // ── Mouse handling ────────────────────────────────────────────────────────
+
+    /// Process a mouse event and return any text that should be yanked to clipboard.
+    pub fn handle_mouse(&mut self, event: MouseEvent) -> Option<String> {
+        match event.kind {
+            MouseEventKind::ScrollUp => {
+                self.scroll_active(-1);
+            }
+            MouseEventKind::ScrollDown => {
+                self.scroll_active(1);
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                if self.selection_mode {
+                    self.sel_start = Some((event.row, event.column));
+                    self.sel_end = Some((event.row, event.column));
+                } else {
+                    self.click_at(event.row, event.column);
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) if self.selection_mode => {
+                self.sel_end = Some((event.row, event.column));
+            }
+            MouseEventKind::Up(MouseButton::Left) if self.selection_mode => {
+                let text = self.extract_selection();
+                self.sel_start = None;
+                self.sel_end = None;
+                if let Some(ref t) = text {
+                    if !t.is_empty() {
+                        self.pending_yank = Some(t.clone());
+                    }
+                }
+                return text;
+            }
+            _ => {}
+        }
+        None
+    }
+
+    /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
+    fn scroll_active(&mut self, delta: i32) {
+        // Wizard diff scroll has priority when a modal is open.
+        if let Some(Modal::Wizard(ref mut ws)) = self.modal {
+            if delta > 0 {
+                ws.diff_scroll = ws.diff_scroll.saturating_add(delta as u16);
+            } else {
+                ws.diff_scroll = ws.diff_scroll.saturating_sub((-delta) as u16);
+            }
+            return;
+        }
+        // Help modal scroll.
+        if let Some(Modal::Help(ref mut hm)) = self.modal {
+            if delta > 0 {
+                hm.scroll = hm.scroll.saturating_add(delta as u16);
+            } else {
+                hm.scroll = hm.scroll.saturating_sub((-delta) as u16);
+            }
+            return;
+        }
+        match &mut self.active_view {
+            ActiveView::Describe(dv) => {
+                if delta > 0 {
+                    dv.scroll = dv.scroll.saturating_add(delta.unsigned_abs() as u16 * 3);
+                } else {
+                    dv.scroll =
+                        dv.scroll.saturating_sub((-delta).unsigned_abs() as u16 * 3);
+                }
+            }
+            ActiveView::Query(qv) => {
+                move_table_selection(&mut qv.table_state, qv.rows.len(), delta as i64);
+            }
+            ActiveView::Resolve(rv) => {
+                move_table_selection(&mut rv.table_state, rv.rows.len(), delta as i64);
+            }
+            ActiveView::Validate(vv) => {
+                move_table_selection(&mut vv.table_state, vv.rows.len(), delta as i64);
+            }
+            ActiveView::Empty => {}
+        }
+    }
+
+    /// Click at a terminal (row, col) position and dispatch the matching hit action.
+    fn click_at(&mut self, row: u16, col: u16) {
+        // Collect matching actions first to avoid borrow issues.
+        let action = self.hit_regions.iter().find_map(|r| {
+            if rect_contains(r.rect, row, col) { Some(&r.action) } else { None }
+        });
+        match action {
+            Some(HitAction::SelectListRow(i)) => {
+                let i = *i;
+                match &mut self.active_view {
+                    ActiveView::Query(qv) => {
+                        qv.table_state.select(Some(i));
+                    }
+                    ActiveView::Resolve(rv) => {
+                        rv.table_state.select(Some(i));
+                    }
+                    ActiveView::Validate(vv) => {
+                        vv.table_state.select(Some(i));
+                    }
+                    _ => {}
+                }
+            }
+            None => {}
+        }
+    }
+
+    /// Materialise the text covered by the current drag selection.
+    fn extract_selection(&self) -> Option<String> {
+        let (Some((r1, c1)), Some((r2, c2))) = (self.sel_start, self.sel_end) else {
+            return None;
+        };
+        let min_row = r1.min(r2);
+        let max_row = r1.max(r2);
+        let min_col = c1.min(c2);
+        let max_col = c1.max(c2);
+        let mut lines: Vec<&str> = Vec::new();
+        for region in &self.hit_regions {
+            let r_y = region.rect.y;
+            let r_x = region.rect.x;
+            let r_x_end = r_x + region.rect.width;
+            if r_y >= min_row && r_y <= max_row && r_x_end > min_col && r_x <= max_col {
+                lines.push(&region.text);
+            }
+        }
+        if lines.is_empty() { None } else { Some(lines.join("\n")) }
+    }
+
+    // ── View key routing ─────────────────────────────────────────────────────
 
     /// Handle view-specific keys, returning `true` when the key was consumed.
     fn handle_view_key(&mut self, code: KeyCode) -> bool {
@@ -443,7 +692,6 @@ impl App {
                 }
             }
             KeyCode::Char('y') => {
-                // Clone the yank text before mutating pending_yank.
                 let yank = match &self.active_view {
                     ActiveView::Query(qv) => qv.selected_row().map(|r| r.name.clone()),
                     ActiveView::Resolve(rv) => rv.selected_row().map(|r| r.name.clone()),
@@ -461,10 +709,9 @@ impl App {
         }
     }
 
+    // ── Palette dispatch ─────────────────────────────────────────────────────
+
     /// Dispatch a committed palette command against the graph and optional context paths.
-    ///
-    /// Called by main.rs after Enter is pressed in Command mode. Fuzzy-find mode (M2+)
-    /// is a no-op here.
     pub fn submit_palette(&mut self, ctx: &SubmitContext<'_>) {
         if self.palette_mode != PaletteMode::Command {
             self.palette_open = false;
@@ -475,6 +722,16 @@ impl App {
         let raw = self.palette_input.value().trim().to_string();
         self.palette_open = false;
         self.palette_input = Input::default();
+        self.palette_history_cursor = None;
+
+        // Append to history (dedupe head, cap at HISTORY_CAP).
+        if !raw.is_empty()
+            && self.palette_history.first().map(|s| s.as_str()) != Some(raw.as_str())
+        {
+            self.palette_history.insert(0, raw.clone());
+            self.palette_history.truncate(HISTORY_CAP);
+            save_palette_history(&self.palette_history);
+        }
 
         let (cmd, rest) = match raw.split_once(' ') {
             Some((c, r)) => (c.to_lowercase(), r.trim().to_string()),
@@ -517,7 +774,6 @@ impl App {
                         return;
                     }
                 };
-                // Filter to tokens whose name.property matches.
                 let candidates: Vec<TokenRecord> = ctx
                     .graph
                     .tokens
@@ -539,7 +795,6 @@ impl App {
                 }
                 let filtered_graph = TokenGraph::from_records(candidates)
                     .with_mode_sets(ctx.graph.mode_sets.clone());
-                // Compute specificity once per token, then sort.
                 let mut with_spec: Vec<(&TokenRecord, u32)> = filtered_graph
                     .tokens
                     .values()
@@ -604,7 +859,6 @@ impl App {
                     return;
                 }
                 let id = rest.trim();
-                // IDs must match ^[a-z][a-z0-9-]*$ (mirrors run_component in cli/main.rs).
                 if id.is_empty()
                     || !id.chars().next().is_some_and(|c| c.is_ascii_lowercase())
                     || !id
@@ -654,7 +908,6 @@ impl App {
                         }
                     }
                 } else {
-                    // Suggest close prefix matches from the loaded component list.
                     let available: Vec<&str> =
                         ctx.graph.components.iter().map(|c| c.name.as_str()).collect();
                     let suggestion = if available.is_empty() {
@@ -736,7 +989,7 @@ impl App {
             "new" | "create" => {
                 let mut ws = WizardState::new_with_intent(rest.trim());
                 ws.refresh_suggestions(ctx.graph);
-                self.modal = Some(Modal::Wizard(ws));
+                self.modal = Some(Modal::Wizard(Box::new(ws)));
                 self.status_message = None;
             }
             other => {
@@ -746,10 +999,9 @@ impl App {
         }
     }
 
+    // ── Misc helpers ─────────────────────────────────────────────────────────
+
     /// Take the pending yank string, clearing it from app state.
-    ///
-    /// Returns `Some(text)` when a yank is pending; `None` otherwise.
-    /// main.rs calls this after writing to the clipboard.
     pub fn take_pending_yank(&mut self) -> Option<String> {
         self.pending_yank.take()
     }
@@ -769,7 +1021,44 @@ impl Default for App {
     }
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── History persistence ───────────────────────────────────────────────────────
+
+/// Resolve the path for the persistent palette history file.
+///
+/// Reads `DESIGN_DATA_TUI_HISTORY` env var first (used in tests), then falls
+/// back to `dirs::data_dir()/design-data-tui/history`.
+pub fn history_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("DESIGN_DATA_TUI_HISTORY") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::data_dir().map(|d| d.join("design-data-tui").join("history"))
+}
+
+fn load_palette_history() -> Vec<String> {
+    let Some(path) = history_path() else { return Vec::new() };
+    std::fs::read_to_string(&path)
+        .map(|s| {
+            s.lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| l.to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn save_palette_history(history: &[String]) {
+    let Some(path) = history_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let content = history.join("\n");
+    let tmp = path.with_extension("tmp");
+    if std::fs::write(&tmp, &content).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
 
 fn layer_str(layer: Layer) -> &'static str {
     match layer {
@@ -780,7 +1069,7 @@ fn layer_str(layer: Layer) -> &'static str {
 }
 
 /// Advance a `TableState` selection by `delta` rows, clamping at the bounds.
-fn move_table_selection(state: &mut TableState, len: usize, delta: i64) {
+pub fn move_table_selection(state: &mut TableState, len: usize, delta: i64) {
     if len == 0 {
         return;
     }
@@ -789,9 +1078,15 @@ fn move_table_selection(state: &mut TableState, len: usize, delta: i64) {
     state.select(Some(next));
 }
 
+/// Test whether `(row, col)` is inside `rect`.
+fn rect_contains(rect: Rect, row: u16, col: u16) -> bool {
+    col >= rect.x
+        && col < rect.x + rect.width
+        && row >= rect.y
+        && row < rect.y + rect.height
+}
+
 /// Parse the rest-string for `:resolve` into a property name + `ResolutionContext`.
-///
-/// Syntax: `property=<name>[,<mode-set>=<mode>...]`
 fn parse_resolve_args(rest: &str) -> Result<(String, ResolutionContext), String> {
     let mut property: Option<String> = None;
     let mut ctx = ResolutionContext::new();

--- a/sdk/tui/src/help.rs
+++ b/sdk/tui/src/help.rs
@@ -1,0 +1,85 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Static help overlay content (press `?` to open, `Esc`/`?` to close).
+
+pub const HELP_TEXT: &str = "\
+GLOBAL
+  q                       Quit (when palette is closed)
+  Ctrl-C                  Always quit
+  ?                       Toggle this help overlay
+  v                       Toggle text-selection mode (drag to copy)
+
+PALETTE  (: opens command mode, / opens fuzzy-find)
+  Esc                     Cancel / close palette
+  Enter                   Dispatch command
+  Tab                     Autocomplete command name
+  Up / Down               Recall palette history (Up = older)
+
+COMMANDS
+  :query <expr>           Filter tokens  e.g. background-color/*
+  :resolve property=<name>[,<mode-set>=<mode>...]
+  :describe <component>   Inspect a component schema
+  :validate               Validate all tokens against schemas
+  :new [<intent>]         Open the token authoring wizard
+
+QUERY / RESOLVE / VALIDATE VIEW
+  Up / k                  Move selection up
+  Down / j                Move selection down
+  Scroll wheel            Move selection
+  Click row               Select that row
+  y                       Yank selected name / message to clipboard
+  Esc                     Return to empty view
+
+DESCRIBE VIEW
+  Up / k                  Scroll up one line
+  Down / j                Scroll down one line
+  PgUp                    Scroll up 10 lines
+  PgDn                    Scroll down 10 lines
+  Scroll wheel            Scroll the body
+  Esc                     Return to empty view
+
+WIZARD — Screen 1 (Intent)
+  Type                    Search existing tokens
+  Up / Down               Navigate suggestions
+  Tab                     Reuse top suggestion (alias path, skips to Screen 4)
+  Enter                   Proceed to Screen 2 (create new)
+  Esc                     Cancel wizard
+
+WIZARD — Screen 2 (Classification)
+  Tab / Shift-Tab         Move between fields
+  Left / Right            Cycle layer (Foundation → Platform → Product)
+  +                       Add a name field
+  Enter                   Proceed to Screen 3
+  Esc                     Cancel wizard
+
+WIZARD — Screen 3 (Values)
+  a                       Set row kind to Alias
+  l                       Set row kind to Literal
+  e                       Edit the active row's value
+  Up / Down               Select row
+  Enter                   Proceed to Screen 4
+  Esc                     Cancel wizard
+
+WIZARD — Screen 4 (Confirm)
+  Type                    Enter rationale (required before submit)
+  Up / Down               Scroll diff preview
+  Scroll wheel            Scroll diff preview
+  Ctrl+S                  Edit $schema URL
+  Enter                   Submit (writes token when --allow-write is set)
+  Esc                     Cancel wizard
+
+MOUSE
+  Scroll wheel            Scroll the active view or wizard diff preview
+  Click row               Select that row in a list or table view
+  v                       Enter text-selection mode
+  Drag (in select mode)   Select text from rows; release copies to clipboard
+  Shift-drag              Native terminal text selection (bypasses capture)
+";

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -9,4 +9,6 @@
 // governing permissions and limitations under the License.
 
 pub mod app;
+pub mod help;
+pub mod theme;
 pub mod wizard;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -21,14 +21,16 @@
 //! - In query/resolve/validate view: Up/k and Down/j navigate; `y` yanks; Esc returns.
 //! - In describe view: Up/k Down/j scroll line-by-line; PgUp/PgDn by 10 lines; Esc returns.
 //! - `q` quits when palette is closed; Ctrl-C always quits.
+//! - `?` opens the help overlay; Esc or `?` closes it.
+//! - `v` toggles text-selection mode; drag to copy.
 
 use std::io::{Write, stderr};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -39,13 +41,27 @@ use ratatui::{
     Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table},
 };
 
-use design_data_tui::app::{ActiveView, App, Modal, StatusKind, StatusMessage, SubmitContext};
+use design_data_tui::app::{
+    ActiveView, App, HitAction, HitRegion, Modal, StatusKind, StatusMessage, SubmitContext,
+};
+use design_data_tui::help::HELP_TEXT;
+use design_data_tui::theme::Theme;
 use design_data_tui::wizard::{ValueKind, WizardCtx, WizardScreen, WizardState};
+
+/// Which visual palette to use.
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum ThemeChoice {
+    /// Terminal-native colors; works in any 256-color terminal.
+    #[default]
+    Terminal,
+    /// Adobe Spectrum palette; requires a 24-bit truecolor terminal.
+    Spectrum,
+}
 
 /// Token dataset loaded once at startup and held for the full session.
 struct DatasetHandle {
@@ -57,6 +73,8 @@ struct DatasetHandle {
     schema_registry: Option<SchemaRegistry>,
     /// When true, wizard Screen 4 Submit writes to disk via `write_token`.
     allow_write: bool,
+    /// Active color theme (terminal-native or Spectrum).
+    theme: Theme,
 }
 
 impl DatasetHandle {
@@ -65,6 +83,7 @@ impl DatasetHandle {
         components_arg: Option<PathBuf>,
         mode_sets_arg: Option<PathBuf>,
         allow_write: bool,
+        theme: Theme,
     ) -> Result<Self> {
         let mut graph = TokenGraph::from_json_dir(&path)
             .into_diagnostic()
@@ -108,6 +127,7 @@ impl DatasetHandle {
             mode_sets_dir,
             schema_registry,
             allow_write,
+            theme,
         })
     }
 
@@ -181,6 +201,10 @@ struct Cli {
     /// flag the wizard shows a diff preview but does not write to the dataset.
     #[arg(long)]
     allow_write: bool,
+    /// Color theme. `terminal` uses terminal-native colors (default).
+    /// `spectrum` uses the Adobe Spectrum palette (requires truecolor terminal).
+    #[arg(long, value_enum, default_value_t = ThemeChoice::Terminal)]
+    theme: ThemeChoice,
 }
 
 /// Write `text` to the system clipboard.
@@ -201,7 +225,7 @@ fn write_clipboard(text: &str) -> std::io::Result<()> {
     #[cfg(target_os = "windows")]
     return Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
-        "clipboard yank is not supported on Windows (coming in M5)",
+        "clipboard yank is not supported on Windows",
     ));
 
     #[cfg(not(target_os = "windows"))]
@@ -236,19 +260,24 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let handle = DatasetHandle::load(cli.dataset, cli.components, cli.mode_sets, cli.allow_write)?;
+    let theme = match cli.theme {
+        ThemeChoice::Terminal => Theme::terminal(),
+        ThemeChoice::Spectrum => Theme::spectrum(),
+    };
+    let handle =
+        DatasetHandle::load(cli.dataset, cli.components, cli.mode_sets, cli.allow_write, theme)?;
 
     // Restore terminal on panic so the shell is not left in a broken state.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
-        let _ = execute!(stderr(), LeaveAlternateScreen);
+        let _ = execute!(stderr(), LeaveAlternateScreen, DisableMouseCapture);
         original_hook(info);
     }));
 
     enable_raw_mode().into_diagnostic()?;
     let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen).into_diagnostic()?;
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture).into_diagnostic()?;
 
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).into_diagnostic()?;
@@ -257,13 +286,22 @@ fn main() -> Result<()> {
 
     // Best-effort cleanup — continue even if individual steps fail.
     let _ = disable_raw_mode();
-    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture);
     let _ = terminal.show_cursor();
 
     result
 }
 
-fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect) {
+fn render_help_modal(f: &mut Frame<'_>, scroll: u16, area: Rect) {
+    let popup_area = centered_rect(80, 90, area);
+    f.render_widget(Clear, popup_area);
+    let para = Paragraph::new(HELP_TEXT)
+        .block(Block::default().borders(Borders::ALL).title(" Help  ?/Esc to close "))
+        .scroll((scroll, 0));
+    f.render_widget(para, popup_area);
+}
+
+fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect, theme: &Theme) {
     let screen_num = ws.screen.number();
     let screen_name = ws.screen.name();
 
@@ -293,19 +331,19 @@ fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect) {
         }
     };
     f.render_widget(
-        Paragraph::new(footer_text).style(Style::default().fg(Color::DarkGray)),
+        Paragraph::new(footer_text).style(Style::default().fg(theme.muted)),
         inner_chunks[1],
     );
 
     match ws.screen {
-        WizardScreen::Intent => render_intent_screen(f, ws, inner_chunks[0]),
+        WizardScreen::Intent => render_intent_screen(f, ws, inner_chunks[0], theme),
         WizardScreen::Classification => render_classification_screen(f, ws, inner_chunks[0]),
-        WizardScreen::Values => render_values_screen(f, ws, inner_chunks[0]),
-        WizardScreen::Confirm => render_confirm_screen(f, ws, inner_chunks[0]),
+        WizardScreen::Values => render_values_screen(f, ws, inner_chunks[0], theme),
+        WizardScreen::Confirm => render_confirm_screen(f, ws, inner_chunks[0], theme),
     }
 }
 
-fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(1), Constraint::Min(0)])
@@ -341,7 +379,8 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
             })
             .collect();
         let widths = [Constraint::Length(2), Constraint::Min(0), Constraint::Length(5)];
-        let table = Table::new(rows, widths).highlight_style(Style::default().bg(Color::DarkGray));
+        let table =
+            Table::new(rows, widths).highlight_style(Style::default().bg(theme.selection_bg));
         f.render_widget(table, chunks[1]);
     }
 }
@@ -382,7 +421,7 @@ fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect)
     f.render_widget(Paragraph::new(lines), area);
 }
 
-fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
     if ws.values.rows.is_empty() {
         f.render_widget(Paragraph::new("  (no mode combinations — graph has no mode sets)"), area);
         return;
@@ -409,7 +448,7 @@ fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
                 ValueKind::Literal => row.literal.value().to_string(),
             };
             let style = if i == ws.values.selected {
-                Style::default().bg(Color::DarkGray)
+                Style::default().bg(theme.selection_bg)
             } else {
                 Style::default()
             };
@@ -428,7 +467,7 @@ fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
     f.render_widget(table, area);
 }
 
-fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
     let rationale_height = 3u16;
     let error_height = if ws.error.is_some() { 1u16 } else { 0u16 };
 
@@ -445,14 +484,14 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
     // Schema URL header / inline editor.
     let schema_line = if ws.editing_schema_url {
         Line::from(vec![
-            Span::styled("  $schema: ", Style::default().fg(Color::Yellow)),
+            Span::styled("  $schema: ", Style::default().fg(theme.accent)),
             Span::raw(ws.schema_url_input.value()),
-            Span::styled("▌", Style::default().fg(Color::Yellow)),
+            Span::styled("▌", Style::default().fg(theme.accent)),
         ])
     } else {
         let url_text = ws.schema_url.as_deref().unwrap_or("(none — Ctrl+S to set)");
         Line::from(vec![
-            Span::styled("  $schema: ", Style::default().fg(Color::DarkGray)),
+            Span::styled("  $schema: ", Style::default().fg(theme.muted)),
             Span::raw(url_text),
         ])
     };
@@ -464,7 +503,7 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
     let rationale_line = if rationale_text.len() > 280 {
         Line::from(vec![
             Span::raw(rationale_text),
-            Span::styled(" ⚠ >280 chars", Style::default().fg(Color::Yellow)),
+            Span::styled(" ⚠ >280 chars", Style::default().fg(theme.warn)),
         ])
     } else {
         Line::from(Span::raw(rationale_text))
@@ -480,37 +519,106 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
         .scroll((ws.diff_scroll, 0));
     f.render_widget(diff_para, chunks[2]);
 
-    // Write error (shown in red; keeps modal open).
+    // Write error (shown in error color; keeps modal open).
     if let Some(ref err) = ws.error {
         f.render_widget(
-            Paragraph::new(format!("  ⚠ {err}")).style(Style::default().fg(Color::Red)),
+            Paragraph::new(format!("  ⚠ {err}")).style(Style::default().fg(theme.error)),
             chunks[3],
         );
     }
+}
+
+/// Rebuild hit regions after a draw, mirroring the layout computed inside the draw closure.
+fn compute_hit_regions(app: &App, status_height: u16, frame_area: Rect) -> Vec<HitRegion> {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(status_height),
+            Constraint::Length(1),
+        ])
+        .split(frame_area);
+
+    let view_area = chunks[1];
+    // Tables have a top border (1) + header row (1) before data rows start.
+    let data_y = view_area.y + 2;
+    let data_height = view_area.height.saturating_sub(2); // available rows
+
+    let mut regions = Vec::new();
+    match &app.active_view {
+        ActiveView::Query(qv) => {
+            for (i, row) in qv.rows.iter().enumerate() {
+                let y = data_y + i as u16;
+                if i as u16 >= data_height {
+                    break;
+                }
+                regions.push(HitRegion {
+                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    action: HitAction::SelectListRow(i),
+                    text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
+                });
+            }
+        }
+        ActiveView::Resolve(rv) => {
+            for (i, row) in rv.rows.iter().enumerate() {
+                let y = data_y + i as u16;
+                if i as u16 >= data_height {
+                    break;
+                }
+                regions.push(HitRegion {
+                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    action: HitAction::SelectListRow(i),
+                    text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
+                });
+            }
+        }
+        ActiveView::Validate(vv) => {
+            for (i, row) in vv.rows.iter().enumerate() {
+                let y = data_y + i as u16;
+                if i as u16 >= data_height {
+                    break;
+                }
+                regions.push(HitRegion {
+                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    action: HitAction::SelectListRow(i),
+                    text: format!(
+                        "{}\t{}\t{}\t{}",
+                        row.severity, row.rule_id, row.token, row.message
+                    ),
+                });
+            }
+        }
+        ActiveView::Empty | ActiveView::Describe(_) => {}
+    }
+    regions
 }
 
 fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &DatasetHandle) -> Result<()> {
     let mut app = App::new();
 
     loop {
+        let mut frame_area = Rect::default();
+        let mut status_height: u16 = 0;
+
         terminal.draw(|f| {
-            let size = f.area();
+            frame_area = f.area();
 
             // Bottom area: status line (when present) + palette prompt.
-            let status_height = if app.status_message.is_some() { 1 } else { 0 };
+            status_height = if app.status_message.is_some() { 1 } else { 0 };
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(1),             // primer header
-                    Constraint::Min(0),                // active view
-                    Constraint::Length(status_height), // status message
-                    Constraint::Length(1),             // palette prompt
+                    Constraint::Length(1),              // primer header
+                    Constraint::Min(0),                 // active view
+                    Constraint::Length(status_height),  // status message
+                    Constraint::Length(1),              // palette prompt
                 ])
-                .split(size);
+                .split(frame_area);
 
             // Primer header.
             let primer_text = Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(Color::Green)),
+                Span::styled("▶ ", Style::default().fg(handle.theme.ok)),
                 Span::raw(handle.primer_line()),
             ]);
             f.render_widget(Paragraph::new(primer_text), chunks[0]);
@@ -555,7 +663,7 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                                 .borders(Borders::ALL)
                                 .title(format!(" Query: {} ", qv.expr_text)),
                         )
-                        .highlight_style(Style::default().bg(Color::DarkGray));
+                        .highlight_style(Style::default().bg(handle.theme.selection_bg));
                     f.render_stateful_widget(table, chunks[1], &mut qv.table_state);
                 }
                 ActiveView::Resolve(ref mut rv) => {
@@ -596,7 +704,7 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                                 .borders(Borders::ALL)
                                 .title(format!(" Resolve: {} ", rv.property)),
                         )
-                        .highlight_style(Style::default().bg(Color::DarkGray));
+                        .highlight_style(Style::default().bg(handle.theme.selection_bg));
                     f.render_stateful_widget(table, chunks[1], &mut rv.table_state);
                 }
                 ActiveView::Describe(ref dv) => {
@@ -641,16 +749,16 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                                 .borders(Borders::ALL)
                                 .title(" Validate "),
                         )
-                        .highlight_style(Style::default().bg(Color::DarkGray));
+                        .highlight_style(Style::default().bg(handle.theme.selection_bg));
                     f.render_stateful_widget(table, chunks[1], &mut vv.table_state);
                 }
             }
 
-            // Status message — green for info, red for errors.
+            // Status message — ok color for info, error color for errors.
             if let Some(ref msg) = app.status_message {
                 let color = match msg.kind {
-                    StatusKind::Info => Color::Green,
-                    StatusKind::Error => Color::Red,
+                    StatusKind::Info => handle.theme.ok,
+                    StatusKind::Error => handle.theme.error,
                 };
                 let status = Paragraph::new(msg.text.as_str())
                     .style(Style::default().fg(color));
@@ -666,35 +774,52 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
             f.render_widget(Paragraph::new(palette_text), chunks[3]);
 
             // Overlay modal (rendered last so it appears on top).
-            if let Some(Modal::Wizard(ref mut ws)) = app.modal {
-                let popup_area = centered_rect(82, 85, size);
-                f.render_widget(Clear, popup_area);
-                render_wizard(f, ws, popup_area);
+            match &mut app.modal {
+                Some(Modal::Wizard(ref mut ws)) => {
+                    let popup_area = centered_rect(82, 85, frame_area);
+                    f.render_widget(Clear, popup_area);
+                    render_wizard(f, ws, popup_area, &handle.theme);
+                }
+                Some(Modal::Help(ref hm)) => {
+                    render_help_modal(f, hm.scroll, frame_area);
+                }
+                None => {}
             }
         }).into_diagnostic()?;
+
+        // Rebuild hit regions from the frame geometry computed during draw.
+        app.hit_regions = compute_hit_regions(&app, status_height, frame_area);
 
         // Copy to clipboard outside the draw closure (needs mutable app).
         if let Some(text) = app.take_pending_yank() {
             if let Err(e) = write_clipboard(&text) {
-                app.status_message = Some(StatusMessage::error(format!("clipboard unavailable: {e}")));
+                app.status_message =
+                    Some(StatusMessage::error(format!("clipboard unavailable: {e}")));
             }
         }
 
         if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
-            if let Event::Key(key) = event::read().into_diagnostic()? {
-                if key.kind == KeyEventKind::Press {
-                    if app.modal.is_some() {
-                        // Modal captures all input; palette is suppressed.
-                        app.handle_modal_key(key, &handle.wizard_ctx());
-                    } else {
-                        let was_open = app.palette_open;
-                        app.handle_key(key);
-                        // Palette just closed via Enter — dispatch command.
-                        if was_open && !app.palette_open && key.code == KeyCode::Enter {
-                            app.submit_palette(&handle.submit_context());
+            match event::read().into_diagnostic()? {
+                Event::Key(key) => {
+                    if key.kind == KeyEventKind::Press {
+                        if app.modal.is_some() {
+                            // Modal captures all input; palette is suppressed.
+                            app.handle_modal_key(key, &handle.wizard_ctx());
+                        } else {
+                            let was_open = app.palette_open;
+                            app.handle_key(key);
+                            // Palette just closed via Enter — dispatch command.
+                            if was_open && !app.palette_open && key.code == KeyCode::Enter {
+                                app.submit_palette(&handle.submit_context());
+                            }
                         }
                     }
                 }
+                Event::Mouse(me) => {
+                    // handle_mouse sets pending_yank; it is drained above next frame.
+                    app.handle_mouse(me);
+                }
+                _ => {}
             }
         }
 

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -529,14 +529,18 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme:
 }
 
 /// Rebuild hit regions after a draw, mirroring the layout computed inside the draw closure.
+///
+/// SYNC WITH draw closure layout: the constraint array below must stay identical to the
+/// one in the `terminal.draw` call in `run()`. If a chunk is added or reordered there,
+/// update this function to match or click targets will silently drift.
 fn compute_hit_regions(app: &App, status_height: u16, frame_area: Rect) -> Vec<HitRegion> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
-            Constraint::Min(0),
-            Constraint::Length(status_height),
-            Constraint::Length(1),
+            Constraint::Length(1),              // primer header  ← SYNC WITH draw closure
+            Constraint::Min(0),                 // active view    ← SYNC WITH draw closure
+            Constraint::Length(status_height),  // status message ← SYNC WITH draw closure
+            Constraint::Length(1),              // palette prompt ← SYNC WITH draw closure
         ])
         .split(frame_area);
 

--- a/sdk/tui/src/theme.rs
+++ b/sdk/tui/src/theme.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Semantic color palette for the TUI.
+//!
+//! Two built-in presets:
+//! - `terminal` (default): terminal-native colors; works in any 256-color terminal.
+//! - `spectrum`: Adobe Spectrum palette; requires a 24-bit (truecolor) terminal.
+
+use ratatui::style::Color;
+
+/// A palette of semantic colors used throughout the TUI.
+pub struct Theme {
+    /// Primary foreground text.
+    pub fg: Color,
+    /// Muted / secondary text (hints, dim labels, DarkGray in terminal preset).
+    pub muted: Color,
+    /// Accent / highlight color (selection highlight, focused borders).
+    pub accent: Color,
+    /// Positive feedback (info messages, ok indicator, primer arrow).
+    pub ok: Color,
+    /// Warning / caution indicator.
+    pub warn: Color,
+    /// Error messages, write failures.
+    pub error: Color,
+    /// Background for selected table rows and drag-select regions.
+    pub selection_bg: Color,
+}
+
+impl Theme {
+    /// Terminal-native default.
+    ///
+    /// Uses `Color::Reset` for fg so the terminal's own foreground remains active;
+    /// other slots map to standard 16-color names supported everywhere.
+    pub fn terminal() -> Self {
+        Self {
+            fg: Color::Reset,
+            muted: Color::DarkGray,
+            accent: Color::Yellow,
+            ok: Color::Green,
+            warn: Color::Yellow,
+            error: Color::Red,
+            selection_bg: Color::DarkGray,
+        }
+    }
+
+    /// Adobe Spectrum palette.
+    ///
+    /// Requires a 24-bit (truecolor) terminal. Key swatches:
+    /// - Accent / Indigo 700: `#4046CA`
+    /// - OK / Celery 700:     `#268E6C`
+    /// - Warn / Orange 700:   `#CB5D00`
+    /// - Error / Red 700:     `#C9252D`
+    /// - Muted / Gray 600:    `#767676`
+    pub fn spectrum() -> Self {
+        Self {
+            fg: Color::Rgb(29, 29, 29),
+            muted: Color::Rgb(118, 118, 118),
+            accent: Color::Rgb(64, 70, 202),
+            ok: Color::Rgb(38, 142, 108),
+            warn: Color::Rgb(203, 93, 0),
+            error: Color::Rgb(201, 37, 45),
+            selection_bg: Color::Rgb(64, 70, 202),
+        }
+    }
+}

--- a/sdk/tui/src/theme.rs
+++ b/sdk/tui/src/theme.rs
@@ -67,6 +67,9 @@ impl Theme {
             ok: Color::Rgb(38, 142, 108),
             warn: Color::Rgb(203, 93, 0),
             error: Color::Rgb(201, 37, 45),
+            // Intentionally matches accent (Indigo 700) to give selected rows visual
+            // weight. A future UX pass may pick a distinct selection swatch if contrast
+            // proves insufficient for light-background text.
             selection_bg: Color::Rgb(64, 70, 202),
         }
     }

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -1,0 +1,312 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! M5 polish milestone tests: mouse, help overlay, palette history, theming.
+
+use std::env;
+
+use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
+use design_data_core::graph::TokenGraph;
+use design_data_tui::app::{App, HitAction, HitRegion, Modal};
+use design_data_tui::theme::Theme;
+use design_data_tui::wizard::WizardCtx;
+use ratatui::layout::Rect;
+use tempfile::TempDir;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }
+}
+
+fn mouse(kind: MouseEventKind, row: u16, col: u16) -> MouseEvent {
+    MouseEvent { kind, row, column: col, modifiers: KeyModifiers::NONE }
+}
+
+fn empty_ctx(graph: &TokenGraph) -> WizardCtx<'_> {
+    WizardCtx { graph, dataset_path: None, schema_registry: None, allow_write: false }
+}
+
+fn open_palette(app: &mut App) {
+    app.handle_key(key(KeyCode::Char(':')));
+}
+
+// ── Help overlay ──────────────────────────────────────────────────────────────
+
+#[test]
+fn question_mark_opens_help_modal() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('?')));
+    assert!(matches!(app.modal, Some(Modal::Help(_))), "? should open help modal");
+}
+
+#[test]
+fn esc_closes_help_modal() {
+    let graph = TokenGraph::default();
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('?')));
+    app.handle_modal_key(key(KeyCode::Esc), &empty_ctx(&graph));
+    assert!(app.modal.is_none(), "Esc should close help modal");
+}
+
+#[test]
+fn question_mark_closes_help_modal() {
+    let graph = TokenGraph::default();
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('?')));
+    app.handle_modal_key(key(KeyCode::Char('?')), &empty_ctx(&graph));
+    assert!(app.modal.is_none(), "second ? should close help modal");
+}
+
+#[test]
+fn pgdn_scrolls_help_body() {
+    let graph = TokenGraph::default();
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('?')));
+    app.handle_modal_key(key(KeyCode::PageDown), &empty_ctx(&graph));
+    if let Some(Modal::Help(ref hm)) = app.modal {
+        assert_eq!(hm.scroll, 10, "PageDown should advance help scroll by 10");
+    } else {
+        panic!("expected Help modal to still be open");
+    }
+}
+
+#[test]
+fn arrow_keys_scroll_help_body() {
+    let graph = TokenGraph::default();
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('?')));
+    let ctx = empty_ctx(&graph);
+    app.handle_modal_key(key(KeyCode::Down), &ctx);
+    app.handle_modal_key(key(KeyCode::Down), &ctx);
+    app.handle_modal_key(key(KeyCode::Up), &ctx);
+    if let Some(Modal::Help(ref hm)) = app.modal {
+        assert_eq!(hm.scroll, 1);
+    } else {
+        panic!("expected Help modal");
+    }
+}
+
+// ── Palette history ───────────────────────────────────────────────────────────
+
+fn with_temp_history<F: FnOnce()>(f: F) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let history_path = dir.path().join("history");
+    env::set_var("DESIGN_DATA_TUI_HISTORY", &history_path);
+    f();
+    env::remove_var("DESIGN_DATA_TUI_HISTORY");
+    dir
+}
+
+#[test]
+fn submit_palette_appends_to_history() {
+    let _dir = with_temp_history(|| {
+        let mut app = App::new();
+        open_palette(&mut app);
+        for ch in "query *".chars() {
+            app.handle_key(key(KeyCode::Char(ch)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+        let graph = TokenGraph::default();
+        let ctx = design_data_tui::app::SubmitContext::new(&graph);
+        app.submit_palette(&ctx);
+
+        assert_eq!(app.palette_history.first().map(|s| s.as_str()), Some("query *"));
+    });
+}
+
+#[test]
+fn up_arrow_in_palette_recalls_last_command() {
+    let _dir = with_temp_history(|| {
+        let mut app = App::new();
+        app.palette_history = vec!["query foo".to_string(), "query bar".to_string()];
+
+        open_palette(&mut app);
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.palette_input.value(), "query foo");
+
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.palette_input.value(), "query bar");
+
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(app.palette_input.value(), "query foo");
+    });
+}
+
+#[test]
+fn history_dedupes_consecutive_duplicates() {
+    let _dir = with_temp_history(|| {
+        let mut app = App::new();
+        app.palette_history = vec!["query *".to_string()];
+        open_palette(&mut app);
+        for ch in "query *".chars() {
+            app.handle_key(key(KeyCode::Char(ch)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+        let graph = TokenGraph::default();
+        let ctx = design_data_tui::app::SubmitContext::new(&graph);
+        app.submit_palette(&ctx);
+
+        assert_eq!(app.palette_history.len(), 1, "same command should not be duplicated");
+    });
+}
+
+#[test]
+fn history_caps_at_200_entries() {
+    let _dir = with_temp_history(|| {
+        let mut app = App::new();
+        app.palette_history = (0..199).map(|i| format!("query token-{i}")).collect();
+
+        open_palette(&mut app);
+        for ch in "query new-token".chars() {
+            app.handle_key(key(KeyCode::Char(ch)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+        let graph = TokenGraph::default();
+        let ctx = design_data_tui::app::SubmitContext::new(&graph);
+        app.submit_palette(&ctx);
+
+        assert_eq!(app.palette_history.len(), 200);
+        assert_eq!(app.palette_history[0], "query new-token");
+    });
+}
+
+// ── Mouse: wheel scroll ───────────────────────────────────────────────────────
+
+#[test]
+fn wheel_scroll_down_increments_describe_scroll() {
+    use design_data_tui::app::ActiveView;
+    let mut app = App::new();
+    app.active_view = ActiveView::Describe(design_data_tui::app::DescribeView {
+        component: "button".to_string(),
+        pretty_json: "{}".to_string(),
+        scroll: 0,
+    });
+    app.handle_mouse(mouse(MouseEventKind::ScrollDown, 5, 5));
+    if let ActiveView::Describe(ref dv) = app.active_view {
+        assert!(dv.scroll > 0, "scroll down should advance describe scroll");
+    }
+}
+
+// ── Mouse: click via hit regions ──────────────────────────────────────────────
+
+#[test]
+fn click_on_hit_region_selects_row() {
+    use design_data_tui::app::{ActiveView, QueryRow, QueryView};
+    let mut app = App::new();
+    let rows = vec![
+        QueryRow {
+            name: "a".into(),
+            value: "1".into(),
+            file: "f".into(),
+            layer: "foundation".into(),
+        },
+        QueryRow {
+            name: "b".into(),
+            value: "2".into(),
+            file: "f".into(),
+            layer: "foundation".into(),
+        },
+        QueryRow {
+            name: "c".into(),
+            value: "3".into(),
+            file: "f".into(),
+            layer: "foundation".into(),
+        },
+    ];
+    app.active_view = ActiveView::Query(QueryView::new("*".to_string(), rows));
+
+    app.hit_regions = vec![
+        HitRegion {
+            rect: Rect { x: 0, y: 2, width: 80, height: 1 },
+            action: HitAction::SelectListRow(0),
+            text: "a".into(),
+        },
+        HitRegion {
+            rect: Rect { x: 0, y: 3, width: 80, height: 1 },
+            action: HitAction::SelectListRow(1),
+            text: "b".into(),
+        },
+        HitRegion {
+            rect: Rect { x: 0, y: 4, width: 80, height: 1 },
+            action: HitAction::SelectListRow(2),
+            text: "c".into(),
+        },
+    ];
+
+    // Click row 1 (y=3).
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 10));
+    if let ActiveView::Query(ref qv) = app.active_view {
+        assert_eq!(qv.table_state.selected(), Some(1), "click should select row 1");
+    }
+}
+
+// ── Mouse: selection mode ─────────────────────────────────────────────────────
+
+#[test]
+fn v_key_enters_selection_mode() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('v')));
+    assert!(app.selection_mode, "v should enable selection mode");
+}
+
+#[test]
+fn v_key_toggles_selection_mode_off() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('v')));
+    app.handle_key(key(KeyCode::Char('v')));
+    assert!(!app.selection_mode, "second v should disable selection mode");
+}
+
+#[test]
+fn drag_records_selection_endpoints() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('v')));
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0));
+    app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 10));
+    assert_eq!(app.sel_start, Some((2, 0)));
+    assert_eq!(app.sel_end, Some((4, 10)));
+}
+
+// ── Theming ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn theme_terminal_has_reset_fg() {
+    use ratatui::style::Color;
+    let t = Theme::terminal();
+    assert_eq!(t.fg, Color::Reset, "terminal theme fg should be Color::Reset");
+}
+
+#[test]
+fn theme_spectrum_overrides_accent() {
+    use ratatui::style::Color;
+    let t = Theme::spectrum();
+    assert_eq!(
+        t.accent,
+        Color::Rgb(64, 70, 202),
+        "spectrum theme accent should be Indigo 700"
+    );
+}
+
+#[test]
+fn theme_terminal_and_spectrum_differ() {
+    let terminal = Theme::terminal();
+    let spectrum = Theme::spectrum();
+    assert_ne!(terminal.accent, spectrum.accent);
+    assert_ne!(terminal.error, spectrum.error);
+}

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -11,6 +11,7 @@
 //! M5 polish milestone tests: mouse, help overlay, palette history, theming.
 
 use std::env;
+use std::sync::Mutex;
 
 use crossterm::event::{
     KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
@@ -104,9 +105,14 @@ fn arrow_keys_scroll_help_body() {
 
 // ── Palette history ───────────────────────────────────────────────────────────
 
+// Serialize env-touching tests to avoid DESIGN_DATA_TUI_HISTORY stomping across
+// concurrently running tests (cargo test runs in parallel by default).
+static HISTORY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
 fn with_temp_history<F: FnOnce()>(f: F) -> TempDir {
     let dir = TempDir::new().unwrap();
     let history_path = dir.path().join("history");
+    let _guard = HISTORY_ENV_LOCK.lock().unwrap();
     env::set_var("DESIGN_DATA_TUI_HISTORY", &history_path);
     f();
     env::remove_var("DESIGN_DATA_TUI_HISTORY");
@@ -183,6 +189,27 @@ fn history_caps_at_200_entries() {
 
         assert_eq!(app.palette_history.len(), 200);
         assert_eq!(app.palette_history[0], "query new-token");
+    });
+}
+
+#[test]
+fn typing_resets_history_cursor() {
+    let _dir = with_temp_history(|| {
+        let mut app = App::new();
+        app.palette_history = vec!["query foo".to_string(), "query bar".to_string()];
+
+        open_palette(&mut app);
+        app.handle_key(key(KeyCode::Up)); // cursor = Some(0)
+        assert_eq!(app.palette_history_cursor, Some(0));
+
+        // Type a character — cursor must reset so the next ↑ starts from head.
+        app.handle_key(key(KeyCode::Char('x')));
+        assert_eq!(app.palette_history_cursor, None, "typing should reset history cursor");
+
+        // Pressing ↑ again should return to index 0 (newest entry), not continue from 1.
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(app.palette_history_cursor, Some(0));
+        assert_eq!(app.palette_input.value(), "query foo");
     });
 }
 


### PR DESCRIPTION
## Description

Implements M5 (the final milestone) of RFC #973 — TUI polish. Adds four
areas in a single PR: mouse support, `?` help overlay, persisted palette
history, and `--theme {terminal,spectrum}`.

## Related Issue

Closes #991 (M5 sub-issue under epic #980).

## Motivation and Context

RFC #973 §Q5 and the M5 exit criterion: the TUI should be demo-recordable
without manual cleanup between takes. Mouse capture, a help overlay, command
recall, and a Spectrum color palette were the four remaining gaps.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — 100 tests pass (17 new in `tests/m5.rs`
  covering mouse click/scroll/drag-select, help open/close/scroll, palette
  history append/recall/dedup/cap, and theme field assertions).
- `cargo clippy -p design-data-tui -- -D warnings` — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.