### PR TITLE
feat(sdk/tui): persist wizard draft across restarts (Q3 of RFC #973)

### DIFF
--- a/.changeset/tui-wizard-persistence.md
+++ b/.changeset/tui-wizard-persistence.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Persist in-progress wizard drafts across TUI restarts (Q3 of RFC #973, closes #993).
+
+- **sdk/tui/src/wizard_draft.rs** (new): serde DTOs mirroring `WizardState`; `to_draft`
+  / `from_draft` conversions; atomic save/load via `DESIGN_DATA_TUI_WIZARD_DRAFT` env
+  (test seam) or `dirs::data_dir()/design-data-tui/wizard-draft.json`.
+- **sdk/tui/src/app.rs**: auto-save on each wizard `WizardEvent::Continue` keystroke;
+  `clear_wizard_draft` on Cancel / Submit; restore via `App::new_with_options(resume)`.
+- **sdk/tui/src/main.rs**: `--no-resume-wizard` flag for demo/recording sessions.
+- **sdk/tui/Cargo.toml**: add `serde` with `derive` feature.
+- **sdk/core/src/graph.rs**: add `serde::Deserialize` to `Layer` (was `Serialize`-only).
+- **sdk/tui/tests/wizard_persistence.rs** (new): 9 tests covering round-trip, restore,
+  clear-on-cancel, keystroke auto-save, and `--no-resume-wizard` suppression.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "dirs",
  "miette",
  "ratatui",
+ "serde",
  "serde_json",
  "similar",
  "tempfile",

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -22,7 +22,10 @@ use crate::CoreError;
 ///
 /// Layer ordering is encoded in the discriminant so `Ord` gives correct
 /// precedence: `Foundation < Platform < Product`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, serde::Serialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default,
+    serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Layer {
     #[default]

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -21,6 +21,7 @@ tui-input = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 miette = { version = "7.4", features = ["fancy"] }
 thiserror = "2.0"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = "2"
 uuid = { version = "1", features = ["v4"] }

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -24,6 +24,9 @@ use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
 use crate::wizard::{WizardCtx, WizardEvent, WizardState};
+use crate::wizard_draft::{
+    clear_wizard_draft, from_draft, load_wizard_draft, save_wizard_draft, to_draft,
+};
 
 /// Command names for Tab autocomplete.
 const KNOWN_COMMANDS: &[&str] = &["new", "query", "resolve", "describe", "validate"];
@@ -285,6 +288,19 @@ pub struct App {
 
 impl App {
     pub fn new() -> Self {
+        Self::new_with_options(true)
+    }
+
+    /// Create the app, optionally restoring an in-progress wizard draft from disk.
+    ///
+    /// Pass `resume_wizard: false` for demo/recording sessions where you want a
+    /// clean slate regardless of what is saved on disk (corresponds to `--no-resume-wizard`).
+    pub fn new_with_options(resume_wizard: bool) -> Self {
+        let modal = if resume_wizard {
+            load_wizard_draft().map(|d| Modal::Wizard(Box::new(from_draft(d))))
+        } else {
+            None
+        };
         Self {
             palette_open: false,
             palette_mode: PaletteMode::Command,
@@ -293,7 +309,7 @@ impl App {
             active_view: ActiveView::Empty,
             status_message: None,
             pending_yank: None,
-            modal: None,
+            modal,
             palette_history: load_palette_history(),
             palette_history_cursor: None,
             hit_regions: Vec::new(),
@@ -465,11 +481,13 @@ impl App {
         match event {
             WizardEvent::Cancel => {
                 self.modal = None;
+                clear_wizard_draft();
                 self.status_message = Some(StatusMessage::info("wizard cancelled"));
             }
             WizardEvent::Submit => {
                 if !ctx.allow_write {
                     self.modal = None;
+                    clear_wizard_draft();
                     self.status_message = Some(StatusMessage::info(
                         "wizard preview ready — pass --allow-write to enable writes",
                     ));
@@ -483,6 +501,7 @@ impl App {
                     match write_result {
                         Some(Ok(written_path)) => {
                             self.modal = None;
+                            clear_wizard_draft();
                             self.status_message = Some(StatusMessage::info(format!(
                                 "wrote {assembled_name} → {written_path}"
                             )));
@@ -491,12 +510,23 @@ impl App {
                             if let Some(Modal::Wizard(ws)) = &mut self.modal {
                                 ws.error = Some(e);
                             }
+                            // Draft stays on disk; the next keystroke will re-save via
+                            // persist_wizard, keeping the last good state.
                         }
                         None => {}
                     }
                 }
             }
-            WizardEvent::Continue => {}
+            WizardEvent::Continue => {
+                self.persist_wizard();
+            }
+        }
+    }
+
+    /// Snapshot the current wizard modal to disk if one is open.
+    fn persist_wizard(&self) {
+        if let Some(Modal::Wizard(ref ws)) = self.modal {
+            save_wizard_draft(&to_draft(ws));
         }
     }
 

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -12,3 +12,4 @@ pub mod app;
 pub mod help;
 pub mod theme;
 pub mod wizard;
+pub mod wizard_draft;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -205,6 +205,10 @@ struct Cli {
     /// `spectrum` uses the Adobe Spectrum palette (requires truecolor terminal).
     #[arg(long, value_enum, default_value_t = ThemeChoice::Terminal)]
     theme: ThemeChoice,
+    /// Do not restore an in-progress wizard draft from the previous session.
+    /// Useful for demo recording where you want a clean slate on every launch.
+    #[arg(long)]
+    no_resume_wizard: bool,
 }
 
 /// Write `text` to the system clipboard.
@@ -266,6 +270,7 @@ fn main() -> Result<()> {
     };
     let handle =
         DatasetHandle::load(cli.dataset, cli.components, cli.mode_sets, cli.allow_write, theme)?;
+    let resume_wizard = !cli.no_resume_wizard;
 
     // Restore terminal on panic so the shell is not left in a broken state.
     let original_hook = std::panic::take_hook();
@@ -282,7 +287,7 @@ fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).into_diagnostic()?;
 
-    let result = run(&mut terminal, &handle);
+    let result = run(&mut terminal, &handle, resume_wizard);
 
     // Best-effort cleanup — continue even if individual steps fail.
     let _ = disable_raw_mode();
@@ -598,8 +603,8 @@ fn compute_hit_regions(app: &App, status_height: u16, frame_area: Rect) -> Vec<H
     regions
 }
 
-fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &DatasetHandle) -> Result<()> {
-    let mut app = App::new();
+fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &DatasetHandle, resume_wizard: bool) -> Result<()> {
+    let mut app = App::new_with_options(resume_wizard);
 
     loop {
         let mut frame_area = Rect::default();

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -36,7 +36,7 @@ pub struct WizardCtx<'a> {
 
 // ── Screen & path enums ──────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum WizardScreen {
     Intent,
     Classification,
@@ -65,7 +65,7 @@ impl WizardScreen {
 }
 
 /// Whether the user is creating a new token or aliasing an existing one.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum WizardPath {
     CreateNew,
     AliasToExisting(String), // token name of the reuse target
@@ -105,7 +105,7 @@ impl ClassificationDraft {
 }
 
 /// Whether a value row uses an alias (reference) or a literal value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ValueKind {
     Alias,
     Literal,

--- a/sdk/tui/src/wizard_draft.rs
+++ b/sdk/tui/src/wizard_draft.rs
@@ -201,7 +201,5 @@ pub fn save_wizard_draft(draft: &WizardDraft) {
 /// Remove the wizard draft file.  Ignores `NotFound`.
 pub fn clear_wizard_draft() {
     let Some(path) = wizard_draft_path() else { return };
-    match std::fs::remove_file(&path) {
-        Ok(()) | Err(_) => {}
-    }
+    let _ = std::fs::remove_file(&path);
 }

--- a/sdk/tui/src/wizard_draft.rs
+++ b/sdk/tui/src/wizard_draft.rs
@@ -1,0 +1,207 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Serializable mirror DTOs for `WizardState` + atomic on-disk persistence.
+//!
+//! Mirrors `app.rs`'s palette-history persistence pattern exactly.
+//! `tui_input::Input` is not `Serialize`, so each `Input` field is stored as
+//! a plain `String` and rehydrated via `Input::from(s)` on load.
+//!
+//! Transient/derivable fields (suggestions, diff_preview, diff_scroll, error,
+//! editing_schema_url, ValuesDraft.editing) are intentionally omitted; they
+//! are either rebuilt by `refresh_suggestions`/`advance_to_confirm` or start
+//! at their default values.
+
+use std::path::PathBuf;
+
+use design_data_core::graph::Layer;
+use serde::{Deserialize, Serialize};
+use tui_input::Input;
+
+use crate::wizard::{
+    ClassificationDraft, NameField, ValueKind, ValueRow, ValuesDraft, WizardPath, WizardScreen,
+    WizardState,
+};
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize)]
+pub struct WizardDraft {
+    pub screen: WizardScreen,
+    pub intent: String,
+    pub selected_suggestion: usize,
+    pub chosen_path: WizardPath,
+    pub classification: ClassificationDraftDto,
+    pub values: ValuesDraftDto,
+    pub rationale: String,
+    pub schema_url: Option<String>,
+    pub schema_url_input: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ClassificationDraftDto {
+    pub layer: Layer,
+    pub property: String,
+    pub name_fields: Vec<NameFieldDto>,
+    pub focused_field: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NameFieldDto {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ValuesDraftDto {
+    pub rows: Vec<ValueRowDto>,
+    pub selected: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ValueRowDto {
+    pub mode_combo: Vec<(String, String)>,
+    pub kind: ValueKind,
+    pub alias_target: String,
+    pub literal: String,
+}
+
+// ── WizardState ↔ WizardDraft conversions ────────────────────────────────────
+
+pub fn to_draft(ws: &WizardState) -> WizardDraft {
+    WizardDraft {
+        screen: ws.screen,
+        intent: ws.intent.value().to_string(),
+        selected_suggestion: ws.selected_suggestion,
+        chosen_path: ws.chosen_path.clone(),
+        classification: ClassificationDraftDto {
+            layer: ws.classification.layer,
+            property: ws.classification.property.value().to_string(),
+            name_fields: ws
+                .classification
+                .name_fields
+                .iter()
+                .map(|f| NameFieldDto {
+                    key: f.key.clone(),
+                    value: f.value.value().to_string(),
+                })
+                .collect(),
+            focused_field: ws.classification.focused_field,
+        },
+        values: ValuesDraftDto {
+            rows: ws
+                .values
+                .rows
+                .iter()
+                .map(|r| ValueRowDto {
+                    mode_combo: r.mode_combo.clone(),
+                    kind: r.kind,
+                    alias_target: r.alias_target.value().to_string(),
+                    literal: r.literal.value().to_string(),
+                })
+                .collect(),
+            selected: ws.values.selected,
+        },
+        rationale: ws.rationale.value().to_string(),
+        schema_url: ws.schema_url.clone(),
+        schema_url_input: ws.schema_url_input.value().to_string(),
+    }
+}
+
+pub fn from_draft(d: WizardDraft) -> WizardState {
+    let schema_url_str = d.schema_url_input.clone();
+    WizardState {
+        screen: d.screen,
+        intent: Input::from(d.intent),
+        // Transient — rebuilt by refresh_suggestions on the Intent screen.
+        suggestions: Vec::new(),
+        selected_suggestion: d.selected_suggestion,
+        chosen_path: d.chosen_path,
+        classification: ClassificationDraft {
+            layer: d.classification.layer,
+            property: Input::from(d.classification.property),
+            name_fields: d
+                .classification
+                .name_fields
+                .into_iter()
+                .map(|f| NameField { key: f.key, value: Input::from(f.value) })
+                .collect(),
+            focused_field: d.classification.focused_field,
+        },
+        values: ValuesDraft {
+            rows: d
+                .values
+                .rows
+                .into_iter()
+                .map(|r| ValueRow {
+                    mode_combo: r.mode_combo,
+                    kind: r.kind,
+                    alias_target: Input::from(r.alias_target),
+                    literal: Input::from(r.literal),
+                })
+                .collect(),
+            selected: d.values.selected,
+            // Transient — reset to false on restore.
+            editing: false,
+        },
+        rationale: Input::from(d.rationale),
+        // Transient — rebuilt by advance_to_confirm / build_diff when user reaches Screen 4.
+        diff_preview: None,
+        diff_scroll: 0,
+        schema_url: d.schema_url,
+        editing_schema_url: false,
+        schema_url_input: Input::from(schema_url_str),
+        error: None,
+    }
+}
+
+// ── On-disk persistence ───────────────────────────────────────────────────────
+
+/// Resolve the path for the persistent wizard draft file.
+///
+/// Reads `DESIGN_DATA_TUI_WIZARD_DRAFT` env var first (test seam), then falls
+/// back to `dirs::data_dir()/design-data-tui/wizard-draft.json`.
+pub fn wizard_draft_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("DESIGN_DATA_TUI_WIZARD_DRAFT") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::data_dir().map(|d| d.join("design-data-tui").join("wizard-draft.json"))
+}
+
+/// Load a wizard draft from disk.  Returns `None` on any I/O or parse error.
+pub fn load_wizard_draft() -> Option<WizardDraft> {
+    let path = wizard_draft_path()?;
+    let text = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Write the wizard draft to disk atomically (write to `.tmp`, then rename).
+pub fn save_wizard_draft(draft: &WizardDraft) {
+    let Some(path) = wizard_draft_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let json = match serde_json::to_string_pretty(draft) {
+        Ok(j) => j,
+        Err(_) => return,
+    };
+    let tmp = path.with_extension("tmp");
+    if std::fs::write(&tmp, &json).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+/// Remove the wizard draft file.  Ignores `NotFound`.
+pub fn clear_wizard_draft() {
+    let Some(path) = wizard_draft_path() else { return };
+    match std::fs::remove_file(&path) {
+        Ok(()) | Err(_) => {}
+    }
+}

--- a/sdk/tui/tests/wizard_persistence.rs
+++ b/sdk/tui/tests/wizard_persistence.rs
@@ -37,8 +37,14 @@ fn empty_ctx(graph: &TokenGraph) -> WizardCtx<'_> {
     WizardCtx { graph, dataset_path: None, schema_registry: None, allow_write: false }
 }
 
-// Serialize env-touching tests to avoid DESIGN_DATA_TUI_WIZARD_DRAFT stomping
-// across concurrently running tests.
+// Serialize env-touching tests within this binary to prevent concurrent tests
+// from stomping on DESIGN_DATA_TUI_WIZARD_DRAFT.
+//
+// Scope note: cargo test compiles each tests/*.rs file into a separate binary,
+// so this Mutex only covers tests inside wizard_persistence.rs. That's sufficient
+// because no other test binary in this crate sets DESIGN_DATA_TUI_WIZARD_DRAFT.
+// If a future test file also needs to touch this var, extract the lock into a
+// shared test-helper crate or use a file-based lock instead.
 static DRAFT_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn with_temp_draft<F: FnOnce()>(f: F) -> TempDir {

--- a/sdk/tui/tests/wizard_persistence.rs
+++ b/sdk/tui/tests/wizard_persistence.rs
@@ -1,0 +1,232 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Wizard draft persistence tests (Q3 of RFC #973).
+
+use std::env;
+use std::sync::Mutex;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+use design_data_core::graph::TokenGraph;
+use design_data_tui::app::{App, Modal};
+use design_data_tui::wizard::{WizardCtx, WizardScreen, WizardState};
+use design_data_tui::wizard_draft::{
+    from_draft, load_wizard_draft, save_wizard_draft, to_draft, wizard_draft_path,
+};
+use tempfile::TempDir;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }
+}
+
+fn empty_ctx(graph: &TokenGraph) -> WizardCtx<'_> {
+    WizardCtx { graph, dataset_path: None, schema_registry: None, allow_write: false }
+}
+
+// Serialize env-touching tests to avoid DESIGN_DATA_TUI_WIZARD_DRAFT stomping
+// across concurrently running tests.
+static DRAFT_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_temp_draft<F: FnOnce()>(f: F) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let draft_path = dir.path().join("wizard-draft.json");
+    let _guard = DRAFT_ENV_LOCK.lock().unwrap();
+    env::set_var("DESIGN_DATA_TUI_WIZARD_DRAFT", &draft_path);
+    f();
+    env::remove_var("DESIGN_DATA_TUI_WIZARD_DRAFT");
+    dir
+}
+
+fn make_wizard_with_intent(intent: &str) -> WizardState {
+    WizardState::new_with_intent(intent)
+}
+
+// ── Round-trip ────────────────────────────────────────────────────────────────
+
+#[test]
+fn round_trip_preserves_intent_and_rationale() {
+    let _dir = with_temp_draft(|| {
+        let ws = make_wizard_with_intent("accent background");
+        let draft = to_draft(&ws);
+        save_wizard_draft(&draft);
+
+        let loaded = load_wizard_draft().expect("draft should be on disk");
+        let restored = from_draft(loaded);
+        assert_eq!(restored.intent.value(), "accent background");
+        assert_eq!(restored.rationale.value(), "");
+    });
+}
+
+#[test]
+fn round_trip_preserves_classification_fields() {
+    use design_data_core::graph::Layer;
+    let _dir = with_temp_draft(|| {
+        let mut ws = make_wizard_with_intent("color");
+        ws.classification.layer = Layer::Platform;
+        // Simulate setting property via Input::from (mirrors how handle_key would do it)
+        ws.classification.property = tui_input::Input::from("background-color".to_string());
+
+        let _loaded = from_draft(load_wizard_draft().unwrap_or_else(|| {
+            let d = to_draft(&ws);
+            save_wizard_draft(&d);
+            load_wizard_draft().unwrap()
+        }));
+
+        // Use to_draft + from_draft directly without file I/O to test conversion.
+        let restored = from_draft(to_draft(&ws));
+        assert_eq!(restored.classification.layer, Layer::Platform);
+        assert_eq!(restored.classification.property.value(), "background-color");
+    });
+}
+
+#[test]
+fn round_trip_preserves_screen() {
+    let _dir = with_temp_draft(|| {
+        let mut ws = make_wizard_with_intent("bg");
+        ws.screen = WizardScreen::Classification;
+        let restored = from_draft(to_draft(&ws));
+        assert_eq!(restored.screen, WizardScreen::Classification);
+    });
+}
+
+// ── Transient fields reset on restore ────────────────────────────────────────
+
+#[test]
+fn restoring_resets_transient_fields() {
+    let ws = make_wizard_with_intent("something");
+    let mut ws2 = from_draft(to_draft(&ws));
+    ws2.diff_preview = Some("fake diff".to_string()); // would be set post-restore
+    let restored = from_draft(to_draft(&ws));
+    assert!(restored.suggestions.is_empty(), "suggestions should be empty on restore");
+    assert!(restored.diff_preview.is_none(), "diff_preview should be None on restore");
+    assert!(restored.error.is_none(), "error should be None on restore");
+    assert!(!restored.editing_schema_url, "editing_schema_url should be false");
+    assert!(!restored.values.editing, "values.editing should be false");
+}
+
+// ── App lifecycle: restore ────────────────────────────────────────────────────
+
+#[test]
+fn app_new_restores_wizard_from_disk() {
+    let _dir = with_temp_draft(|| {
+        // Write a draft to disk.
+        let ws = make_wizard_with_intent("restore test");
+        save_wizard_draft(&to_draft(&ws));
+
+        // A fresh App should pick it up.
+        let app = App::new();
+        assert!(
+            matches!(app.modal, Some(Modal::Wizard(_))),
+            "App::new() should restore wizard from disk"
+        );
+        if let Some(Modal::Wizard(ref ws)) = app.modal {
+            assert_eq!(ws.intent.value(), "restore test");
+        }
+    });
+}
+
+#[test]
+fn app_new_with_options_false_ignores_draft() {
+    let _dir = with_temp_draft(|| {
+        let ws = make_wizard_with_intent("should be ignored");
+        save_wizard_draft(&to_draft(&ws));
+
+        let app = App::new_with_options(false);
+        assert!(
+            app.modal.is_none(),
+            "--no-resume-wizard: modal should be None even if draft exists on disk"
+        );
+
+        // Draft file should still be there (we didn't delete it).
+        let path = wizard_draft_path().unwrap();
+        assert!(path.exists(), "draft file should remain untouched with --no-resume-wizard");
+    });
+}
+
+#[test]
+fn app_new_with_no_draft_starts_with_no_modal() {
+    let _dir = with_temp_draft(|| {
+        // No draft file exists — no wizard on startup.
+        let app = App::new();
+        assert!(app.modal.is_none(), "no draft → no modal");
+    });
+}
+
+// ── App lifecycle: clear on cancel ───────────────────────────────────────────
+
+#[test]
+fn cancelling_wizard_clears_disk_draft() {
+    let _dir = with_temp_draft(|| {
+        let graph = TokenGraph::default();
+        let mut app = App::new();
+
+        // Open the wizard via keyboard.
+        app.handle_key(key(KeyCode::Char(':')));
+        for ch in "new test token".chars() {
+            app.handle_key(key(KeyCode::Char(ch)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+        let ctx = design_data_tui::app::SubmitContext::new(&graph);
+        app.submit_palette(&ctx);
+        assert!(app.modal.is_some(), "wizard should be open");
+
+        // Persist something.
+        if let Some(Modal::Wizard(ref ws)) = app.modal {
+            save_wizard_draft(&to_draft(ws));
+        }
+        assert!(wizard_draft_path().unwrap().exists(), "draft should be on disk");
+
+        // Cancel.
+        app.handle_modal_key(key(KeyCode::Esc), &empty_ctx(&graph));
+        assert!(app.modal.is_none(), "modal should be closed after Esc");
+        assert!(
+            !wizard_draft_path().unwrap().exists(),
+            "draft should be cleared after cancel"
+        );
+    });
+}
+
+// ── App lifecycle: auto-save on keystrokes ────────────────────────────────────
+
+#[test]
+fn wizard_keystroke_persists_state() {
+    let _dir = with_temp_draft(|| {
+        let graph = TokenGraph::default();
+        let mut app = App::new();
+
+        // Open wizard.
+        app.handle_key(key(KeyCode::Char(':')));
+        for ch in "new".chars() {
+            app.handle_key(key(KeyCode::Char(ch)));
+        }
+        app.handle_key(key(KeyCode::Enter));
+        let ctx = design_data_tui::app::SubmitContext::new(&graph);
+        app.submit_palette(&ctx);
+
+        // Type into intent field — each key should persist.
+        let wiz_ctx = empty_ctx(&graph);
+        app.handle_modal_key(key(KeyCode::Char('a')), &wiz_ctx);
+        app.handle_modal_key(key(KeyCode::Char('b')), &wiz_ctx);
+
+        let draft_path = wizard_draft_path().unwrap();
+        assert!(draft_path.exists(), "wizard keystrokes should auto-save draft");
+
+        let loaded = load_wizard_draft().expect("draft should be loadable");
+        let restored = from_draft(loaded);
+        assert_eq!(restored.intent.value(), "ab", "persisted intent should match typed text");
+    });
+}

--- a/sdk/tui/tests/wizard_persistence.rs
+++ b/sdk/tui/tests/wizard_persistence.rs
@@ -86,13 +86,6 @@ fn round_trip_preserves_classification_fields() {
         // Simulate setting property via Input::from (mirrors how handle_key would do it)
         ws.classification.property = tui_input::Input::from("background-color".to_string());
 
-        let _loaded = from_draft(load_wizard_draft().unwrap_or_else(|| {
-            let d = to_draft(&ws);
-            save_wizard_draft(&d);
-            load_wizard_draft().unwrap()
-        }));
-
-        // Use to_draft + from_draft directly without file I/O to test conversion.
         let restored = from_draft(to_draft(&ws));
         assert_eq!(restored.classification.layer, Layer::Platform);
         assert_eq!(restored.classification.property.value(), "background-color");


### PR DESCRIPTION
## Description

Implements Q3 from RFC #973: persist an in-progress wizard draft to disk and
restore it on the next TUI launch. A single draft file is written atomically
after each wizard keystroke and cleared on Cancel or successful Submit.

## Related Issue

Closes #993

## Motivation and Context

Without persistence, any quit (or crash) mid-wizard loses all work. This PR
makes the wizard recoverable — matching the demo-grade polish bar set in M5 —
while staying narrowly scoped: one draft, palette-history pattern, no new UX.

## Design decisions

**Restoring with `editing: false`** — `ValuesDraft::editing` controls whether
keystrokes are routed into the active cell. On restore the wizard always lands
in navigation mode (not mid-cell-edit). A user who quit mid-cell will see the
partial value in the cell but won't be in edit mode; pressing `e` re-enters
it. This is safe and intentional — restoring mid-edit state would be surprising
and is impossible to represent faithfully after a process restart.

**No schema version on the draft file** — If a future PR adds a field to
`WizardDraft` (or renames a variant), `serde_json::from_str` will fail and
`load_wizard_draft()` returns `None`, silently discarding the draft. This is
acceptable for a local dev-tool best-effort save (same stance as palette
history). Anyone adding a field to `WizardDraft` should know: the old draft is
silently dropped on the next launch — no migration, no user-visible error.
Add a `#[serde(default)]` annotation to new optional fields if backwards
compat matters.

**Silent save failures** — `save_wizard_draft` swallows serialization and I/O
errors (returns `()`). This mirrors the palette-history pattern: best-effort
save, no disruption to the UI event loop on failure.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — 110 tests pass (9 new in
  `tests/wizard_persistence.rs` + 101 prior).
- `cargo clippy --workspace -- -D warnings` — clean.
- Changeset linter (`node tools/changeset-linter/src/cli.js check --fail-on-warnings`) — 11/11 valid.
- Manual end-to-end: opened wizard, filled intent + classification, quit with `q`,
  relaunched — wizard reopened at Classification screen with typed values present.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.