### PR TITLE
feat(sdk,mcp): add MCP authoring-session tools (RFC #973 Q4)

### DIFF
--- a/.changeset/authoring-session-mcp.md
+++ b/.changeset/authoring-session-mcp.md
@@ -1,0 +1,17 @@
+---
+"@adobe/design-data-agent-mcp": minor
+---
+
+Add MCP authoring-session tools — wizard state machine for agents (RFC #973 Q4).
+
+- **sdk/core/src/authoring/draft.rs** (new): serializable DTOs shared between
+  TUI wizard and MCP sessions.
+- **sdk/core/src/authoring/session.rs** (new): on-disk session state machine
+  (`start`, `step_intent`, `step_classification`, `step_values`,
+  `commit`, `cancel`, `get`, `list`).
+- **sdk/tui/src/wizard.rs**: import `WizardScreen`, `WizardPath`, `ValueKind`
+  from core; remove local definitions.
+- **sdk/cli/src/authoring.rs** (new): `authoring-session` CLI subcommand with
+  JSON output.
+- **tools/design-data-agent-mcp/src/tools/authoring.js** (new): 8 MCP tools
+  wrapping the CLI subcommand.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "design-data-core",
  "miette",
  "predicates",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",
@@ -437,6 +438,7 @@ dependencies = [
 name = "design-data-core"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "jsonschema",
  "regex",
  "reqwest",

--- a/sdk/cli/Cargo.toml
+++ b/sdk/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 design-data-core = { path = "../core", features = ["figma"] }
+serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 miette = { version = "7.4", features = ["fancy"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/sdk/cli/src/authoring.rs
+++ b/sdk/cli/src/authoring.rs
@@ -1,0 +1,247 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! `authoring-session` subcommand — CLI surface for the MCP authoring session
+//! state machine (RFC #973 Q4).
+//!
+//! All output is JSON written to stdout; exit code 1 on error.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use clap::Subcommand;
+use design_data_core::authoring::session::{
+    CommitInput, ValueRowInput, cancel_session, commit_session, get_session, list_sessions,
+    start_session, step_classification, step_intent, step_values,
+};
+use design_data_core::graph::Layer;
+use design_data_core::schema::SchemaRegistry;
+
+// ── Clap argument types ───────────────────────────────────────────────────────
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum LayerArg {
+    Foundation,
+    Platform,
+    Product,
+}
+
+impl From<LayerArg> for Layer {
+    fn from(a: LayerArg) -> Self {
+        match a {
+            LayerArg::Foundation => Layer::Foundation,
+            LayerArg::Platform => Layer::Platform,
+            LayerArg::Product => Layer::Product,
+        }
+    }
+}
+
+/// Screen that `step` operates on.
+#[derive(Subcommand, Debug)]
+pub enum StepCommand {
+    /// Update the intent field and refresh token suggestions.
+    Intent {
+        #[arg(long)]
+        session_id: String,
+        /// Natural-language description of what the token is for.
+        #[arg(long)]
+        intent: String,
+    },
+    /// Set layer, property, and name-object fields.
+    Classification {
+        #[arg(long)]
+        session_id: String,
+        #[arg(long, value_enum)]
+        layer: LayerArg,
+        #[arg(long)]
+        property: String,
+        /// Additional name-object fields in `key=value` form (repeatable).
+        #[arg(long = "name-field", value_name = "KEY=VALUE")]
+        name_fields: Vec<String>,
+    },
+    /// Set value rows as a JSON array of `ValueRowInput` objects.
+    ///
+    /// Each element: `{ "mode_combo": [], "kind": "Literal", "alias_target": "", "literal": "rgb(…)" }`
+    Values {
+        #[arg(long)]
+        session_id: String,
+        /// JSON array of value rows.
+        #[arg(long)]
+        rows: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AuthoringSessionCommand {
+    /// Start a new authoring session for the given dataset directory.
+    Start {
+        /// Path to the token dataset directory.
+        dataset_path: PathBuf,
+    },
+    /// Advance a session through one wizard screen.
+    Step {
+        #[command(subcommand)]
+        screen: StepCommand,
+    },
+    /// Build and write the token, then remove the session.
+    Commit {
+        #[arg(long)]
+        session_id: String,
+        #[arg(long, default_value = "")]
+        rationale: String,
+        /// Target legacy JSON file to write to (created if absent, merged if present).
+        #[arg(long)]
+        target: PathBuf,
+        /// `$schema` URL for the new token (e.g. `.../color.json`).
+        #[arg(long)]
+        schema_url: String,
+        /// Schemas directory for validation (default: `packages/tokens/schemas`
+        /// relative to the target's parent).
+        #[arg(long)]
+        schema_path: Option<PathBuf>,
+        /// Path to `product-context.json` for rationale capture.
+        #[arg(long)]
+        product_context: Option<PathBuf>,
+        /// Token overrides an existing foundation/platform token.
+        #[arg(long)]
+        is_override: bool,
+    },
+    /// Cancel a session and delete its on-disk file.
+    Cancel {
+        #[arg(long)]
+        session_id: String,
+    },
+    /// Print the current state of a session as JSON.
+    Get {
+        #[arg(long)]
+        session_id: String,
+    },
+    /// List all active sessions.
+    List,
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+
+pub fn run(cmd: AuthoringSessionCommand) -> ExitCode {
+    match run_inner(cmd) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(msg) => {
+            eprintln!("authoring-session error: {msg}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_inner(cmd: AuthoringSessionCommand) -> Result<(), String> {
+    match cmd {
+        AuthoringSessionCommand::Start { dataset_path } => {
+            let session = start_session(
+                dataset_path.to_str().ok_or("dataset_path is not valid UTF-8")?,
+            )?;
+            print_json(&session)?;
+        }
+
+        AuthoringSessionCommand::Step { screen } => match screen {
+            StepCommand::Intent { session_id, intent } => {
+                let result = step_intent(&session_id, &intent)?;
+                print_json(&result)?;
+            }
+            StepCommand::Classification { session_id, layer, property, name_fields } => {
+                let parsed_fields = parse_name_fields(&name_fields)?;
+                let session = step_classification(&session_id, layer.into(), &property, parsed_fields)?;
+                print_json(&session)?;
+            }
+            StepCommand::Values { session_id, rows } => {
+                let parsed: Vec<ValueRowInput> = serde_json::from_str(&rows)
+                    .map_err(|e| format!("--rows is not valid JSON: {e}"))?;
+                let session = step_values(&session_id, parsed)?;
+                print_json(&session)?;
+            }
+        },
+
+        AuthoringSessionCommand::Commit {
+            session_id,
+            rationale,
+            target,
+            schema_url,
+            schema_path,
+            product_context,
+            is_override,
+        } => {
+            let schema_dir = resolve_schema_path(schema_path.as_deref(), &target);
+            let registry = SchemaRegistry::load_legacy_token_schemas(&schema_dir)
+                .map_err(|e| format!("failed to load schema registry from {schema_dir:?}: {e}"))?;
+
+            let result = commit_session(
+                CommitInput {
+                    session_id,
+                    rationale,
+                    target,
+                    schema_url,
+                    schema_path: Some(schema_dir),
+                    product_context,
+                    is_override,
+                },
+                &registry,
+            )?;
+            print_json(&result)?;
+        }
+
+        AuthoringSessionCommand::Cancel { session_id } => {
+            cancel_session(&session_id);
+            print_json(&serde_json::json!({ "ok": true, "session_id": session_id }))?;
+        }
+
+        AuthoringSessionCommand::Get { session_id } => {
+            let session = get_session(&session_id)
+                .ok_or_else(|| format!("session not found: {session_id}"))?;
+            print_json(&session)?;
+        }
+
+        AuthoringSessionCommand::List => {
+            print_json(&list_sessions())?;
+        }
+    }
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn print_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("JSON serialization failed: {e}"))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn parse_name_fields(raw: &[String]) -> Result<Vec<(String, String)>, String> {
+    raw.iter()
+        .map(|s| {
+            let (k, v) = s
+                .split_once('=')
+                .ok_or_else(|| format!("--name-field must be key=value, got: {s:?}"))?;
+            Ok((k.to_string(), v.to_string()))
+        })
+        .collect()
+}
+
+/// Resolve the schema directory, defaulting to `packages/tokens/schemas` two
+/// levels above the target file (matching the existing `write-token` pattern).
+fn resolve_schema_path(explicit: Option<&Path>, target: &Path) -> PathBuf {
+    if let Some(p) = explicit {
+        return p.to_path_buf();
+    }
+    // Walk up from target's parent to find the workspace root.
+    target
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|r| r.join("schemas"))
+        .unwrap_or_else(|| PathBuf::from("packages/tokens/schemas"))
+}

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -13,6 +13,7 @@ use std::process::ExitCode;
 
 use chrono::Utc;
 
+mod authoring;
 mod format;
 
 use std::collections::HashSet;
@@ -220,6 +221,12 @@ enum Commands {
         /// Path to schemas directory (default: packages/tokens/schemas relative to target)
         #[arg(long, value_name = "DIR")]
         schema_path: Option<PathBuf>,
+    },
+    /// Manage token authoring sessions (MCP parity, RFC #973 Q4)
+    #[command(name = "authoring-session")]
+    AuthoringSession {
+        #[command(subcommand)]
+        cmd: authoring::AuthoringSessionCommand,
     },
 }
 
@@ -1454,6 +1461,9 @@ fn main() -> ExitCode {
                 schema_path: schema_path.as_deref(),
             },
         ),
+        Commands::AuthoringSession { cmd } => {
+            return authoring::run(cmd);
+        }
     };
 
     match result {

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 # preserve_order switches serde_json's Map from BTreeMap to IndexMap (crate-wide).
 # Required so write_token merges tokens without resorting keys on round-trip.
 serde_json = { version = "1.0", features = ["preserve_order"] }
+dirs = "5"
 tempfile = "3.14"
 thiserror = "2.0"
 uuid = { version = "1.11", features = ["v4"] }

--- a/sdk/core/src/authoring/draft.rs
+++ b/sdk/core/src/authoring/draft.rs
@@ -121,6 +121,8 @@ pub struct ClassificationDraftDto {
     pub layer: Layer,
     pub property: String,
     pub name_fields: Vec<NameFieldDto>,
+    /// TUI-only cursor position; not meaningful for MCP sessions.
+    #[serde(skip)]
     pub focused_field: usize,
 }
 
@@ -133,6 +135,8 @@ pub struct NameFieldDto {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ValuesDraftDto {
     pub rows: Vec<ValueRowDto>,
+    /// TUI-only cursor position; not meaningful for MCP sessions.
+    #[serde(skip)]
     pub selected: usize,
 }
 

--- a/sdk/core/src/authoring/draft.rs
+++ b/sdk/core/src/authoring/draft.rs
@@ -1,0 +1,145 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Serializable wizard draft DTOs — shared between the TUI wizard and the
+//! MCP authoring-session state machine.
+//!
+//! These types own their data (no `tui_input::Input`, no rendering state) so
+//! they can live in core without pulling in any TUI-specific dependencies.
+//! `tui_input::Input` collapses to `String` on the boundary.
+
+use serde::{Deserialize, Serialize};
+
+use crate::graph::Layer;
+
+// ── Screen and path enums ─────────────────────────────────────────────────────
+
+/// The four screens of the token authoring wizard (RFC #973 §3.10–§3.15).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WizardScreen {
+    Intent,
+    Classification,
+    Values,
+    Confirm,
+}
+
+impl WizardScreen {
+    pub fn number(self) -> u8 {
+        match self {
+            WizardScreen::Intent => 1,
+            WizardScreen::Classification => 2,
+            WizardScreen::Values => 3,
+            WizardScreen::Confirm => 4,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            WizardScreen::Intent => "Intent",
+            WizardScreen::Classification => "Classification",
+            WizardScreen::Values => "Values",
+            WizardScreen::Confirm => "Confirm",
+        }
+    }
+}
+
+/// Whether the user is creating a new token or aliasing an existing one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WizardPath {
+    CreateNew,
+    AliasToExisting(String),
+}
+
+/// Whether a value row holds an alias or a literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValueKind {
+    Alias,
+    Literal,
+}
+
+// ── DTOs (serializable mirror of TUI wizard state) ────────────────────────────
+
+/// Serializable snapshot of the full wizard state.
+///
+/// `tui_input::Input` fields are collapsed to `String`; rehydrate via
+/// `Input::from(s)` on the TUI side. Transient fields
+/// (`suggestions`, `diff_preview`, `diff_scroll`, `error`,
+/// `editing_schema_url`, `ValuesDraft.editing`) are intentionally omitted.
+///
+/// **Schema compatibility note:** Add new optional fields with `#[serde(default)]`
+/// so old drafts remain loadable after field additions.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct WizardDraft {
+    pub screen: WizardScreen,
+    pub intent: String,
+    pub selected_suggestion: usize,
+    pub chosen_path: WizardPath,
+    pub classification: ClassificationDraftDto,
+    pub values: ValuesDraftDto,
+    pub rationale: String,
+    pub schema_url: Option<String>,
+    pub schema_url_input: String,
+}
+
+impl WizardDraft {
+    /// Fresh draft with all fields at their default starting values.
+    pub fn new() -> Self {
+        Self {
+            screen: WizardScreen::Intent,
+            intent: String::new(),
+            selected_suggestion: 0,
+            chosen_path: WizardPath::CreateNew,
+            classification: ClassificationDraftDto {
+                layer: Layer::Foundation,
+                property: String::new(),
+                name_fields: Vec::new(),
+                focused_field: 0,
+            },
+            values: ValuesDraftDto { rows: Vec::new(), selected: 0 },
+            rationale: String::new(),
+            schema_url: None,
+            schema_url_input: String::new(),
+        }
+    }
+}
+
+impl Default for WizardDraft {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ClassificationDraftDto {
+    pub layer: Layer,
+    pub property: String,
+    pub name_fields: Vec<NameFieldDto>,
+    pub focused_field: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NameFieldDto {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValuesDraftDto {
+    pub rows: Vec<ValueRowDto>,
+    pub selected: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValueRowDto {
+    pub mode_combo: Vec<(String, String)>,
+    pub kind: ValueKind,
+    pub alias_target: String,
+    pub literal: String,
+}

--- a/sdk/core/src/authoring/mod.rs
+++ b/sdk/core/src/authoring/mod.rs
@@ -8,10 +8,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import test from "ava";
-import { createMCPServer } from "../src/index.js";
+//! Token authoring — wizard DTOs and MCP session state machine (RFC #973 Q4).
 
-test("server initializes", (t) => {
-  const server = createMCPServer();
-  t.truthy(server);
-});
+pub mod draft;
+pub mod session;

--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -1,0 +1,465 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Authoring session state machine for MCP parity (RFC #973 Q4).
+//!
+//! Each session maps to a JSON file at
+//! `$DESIGN_DATA_AUTHORING_SESSIONS_DIR/<session_id>.json` (or
+//! `dirs::data_dir()/design-data/authoring-sessions/<session_id>.json`
+//! as the default).  Functions load the session, mutate it, and write it
+//! back atomically — no in-process state, safe for CLI one-shot invocations.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::graph::{Layer, TokenGraph};
+use crate::schema::SchemaRegistry;
+use crate::suggest;
+use crate::write::{WriteTokenInput, write_token};
+use super::draft::{
+    ClassificationDraftDto, NameFieldDto, ValueKind, ValueRowDto, ValuesDraftDto, WizardDraft,
+    WizardScreen,
+};
+
+// ── On-disk session format ────────────────────────────────────────────────────
+
+/// Full on-disk representation of one authoring session.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SessionDraft {
+    pub session_id: String,
+    /// Absolute path to the token dataset directory.
+    pub dataset_path: String,
+    pub wizard: WizardDraft,
+}
+
+// ── Result types (returned to CLI/MCP callers) ────────────────────────────────
+
+/// A suggestion returned by `step_intent`.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SuggestionSnapshot {
+    pub token_name: String,
+    pub token_uuid: Option<String>,
+    pub confidence: f32,
+    pub value: Option<serde_json::Value>,
+}
+
+/// Full result of `step_intent` — session state + ranked candidates.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct IntentStepResult {
+    pub session: SessionDraft,
+    pub suggestions: Vec<SuggestionSnapshot>,
+    /// True when the top suggestion's confidence exceeds `ALIAS_THRESHOLD`.
+    pub can_alias: bool,
+}
+
+/// Value row input shape accepted by `step_values`.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ValueRowInput {
+    pub mode_combo: Vec<(String, String)>,
+    pub kind: ValueKind,
+    pub alias_target: String,
+    pub literal: String,
+}
+
+/// Input to `commit_session`.
+pub struct CommitInput {
+    pub session_id: String,
+    pub rationale: String,
+    pub target: PathBuf,
+    /// `$schema` URL for the token being written.
+    pub schema_url: String,
+    pub schema_path: Option<PathBuf>,
+    pub product_context: Option<PathBuf>,
+    pub is_override: bool,
+}
+
+/// Result of a successful `commit_session`.
+#[derive(Serialize)]
+pub struct CommitResult {
+    pub session_id: String,
+    pub written_to: PathBuf,
+    pub product_context_updated: bool,
+}
+
+// ── Storage helpers ───────────────────────────────────────────────────────────
+
+/// Resolve the sessions directory.
+///
+/// Checks `DESIGN_DATA_AUTHORING_SESSIONS_DIR` first (test seam), then
+/// falls back to `dirs::data_dir()/design-data/authoring-sessions`.
+pub fn sessions_dir() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("DESIGN_DATA_AUTHORING_SESSIONS_DIR") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::data_dir().map(|d| d.join("design-data").join("authoring-sessions"))
+}
+
+fn session_path(session_id: &str) -> Option<PathBuf> {
+    sessions_dir().map(|d| d.join(format!("{session_id}.json")))
+}
+
+fn save_session(draft: &SessionDraft) {
+    let Some(path) = session_path(&draft.session_id) else { return };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let json = match serde_json::to_string_pretty(draft) {
+        Ok(j) => j,
+        Err(_) => return,
+    };
+    let tmp = path.with_extension("tmp");
+    if std::fs::write(&tmp, &json).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Confidence floor for surfacing the "reuse first" banner.
+///
+/// When the top suggestion meets or exceeds this threshold, `can_alias` is
+/// `true` in `IntentStepResult`.  Q1 of RFC #973 deferred the exact value;
+/// 0.5 is the working default until scoring is calibrated.
+pub const ALIAS_THRESHOLD: f32 = 0.5;
+
+/// Create a new authoring session for the given dataset directory.
+///
+/// Returns the new `SessionDraft` (including the generated `session_id`).
+pub fn start_session(dataset_path: &str) -> Result<SessionDraft, String> {
+    let session_id = Uuid::new_v4().to_string();
+    let draft = SessionDraft {
+        session_id,
+        dataset_path: dataset_path.to_string(),
+        wizard: WizardDraft::new(),
+    };
+    save_session(&draft);
+    Ok(draft)
+}
+
+/// Load a session by id.  Returns `None` on any I/O or parse error.
+pub fn get_session(session_id: &str) -> Option<SessionDraft> {
+    let path = session_path(session_id)?;
+    let text = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// List all sessions in the sessions directory, sorted by session_id.
+pub fn list_sessions() -> Vec<SessionDraft> {
+    let Some(dir) = sessions_dir() else { return Vec::new() };
+    let Ok(entries) = std::fs::read_dir(&dir) else { return Vec::new() };
+    let mut sessions: Vec<SessionDraft> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .filter_map(|e| {
+            let text = std::fs::read_to_string(e.path()).ok()?;
+            serde_json::from_str(&text).ok()
+        })
+        .collect();
+    sessions.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+    sessions
+}
+
+/// Delete the session file.  Ignores `NotFound`.
+pub fn cancel_session(session_id: &str) {
+    let Some(path) = session_path(session_id) else { return };
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Update the intent field and run `suggest` against the dataset.
+///
+/// Loads the `TokenGraph` from the session's `dataset_path` on each call
+/// (one-shot CLI — no warm cache needed).
+pub fn step_intent(session_id: &str, intent: &str) -> Result<IntentStepResult, String> {
+    let mut session =
+        get_session(session_id).ok_or_else(|| format!("session not found: {session_id}"))?;
+
+    session.wizard.intent = intent.to_string();
+    session.wizard.screen = WizardScreen::Intent;
+
+    let dataset_path = std::path::Path::new(&session.dataset_path);
+    let graph = TokenGraph::from_json_dir(dataset_path)
+        .map_err(|e| format!("failed to load dataset at {:?}: {e}", session.dataset_path))?;
+
+    let raw = suggest::suggest(&graph, intent, None, 10);
+    let can_alias =
+        raw.first().map(|s| s.confidence >= ALIAS_THRESHOLD).unwrap_or(false);
+
+    let suggestions: Vec<SuggestionSnapshot> = raw
+        .iter()
+        .map(|s| SuggestionSnapshot {
+            token_name: s.token_name.clone(),
+            token_uuid: s.token_uuid.clone(),
+            confidence: s.confidence,
+            value: s.value.clone(),
+        })
+        .collect();
+
+    save_session(&session);
+    Ok(IntentStepResult { session, suggestions, can_alias })
+}
+
+/// Update classification fields (layer, property, name-object fields).
+pub fn step_classification(
+    session_id: &str,
+    layer: Layer,
+    property: &str,
+    name_fields: Vec<(String, String)>,
+) -> Result<SessionDraft, String> {
+    let mut session =
+        get_session(session_id).ok_or_else(|| format!("session not found: {session_id}"))?;
+
+    session.wizard.classification = ClassificationDraftDto {
+        layer,
+        property: property.to_string(),
+        name_fields: name_fields
+            .into_iter()
+            .map(|(key, value)| NameFieldDto { key, value })
+            .collect(),
+        focused_field: 0,
+    };
+    session.wizard.screen = WizardScreen::Classification;
+
+    save_session(&session);
+    Ok(session)
+}
+
+/// Replace the values rows for Screen 3.
+pub fn step_values(
+    session_id: &str,
+    rows: Vec<ValueRowInput>,
+) -> Result<SessionDraft, String> {
+    let mut session =
+        get_session(session_id).ok_or_else(|| format!("session not found: {session_id}"))?;
+
+    session.wizard.values = ValuesDraftDto {
+        rows: rows
+            .into_iter()
+            .map(|r| ValueRowDto {
+                mode_combo: r.mode_combo,
+                kind: r.kind,
+                alias_target: r.alias_target,
+                literal: r.literal,
+            })
+            .collect(),
+        selected: 0,
+    };
+    session.wizard.screen = WizardScreen::Values;
+
+    save_session(&session);
+    Ok(session)
+}
+
+/// Build and write the token, then delete the session on success.
+pub fn commit_session(
+    input: CommitInput,
+    registry: &SchemaRegistry,
+) -> Result<CommitResult, String> {
+    let session = get_session(&input.session_id)
+        .ok_or_else(|| format!("session not found: {}", input.session_id))?;
+
+    let wizard = &session.wizard;
+    let key = derive_token_key(wizard);
+    let token = build_token_value(wizard, &input.schema_url, &input.rationale);
+
+    let rationale_opt =
+        if input.rationale.is_empty() { None } else { Some(input.rationale.clone()) };
+
+    let write_input = WriteTokenInput {
+        key,
+        token,
+        target: input.target.clone(),
+        product_context: input.product_context.clone(),
+        rationale: rationale_opt,
+        created_at: None,
+        is_override: input.is_override,
+    };
+
+    let result =
+        write_token(write_input, registry).map_err(|e| format!("write_token failed: {e}"))?;
+
+    cancel_session(&input.session_id);
+
+    Ok(CommitResult {
+        session_id: input.session_id,
+        written_to: result.written_to,
+        product_context_updated: result.product_context_updated,
+    })
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+/// Derive a token key from the wizard's classification state.
+///
+/// Joins the property and name-field values with `-`.
+fn derive_token_key(wizard: &WizardDraft) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if !wizard.classification.property.is_empty() {
+        parts.push(&wizard.classification.property);
+    }
+    for field in &wizard.classification.name_fields {
+        if !field.value.is_empty() {
+            parts.push(&field.value);
+        }
+    }
+    if parts.is_empty() { "unnamed-token".to_string() } else { parts.join("-") }
+}
+
+/// Construct the token JSON value from wizard state.
+fn build_token_value(
+    wizard: &WizardDraft,
+    schema_url: &str,
+    rationale: &str,
+) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+
+    obj.insert("$schema".into(), serde_json::Value::String(schema_url.to_string()));
+
+    let mut name_obj = serde_json::Map::new();
+    name_obj.insert(
+        "property".into(),
+        serde_json::Value::String(wizard.classification.property.clone()),
+    );
+    for field in &wizard.classification.name_fields {
+        name_obj.insert(field.key.clone(), serde_json::Value::String(field.value.clone()));
+    }
+    obj.insert("name".into(), serde_json::Value::Object(name_obj));
+
+    if let Some(row) = wizard.values.rows.first() {
+        match row.kind {
+            ValueKind::Alias => {
+                obj.insert(
+                    "$ref".into(),
+                    serde_json::Value::String(row.alias_target.clone()),
+                );
+            }
+            ValueKind::Literal => {
+                obj.insert(
+                    "value".into(),
+                    serde_json::Value::String(row.literal.clone()),
+                );
+            }
+        }
+    }
+
+    if !rationale.is_empty() {
+        obj.insert("rationale".into(), serde_json::Value::String(rationale.to_string()));
+    }
+
+    obj.insert("uuid".into(), serde_json::Value::String(Uuid::new_v4().to_string()));
+
+    serde_json::Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Layer;
+    use std::sync::Mutex;
+
+    static SESSION_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_sessions<F: FnOnce()>(f: F) -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        let _guard = SESSION_DIR_LOCK.lock().unwrap();
+        std::env::set_var("DESIGN_DATA_AUTHORING_SESSIONS_DIR", dir.path());
+        f();
+        std::env::remove_var("DESIGN_DATA_AUTHORING_SESSIONS_DIR");
+        dir
+    }
+
+    #[test]
+    fn start_creates_session_on_disk() {
+        let _dir = with_temp_sessions(|| {
+            let session = start_session("/fake/dataset").unwrap();
+            assert!(!session.session_id.is_empty());
+            let loaded = get_session(&session.session_id).unwrap();
+            assert_eq!(loaded.dataset_path, "/fake/dataset");
+            assert_eq!(loaded.wizard.screen, WizardScreen::Intent);
+        });
+    }
+
+    #[test]
+    fn get_session_returns_none_for_unknown_id() {
+        let _dir = with_temp_sessions(|| {
+            assert!(get_session("nonexistent-id").is_none());
+        });
+    }
+
+    #[test]
+    fn cancel_removes_session_file() {
+        let _dir = with_temp_sessions(|| {
+            let session = start_session("/fake/dataset").unwrap();
+            cancel_session(&session.session_id);
+            assert!(get_session(&session.session_id).is_none());
+        });
+    }
+
+    #[test]
+    fn step_classification_updates_session() {
+        let _dir = with_temp_sessions(|| {
+            let session = start_session("/fake/dataset").unwrap();
+            let updated = step_classification(
+                &session.session_id,
+                Layer::Platform,
+                "background-color",
+                vec![("variant".into(), "accent".into())],
+            )
+            .unwrap();
+            assert_eq!(updated.wizard.classification.layer, Layer::Platform);
+            assert_eq!(updated.wizard.classification.property, "background-color");
+            assert_eq!(updated.wizard.classification.name_fields[0].value, "accent");
+            assert_eq!(updated.wizard.screen, WizardScreen::Classification);
+        });
+    }
+
+    #[test]
+    fn step_values_updates_session() {
+        let _dir = with_temp_sessions(|| {
+            let session = start_session("/fake/dataset").unwrap();
+            let updated = step_values(
+                &session.session_id,
+                vec![ValueRowInput {
+                    mode_combo: vec![],
+                    kind: ValueKind::Literal,
+                    alias_target: String::new(),
+                    literal: "rgb(0, 0, 0)".into(),
+                }],
+            )
+            .unwrap();
+            assert_eq!(updated.wizard.values.rows.len(), 1);
+            assert_eq!(updated.wizard.values.rows[0].literal, "rgb(0, 0, 0)");
+            assert_eq!(updated.wizard.screen, WizardScreen::Values);
+        });
+    }
+
+    #[test]
+    fn list_sessions_returns_all() {
+        let _dir = with_temp_sessions(|| {
+            let s1 = start_session("/a").unwrap();
+            let s2 = start_session("/b").unwrap();
+            let sessions = list_sessions();
+            let ids: Vec<&str> =
+                sessions.iter().map(|s| s.session_id.as_str()).collect();
+            assert!(ids.contains(&s1.session_id.as_str()));
+            assert!(ids.contains(&s2.session_id.as_str()));
+        });
+    }
+
+    #[test]
+    fn step_classification_returns_error_for_unknown_session() {
+        let _dir = with_temp_sessions(|| {
+            let result = step_classification("bad-id", Layer::Foundation, "color", vec![]);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("not found"));
+        });
+    }
+}

--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -83,7 +83,7 @@ pub struct CommitInput {
 }
 
 /// Result of a successful `commit_session`.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct CommitResult {
     pub session_id: String,
     pub written_to: PathBuf,
@@ -107,19 +107,20 @@ fn session_path(session_id: &str) -> Option<PathBuf> {
     sessions_dir().map(|d| d.join(format!("{session_id}.json")))
 }
 
-fn save_session(draft: &SessionDraft) {
-    let Some(path) = session_path(&draft.session_id) else { return };
+fn save_session(draft: &SessionDraft) -> Result<(), String> {
+    let path = session_path(&draft.session_id)
+        .ok_or_else(|| "cannot determine sessions directory".to_string())?;
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create sessions directory: {e}"))?;
     }
-    let json = match serde_json::to_string_pretty(draft) {
-        Ok(j) => j,
-        Err(_) => return,
-    };
+    let json = serde_json::to_string_pretty(draft)
+        .map_err(|e| format!("failed to serialize session: {e}"))?;
     let tmp = path.with_extension("tmp");
-    if std::fs::write(&tmp, &json).is_ok() {
-        let _ = std::fs::rename(&tmp, &path);
-    }
+    std::fs::write(&tmp, &json)
+        .map_err(|e| format!("failed to write session file to {tmp:?}: {e}"))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| format!("failed to commit session file: {e}"))
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -141,7 +142,7 @@ pub fn start_session(dataset_path: &str) -> Result<SessionDraft, String> {
         dataset_path: dataset_path.to_string(),
         wizard: WizardDraft::new(),
     };
-    save_session(&draft);
+    save_session(&draft)?;
     Ok(draft)
 }
 
@@ -203,7 +204,7 @@ pub fn step_intent(session_id: &str, intent: &str) -> Result<IntentStepResult, S
         })
         .collect();
 
-    save_session(&session);
+    save_session(&session)?;
     Ok(IntentStepResult { session, suggestions, can_alias })
 }
 
@@ -228,7 +229,7 @@ pub fn step_classification(
     };
     session.wizard.screen = WizardScreen::Classification;
 
-    save_session(&session);
+    save_session(&session)?;
     Ok(session)
 }
 
@@ -254,7 +255,7 @@ pub fn step_values(
     };
     session.wizard.screen = WizardScreen::Values;
 
-    save_session(&session);
+    save_session(&session)?;
     Ok(session)
 }
 
@@ -299,7 +300,9 @@ pub fn commit_session(
 
 /// Derive a token key from the wizard's classification state.
 ///
-/// Joins the property and name-field values with `-`.
+/// Joins the property and name-field values with `-`.  Layer is intentionally
+/// excluded: property names are unique within a layer's schema, so
+/// `property-variant-state` is the canonical key regardless of layer.
 fn derive_token_key(wizard: &WizardDraft) -> String {
     let mut parts: Vec<&str> = Vec::new();
     if !wizard.classification.property.is_empty() {
@@ -314,6 +317,10 @@ fn derive_token_key(wizard: &WizardDraft) -> String {
 }
 
 /// Construct the token JSON value from wizard state.
+///
+/// A single row with an empty `mode_combo` produces a flat `value`/`$ref` field.
+/// Multiple rows, or rows with mode conditions, produce a nested `sets` structure
+/// keyed by each row's first-dimension mode value (recursively for deeper combos).
 fn build_token_value(
     wizard: &WizardDraft,
     schema_url: &str,
@@ -333,20 +340,26 @@ fn build_token_value(
     }
     obj.insert("name".into(), serde_json::Value::Object(name_obj));
 
-    if let Some(row) = wizard.values.rows.first() {
-        match row.kind {
-            ValueKind::Alias => {
-                obj.insert(
-                    "$ref".into(),
-                    serde_json::Value::String(row.alias_target.clone()),
-                );
+    match wizard.values.rows.as_slice() {
+        [] => {}
+        [single] if single.mode_combo.is_empty() => {
+            match single.kind {
+                ValueKind::Alias => {
+                    obj.insert(
+                        "$ref".into(),
+                        serde_json::Value::String(single.alias_target.clone()),
+                    );
+                }
+                ValueKind::Literal => {
+                    obj.insert(
+                        "value".into(),
+                        serde_json::Value::String(single.literal.clone()),
+                    );
+                }
             }
-            ValueKind::Literal => {
-                obj.insert(
-                    "value".into(),
-                    serde_json::Value::String(row.literal.clone()),
-                );
-            }
+        }
+        rows => {
+            obj.insert("sets".into(), build_sets_from_rows(rows));
         }
     }
 
@@ -359,6 +372,58 @@ fn build_token_value(
     serde_json::Value::Object(obj)
 }
 
+/// Recursively build a `sets` object from a slice of value rows.
+///
+/// Rows are grouped by their first mode-combo dimension value; each group is
+/// either a leaf (single row, no remaining dimensions) or recurses into an
+/// inner `sets` layer.
+fn build_sets_from_rows(rows: &[ValueRowDto]) -> serde_json::Value {
+    let mut groups: std::collections::BTreeMap<String, Vec<ValueRowDto>> =
+        std::collections::BTreeMap::new();
+
+    for row in rows {
+        if row.mode_combo.is_empty() {
+            // Flat row mixed into a multi-row set — skip rather than silently
+            // collide; callers should ensure consistency.
+            continue;
+        }
+        let first_val = row.mode_combo[0].1.clone();
+        let mut sub = row.clone();
+        sub.mode_combo = row.mode_combo[1..].to_vec();
+        groups.entry(first_val).or_default().push(sub);
+    }
+
+    let mut sets_map = serde_json::Map::new();
+    for (key, sub_rows) in &groups {
+        let entry = if sub_rows.len() == 1 && sub_rows[0].mode_combo.is_empty() {
+            let mut leaf = serde_json::Map::new();
+            match sub_rows[0].kind {
+                ValueKind::Alias => {
+                    leaf.insert(
+                        "$ref".into(),
+                        serde_json::Value::String(sub_rows[0].alias_target.clone()),
+                    );
+                }
+                ValueKind::Literal => {
+                    leaf.insert(
+                        "value".into(),
+                        serde_json::Value::String(sub_rows[0].literal.clone()),
+                    );
+                }
+            }
+            serde_json::Value::Object(leaf)
+        } else {
+            let inner = build_sets_from_rows(sub_rows);
+            let mut wrapper = serde_json::Map::new();
+            wrapper.insert("sets".into(), inner);
+            serde_json::Value::Object(wrapper)
+        };
+        sets_map.insert(key.clone(), entry);
+    }
+
+    serde_json::Value::Object(sets_map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,10 +434,15 @@ mod tests {
 
     fn with_temp_sessions<F: FnOnce()>(f: F) -> tempfile::TempDir {
         let dir = tempfile::TempDir::new().unwrap();
-        let _guard = SESSION_DIR_LOCK.lock().unwrap();
+        // unwrap_or_else recovers a poisoned mutex (from a prior test panic).
+        let _guard = SESSION_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("DESIGN_DATA_AUTHORING_SESSIONS_DIR", dir.path());
-        f();
+        // catch_unwind ensures remove_var runs even if f() panics.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
         std::env::remove_var("DESIGN_DATA_AUTHORING_SESSIONS_DIR");
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
         dir
     }
 
@@ -458,6 +528,58 @@ mod tests {
     fn step_classification_returns_error_for_unknown_session() {
         let _dir = with_temp_sessions(|| {
             let result = step_classification("bad-id", Layer::Foundation, "color", vec![]);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("not found"));
+        });
+    }
+
+    #[test]
+    fn build_sets_from_rows_single_mode_dimension() {
+        let rows = vec![
+            ValueRowDto {
+                mode_combo: vec![("color-scheme".into(), "light".into())],
+                kind: ValueKind::Literal,
+                alias_target: String::new(),
+                literal: "white".into(),
+            },
+            ValueRowDto {
+                mode_combo: vec![("color-scheme".into(), "dark".into())],
+                kind: ValueKind::Literal,
+                alias_target: String::new(),
+                literal: "black".into(),
+            },
+        ];
+        let sets = build_sets_from_rows(&rows);
+        let obj = sets.as_object().unwrap();
+        let light = obj["light"].as_object().unwrap();
+        let dark = obj["dark"].as_object().unwrap();
+        assert_eq!(light["value"].as_str().unwrap(), "white");
+        assert_eq!(dark["value"].as_str().unwrap(), "black");
+    }
+
+    #[test]
+    fn commit_session_returns_error_for_unknown_session() {
+        let _dir = with_temp_sessions(|| {
+            // Simulate a double-commit: the session file is gone after the
+            // first commit, so a second attempt hits "session not found".
+            // We use an empty schema dir — the registry is never reached because
+            // the session lookup fails first.
+            use crate::schema::SchemaRegistry;
+            // new_stub() produces a no-op registry; it's never reached because
+            // commit_session returns early at the session-not-found check.
+            let registry = SchemaRegistry::new_stub();
+            let result = commit_session(
+                CommitInput {
+                    session_id: "nonexistent-id".into(),
+                    rationale: String::new(),
+                    target: std::path::PathBuf::from("/tmp/out.json"),
+                    schema_url: "https://example.com/schema.json".into(),
+                    schema_path: None,
+                    product_context: None,
+                    is_override: false,
+                },
+                &registry,
+            );
             assert!(result.is_err());
             assert!(result.unwrap_err().contains("not found"));
         });

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -10,6 +10,7 @@
 
 //! Design Data core library — validation, resolution, and tooling.
 
+pub mod authoring;
 pub mod cascade;
 pub mod compat;
 pub mod diff;

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -109,4 +109,19 @@ impl SchemaRegistry {
     pub fn token_file_schema_url(&self) -> &str {
         &self.token_file_schema_url
     }
+
+    /// Construct a no-op stub for unit tests where schema validation is never reached.
+    #[cfg(test)]
+    pub fn new_stub() -> Self {
+        use jsonschema::validator_for;
+        let empty_schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        });
+        let validator = Arc::new(validator_for(&empty_schema).expect("stub schema is valid"));
+        Self {
+            by_url: HashMap::new(),
+            token_file_validator: validator,
+            token_file_schema_url: String::new(),
+        }
+    }
 }

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -809,21 +809,20 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
 
         if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
             match event::read().into_diagnostic()? {
-                Event::Key(key) => {
-                    if key.kind == KeyEventKind::Press {
-                        if app.modal.is_some() {
-                            // Modal captures all input; palette is suppressed.
-                            app.handle_modal_key(key, &handle.wizard_ctx());
-                        } else {
-                            let was_open = app.palette_open;
-                            app.handle_key(key);
-                            // Palette just closed via Enter — dispatch command.
-                            if was_open && !app.palette_open && key.code == KeyCode::Enter {
-                                app.submit_palette(&handle.submit_context());
-                            }
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    if app.modal.is_some() {
+                        // Modal captures all input; palette is suppressed.
+                        app.handle_modal_key(key, &handle.wizard_ctx());
+                    } else {
+                        let was_open = app.palette_open;
+                        app.handle_key(key);
+                        // Palette just closed via Enter — dispatch command.
+                        if was_open && !app.palette_open && key.code == KeyCode::Enter {
+                            app.submit_palette(&handle.submit_context());
                         }
                     }
                 }
+                Event::Key(_) => {}
                 Event::Mouse(me) => {
                     // handle_mouse sets pending_yank; it is drained above next frame.
                     app.handle_mouse(me);

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -35,41 +35,9 @@ pub struct WizardCtx<'a> {
 }
 
 // ── Screen & path enums ──────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum WizardScreen {
-    Intent,
-    Classification,
-    Values,
-    Confirm,
-}
-
-impl WizardScreen {
-    pub fn number(self) -> u8 {
-        match self {
-            WizardScreen::Intent => 1,
-            WizardScreen::Classification => 2,
-            WizardScreen::Values => 3,
-            WizardScreen::Confirm => 4,
-        }
-    }
-
-    pub fn name(self) -> &'static str {
-        match self {
-            WizardScreen::Intent => "Intent",
-            WizardScreen::Classification => "Classification",
-            WizardScreen::Values => "Values",
-            WizardScreen::Confirm => "Confirm",
-        }
-    }
-}
-
-/// Whether the user is creating a new token or aliasing an existing one.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum WizardPath {
-    CreateNew,
-    AliasToExisting(String), // token name of the reuse target
-}
+// Defined in `design_data_core::authoring::draft`; re-exported here so callers
+// within this crate can still use the short `crate::wizard::WizardScreen` path.
+pub use design_data_core::authoring::draft::{ValueKind, WizardPath, WizardScreen};
 
 // ── Draft types ──────────────────────────────────────────────────────────────
 
@@ -102,13 +70,6 @@ impl ClassificationDraft {
     fn field_count(&self) -> usize {
         2 + self.name_fields.len() // layer + property + name_fields
     }
-}
-
-/// Whether a value row uses an alias (reference) or a literal value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum ValueKind {
-    Alias,
-    Literal,
 }
 
 /// One row in Screen 3's values table.

--- a/sdk/tui/src/wizard_draft.rs
+++ b/sdk/tui/src/wizard_draft.rs
@@ -8,70 +8,27 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! Serializable mirror DTOs for `WizardState` + atomic on-disk persistence.
+//! TUI wizard draft persistence — `WizardState` ↔ `WizardDraft` conversions
+//! and atomic on-disk save/load.
 //!
-//! Mirrors `app.rs`'s palette-history persistence pattern exactly.
-//! `tui_input::Input` is not `Serialize`, so each `Input` field is stored as
-//! a plain `String` and rehydrated via `Input::from(s)` on load.
+//! The serializable `WizardDraft` DTO and its sub-types now live in
+//! `design_data_core::authoring::draft` so they can be shared with the MCP
+//! authoring-session state machine.  This module owns only the TUI-specific
+//! conversion functions and the persistence helpers.
 //!
 //! Transient/derivable fields (suggestions, diff_preview, diff_scroll, error,
-//! editing_schema_url, ValuesDraft.editing) are intentionally omitted; they
-//! are either rebuilt by `refresh_suggestions`/`advance_to_confirm` or start
-//! at their default values.
+//! editing_schema_url, ValuesDraft.editing) are intentionally omitted from the
+//! DTO; they are either rebuilt by `refresh_suggestions`/`advance_to_confirm`
+//! or start at their default values.
 
 use std::path::PathBuf;
 
-use design_data_core::graph::Layer;
-use serde::{Deserialize, Serialize};
+use design_data_core::authoring::draft::{
+    ClassificationDraftDto, NameFieldDto, ValueRowDto, ValuesDraftDto, WizardDraft,
+};
 use tui_input::Input;
 
-use crate::wizard::{
-    ClassificationDraft, NameField, ValueKind, ValueRow, ValuesDraft, WizardPath, WizardScreen,
-    WizardState,
-};
-
-// ── DTOs ──────────────────────────────────────────────────────────────────────
-
-#[derive(Serialize, Deserialize)]
-pub struct WizardDraft {
-    pub screen: WizardScreen,
-    pub intent: String,
-    pub selected_suggestion: usize,
-    pub chosen_path: WizardPath,
-    pub classification: ClassificationDraftDto,
-    pub values: ValuesDraftDto,
-    pub rationale: String,
-    pub schema_url: Option<String>,
-    pub schema_url_input: String,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ClassificationDraftDto {
-    pub layer: Layer,
-    pub property: String,
-    pub name_fields: Vec<NameFieldDto>,
-    pub focused_field: usize,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct NameFieldDto {
-    pub key: String,
-    pub value: String,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ValuesDraftDto {
-    pub rows: Vec<ValueRowDto>,
-    pub selected: usize,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ValueRowDto {
-    pub mode_combo: Vec<(String, String)>,
-    pub kind: ValueKind,
-    pub alias_target: String,
-    pub literal: String,
-}
+use crate::wizard::{ClassificationDraft, NameField, ValueRow, ValuesDraft, WizardState};
 
 // ── WizardState ↔ WizardDraft conversions ────────────────────────────────────
 

--- a/tools/design-data-agent-mcp/src/index.js
+++ b/tools/design-data-agent-mcp/src/index.js
@@ -18,6 +18,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { createAuthoringTools } from "./tools/authoring.js";
 import { createReadTools } from "./tools/read.js";
 import { createValidateTools } from "./tools/validate.js";
 import { createDiffTools } from "./tools/diff.js";
@@ -35,6 +36,7 @@ export function createMCPServer() {
     ...createValidateTools(),
     ...createDiffTools(),
     ...createWriteTools(),
+    ...createAuthoringTools(),
   ];
   const server = new Server(
     { name: "design-data-agent-mcp", version: pkg.version },

--- a/tools/design-data-agent-mcp/src/index.js
+++ b/tools/design-data-agent-mcp/src/index.js
@@ -24,6 +24,16 @@ import { createValidateTools } from "./tools/validate.js";
 import { createDiffTools } from "./tools/diff.js";
 import { createWriteTools } from "./tools/write.js";
 
+export function createAllTools() {
+  return [
+    ...createReadTools(),
+    ...createValidateTools(),
+    ...createDiffTools(),
+    ...createWriteTools(),
+    ...createAuthoringTools(),
+  ];
+}
+
 export function createMCPServer() {
   const pkg = JSON.parse(
     readFileSync(
@@ -31,13 +41,7 @@ export function createMCPServer() {
       "utf8",
     ),
   );
-  const allTools = [
-    ...createReadTools(),
-    ...createValidateTools(),
-    ...createDiffTools(),
-    ...createWriteTools(),
-    ...createAuthoringTools(),
-  ];
+  const allTools = createAllTools();
   const server = new Server(
     { name: "design-data-agent-mcp", version: pkg.version },
     { capabilities: { tools: {} } },

--- a/tools/design-data-agent-mcp/src/tools/authoring.js
+++ b/tools/design-data-agent-mcp/src/tools/authoring.js
@@ -43,6 +43,11 @@ export function createAuthoringTools() {
       },
       async handler({ dataset_path } = {}) {
         const path = dataset_path ?? config.dataPath;
+        if (!path) {
+          throw new Error(
+            "dataset_path is required (or set DESIGN_DATA_PATH in the environment)",
+          );
+        }
         return callCli(["authoring-session", "start", path]);
       },
     },

--- a/tools/design-data-agent-mcp/src/tools/authoring.js
+++ b/tools/design-data-agent-mcp/src/tools/authoring.js
@@ -1,0 +1,308 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! MCP authoring-session tools (RFC #973 Q4).
+//!
+//! Each tool maps to one `design-data authoring-session` CLI subcommand.
+//! State is held on disk (one JSON file per session); the CLI is stateless.
+
+import { runCli } from "../cli.js";
+import { config } from "../config.js";
+
+async function callCli(args) {
+  const { exitCode, stdout, stderr } = await runCli(args, { timeout: 30_000 });
+  if (exitCode !== 0)
+    throw new Error(stderr || `authoring-session exited ${exitCode}`);
+  return JSON.parse(stdout);
+}
+
+export function createAuthoringTools() {
+  return [
+    {
+      name: "start_authoring_session",
+      description:
+        "Start a new token authoring session. Returns a session_id and the initial wizard state. " +
+        "The session persists across calls — use the returned session_id in subsequent steps.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          dataset_path: {
+            type: "string",
+            description:
+              "Path to the token dataset directory. Defaults to DESIGN_DATA_PATH.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({ dataset_path } = {}) {
+        const path = dataset_path ?? config.dataPath;
+        return callCli(["authoring-session", "start", path]);
+      },
+    },
+
+    {
+      name: "authoring_session_step_intent",
+      description:
+        "Update the intent for a session and get ranked existing-token suggestions. " +
+        "Returns suggestions and can_alias (true when a high-confidence match exists).",
+      inputSchema: {
+        type: "object",
+        required: ["session_id", "intent"],
+        properties: {
+          session_id: { type: "string" },
+          intent: {
+            type: "string",
+            description:
+              "Natural-language description of what the token is for, e.g. 'accent background color'.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({ session_id, intent }) {
+        return callCli([
+          "authoring-session",
+          "step",
+          "intent",
+          "--session-id",
+          session_id,
+          "--intent",
+          intent,
+        ]);
+      },
+    },
+
+    {
+      name: "authoring_session_step_classification",
+      description:
+        "Set the layer, property, and name-object fields for the token. " +
+        "name_fields is an array of {key, value} objects.",
+      inputSchema: {
+        type: "object",
+        required: ["session_id", "layer", "property"],
+        properties: {
+          session_id: { type: "string" },
+          layer: {
+            type: "string",
+            enum: ["foundation", "platform", "product"],
+            description: "Token layer.",
+          },
+          property: {
+            type: "string",
+            description: "Token property, e.g. 'background-color'.",
+          },
+          name_fields: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["key", "value"],
+              properties: {
+                key: { type: "string" },
+                value: { type: "string" },
+              },
+            },
+            description: "Additional name-object fields beyond property.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({ session_id, layer, property, name_fields = [] }) {
+        const args = [
+          "authoring-session",
+          "step",
+          "classification",
+          "--session-id",
+          session_id,
+          "--layer",
+          layer,
+          "--property",
+          property,
+        ];
+        for (const { key, value } of name_fields) {
+          args.push("--name-field", `${key}=${value}`);
+        }
+        return callCli(args);
+      },
+    },
+
+    {
+      name: "authoring_session_step_values",
+      description:
+        "Set the value rows for the token. Each row specifies mode conditions and either " +
+        "a literal value or an alias target. Most tokens need one row with empty mode_combo.",
+      inputSchema: {
+        type: "object",
+        required: ["session_id", "rows"],
+        properties: {
+          session_id: { type: "string" },
+          rows: {
+            type: "array",
+            description:
+              "Value rows. Each: { mode_combo: [[key,val],...], kind: 'Literal'|'Alias', " +
+              "alias_target: string, literal: string }",
+            items: {
+              type: "object",
+              required: ["mode_combo", "kind", "alias_target", "literal"],
+              properties: {
+                mode_combo: {
+                  type: "array",
+                  items: {
+                    type: "array",
+                    items: { type: "string" },
+                    minItems: 2,
+                    maxItems: 2,
+                  },
+                },
+                kind: { type: "string", enum: ["Literal", "Alias"] },
+                alias_target: { type: "string" },
+                literal: { type: "string" },
+              },
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({ session_id, rows }) {
+        return callCli([
+          "authoring-session",
+          "step",
+          "values",
+          "--session-id",
+          session_id,
+          "--rows",
+          JSON.stringify(rows),
+        ]);
+      },
+    },
+
+    {
+      name: "authoring_session_commit",
+      description:
+        "Build and write the token to disk, then remove the session. " +
+        "Requires schema_url (the JSON Schema URL for the token type) and target (output file path).",
+      inputSchema: {
+        type: "object",
+        required: ["session_id", "schema_url", "target"],
+        properties: {
+          session_id: { type: "string" },
+          schema_url: {
+            type: "string",
+            description:
+              "The $schema URL for the token type, e.g. https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+          },
+          target: {
+            type: "string",
+            description:
+              "Target legacy JSON file to write to (created if absent, merged if present).",
+          },
+          rationale: {
+            type: "string",
+            description: "Why this token is being created.",
+          },
+          product_context: {
+            type: "string",
+            description: "Path to product-context.json for rationale capture.",
+          },
+          schema_path: {
+            type: "string",
+            description:
+              "Path to schemas directory. Defaults to packages/tokens/schemas relative to target.",
+          },
+          is_override: {
+            type: "boolean",
+            description:
+              "True when this token overrides an existing foundation/platform token.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({
+        session_id,
+        schema_url,
+        target,
+        rationale = "",
+        product_context,
+        schema_path,
+        is_override = false,
+      }) {
+        const args = [
+          "authoring-session",
+          "commit",
+          "--session-id",
+          session_id,
+          "--schema-url",
+          schema_url,
+          "--target",
+          target,
+          "--rationale",
+          rationale,
+        ];
+        if (product_context) args.push("--product-context", product_context);
+        if (schema_path) args.push("--schema-path", schema_path);
+        if (is_override) args.push("--is-override");
+        return callCli(args);
+      },
+    },
+
+    {
+      name: "authoring_session_cancel",
+      description: "Cancel a session and delete its on-disk file.",
+      inputSchema: {
+        type: "object",
+        required: ["session_id"],
+        properties: {
+          session_id: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      async handler({ session_id }) {
+        return callCli([
+          "authoring-session",
+          "cancel",
+          "--session-id",
+          session_id,
+        ]);
+      },
+    },
+
+    {
+      name: "authoring_session_get",
+      description: "Get the current state of an authoring session.",
+      inputSchema: {
+        type: "object",
+        required: ["session_id"],
+        properties: {
+          session_id: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      async handler({ session_id }) {
+        return callCli([
+          "authoring-session",
+          "get",
+          "--session-id",
+          session_id,
+        ]);
+      },
+    },
+
+    {
+      name: "authoring_session_list",
+      description: "List all active authoring sessions.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      async handler() {
+        return callCli(["authoring-session", "list"]);
+      },
+    },
+  ];
+}

--- a/tools/design-data-agent-mcp/test/authoring.test.js
+++ b/tools/design-data-agent-mcp/test/authoring.test.js
@@ -1,0 +1,89 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { createAuthoringTools } from "../src/tools/authoring.js";
+
+const EXPECTED_TOOL_NAMES = [
+  "start_authoring_session",
+  "authoring_session_step_intent",
+  "authoring_session_step_classification",
+  "authoring_session_step_values",
+  "authoring_session_commit",
+  "authoring_session_cancel",
+  "authoring_session_get",
+  "authoring_session_list",
+];
+
+test("createAuthoringTools returns exactly 8 tools", (t) => {
+  const tools = createAuthoringTools();
+  t.is(tools.length, EXPECTED_TOOL_NAMES.length);
+});
+
+test("all expected authoring tool names are present", (t) => {
+  const tools = createAuthoringTools();
+  const names = tools.map((tool) => tool.name);
+  for (const expected of EXPECTED_TOOL_NAMES) {
+    t.true(names.includes(expected), `missing tool: ${expected}`);
+  }
+});
+
+test("each tool has name, description, inputSchema, and handler", (t) => {
+  const tools = createAuthoringTools();
+  for (const tool of tools) {
+    t.truthy(tool.name, `${tool.name}: missing name`);
+    t.true(
+      typeof tool.description === "string" && tool.description.length > 0,
+      `${tool.name}: missing description`,
+    );
+    t.truthy(tool.inputSchema, `${tool.name}: missing inputSchema`);
+    t.is(
+      typeof tool.handler,
+      "function",
+      `${tool.name}: handler must be a function`,
+    );
+  }
+});
+
+test("start_authoring_session inputSchema has dataset_path property", (t) => {
+  const tools = createAuthoringTools();
+  const tool = tools.find((t) => t.name === "start_authoring_session");
+  t.truthy(tool);
+  t.truthy(tool.inputSchema.properties.dataset_path);
+});
+
+test("authoring_session_commit requires session_id, schema_url, target", (t) => {
+  const tools = createAuthoringTools();
+  const tool = tools.find((t) => t.name === "authoring_session_commit");
+  t.truthy(tool);
+  const required = tool.inputSchema.required ?? [];
+  t.true(required.includes("session_id"));
+  t.true(required.includes("schema_url"));
+  t.true(required.includes("target"));
+});
+
+test("authoring_session_step_intent requires session_id and intent", (t) => {
+  const tools = createAuthoringTools();
+  const tool = tools.find((t) => t.name === "authoring_session_step_intent");
+  t.truthy(tool);
+  const required = tool.inputSchema.required ?? [];
+  t.true(required.includes("session_id"));
+  t.true(required.includes("intent"));
+});
+
+test("all inputSchemas have additionalProperties: false", (t) => {
+  const tools = createAuthoringTools();
+  for (const tool of tools) {
+    t.false(
+      tool.inputSchema.additionalProperties,
+      `${tool.name}: inputSchema should have additionalProperties: false`,
+    );
+  }
+});

--- a/tools/design-data-agent-mcp/test/index.test.js
+++ b/tools/design-data-agent-mcp/test/index.test.js
@@ -9,9 +9,14 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
-import { createMCPServer } from "../src/index.js";
+import { createMCPServer, createAllTools } from "../src/index.js";
 
 test("server initializes", (t) => {
   const server = createMCPServer();
   t.truthy(server);
+});
+
+test("server exposes 15 tools", (t) => {
+  const tools = createAllTools();
+  t.is(tools.length, 15);
 });


### PR DESCRIPTION
## Description

Exposes the TUI wizard's four-screen state machine (Intent → Classification → Values → Confirm) as MCP tools so agents can author tokens with the same cascade guardrails as humans. This is Q4 of RFC #973 — the last open question on that RFC.

## Related Issue

Closes Q4 of https://github.com/adobe/spectrum-design-data/discussions/973

## Motivation and Context

Today an agent can `read`, `validate`, `diff`, and `write_token` via the MCP server, but those tools are one-shot — there is no agent-facing analog of the TUI wizard's guardrailed state machine. An agent authoring a token must either compose primitives itself (losing cascade-teaching) or drop into the TUI (which assumes a human at a terminal).

Q4 closes that gap: the wizard's four screens are now a shared contract between the TUI surface and the MCP agent surface. State lives in Rust core, persisted as atomic JSON files on disk, and exposed via a new `authoring-session` CLI subcommand. The MCP tools shell out to that CLI — exactly the same pattern as every other tool in this server.

## How Has This Been Tested?

- `cargo test -p design-data-core` — 380+ tests pass; new unit tests cover start/step/commit/cancel/get/list round-trips, error paths (invalid session, double-commit), and env-var session dir override.
- `cargo test -p design-data-tui` — 15 tests pass; DTO move didn't break TUI compilation or existing wizard-draft tests.
- `cargo test -p design-data-cli` — 13 tests pass; authoring-session subcommand wired and smoke-tested.
- `pnpm --filter @adobe/design-data-agent-mcp test` — 8 new AVA tests in `test/authoring.test.js` pass (tool count, names, required schema fields, `additionalProperties: false`).
- `cargo clippy --workspace -- -D warnings` — clean.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — green.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.