### PR TITLE
feat(sdk/tui): standalone naming wizard (RFC #973 Q2 Track A)

### DIFF
--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -23,13 +23,14 @@ use ratatui::widgets::TableState;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
+use crate::naming::{NamingEvent, NamingWizardState};
 use crate::wizard::{WizardCtx, WizardEvent, WizardState};
 use crate::wizard_draft::{
     clear_wizard_draft, from_draft, load_wizard_draft, save_wizard_draft, to_draft,
 };
 
 /// Command names for Tab autocomplete.
-const KNOWN_COMMANDS: &[&str] = &["new", "query", "resolve", "describe", "validate"];
+const KNOWN_COMMANDS: &[&str] = &["name", "new", "query", "resolve", "describe", "validate"];
 
 /// Max palette history entries persisted to disk.
 const HISTORY_CAP: usize = 200;
@@ -204,6 +205,7 @@ pub struct HelpModal {
 /// An overlay modal that temporarily captures all keyboard input.
 pub enum Modal {
     Wizard(Box<WizardState>),
+    Naming(Box<NamingWizardState>),
     Help(HelpModal),
 }
 
@@ -474,6 +476,24 @@ impl App {
             return;
         }
 
+        // Naming modal — handled independently; no WizardCtx needed.
+        if let Some(Modal::Naming(ref mut ns)) = self.modal {
+            let event = ns.handle_key(key, ctx.graph);
+            match event {
+                NamingEvent::Cancel => {
+                    self.modal = None;
+                    self.status_message = Some(StatusMessage::info("naming wizard cancelled"));
+                }
+                NamingEvent::Copy(name) => {
+                    self.pending_yank = Some(name.clone());
+                    self.status_message =
+                        Some(StatusMessage::info(format!("copied: {name}")));
+                }
+                NamingEvent::Continue => {}
+            }
+            return;
+        }
+
         let event = match &mut self.modal {
             Some(Modal::Wizard(ws)) => ws.handle_key(key, ctx),
             _ => return,
@@ -570,6 +590,10 @@ impl App {
 
     /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
     fn scroll_active(&mut self, delta: i32) {
+        // Naming modal has no scrollable content.
+        if matches!(self.modal, Some(Modal::Naming(_))) {
+            return;
+        }
         // Wizard diff scroll has priority when a modal is open.
         if let Some(Modal::Wizard(ref mut ws)) = self.modal {
             if delta > 0 {
@@ -1018,6 +1042,12 @@ impl App {
                             Some(StatusMessage::error(format!("validate: {e}")));
                     }
                 }
+            }
+            "name" => {
+                let mut ns = NamingWizardState::new_with_intent(rest.trim());
+                ns.refresh_suggestions(ctx.graph);
+                self.modal = Some(Modal::Naming(Box::new(ns)));
+                self.status_message = None;
             }
             "new" | "create" => {
                 let mut ws = WizardState::new_with_intent(rest.trim());

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod app;
 pub mod help;
+pub mod naming;
 pub mod theme;
 pub mod wizard;
 pub mod wizard_draft;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -483,7 +483,7 @@ fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &
 
     let outer = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Name · {screen_num}/3 · {screen_name} "));
+        .title(format!(" Name · {screen_num}/{} · {screen_name} ", NamingScreen::SCREEN_COUNT));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 
@@ -495,7 +495,7 @@ fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &
     let footer_text = match ns.screen {
         NamingScreen::Intent => "Enter: continue  ↑↓: select suggestion  Esc: cancel",
         NamingScreen::Classification => {
-            "Tab/Shift-Tab: next/prev field  ←→: cycle layer  +: add name field  Enter: done  Esc: cancel"
+            "Tab/Shift-Tab: next/prev field  ←→/b: cycle layer / back to intent  +: add name field  Enter: done  Esc: cancel"
         }
         NamingScreen::Result => "c/y: copy name  e: edit  Esc/q: close",
     };

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -50,8 +50,9 @@ use design_data_tui::app::{
     ActiveView, App, HitAction, HitRegion, Modal, StatusKind, StatusMessage, SubmitContext,
 };
 use design_data_tui::help::HELP_TEXT;
+use design_data_tui::naming::{NamingScreen, NamingWizardState};
 use design_data_tui::theme::Theme;
-use design_data_tui::wizard::{ValueKind, WizardCtx, WizardScreen, WizardState};
+use design_data_tui::wizard::{ClassificationDraft, ValueKind, WizardCtx, WizardScreen, WizardState};
 
 /// Which visual palette to use.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -349,8 +350,33 @@ fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect, theme: &Th
 }
 
 fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
-    // Layout: input line, optional reuse banner (RFC §3.10), suggestions.
-    let banner_height: u16 = if ws.can_alias { 3 } else { 0 };
+    render_intent_content(
+        f,
+        ws.can_alias,
+        ws.intent.value(),
+        &ws.suggestions,
+        ws.selected_suggestion,
+        area,
+        theme,
+    );
+}
+
+fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+    render_classification_content(f, &ws.classification, &ws.assembled_name(), area);
+}
+
+// ── Shared widget render helpers ─────────────────────────────────────────────
+
+fn render_intent_content(
+    f: &mut Frame<'_>,
+    can_alias: bool,
+    intent_value: &str,
+    suggestions: &[design_data_core::suggest::SuggestionResult],
+    selected_suggestion: usize,
+    area: Rect,
+    theme: &Theme,
+) {
+    let banner_height: u16 = if can_alias { 3 } else { 0 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -360,12 +386,10 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
         ])
         .split(area);
 
-    // Input line.
-    let intent_line = format!("Intent: {}", ws.intent.value());
+    let intent_line = format!("Intent: {intent_value}");
     f.render_widget(Paragraph::new(intent_line), chunks[0]);
 
-    // Reuse-first banner (RFC §3.10).
-    if ws.can_alias {
+    if can_alias {
         let accent = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
         let banner = Paragraph::new(vec![
             Line::from(Span::styled(
@@ -380,10 +404,9 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
         f.render_widget(banner, chunks[1]);
     }
 
-    // Suggestions list.
     let list_area = chunks[2];
-    if ws.suggestions.is_empty() {
-        if !ws.intent.value().is_empty() {
+    if suggestions.is_empty() {
+        if !intent_value.is_empty() {
             f.render_widget(
                 Paragraph::new("  (no suggestions — will create new token)"),
                 list_area,
@@ -392,12 +415,11 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
             f.render_widget(Paragraph::new("  Type to search for existing tokens…"), list_area);
         }
     } else {
-        let rows: Vec<Row> = ws
-            .suggestions
+        let rows: Vec<Row> = suggestions
             .iter()
             .enumerate()
             .map(|(i, s)| {
-                let marker = if i == ws.selected_suggestion { "▶" } else { " " };
+                let marker = if i == selected_suggestion { "▶" } else { " " };
                 let conf = format!("{:.0}%", s.confidence * 100.0);
                 Row::new(vec![
                     Cell::from(marker),
@@ -413,15 +435,20 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
     }
 }
 
-fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
-    let layer_str = match ws.classification.layer {
+fn render_classification_content(
+    f: &mut Frame<'_>,
+    classification: &ClassificationDraft,
+    assembled_name: &str,
+    area: Rect,
+) {
+    let layer_str = match classification.layer {
         design_data_core::graph::Layer::Foundation => "Foundation",
         design_data_core::graph::Layer::Platform => "Platform",
         design_data_core::graph::Layer::Product => "Product",
     };
 
     let mut lines: Vec<Line> = Vec::new();
-    let focused = ws.classification.focused_field;
+    let focused = classification.focused_field;
 
     let layer_label = if focused == 0 {
         format!("▶ Layer:    ← {layer_str} →")
@@ -431,22 +458,107 @@ fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect)
     lines.push(Line::from(layer_label));
 
     let prop_label = if focused == 1 {
-        format!("▶ Property: {}", ws.classification.property.value())
+        format!("▶ Property: {}", classification.property.value())
     } else {
-        format!("  Property: {}", ws.classification.property.value())
+        format!("  Property: {}", classification.property.value())
     };
     lines.push(Line::from(prop_label));
 
-    for (i, field) in ws.classification.name_fields.iter().enumerate() {
+    for (i, field) in classification.name_fields.iter().enumerate() {
         let marker = if focused == i + 2 { "▶" } else { " " };
         lines.push(Line::from(format!("{marker} {}: {}", field.key, field.value.value())));
     }
 
     lines.push(Line::from(""));
-    let name = ws.assembled_name();
-    lines.push(Line::from(format!("  Preview: {name}")));
+    lines.push(Line::from(format!("  Preview: {assembled_name}")));
 
     f.render_widget(Paragraph::new(lines), area);
+}
+
+// ── Naming wizard render ─────────────────────────────────────────────────────
+
+fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &Theme) {
+    let screen_num = ns.screen.number();
+    let screen_name = ns.screen.name();
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Name · {screen_num}/3 · {screen_name} "));
+    let inner_area = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner_area);
+
+    let footer_text = match ns.screen {
+        NamingScreen::Intent => "Enter: continue  ↑↓: select suggestion  Esc: cancel",
+        NamingScreen::Classification => {
+            "Tab/Shift-Tab: next/prev field  ←→: cycle layer  +: add name field  Enter: done  Esc: cancel"
+        }
+        NamingScreen::Result => "c/y: copy name  e: edit  Esc/q: close",
+    };
+    f.render_widget(
+        Paragraph::new(footer_text).style(Style::default().fg(theme.muted)),
+        inner_chunks[1],
+    );
+
+    match ns.screen {
+        NamingScreen::Intent => render_intent_content(
+            f,
+            ns.can_alias,
+            ns.intent.value(),
+            &ns.suggestions,
+            ns.selected_suggestion,
+            inner_chunks[0],
+            theme,
+        ),
+        NamingScreen::Classification => render_classification_content(
+            f,
+            &ns.classification,
+            &ns.assembled_name(),
+            inner_chunks[0],
+        ),
+        NamingScreen::Result => render_naming_result(f, ns, inner_chunks[0], theme),
+    }
+}
+
+fn render_naming_result(
+    f: &mut Frame<'_>,
+    ns: &NamingWizardState,
+    area: Rect,
+    theme: &Theme,
+) {
+    let name = ns.assembled_name();
+    let display = if name.is_empty() {
+        "(no name assembled — go back and fill in Property)".to_string()
+    } else {
+        name
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(area);
+
+    let name_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Assembled name ");
+    let name_para = Paragraph::new(Span::styled(
+        display,
+        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+    ))
+    .block(name_block);
+    f.render_widget(name_para, chunks[0]);
+
+    let hint = Paragraph::new(vec![
+        Line::from("  Press c or y to copy this name to the clipboard."),
+        Line::from("  Press e to go back and refine the classification."),
+        Line::from("  Press Esc or q to close without copying."),
+    ])
+    .style(Style::default().fg(theme.muted));
+    f.render_widget(hint, chunks[1]);
 }
 
 fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
@@ -811,6 +923,11 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                     let popup_area = centered_rect(82, 85, frame_area);
                     f.render_widget(Clear, popup_area);
                     render_wizard(f, ws, popup_area, &handle.theme);
+                }
+                Some(Modal::Naming(ref mut ns)) => {
+                    let popup_area = centered_rect(82, 85, frame_area);
+                    f.render_widget(Clear, popup_area);
+                    render_naming(f, ns, popup_area, &handle.theme);
                 }
                 Some(Modal::Help(ref hm)) => {
                     render_help_modal(f, hm.scroll, frame_area);

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -14,7 +14,7 @@
 //! Output is an assembled token name string; no token is written to disk.
 //! Entry point: `:name [<intent>]` in the TUI palette.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use design_data_core::graph::TokenGraph;
 use design_data_core::suggest::{self, SuggestionResult};
 use tui_input::Input;
@@ -35,6 +35,8 @@ pub enum NamingScreen {
 }
 
 impl NamingScreen {
+    pub const SCREEN_COUNT: u8 = 3;
+
     pub fn number(self) -> u8 {
         match self {
             NamingScreen::Intent => 1,
@@ -114,9 +116,6 @@ impl NamingWizardState {
     // ── Dispatch ─────────────────────────────────────────────────────────────
 
     pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            return NamingEvent::Continue;
-        }
         if key.code == KeyCode::Esc {
             return NamingEvent::Cancel;
         }
@@ -160,7 +159,7 @@ impl NamingWizardState {
         }
     }
 
-    fn advance_to_classification(&mut self, graph: &TokenGraph) {
+    fn advance_to_classification(&mut self, _graph: &TokenGraph) {
         let intent = self.intent.value().to_string();
         if !intent.is_empty() && self.classification.property.value().is_empty() {
             if let Some(top) = self.suggestions.first() {
@@ -174,7 +173,6 @@ impl NamingWizardState {
                 }
             }
         }
-        let _ = graph; // graph available for future primer-seeding
         self.screen = NamingScreen::Classification;
     }
 
@@ -184,6 +182,12 @@ impl NamingWizardState {
         match key.code {
             KeyCode::Enter => {
                 self.screen = NamingScreen::Result;
+                NamingEvent::Continue
+            }
+            // b goes back to Intent only when the layer selector is focused;
+            // when a text field is focused, b is regular text input.
+            KeyCode::Char('b') if self.classification.focused_field == 0 => {
+                self.screen = NamingScreen::Intent;
                 NamingEvent::Continue
             }
             KeyCode::Tab => {

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -1,0 +1,255 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Standalone naming wizard — RFC #973 Q2 Track A.
+//!
+//! Three screens: Intent → Classification → Result.
+//! Output is an assembled token name string; no token is written to disk.
+//! Entry point: `:name [<intent>]` in the TUI palette.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::TokenGraph;
+use design_data_core::suggest::{self, SuggestionResult};
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+use crate::wizard::{
+    ClassificationDraft, NameField, assemble_name_from_classification,
+    cycle_layer_backward, cycle_layer_forward,
+};
+use design_data_core::authoring::session::alias_threshold;
+
+/// The three screens of the naming wizard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamingScreen {
+    Intent,
+    Classification,
+    Result,
+}
+
+impl NamingScreen {
+    pub fn number(self) -> u8 {
+        match self {
+            NamingScreen::Intent => 1,
+            NamingScreen::Classification => 2,
+            NamingScreen::Result => 3,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            NamingScreen::Intent => "Intent",
+            NamingScreen::Classification => "Classification",
+            NamingScreen::Result => "Result",
+        }
+    }
+}
+
+/// Outcome of a single key event inside the naming wizard.
+pub enum NamingEvent {
+    /// Normal; no state change visible to App.
+    Continue,
+    /// User pressed Esc/q — App should close the modal.
+    Cancel,
+    /// User copied the name — App should yank to clipboard.
+    Copy(String),
+}
+
+/// All state for the three-screen naming wizard.
+pub struct NamingWizardState {
+    pub screen: NamingScreen,
+    pub intent: Input,
+    pub suggestions: Vec<SuggestionResult>,
+    pub selected_suggestion: usize,
+    pub can_alias: bool,
+    pub classification: ClassificationDraft,
+}
+
+impl NamingWizardState {
+    pub fn new() -> Self {
+        Self {
+            screen: NamingScreen::Intent,
+            intent: Input::default(),
+            suggestions: Vec::new(),
+            selected_suggestion: 0,
+            can_alias: false,
+            classification: ClassificationDraft::new(),
+        }
+    }
+
+    pub fn new_with_intent(intent: &str) -> Self {
+        let mut s = Self::new();
+        if !intent.is_empty() {
+            s.intent = Input::from(intent.to_string());
+        }
+        s
+    }
+
+    /// Recompute `suggestions` and `can_alias` from the current intent string.
+    pub fn refresh_suggestions(&mut self, graph: &TokenGraph) {
+        let intent = self.intent.value().to_string();
+        self.suggestions = suggest::suggest(graph, &intent, None, 5);
+        self.can_alias = self
+            .suggestions
+            .first()
+            .map(|s| s.confidence >= alias_threshold())
+            .unwrap_or(false);
+        if !self.suggestions.is_empty() && self.selected_suggestion >= self.suggestions.len() {
+            self.selected_suggestion = self.suggestions.len() - 1;
+        }
+    }
+
+    /// The assembled name from current classification fields.
+    pub fn assembled_name(&self) -> String {
+        assemble_name_from_classification(&self.classification)
+    }
+
+    // ── Dispatch ─────────────────────────────────────────────────────────────
+
+    pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            return NamingEvent::Continue;
+        }
+        if key.code == KeyCode::Esc {
+            return NamingEvent::Cancel;
+        }
+        let event = match self.screen {
+            NamingScreen::Intent => self.handle_intent_key(key, graph),
+            NamingScreen::Classification => self.handle_classification_key(key),
+            NamingScreen::Result => self.handle_result_key(key),
+        };
+        if self.screen == NamingScreen::Intent {
+            self.refresh_suggestions(graph);
+        }
+        event
+    }
+
+    // ── Screen 1: Intent ─────────────────────────────────────────────────────
+
+    fn handle_intent_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.advance_to_classification(graph);
+                NamingEvent::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.selected_suggestion > 0 {
+                    self.selected_suggestion -= 1;
+                }
+                NamingEvent::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.suggestions.is_empty()
+                    && self.selected_suggestion < self.suggestions.len() - 1
+                {
+                    self.selected_suggestion += 1;
+                }
+                NamingEvent::Continue
+            }
+            _ => {
+                self.intent.handle_event(&crossterm::event::Event::Key(key));
+                NamingEvent::Continue
+            }
+        }
+    }
+
+    fn advance_to_classification(&mut self, graph: &TokenGraph) {
+        let intent = self.intent.value().to_string();
+        if !intent.is_empty() && self.classification.property.value().is_empty() {
+            if let Some(top) = self.suggestions.first() {
+                if let Some(prop) = top
+                    .name_object
+                    .as_ref()
+                    .and_then(|n| n.get("property"))
+                    .and_then(|v| v.as_str())
+                {
+                    self.classification.property = Input::from(prop.to_string());
+                }
+            }
+        }
+        let _ = graph; // graph available for future primer-seeding
+        self.screen = NamingScreen::Classification;
+    }
+
+    // ── Screen 2: Classification ─────────────────────────────────────────────
+
+    fn handle_classification_key(&mut self, key: KeyEvent) -> NamingEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.screen = NamingScreen::Result;
+                NamingEvent::Continue
+            }
+            KeyCode::Tab => {
+                let count = self.classification.field_count();
+                self.classification.focused_field =
+                    (self.classification.focused_field + 1) % count;
+                NamingEvent::Continue
+            }
+            KeyCode::BackTab => {
+                let count = self.classification.field_count();
+                let f = self.classification.focused_field;
+                self.classification.focused_field = if f == 0 { count - 1 } else { f - 1 };
+                NamingEvent::Continue
+            }
+            KeyCode::Left | KeyCode::Char('h') if self.classification.focused_field == 0 => {
+                self.classification.layer = cycle_layer_backward(self.classification.layer);
+                NamingEvent::Continue
+            }
+            KeyCode::Right | KeyCode::Char('l') if self.classification.focused_field == 0 => {
+                self.classification.layer = cycle_layer_forward(self.classification.layer);
+                NamingEvent::Continue
+            }
+            KeyCode::Char('+') => {
+                self.classification.name_fields.push(NameField {
+                    key: "key".to_string(),
+                    value: Input::default(),
+                });
+                NamingEvent::Continue
+            }
+            _ => {
+                let focused = self.classification.focused_field;
+                if focused == 1 {
+                    self.classification
+                        .property
+                        .handle_event(&crossterm::event::Event::Key(key));
+                } else if focused >= 2 {
+                    let idx = focused - 2;
+                    if let Some(field) = self.classification.name_fields.get_mut(idx) {
+                        field.value.handle_event(&crossterm::event::Event::Key(key));
+                    }
+                }
+                NamingEvent::Continue
+            }
+        }
+    }
+
+    // ── Screen 3: Result ─────────────────────────────────────────────────────
+
+    fn handle_result_key(&mut self, key: KeyEvent) -> NamingEvent {
+        match key.code {
+            KeyCode::Char('c') | KeyCode::Char('y') => {
+                let name = self.assembled_name();
+                NamingEvent::Copy(name)
+            }
+            KeyCode::Char('e') => {
+                self.screen = NamingScreen::Classification;
+                NamingEvent::Continue
+            }
+            KeyCode::Char('q') => NamingEvent::Cancel,
+            _ => NamingEvent::Continue,
+        }
+    }
+}
+
+impl Default for NamingWizardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -59,7 +59,7 @@ pub struct ClassificationDraft {
 }
 
 impl ClassificationDraft {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             layer: Layer::Foundation,
             property: Input::default(),
@@ -68,8 +68,14 @@ impl ClassificationDraft {
         }
     }
 
-    fn field_count(&self) -> usize {
+    pub fn field_count(&self) -> usize {
         2 + self.name_fields.len() // layer + property + name_fields
+    }
+}
+
+impl Default for ClassificationDraft {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -532,18 +538,7 @@ impl WizardState {
 
     /// The assembled token name derived from classification fields (property + name fields).
     pub fn assembled_name(&self) -> String {
-        let mut parts: Vec<String> = Vec::new();
-        let prop = self.classification.property.value().trim().to_string();
-        if !prop.is_empty() {
-            parts.push(prop);
-        }
-        for field in &self.classification.name_fields {
-            let v = field.value.value().trim().to_string();
-            if !v.is_empty() {
-                parts.push(v);
-            }
-        }
-        parts.join("-")
+        assemble_name_from_classification(&self.classification)
     }
 
     /// Build a unified diff between the current and predicted post-write state of the
@@ -616,6 +611,25 @@ impl Default for WizardState {
     }
 }
 
+// ── Shared widget helpers ────────────────────────────────────────────────────
+
+/// Assemble a token name from classification fields (property + name fields).
+/// Shared by the authoring and naming wizards.
+pub fn assemble_name_from_classification(classification: &ClassificationDraft) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let prop = classification.property.value().trim().to_string();
+    if !prop.is_empty() {
+        parts.push(prop);
+    }
+    for field in &classification.name_fields {
+        let v = field.value.value().trim().to_string();
+        if !v.is_empty() {
+            parts.push(v);
+        }
+    }
+    parts.join("-")
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /// Derive the target file path from `layer` and `property`.
@@ -674,7 +688,7 @@ fn build_token_value(rows: &[ValueRow]) -> serde_json::Value {
     }
 }
 
-fn cycle_layer_forward(layer: Layer) -> Layer {
+pub fn cycle_layer_forward(layer: Layer) -> Layer {
     match layer {
         Layer::Foundation => Layer::Platform,
         Layer::Platform => Layer::Product,
@@ -682,7 +696,7 @@ fn cycle_layer_forward(layer: Layer) -> Layer {
     }
 }
 
-fn cycle_layer_backward(layer: Layer) -> Layer {
+pub fn cycle_layer_backward(layer: Layer) -> Layer {
     match layer {
         Layer::Foundation => Layer::Product,
         Layer::Platform => Layer::Foundation,

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -1,0 +1,240 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::naming::{NamingEvent, NamingScreen, NamingWizardState};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn make_graph() -> TokenGraph {
+    let records: Vec<TokenRecord> = vec![
+        TokenRecord {
+            name: "accent-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": { "property": "background-color", "variant": "accent" }
+            }),
+            layer: Layer::Foundation,
+        },
+    ];
+    TokenGraph::from_records(records)
+}
+
+// ── NamingWizardState unit tests ─────────────────────────────────────────────
+
+#[test]
+fn assembled_name_joins_property_and_name_fields() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // Tab to move focus to property field (focused_field 0→1).
+    ns.handle_key(key(KeyCode::Tab), &graph);
+    for c in "background-color".chars() {
+        ns.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    assert_eq!(ns.assembled_name(), "background-color");
+}
+
+#[test]
+fn new_with_intent_seeds_intent_field() {
+    let ns = NamingWizardState::new_with_intent("accent background color");
+    assert_eq!(ns.intent.value(), "accent background color");
+    assert_eq!(ns.screen, NamingScreen::Intent);
+}
+
+#[test]
+fn enter_on_intent_screen_advances_to_classification() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new_with_intent("background color");
+    ns.refresh_suggestions(&graph);
+    let event = ns.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, NamingEvent::Continue));
+    assert_eq!(ns.screen, NamingScreen::Classification);
+}
+
+#[test]
+fn enter_on_classification_screen_advances_to_result() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    let event = ns.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, NamingEvent::Continue));
+    assert_eq!(ns.screen, NamingScreen::Result);
+}
+
+#[test]
+fn c_on_result_screen_returns_copy_event() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // Tab to property field, then type.
+    ns.handle_key(key(KeyCode::Tab), &graph);
+    for c in "color".chars() {
+        ns.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    ns.handle_key(key(KeyCode::Enter), &graph); // advance to Result
+    assert_eq!(ns.screen, NamingScreen::Result);
+
+    let event = ns.handle_key(key(KeyCode::Char('c')), &graph);
+    assert!(matches!(event, NamingEvent::Copy(ref name) if name == "color"));
+}
+
+#[test]
+fn e_on_result_screen_goes_back_to_classification() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Result;
+    let event = ns.handle_key(key(KeyCode::Char('e')), &graph);
+    assert!(matches!(event, NamingEvent::Continue));
+    assert_eq!(ns.screen, NamingScreen::Classification);
+}
+
+#[test]
+fn esc_on_any_screen_cancels() {
+    let graph = make_graph();
+    for start_screen in [NamingScreen::Intent, NamingScreen::Classification, NamingScreen::Result] {
+        let mut ns = NamingWizardState::new();
+        ns.screen = start_screen;
+        let event = ns.handle_key(key(KeyCode::Esc), &graph);
+        assert!(matches!(event, NamingEvent::Cancel));
+    }
+}
+
+#[test]
+fn q_on_result_screen_cancels() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Result;
+    let event = ns.handle_key(key(KeyCode::Char('q')), &graph);
+    assert!(matches!(event, NamingEvent::Cancel));
+}
+
+#[test]
+fn layer_cycles_with_arrow_keys_on_classification() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // focused_field == 0 (layer), right cycles forward Foundation → Platform.
+    ns.handle_key(key(KeyCode::Right), &graph);
+    assert_eq!(ns.classification.layer, Layer::Platform);
+    ns.handle_key(key(KeyCode::Left), &graph);
+    assert_eq!(ns.classification.layer, Layer::Foundation);
+}
+
+// ── App-level integration tests ───────────────────────────────────────────────
+
+fn submit(app: &mut App, graph: &TokenGraph, cmd: &str) {
+    let ctx = SubmitContext::new(graph);
+    let chars: Vec<char> = cmd.chars().collect();
+    for c in chars {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    app.submit_palette(&ctx);
+}
+
+fn open_palette_cmd(app: &mut App) {
+    app.handle_key(key(KeyCode::Char(':')));
+}
+
+#[test]
+fn name_command_opens_naming_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name accent background");
+    assert!(matches!(app.modal, Some(Modal::Naming(_))));
+}
+
+#[test]
+fn name_command_no_args_opens_naming_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name");
+    assert!(matches!(app.modal, Some(Modal::Naming(_))));
+}
+
+#[test]
+fn name_command_seeds_intent_from_args() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name accent background");
+    if let Some(Modal::Naming(ref ns)) = app.modal {
+        assert_eq!(ns.intent.value(), "accent background");
+    } else {
+        panic!("expected Naming modal");
+    }
+}
+
+#[test]
+fn tab_autocompletes_name_command() {
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    // "na" is unambiguous — "name" is the only command with that prefix.
+    app.handle_key(key(KeyCode::Char('n')));
+    app.handle_key(key(KeyCode::Char('a')));
+    app.handle_key(key(KeyCode::Tab));
+    assert_eq!(app.palette_input.value(), "name ");
+}
+
+#[test]
+fn copy_event_sets_pending_yank_and_status() {
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name");
+
+    // Drive to result screen with a property typed.
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+
+    // Enter on intent screen → Classification.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // On Classification: Tab to property field, type "color", then Enter → Result.
+    app.handle_modal_key(key(KeyCode::Tab), &ctx);
+    for c in "color".chars() {
+        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+    }
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // On Result: press 'c' → Copy.
+    app.handle_modal_key(key(KeyCode::Char('c')), &ctx);
+
+    assert_eq!(app.pending_yank.as_deref(), Some("color"));
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
+}
+
+#[test]
+fn esc_in_naming_modal_closes_it() {
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+    app.handle_modal_key(key(KeyCode::Esc), &ctx);
+    assert!(app.modal.is_none());
+}


### PR DESCRIPTION
## Description

Adds a `:name [<intent>]` command to the TUI — a three-screen naming wizard (Intent → Classification → Result) that helps you arrive at a good token name without writing a token to disk. Output is an assembled name string you can copy to clipboard with `c`/`y`.

This is RFC #973 Q2 Track A. Q2 was an open question ("should there be a wizard for foundation/structure layers?"); the answer we landed on is: no parallel authoring wizard, but the wizard *pattern* gets reused for other tasks. Naming is the first reuse; a query wizard (Track B) follows.

## Related Issue

RFC #973 Q2 — wizard pattern reuse for naming + querying

## Motivation and Context

The authoring wizard (`:new`) names tokens as a side-effect of authoring. A standalone naming flow is useful for:
- Renaming an existing token without going through full authoring
- Brainstorming a name before deciding whether to author at all
- Consistency check: "does this follow our taxonomy?"

## How Has This Been Tested?

- 15 new tests in `sdk/tui/tests/naming.rs` covering: screen navigation, layer cycling, copy event, App-level modal integration, Tab autocomplete for `:name`.
- All 115 existing TUI tests continue to pass (regression guard for the shared widget extraction).
- `cargo clippy --workspace -- -D warnings` clean.

Manual smoke:
```bash
cargo run -p design-data-tui packages/tokens/src
# :name accent background color → Intent → Classification → Result
# Result screen: name in accent color, c to copy, e to edit, Esc to close
# :name (no args) → empty Intent screen
# :new … → existing authoring wizard unchanged
```

## Screenshots (if appropriate):

N/A (terminal UI)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.