### PR TITLE
feat(sdk/tui): standalone query wizard via :find (RFC #973 Q2 Track B)

### DIFF
--- a/sdk/core/src/registry.rs
+++ b/sdk/core/src/registry.rs
@@ -69,7 +69,7 @@ impl RegistryData {
     }
 
     /// Look up the vocabulary set for a name-object field.
-    /// Returns `None` for fields without a registry (e.g. `property`, mode-set fields).
+    /// Returns `None` for fields without a registry (e.g. mode-set fields).
     pub fn for_field(&self, field: &str) -> Option<&HashSet<String>> {
         self.registries.get(field)
     }

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -23,6 +23,7 @@ use ratatui::widgets::TableState;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
+use crate::find::{FindEvent, FindWizardState};
 use crate::naming::{NamingEvent, NamingWizardState};
 use crate::wizard::{WizardCtx, WizardEvent, WizardState};
 use crate::wizard_draft::{
@@ -30,7 +31,8 @@ use crate::wizard_draft::{
 };
 
 /// Command names for Tab autocomplete.
-const KNOWN_COMMANDS: &[&str] = &["name", "new", "query", "resolve", "describe", "validate"];
+const KNOWN_COMMANDS: &[&str] =
+    &["find", "name", "new", "query", "resolve", "describe", "validate"];
 
 /// Max palette history entries persisted to disk.
 const HISTORY_CAP: usize = 200;
@@ -79,7 +81,7 @@ pub struct QueryRow {
 }
 
 impl QueryRow {
-    fn from_record(t: &TokenRecord) -> Self {
+    pub(crate) fn from_record(t: &TokenRecord) -> Self {
         let value = t
             .raw
             .get("value")
@@ -204,6 +206,7 @@ pub struct HelpModal {
 
 /// An overlay modal that temporarily captures all keyboard input.
 pub enum Modal {
+    Find(Box<FindWizardState>),
     Wizard(Box<WizardState>),
     Naming(Box<NamingWizardState>),
     Help(HelpModal),
@@ -476,6 +479,26 @@ impl App {
             return;
         }
 
+        // Find wizard modal.
+        if let Some(Modal::Find(ref mut fs)) = self.modal {
+            let event = fs.handle_key(key, ctx.graph);
+            match event {
+                FindEvent::Cancel => {
+                    self.modal = None;
+                    self.status_message = Some(StatusMessage::info("find wizard cancelled"));
+                }
+                FindEvent::OpenResults(view) => {
+                    let count = view.rows.len();
+                    self.active_view = ActiveView::Query(view);
+                    self.status_message =
+                        Some(StatusMessage::info(format!("{count} token(s) matched")));
+                    self.modal = None;
+                }
+                FindEvent::Continue => {}
+            }
+            return;
+        }
+
         // Naming modal — handled independently; no WizardCtx needed.
         if let Some(Modal::Naming(ref mut ns)) = self.modal {
             let event = ns.handle_key(key, ctx.graph);
@@ -590,8 +613,8 @@ impl App {
 
     /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
     fn scroll_active(&mut self, delta: i32) {
-        // Naming modal has no scrollable content.
-        if matches!(self.modal, Some(Modal::Naming(_))) {
+        // Find and Naming modals have no scrollable content.
+        if matches!(self.modal, Some(Modal::Find(_)) | Some(Modal::Naming(_))) {
             return;
         }
         // Wizard diff scroll has priority when a modal is open.
@@ -1042,6 +1065,11 @@ impl App {
                             Some(StatusMessage::error(format!("validate: {e}")));
                     }
                 }
+            }
+            "find" => {
+                let fs = FindWizardState::new_with_intent(rest.trim());
+                self.modal = Some(Modal::Find(Box::new(fs)));
+                self.status_message = None;
             }
             "name" => {
                 let mut ns = NamingWizardState::new_with_intent(rest.trim());

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -23,13 +23,14 @@ use ratatui::widgets::TableState;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
+use crate::naming::{NamingEvent, NamingWizardState};
 use crate::wizard::{WizardCtx, WizardEvent, WizardState};
 use crate::wizard_draft::{
     clear_wizard_draft, from_draft, load_wizard_draft, save_wizard_draft, to_draft,
 };
 
 /// Command names for Tab autocomplete.
-const KNOWN_COMMANDS: &[&str] = &["new", "query", "resolve", "describe", "validate"];
+const KNOWN_COMMANDS: &[&str] = &["name", "new", "query", "resolve", "describe", "validate"];
 
 /// Max palette history entries persisted to disk.
 const HISTORY_CAP: usize = 200;
@@ -204,6 +205,7 @@ pub struct HelpModal {
 /// An overlay modal that temporarily captures all keyboard input.
 pub enum Modal {
     Wizard(Box<WizardState>),
+    Naming(Box<NamingWizardState>),
     Help(HelpModal),
 }
 
@@ -474,6 +476,24 @@ impl App {
             return;
         }
 
+        // Naming modal — handled independently; no WizardCtx needed.
+        if let Some(Modal::Naming(ref mut ns)) = self.modal {
+            let event = ns.handle_key(key, ctx.graph);
+            match event {
+                NamingEvent::Cancel => {
+                    self.modal = None;
+                    self.status_message = Some(StatusMessage::info("naming wizard cancelled"));
+                }
+                NamingEvent::Copy(name) => {
+                    self.pending_yank = Some(name.clone());
+                    self.status_message =
+                        Some(StatusMessage::info(format!("copied: {name}")));
+                }
+                NamingEvent::Continue => {}
+            }
+            return;
+        }
+
         let event = match &mut self.modal {
             Some(Modal::Wizard(ws)) => ws.handle_key(key, ctx),
             _ => return,
@@ -570,6 +590,10 @@ impl App {
 
     /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
     fn scroll_active(&mut self, delta: i32) {
+        // Naming modal has no scrollable content.
+        if matches!(self.modal, Some(Modal::Naming(_))) {
+            return;
+        }
         // Wizard diff scroll has priority when a modal is open.
         if let Some(Modal::Wizard(ref mut ws)) = self.modal {
             if delta > 0 {
@@ -1018,6 +1042,12 @@ impl App {
                             Some(StatusMessage::error(format!("validate: {e}")));
                     }
                 }
+            }
+            "name" => {
+                let mut ns = NamingWizardState::new_with_intent(rest.trim());
+                ns.refresh_suggestions(ctx.graph);
+                self.modal = Some(Modal::Naming(Box::new(ns)));
+                self.status_message = None;
             }
             "new" | "create" => {
                 let mut ws = WizardState::new_with_intent(rest.trim());

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -1,0 +1,315 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Standalone find/query wizard — RFC #973 Q2 Track B.
+//!
+//! Two screens: Filters → Preview.
+//! On accept, emits `FindEvent::OpenResults(QueryView)`; the modal closes and
+//! `ActiveView::Query` takes over without a third wizard screen.
+//! Entry point: `:find [<intent>]` in the TUI palette.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use design_data_core::graph::{Layer, TokenGraph};
+use design_data_core::registry::RegistryData;
+use design_data_core::{query, suggest};
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+use crate::app::{QueryRow, QueryView};
+
+/// The two wizard screens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindScreen {
+    Filters,
+    Preview,
+}
+
+impl FindScreen {
+    pub const SCREEN_COUNT: u8 = 2;
+
+    pub fn number(self) -> u8 {
+        match self {
+            FindScreen::Filters => 1,
+            FindScreen::Preview => 2,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            FindScreen::Filters => "Filters",
+            FindScreen::Preview => "Preview",
+        }
+    }
+}
+
+/// Outcome of a single key event inside the find wizard.
+pub enum FindEvent {
+    /// Normal; no state change visible to App.
+    Continue,
+    /// User pressed Esc — App should close the modal.
+    Cancel,
+    /// User accepted the preview — App should open this view and close the modal.
+    OpenResults(QueryView),
+}
+
+/// All state for the two-screen find wizard.
+pub struct FindWizardState {
+    pub screen: FindScreen,
+    /// Structured filter inputs (focused_field indices 0–3).
+    pub property: Input,
+    pub component: Input,
+    pub variant: Input,
+    pub state: Input,
+    /// Fallback free-text intent (focused_field index 4).
+    /// Used when no structured filter is filled; drives suggest::suggest.
+    pub intent: Input,
+    /// Which field has keyboard focus (0=property, 1=component, 2=variant, 3=state, 4=intent).
+    pub focused_field: usize,
+    /// Registry-sourced autocomplete suggestions for the property field.
+    pub property_suggestions: Vec<String>,
+    pub selected_property_suggestion: usize,
+    /// All rows from the most recent preview refresh.
+    pub preview_rows: Vec<QueryRow>,
+    /// Total match count (== `preview_rows.len()`).
+    pub preview_count: usize,
+    /// Parse or query error from the most recent refresh, if any.
+    pub preview_error: Option<String>,
+}
+
+impl FindWizardState {
+    pub const FIELD_COUNT: usize = 5;
+
+    pub fn new() -> Self {
+        Self {
+            screen: FindScreen::Filters,
+            property: Input::default(),
+            component: Input::default(),
+            variant: Input::default(),
+            state: Input::default(),
+            intent: Input::default(),
+            focused_field: 0,
+            property_suggestions: Vec::new(),
+            selected_property_suggestion: 0,
+            preview_rows: Vec::new(),
+            preview_count: 0,
+            preview_error: None,
+        }
+    }
+
+    /// Create a state pre-seeded with an intent string.
+    ///
+    /// Seeds the intent field and sets focus there so the user can refine or
+    /// immediately press Enter to see suggest-ranked results.
+    pub fn new_with_intent(intent: &str) -> Self {
+        let mut s = Self::new();
+        if !intent.is_empty() {
+            s.intent = Input::from(intent.to_string());
+            s.focused_field = 4;
+        }
+        s
+    }
+
+    /// Build a query DSL expression from the structured filter fields.
+    ///
+    /// Returns `None` when no structured filter is set, signalling the
+    /// intent-fallback path in `refresh_preview`.
+    pub fn assemble_expr(&self) -> Option<String> {
+        let mut parts = Vec::new();
+        let prop = self.property.value().trim().to_string();
+        let comp = self.component.value().trim().to_string();
+        let var = self.variant.value().trim().to_string();
+        let st = self.state.value().trim().to_string();
+
+        if !prop.is_empty() {
+            parts.push(format!("property={prop}"));
+        }
+        if !comp.is_empty() {
+            parts.push(format!("component={comp}"));
+        }
+        if !var.is_empty() {
+            parts.push(format!("variant={var}"));
+        }
+        if !st.is_empty() {
+            parts.push(format!("state={st}"));
+        }
+
+        if parts.is_empty() { None } else { Some(parts.join(",")) }
+    }
+
+    /// Refresh `preview_rows`, `preview_count`, and `preview_error`.
+    ///
+    /// Uses structured-filter path when any filter field is non-empty;
+    /// falls back to `suggest::suggest` when only `intent` is filled.
+    pub fn refresh_preview(&mut self, graph: &TokenGraph) {
+        if let Some(expr_str) = self.assemble_expr() {
+            match query::parse(&expr_str) {
+                Ok(filter) => {
+                    let records = query::filter(graph, &filter);
+                    self.preview_count = records.len();
+                    self.preview_rows =
+                        records.iter().map(|r| QueryRow::from_record(r)).collect();
+                    self.preview_error = None;
+                }
+                Err(e) => {
+                    self.preview_count = 0;
+                    self.preview_rows.clear();
+                    self.preview_error = Some(e.to_string());
+                }
+            }
+        } else if !self.intent.value().trim().is_empty() {
+            let intent = self.intent.value().to_string();
+            let prop_hint = {
+                let v = self.property.value().trim().to_string();
+                if v.is_empty() { None } else { Some(v) }
+            };
+            let results = suggest::suggest(graph, &intent, prop_hint.as_deref(), 20);
+            self.preview_count = results.len();
+            self.preview_rows = results.iter().map(suggestion_to_row).collect();
+            self.preview_error = None;
+        } else {
+            self.preview_count = 0;
+            self.preview_rows.clear();
+            self.preview_error = None;
+        }
+    }
+
+    /// Recompute property autocomplete suggestions from the registry.
+    pub fn refresh_property_suggestions(&mut self) {
+        let typed = self.property.value().trim().to_lowercase();
+        if typed.is_empty() {
+            self.property_suggestions.clear();
+            self.selected_property_suggestion = 0;
+            return;
+        }
+        if let Some(terms) = RegistryData::embedded().for_field("property") {
+            let mut matching: Vec<String> =
+                terms.iter().filter(|t| t.to_lowercase().contains(&typed)).cloned().collect();
+            matching.sort();
+            matching.truncate(8);
+            self.property_suggestions = matching;
+        } else {
+            self.property_suggestions.clear();
+        }
+        if self.selected_property_suggestion >= self.property_suggestions.len() {
+            self.selected_property_suggestion = 0;
+        }
+    }
+
+    // ── Dispatch ─────────────────────────────────────────────────────────────
+
+    pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> FindEvent {
+        if key.code == KeyCode::Esc {
+            return FindEvent::Cancel;
+        }
+        match self.screen {
+            FindScreen::Filters => self.handle_filters_key(key, graph),
+            FindScreen::Preview => self.handle_preview_key(key),
+        }
+    }
+
+    // ── Screen 1: Filters ────────────────────────────────────────────────────
+
+    fn handle_filters_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> FindEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.refresh_preview(graph);
+                self.screen = FindScreen::Preview;
+                FindEvent::Continue
+            }
+            KeyCode::Tab => {
+                self.focused_field = (self.focused_field + 1) % Self::FIELD_COUNT;
+                FindEvent::Continue
+            }
+            KeyCode::BackTab => {
+                let f = self.focused_field;
+                self.focused_field = if f == 0 { Self::FIELD_COUNT - 1 } else { f - 1 };
+                FindEvent::Continue
+            }
+            KeyCode::Up if self.focused_field == 0 => {
+                if self.selected_property_suggestion > 0 {
+                    self.selected_property_suggestion -= 1;
+                }
+                FindEvent::Continue
+            }
+            KeyCode::Down if self.focused_field == 0 => {
+                if !self.property_suggestions.is_empty()
+                    && self.selected_property_suggestion
+                        < self.property_suggestions.len() - 1
+                {
+                    self.selected_property_suggestion += 1;
+                }
+                FindEvent::Continue
+            }
+            _ => {
+                self.dispatch_to_focused_field(key);
+                if self.focused_field == 0 {
+                    self.refresh_property_suggestions();
+                }
+                FindEvent::Continue
+            }
+        }
+    }
+
+    fn dispatch_to_focused_field(&mut self, key: KeyEvent) {
+        let ev = crossterm::event::Event::Key(key);
+        match self.focused_field {
+            0 => { self.property.handle_event(&ev); }
+            1 => { self.component.handle_event(&ev); }
+            2 => { self.variant.handle_event(&ev); }
+            3 => { self.state.handle_event(&ev); }
+            4 => { self.intent.handle_event(&ev); }
+            _ => {}
+        }
+    }
+
+    // ── Screen 2: Preview ────────────────────────────────────────────────────
+
+    fn handle_preview_key(&mut self, key: KeyEvent) -> FindEvent {
+        match key.code {
+            KeyCode::Enter => {
+                let expr = self
+                    .assemble_expr()
+                    .unwrap_or_else(|| self.intent.value().trim().to_string());
+                let rows = std::mem::take(&mut self.preview_rows);
+                FindEvent::OpenResults(QueryView::new(expr, rows))
+            }
+            KeyCode::Char('e') => {
+                self.screen = FindScreen::Filters;
+                FindEvent::Continue
+            }
+            KeyCode::Char('q') => FindEvent::Cancel,
+            _ => FindEvent::Continue,
+        }
+    }
+}
+
+impl Default for FindWizardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn suggestion_to_row(s: &suggest::SuggestionResult) -> QueryRow {
+    let value = s
+        .value
+        .as_ref()
+        .map(|v| {
+            if v.is_string() { v.as_str().unwrap_or("").to_string() } else { v.to_string() }
+        })
+        .unwrap_or_default();
+    let file =
+        s.file.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or_default();
+    let layer = match s.layer {
+        Layer::Foundation => "foundation",
+        Layer::Platform => "platform",
+        Layer::Product => "product",
+    };
+    QueryRow { name: s.token_name.clone(), value, file, layer: layer.to_string() }
+}

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod app;
 pub mod help;
+pub mod naming;
 pub mod theme;
 pub mod wizard;
 pub mod wizard_draft;

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -9,6 +9,7 @@
 // governing permissions and limitations under the License.
 
 pub mod app;
+pub mod find;
 pub mod help;
 pub mod naming;
 pub mod theme;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -483,7 +483,7 @@ fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &
 
     let outer = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Name · {screen_num}/3 · {screen_name} "));
+        .title(format!(" Name · {screen_num}/{} · {screen_name} ", NamingScreen::SCREEN_COUNT));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 
@@ -495,7 +495,7 @@ fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &
     let footer_text = match ns.screen {
         NamingScreen::Intent => "Enter: continue  ↑↓: select suggestion  Esc: cancel",
         NamingScreen::Classification => {
-            "Tab/Shift-Tab: next/prev field  ←→: cycle layer  +: add name field  Enter: done  Esc: cancel"
+            "Tab/Shift-Tab: next/prev field  ←→/b: cycle layer / back to intent  +: add name field  Enter: done  Esc: cancel"
         }
         NamingScreen::Result => "c/y: copy name  e: edit  Esc/q: close",
     };

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -50,8 +50,9 @@ use design_data_tui::app::{
     ActiveView, App, HitAction, HitRegion, Modal, StatusKind, StatusMessage, SubmitContext,
 };
 use design_data_tui::help::HELP_TEXT;
+use design_data_tui::naming::{NamingScreen, NamingWizardState};
 use design_data_tui::theme::Theme;
-use design_data_tui::wizard::{ValueKind, WizardCtx, WizardScreen, WizardState};
+use design_data_tui::wizard::{ClassificationDraft, ValueKind, WizardCtx, WizardScreen, WizardState};
 
 /// Which visual palette to use.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -349,8 +350,33 @@ fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect, theme: &Th
 }
 
 fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
-    // Layout: input line, optional reuse banner (RFC §3.10), suggestions.
-    let banner_height: u16 = if ws.can_alias { 3 } else { 0 };
+    render_intent_content(
+        f,
+        ws.can_alias,
+        ws.intent.value(),
+        &ws.suggestions,
+        ws.selected_suggestion,
+        area,
+        theme,
+    );
+}
+
+fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
+    render_classification_content(f, &ws.classification, &ws.assembled_name(), area);
+}
+
+// ── Shared widget render helpers ─────────────────────────────────────────────
+
+fn render_intent_content(
+    f: &mut Frame<'_>,
+    can_alias: bool,
+    intent_value: &str,
+    suggestions: &[design_data_core::suggest::SuggestionResult],
+    selected_suggestion: usize,
+    area: Rect,
+    theme: &Theme,
+) {
+    let banner_height: u16 = if can_alias { 3 } else { 0 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -360,12 +386,10 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
         ])
         .split(area);
 
-    // Input line.
-    let intent_line = format!("Intent: {}", ws.intent.value());
+    let intent_line = format!("Intent: {intent_value}");
     f.render_widget(Paragraph::new(intent_line), chunks[0]);
 
-    // Reuse-first banner (RFC §3.10).
-    if ws.can_alias {
+    if can_alias {
         let accent = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
         let banner = Paragraph::new(vec![
             Line::from(Span::styled(
@@ -380,10 +404,9 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
         f.render_widget(banner, chunks[1]);
     }
 
-    // Suggestions list.
     let list_area = chunks[2];
-    if ws.suggestions.is_empty() {
-        if !ws.intent.value().is_empty() {
+    if suggestions.is_empty() {
+        if !intent_value.is_empty() {
             f.render_widget(
                 Paragraph::new("  (no suggestions — will create new token)"),
                 list_area,
@@ -392,12 +415,11 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
             f.render_widget(Paragraph::new("  Type to search for existing tokens…"), list_area);
         }
     } else {
-        let rows: Vec<Row> = ws
-            .suggestions
+        let rows: Vec<Row> = suggestions
             .iter()
             .enumerate()
             .map(|(i, s)| {
-                let marker = if i == ws.selected_suggestion { "▶" } else { " " };
+                let marker = if i == selected_suggestion { "▶" } else { " " };
                 let conf = format!("{:.0}%", s.confidence * 100.0);
                 Row::new(vec![
                     Cell::from(marker),
@@ -413,15 +435,20 @@ fn render_intent_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: 
     }
 }
 
-fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect) {
-    let layer_str = match ws.classification.layer {
+fn render_classification_content(
+    f: &mut Frame<'_>,
+    classification: &ClassificationDraft,
+    assembled_name: &str,
+    area: Rect,
+) {
+    let layer_str = match classification.layer {
         design_data_core::graph::Layer::Foundation => "Foundation",
         design_data_core::graph::Layer::Platform => "Platform",
         design_data_core::graph::Layer::Product => "Product",
     };
 
     let mut lines: Vec<Line> = Vec::new();
-    let focused = ws.classification.focused_field;
+    let focused = classification.focused_field;
 
     let layer_label = if focused == 0 {
         format!("▶ Layer:    ← {layer_str} →")
@@ -431,22 +458,107 @@ fn render_classification_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect)
     lines.push(Line::from(layer_label));
 
     let prop_label = if focused == 1 {
-        format!("▶ Property: {}", ws.classification.property.value())
+        format!("▶ Property: {}", classification.property.value())
     } else {
-        format!("  Property: {}", ws.classification.property.value())
+        format!("  Property: {}", classification.property.value())
     };
     lines.push(Line::from(prop_label));
 
-    for (i, field) in ws.classification.name_fields.iter().enumerate() {
+    for (i, field) in classification.name_fields.iter().enumerate() {
         let marker = if focused == i + 2 { "▶" } else { " " };
         lines.push(Line::from(format!("{marker} {}: {}", field.key, field.value.value())));
     }
 
     lines.push(Line::from(""));
-    let name = ws.assembled_name();
-    lines.push(Line::from(format!("  Preview: {name}")));
+    lines.push(Line::from(format!("  Preview: {assembled_name}")));
 
     f.render_widget(Paragraph::new(lines), area);
+}
+
+// ── Naming wizard render ─────────────────────────────────────────────────────
+
+fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &Theme) {
+    let screen_num = ns.screen.number();
+    let screen_name = ns.screen.name();
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Name · {screen_num}/3 · {screen_name} "));
+    let inner_area = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner_area);
+
+    let footer_text = match ns.screen {
+        NamingScreen::Intent => "Enter: continue  ↑↓: select suggestion  Esc: cancel",
+        NamingScreen::Classification => {
+            "Tab/Shift-Tab: next/prev field  ←→: cycle layer  +: add name field  Enter: done  Esc: cancel"
+        }
+        NamingScreen::Result => "c/y: copy name  e: edit  Esc/q: close",
+    };
+    f.render_widget(
+        Paragraph::new(footer_text).style(Style::default().fg(theme.muted)),
+        inner_chunks[1],
+    );
+
+    match ns.screen {
+        NamingScreen::Intent => render_intent_content(
+            f,
+            ns.can_alias,
+            ns.intent.value(),
+            &ns.suggestions,
+            ns.selected_suggestion,
+            inner_chunks[0],
+            theme,
+        ),
+        NamingScreen::Classification => render_classification_content(
+            f,
+            &ns.classification,
+            &ns.assembled_name(),
+            inner_chunks[0],
+        ),
+        NamingScreen::Result => render_naming_result(f, ns, inner_chunks[0], theme),
+    }
+}
+
+fn render_naming_result(
+    f: &mut Frame<'_>,
+    ns: &NamingWizardState,
+    area: Rect,
+    theme: &Theme,
+) {
+    let name = ns.assembled_name();
+    let display = if name.is_empty() {
+        "(no name assembled — go back and fill in Property)".to_string()
+    } else {
+        name
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(area);
+
+    let name_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Assembled name ");
+    let name_para = Paragraph::new(Span::styled(
+        display,
+        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+    ))
+    .block(name_block);
+    f.render_widget(name_para, chunks[0]);
+
+    let hint = Paragraph::new(vec![
+        Line::from("  Press c or y to copy this name to the clipboard."),
+        Line::from("  Press e to go back and refine the classification."),
+        Line::from("  Press Esc or q to close without copying."),
+    ])
+    .style(Style::default().fg(theme.muted));
+    f.render_widget(hint, chunks[1]);
 }
 
 fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
@@ -811,6 +923,11 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
                     let popup_area = centered_rect(82, 85, frame_area);
                     f.render_widget(Clear, popup_area);
                     render_wizard(f, ws, popup_area, &handle.theme);
+                }
+                Some(Modal::Naming(ref mut ns)) => {
+                    let popup_area = centered_rect(82, 85, frame_area);
+                    f.render_widget(Clear, popup_area);
+                    render_naming(f, ns, popup_area, &handle.theme);
                 }
                 Some(Modal::Help(ref hm)) => {
                     render_help_modal(f, hm.scroll, frame_area);

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -49,6 +49,7 @@ use ratatui::{
 use design_data_tui::app::{
     ActiveView, App, HitAction, HitRegion, Modal, StatusKind, StatusMessage, SubmitContext,
 };
+use design_data_tui::find::{FindScreen, FindWizardState};
 use design_data_tui::help::HELP_TEXT;
 use design_data_tui::naming::{NamingScreen, NamingWizardState};
 use design_data_tui::theme::Theme;
@@ -561,6 +562,192 @@ fn render_naming_result(
     f.render_widget(hint, chunks[1]);
 }
 
+// ── Find wizard render ───────────────────────────────────────────────────────
+
+fn render_find(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
+    let screen_num = fs.screen.number();
+    let screen_name = fs.screen.name();
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Find · {screen_num}/{} · {screen_name} ", FindScreen::SCREEN_COUNT));
+    let inner_area = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner_area);
+
+    let footer_text = match fs.screen {
+        FindScreen::Filters => {
+            "Tab/Shift-Tab: next field  ↑↓: cycle property suggestions  Enter: preview  Esc: cancel"
+        }
+        FindScreen::Preview => "Enter: open results  e: edit filters  Esc/q: cancel",
+    };
+    f.render_widget(
+        Paragraph::new(footer_text).style(Style::default().fg(theme.muted)),
+        inner_chunks[1],
+    );
+
+    match fs.screen {
+        FindScreen::Filters => render_filters_screen(f, fs, inner_chunks[0], theme),
+        FindScreen::Preview => render_preview_screen(f, fs, inner_chunks[0], theme),
+    }
+}
+
+fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
+    let foc = fs.focused_field;
+    let suggest_count = fs.property_suggestions.len() as u16;
+    // Reserve rows for property suggestion dropdown (at most 8, never more than area).
+    let dropdown_h = suggest_count.min(8);
+
+    // Layout: header rows (label + optional dropdown), then remaining fields, then match count.
+    let field_rows = 4u16; // component, variant, state, intent
+    let match_row = 1u16;
+    let available = area.height.saturating_sub(1 + dropdown_h + field_rows + match_row + 1);
+    let _ = available; // layout is fixed; this is just for reference
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),                  // property label
+            Constraint::Length(dropdown_h),          // suggestion dropdown (0 when empty)
+            Constraint::Length(field_rows),          // component / variant / state / intent
+            Constraint::Length(1),                   // match count
+            Constraint::Min(0),                      // padding
+        ])
+        .split(area);
+
+    // Property field.
+    let prop_marker = if foc == 0 { "▶" } else { " " };
+    let prop_line = format!("{prop_marker} Property: {}", fs.property.value());
+    f.render_widget(
+        Paragraph::new(prop_line).style(if foc == 0 {
+            Style::default().fg(theme.accent)
+        } else {
+            Style::default()
+        }),
+        chunks[0],
+    );
+
+    // Suggestion dropdown (only when on property field and there are suggestions).
+    if dropdown_h > 0 {
+        let rows: Vec<Row> = fs
+            .property_suggestions
+            .iter()
+            .enumerate()
+            .map(|(i, term)| {
+                let marker = if i == fs.selected_property_suggestion { "  ▸" } else { "   " };
+                Row::new(vec![Cell::from(format!("{marker} {term}"))])
+                    .style(if i == fs.selected_property_suggestion {
+                        Style::default().bg(theme.selection_bg)
+                    } else {
+                        Style::default().fg(theme.muted)
+                    })
+            })
+            .collect();
+        let widths = [Constraint::Min(0)];
+        f.render_widget(Table::new(rows, widths), chunks[1]);
+    }
+
+    // Component, variant, state, intent fields.
+    let field_area = chunks[2];
+    let sub = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(field_area);
+
+    let labels = [
+        (1usize, "Component", fs.component.value()),
+        (2, "Variant  ", fs.variant.value()),
+        (3, "State    ", fs.state.value()),
+        (4, "Intent   ", fs.intent.value()),
+    ];
+    for (idx, (field_idx, label, val)) in labels.iter().enumerate() {
+        let marker = if foc == *field_idx { "▶" } else { " " };
+        let text = format!("{marker} {label}: {val}");
+        f.render_widget(
+            Paragraph::new(text).style(if foc == *field_idx {
+                Style::default().fg(theme.accent)
+            } else {
+                Style::default()
+            }),
+            sub[idx],
+        );
+    }
+
+    // Match count.
+    let count_text = if let Some(ref err) = fs.preview_error {
+        format!("  parse error: {err}")
+    } else if !fs.preview_rows.is_empty() || fs.preview_count > 0 {
+        format!("  {} token(s) matched", fs.preview_count)
+    } else {
+        "  (fill in filters then press Enter to preview)".to_string()
+    };
+    f.render_widget(
+        Paragraph::new(count_text).style(Style::default().fg(theme.muted)),
+        chunks[3],
+    );
+}
+
+fn render_preview_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
+    let expr = fs
+        .assemble_expr()
+        .unwrap_or_else(|| format!("intent: {}", fs.intent.value().trim()));
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // expression line
+            Constraint::Length(1), // match count
+            Constraint::Min(0),    // results table
+        ])
+        .split(area);
+
+    f.render_widget(Paragraph::new(format!("  Query: {expr}")), chunks[0]);
+
+    let count_text = if let Some(ref err) = fs.preview_error {
+        format!("  error: {err}")
+    } else {
+        format!("  {} token(s) matched", fs.preview_count)
+    };
+    f.render_widget(
+        Paragraph::new(count_text).style(Style::default().fg(theme.muted)),
+        chunks[1],
+    );
+
+    let display_rows: Vec<Row> = fs
+        .preview_rows
+        .iter()
+        .take(20)
+        .map(|r| {
+            Row::new(vec![
+                Cell::from(r.name.as_str()),
+                Cell::from(r.layer.as_str()).style(Style::default().fg(theme.muted)),
+            ])
+        })
+        .collect();
+    if !display_rows.is_empty() {
+        let widths = [Constraint::Min(0), Constraint::Length(10)];
+        f.render_widget(
+            Table::new(display_rows, widths)
+                .highlight_style(Style::default().bg(theme.selection_bg)),
+            chunks[2],
+        );
+    } else if fs.preview_error.is_none() {
+        f.render_widget(
+            Paragraph::new("  (no tokens matched)").style(Style::default().fg(theme.muted)),
+            chunks[2],
+        );
+    }
+}
+
 fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
     if ws.values.rows.is_empty() {
         f.render_widget(Paragraph::new("  (no mode combinations — graph has no mode sets)"), area);
@@ -919,6 +1106,11 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
 
             // Overlay modal (rendered last so it appears on top).
             match &mut app.modal {
+                Some(Modal::Find(ref mut fs)) => {
+                    let popup_area = centered_rect(82, 85, frame_area);
+                    f.render_widget(Clear, popup_area);
+                    render_find(f, fs, popup_area, &handle.theme);
+                }
                 Some(Modal::Wizard(ref mut ws)) => {
                     let popup_area = centered_rect(82, 85, frame_area);
                     f.render_widget(Clear, popup_area);

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -14,7 +14,7 @@
 //! Output is an assembled token name string; no token is written to disk.
 //! Entry point: `:name [<intent>]` in the TUI palette.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use design_data_core::graph::TokenGraph;
 use design_data_core::suggest::{self, SuggestionResult};
 use tui_input::Input;
@@ -35,6 +35,8 @@ pub enum NamingScreen {
 }
 
 impl NamingScreen {
+    pub const SCREEN_COUNT: u8 = 3;
+
     pub fn number(self) -> u8 {
         match self {
             NamingScreen::Intent => 1,
@@ -114,9 +116,6 @@ impl NamingWizardState {
     // ── Dispatch ─────────────────────────────────────────────────────────────
 
     pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            return NamingEvent::Continue;
-        }
         if key.code == KeyCode::Esc {
             return NamingEvent::Cancel;
         }
@@ -160,7 +159,7 @@ impl NamingWizardState {
         }
     }
 
-    fn advance_to_classification(&mut self, graph: &TokenGraph) {
+    fn advance_to_classification(&mut self, _graph: &TokenGraph) {
         let intent = self.intent.value().to_string();
         if !intent.is_empty() && self.classification.property.value().is_empty() {
             if let Some(top) = self.suggestions.first() {
@@ -174,7 +173,6 @@ impl NamingWizardState {
                 }
             }
         }
-        let _ = graph; // graph available for future primer-seeding
         self.screen = NamingScreen::Classification;
     }
 
@@ -184,6 +182,12 @@ impl NamingWizardState {
         match key.code {
             KeyCode::Enter => {
                 self.screen = NamingScreen::Result;
+                NamingEvent::Continue
+            }
+            // b goes back to Intent only when the layer selector is focused;
+            // when a text field is focused, b is regular text input.
+            KeyCode::Char('b') if self.classification.focused_field == 0 => {
+                self.screen = NamingScreen::Intent;
                 NamingEvent::Continue
             }
             KeyCode::Tab => {

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -1,0 +1,255 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Standalone naming wizard — RFC #973 Q2 Track A.
+//!
+//! Three screens: Intent → Classification → Result.
+//! Output is an assembled token name string; no token is written to disk.
+//! Entry point: `:name [<intent>]` in the TUI palette.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::TokenGraph;
+use design_data_core::suggest::{self, SuggestionResult};
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+use crate::wizard::{
+    ClassificationDraft, NameField, assemble_name_from_classification,
+    cycle_layer_backward, cycle_layer_forward,
+};
+use design_data_core::authoring::session::alias_threshold;
+
+/// The three screens of the naming wizard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NamingScreen {
+    Intent,
+    Classification,
+    Result,
+}
+
+impl NamingScreen {
+    pub fn number(self) -> u8 {
+        match self {
+            NamingScreen::Intent => 1,
+            NamingScreen::Classification => 2,
+            NamingScreen::Result => 3,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            NamingScreen::Intent => "Intent",
+            NamingScreen::Classification => "Classification",
+            NamingScreen::Result => "Result",
+        }
+    }
+}
+
+/// Outcome of a single key event inside the naming wizard.
+pub enum NamingEvent {
+    /// Normal; no state change visible to App.
+    Continue,
+    /// User pressed Esc/q — App should close the modal.
+    Cancel,
+    /// User copied the name — App should yank to clipboard.
+    Copy(String),
+}
+
+/// All state for the three-screen naming wizard.
+pub struct NamingWizardState {
+    pub screen: NamingScreen,
+    pub intent: Input,
+    pub suggestions: Vec<SuggestionResult>,
+    pub selected_suggestion: usize,
+    pub can_alias: bool,
+    pub classification: ClassificationDraft,
+}
+
+impl NamingWizardState {
+    pub fn new() -> Self {
+        Self {
+            screen: NamingScreen::Intent,
+            intent: Input::default(),
+            suggestions: Vec::new(),
+            selected_suggestion: 0,
+            can_alias: false,
+            classification: ClassificationDraft::new(),
+        }
+    }
+
+    pub fn new_with_intent(intent: &str) -> Self {
+        let mut s = Self::new();
+        if !intent.is_empty() {
+            s.intent = Input::from(intent.to_string());
+        }
+        s
+    }
+
+    /// Recompute `suggestions` and `can_alias` from the current intent string.
+    pub fn refresh_suggestions(&mut self, graph: &TokenGraph) {
+        let intent = self.intent.value().to_string();
+        self.suggestions = suggest::suggest(graph, &intent, None, 5);
+        self.can_alias = self
+            .suggestions
+            .first()
+            .map(|s| s.confidence >= alias_threshold())
+            .unwrap_or(false);
+        if !self.suggestions.is_empty() && self.selected_suggestion >= self.suggestions.len() {
+            self.selected_suggestion = self.suggestions.len() - 1;
+        }
+    }
+
+    /// The assembled name from current classification fields.
+    pub fn assembled_name(&self) -> String {
+        assemble_name_from_classification(&self.classification)
+    }
+
+    // ── Dispatch ─────────────────────────────────────────────────────────────
+
+    pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            return NamingEvent::Continue;
+        }
+        if key.code == KeyCode::Esc {
+            return NamingEvent::Cancel;
+        }
+        let event = match self.screen {
+            NamingScreen::Intent => self.handle_intent_key(key, graph),
+            NamingScreen::Classification => self.handle_classification_key(key),
+            NamingScreen::Result => self.handle_result_key(key),
+        };
+        if self.screen == NamingScreen::Intent {
+            self.refresh_suggestions(graph);
+        }
+        event
+    }
+
+    // ── Screen 1: Intent ─────────────────────────────────────────────────────
+
+    fn handle_intent_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.advance_to_classification(graph);
+                NamingEvent::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.selected_suggestion > 0 {
+                    self.selected_suggestion -= 1;
+                }
+                NamingEvent::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.suggestions.is_empty()
+                    && self.selected_suggestion < self.suggestions.len() - 1
+                {
+                    self.selected_suggestion += 1;
+                }
+                NamingEvent::Continue
+            }
+            _ => {
+                self.intent.handle_event(&crossterm::event::Event::Key(key));
+                NamingEvent::Continue
+            }
+        }
+    }
+
+    fn advance_to_classification(&mut self, graph: &TokenGraph) {
+        let intent = self.intent.value().to_string();
+        if !intent.is_empty() && self.classification.property.value().is_empty() {
+            if let Some(top) = self.suggestions.first() {
+                if let Some(prop) = top
+                    .name_object
+                    .as_ref()
+                    .and_then(|n| n.get("property"))
+                    .and_then(|v| v.as_str())
+                {
+                    self.classification.property = Input::from(prop.to_string());
+                }
+            }
+        }
+        let _ = graph; // graph available for future primer-seeding
+        self.screen = NamingScreen::Classification;
+    }
+
+    // ── Screen 2: Classification ─────────────────────────────────────────────
+
+    fn handle_classification_key(&mut self, key: KeyEvent) -> NamingEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.screen = NamingScreen::Result;
+                NamingEvent::Continue
+            }
+            KeyCode::Tab => {
+                let count = self.classification.field_count();
+                self.classification.focused_field =
+                    (self.classification.focused_field + 1) % count;
+                NamingEvent::Continue
+            }
+            KeyCode::BackTab => {
+                let count = self.classification.field_count();
+                let f = self.classification.focused_field;
+                self.classification.focused_field = if f == 0 { count - 1 } else { f - 1 };
+                NamingEvent::Continue
+            }
+            KeyCode::Left | KeyCode::Char('h') if self.classification.focused_field == 0 => {
+                self.classification.layer = cycle_layer_backward(self.classification.layer);
+                NamingEvent::Continue
+            }
+            KeyCode::Right | KeyCode::Char('l') if self.classification.focused_field == 0 => {
+                self.classification.layer = cycle_layer_forward(self.classification.layer);
+                NamingEvent::Continue
+            }
+            KeyCode::Char('+') => {
+                self.classification.name_fields.push(NameField {
+                    key: "key".to_string(),
+                    value: Input::default(),
+                });
+                NamingEvent::Continue
+            }
+            _ => {
+                let focused = self.classification.focused_field;
+                if focused == 1 {
+                    self.classification
+                        .property
+                        .handle_event(&crossterm::event::Event::Key(key));
+                } else if focused >= 2 {
+                    let idx = focused - 2;
+                    if let Some(field) = self.classification.name_fields.get_mut(idx) {
+                        field.value.handle_event(&crossterm::event::Event::Key(key));
+                    }
+                }
+                NamingEvent::Continue
+            }
+        }
+    }
+
+    // ── Screen 3: Result ─────────────────────────────────────────────────────
+
+    fn handle_result_key(&mut self, key: KeyEvent) -> NamingEvent {
+        match key.code {
+            KeyCode::Char('c') | KeyCode::Char('y') => {
+                let name = self.assembled_name();
+                NamingEvent::Copy(name)
+            }
+            KeyCode::Char('e') => {
+                self.screen = NamingScreen::Classification;
+                NamingEvent::Continue
+            }
+            KeyCode::Char('q') => NamingEvent::Cancel,
+            _ => NamingEvent::Continue,
+        }
+    }
+}
+
+impl Default for NamingWizardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -59,7 +59,7 @@ pub struct ClassificationDraft {
 }
 
 impl ClassificationDraft {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             layer: Layer::Foundation,
             property: Input::default(),
@@ -68,8 +68,14 @@ impl ClassificationDraft {
         }
     }
 
-    fn field_count(&self) -> usize {
+    pub fn field_count(&self) -> usize {
         2 + self.name_fields.len() // layer + property + name_fields
+    }
+}
+
+impl Default for ClassificationDraft {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -532,18 +538,7 @@ impl WizardState {
 
     /// The assembled token name derived from classification fields (property + name fields).
     pub fn assembled_name(&self) -> String {
-        let mut parts: Vec<String> = Vec::new();
-        let prop = self.classification.property.value().trim().to_string();
-        if !prop.is_empty() {
-            parts.push(prop);
-        }
-        for field in &self.classification.name_fields {
-            let v = field.value.value().trim().to_string();
-            if !v.is_empty() {
-                parts.push(v);
-            }
-        }
-        parts.join("-")
+        assemble_name_from_classification(&self.classification)
     }
 
     /// Build a unified diff between the current and predicted post-write state of the
@@ -616,6 +611,25 @@ impl Default for WizardState {
     }
 }
 
+// ── Shared widget helpers ────────────────────────────────────────────────────
+
+/// Assemble a token name from classification fields (property + name fields).
+/// Shared by the authoring and naming wizards.
+pub fn assemble_name_from_classification(classification: &ClassificationDraft) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let prop = classification.property.value().trim().to_string();
+    if !prop.is_empty() {
+        parts.push(prop);
+    }
+    for field in &classification.name_fields {
+        let v = field.value.value().trim().to_string();
+        if !v.is_empty() {
+            parts.push(v);
+        }
+    }
+    parts.join("-")
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /// Derive the target file path from `layer` and `property`.
@@ -674,7 +688,7 @@ fn build_token_value(rows: &[ValueRow]) -> serde_json::Value {
     }
 }
 
-fn cycle_layer_forward(layer: Layer) -> Layer {
+pub fn cycle_layer_forward(layer: Layer) -> Layer {
     match layer {
         Layer::Foundation => Layer::Platform,
         Layer::Platform => Layer::Product,
@@ -682,7 +696,7 @@ fn cycle_layer_forward(layer: Layer) -> Layer {
     }
 }
 
-fn cycle_layer_backward(layer: Layer) -> Layer {
+pub fn cycle_layer_backward(layer: Layer) -> Layer {
     match layer {
         Layer::Foundation => Layer::Product,
         Layer::Platform => Layer::Foundation,

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -1,0 +1,388 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::find::{FindEvent, FindScreen, FindWizardState};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn make_graph() -> TokenGraph {
+    let records: Vec<TokenRecord> = vec![
+        TokenRecord {
+            name: "accent-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": {
+                    "property": "background-color",
+                    "variant": "accent"
+                }
+            }),
+            layer: Layer::Foundation,
+        },
+        TokenRecord {
+            name: "neutral-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 1,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#FFFFFF",
+                "name": {
+                    "property": "background-color",
+                    "variant": "neutral"
+                }
+            }),
+            layer: Layer::Foundation,
+        },
+        TokenRecord {
+            name: "button-accent-color".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 2,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": {
+                    "property": "color",
+                    "component": "button",
+                    "variant": "accent"
+                }
+            }),
+            layer: Layer::Platform,
+        },
+    ];
+    TokenGraph::from_records(records)
+}
+
+// ── FindWizardState unit tests ───────────────────────────────────────────────
+
+#[test]
+fn new_state_is_on_filters_screen() {
+    let fs = FindWizardState::new();
+    assert_eq!(fs.screen, FindScreen::Filters);
+}
+
+#[test]
+fn new_with_intent_seeds_intent_field_and_focuses_it() {
+    let fs = FindWizardState::new_with_intent("accent background");
+    assert_eq!(fs.intent.value(), "accent background");
+    assert_eq!(fs.focused_field, 4); // intent field index
+}
+
+#[test]
+fn new_with_empty_intent_leaves_focus_at_property() {
+    let fs = FindWizardState::new_with_intent("");
+    assert_eq!(fs.focused_field, 0);
+}
+
+#[test]
+fn assemble_expr_from_property_and_variant() {
+    let mut fs = FindWizardState::new();
+    // Tab to property field (already there at 0), type value.
+    let graph = make_graph();
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    // Tab to component (skip), Tab to variant.
+    fs.handle_key(key(KeyCode::Tab), &graph); // → component
+    fs.handle_key(key(KeyCode::Tab), &graph); // → variant
+    for c in "accent".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    let expr = fs.assemble_expr().unwrap();
+    assert_eq!(expr, "property=background-color,variant=accent");
+}
+
+#[test]
+fn assemble_expr_returns_none_when_all_fields_empty() {
+    let fs = FindWizardState::new();
+    assert!(fs.assemble_expr().is_none());
+}
+
+#[test]
+fn refresh_preview_populates_rows_for_structured_filter() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // Set property field directly via handle_key.
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    fs.refresh_preview(&graph);
+    assert_eq!(fs.preview_count, 2); // accent + neutral background-color tokens
+    assert!(fs.preview_error.is_none());
+}
+
+#[test]
+fn refresh_preview_uses_suggest_when_only_intent_filled() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new_with_intent("accent background");
+    fs.refresh_preview(&graph);
+    // suggest should find the accent-background-color-default token.
+    assert!(fs.preview_count > 0);
+    assert!(fs.preview_rows.iter().any(|r| r.name.contains("accent")));
+    assert!(fs.preview_error.is_none());
+}
+
+#[test]
+fn refresh_preview_is_empty_when_nothing_filled() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.refresh_preview(&graph);
+    assert_eq!(fs.preview_count, 0);
+    assert!(fs.preview_rows.is_empty());
+    assert!(fs.preview_error.is_none());
+}
+
+#[test]
+fn enter_on_filters_advances_to_preview() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, FindEvent::Continue));
+    assert_eq!(fs.screen, FindScreen::Preview);
+}
+
+#[test]
+fn enter_on_preview_emits_open_results() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // Set property field.
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    // Advance to preview.
+    fs.handle_key(key(KeyCode::Enter), &graph);
+    assert_eq!(fs.screen, FindScreen::Preview);
+    // Accept preview.
+    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, FindEvent::OpenResults(_)));
+}
+
+#[test]
+fn open_results_view_has_correct_row_count() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Enter), &graph); // Accept
+    if let FindEvent::OpenResults(view) = event {
+        assert_eq!(view.rows.len(), 2);
+        assert_eq!(view.expr_text, "property=background-color");
+    } else {
+        panic!("expected OpenResults");
+    }
+}
+
+#[test]
+fn e_on_preview_goes_back_to_filters() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Char('e')), &graph);
+    assert!(matches!(event, FindEvent::Continue));
+    assert_eq!(fs.screen, FindScreen::Filters);
+}
+
+#[test]
+fn esc_cancels_on_filters_screen() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    let event = fs.handle_key(key(KeyCode::Esc), &graph);
+    assert!(matches!(event, FindEvent::Cancel));
+}
+
+#[test]
+fn esc_cancels_on_preview_screen() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Esc), &graph);
+    assert!(matches!(event, FindEvent::Cancel));
+}
+
+#[test]
+fn q_cancels_on_preview_screen() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Char('q')), &graph);
+    assert!(matches!(event, FindEvent::Cancel));
+}
+
+#[test]
+fn tab_cycles_through_fields() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    assert_eq!(fs.focused_field, 0);
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    assert_eq!(fs.focused_field, 1);
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    assert_eq!(fs.focused_field, 2);
+    // BackTab goes backward.
+    fs.handle_key(key(KeyCode::BackTab), &graph);
+    assert_eq!(fs.focused_field, 1);
+}
+
+#[test]
+fn tab_wraps_around_from_last_to_first_field() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // Jump to last field (4 = intent).
+    for _ in 0..4 {
+        fs.handle_key(key(KeyCode::Tab), &graph);
+    }
+    assert_eq!(fs.focused_field, 4);
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    assert_eq!(fs.focused_field, 0);
+}
+
+#[test]
+fn property_suggestions_filter_by_typed_prefix() {
+    let mut fs = FindWizardState::new();
+    let graph = make_graph();
+    for c in "background".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    // The registry should have terms containing "background".
+    assert!(!fs.property_suggestions.is_empty());
+    assert!(fs.property_suggestions.iter().all(|s| s.contains("background")));
+}
+
+#[test]
+fn up_down_navigate_property_suggestions() {
+    let mut fs = FindWizardState::new();
+    let graph = make_graph();
+    // Type something to get suggestions.
+    for c in "back".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    let initial = fs.selected_property_suggestion;
+    if fs.property_suggestions.len() > 1 {
+        fs.handle_key(key(KeyCode::Down), &graph);
+        assert_eq!(fs.selected_property_suggestion, initial + 1);
+        fs.handle_key(key(KeyCode::Up), &graph);
+        assert_eq!(fs.selected_property_suggestion, initial);
+    }
+}
+
+// ── App-level integration tests ──────────────────────────────────────────────
+
+fn submit(app: &mut App, graph: &TokenGraph, cmd: &str) {
+    let ctx = SubmitContext::new(graph);
+    for c in cmd.chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    app.submit_palette(&ctx);
+}
+
+fn open_palette_cmd(app: &mut App) {
+    app.handle_key(key(KeyCode::Char(':')));
+}
+
+#[test]
+fn find_command_opens_find_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+    assert!(matches!(app.modal, Some(Modal::Find(_))));
+}
+
+#[test]
+fn find_command_with_args_seeds_intent() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find accent background");
+    if let Some(Modal::Find(ref fs)) = app.modal {
+        assert_eq!(fs.intent.value(), "accent background");
+    } else {
+        panic!("expected Find modal");
+    }
+}
+
+#[test]
+fn find_command_no_args_opens_empty_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+    assert!(matches!(app.modal, Some(Modal::Find(_))));
+}
+
+#[test]
+fn tab_autocompletes_find_command() {
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    // "fi" is unambiguous — only "find" starts with "fi".
+    app.handle_key(key(KeyCode::Char('f')));
+    app.handle_key(key(KeyCode::Char('i')));
+    app.handle_key(key(KeyCode::Tab));
+    assert_eq!(app.palette_input.value(), "find ");
+}
+
+#[test]
+fn esc_in_find_modal_closes_it() {
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+    app.handle_modal_key(key(KeyCode::Esc), &ctx);
+    assert!(app.modal.is_none());
+}
+
+#[test]
+fn accepting_preview_opens_query_view_and_closes_modal() {
+    use design_data_tui::app::ActiveView;
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+
+    // On Filters: type property, then Enter → Preview.
+    if let Some(Modal::Find(ref mut fs)) = app.modal {
+        for c in "background-color".chars() {
+            fs.handle_key(key(KeyCode::Char(c)), &graph);
+        }
+    }
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Preview
+
+    // On Preview: Enter → OpenResults.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+
+    assert!(app.modal.is_none());
+    assert!(matches!(app.active_view, ActiveView::Query(_)));
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("matched"), "expected 'matched' in status: {msg}");
+}

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -1,0 +1,240 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::naming::{NamingEvent, NamingScreen, NamingWizardState};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn make_graph() -> TokenGraph {
+    let records: Vec<TokenRecord> = vec![
+        TokenRecord {
+            name: "accent-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": { "property": "background-color", "variant": "accent" }
+            }),
+            layer: Layer::Foundation,
+        },
+    ];
+    TokenGraph::from_records(records)
+}
+
+// ── NamingWizardState unit tests ─────────────────────────────────────────────
+
+#[test]
+fn assembled_name_joins_property_and_name_fields() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // Tab to move focus to property field (focused_field 0→1).
+    ns.handle_key(key(KeyCode::Tab), &graph);
+    for c in "background-color".chars() {
+        ns.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    assert_eq!(ns.assembled_name(), "background-color");
+}
+
+#[test]
+fn new_with_intent_seeds_intent_field() {
+    let ns = NamingWizardState::new_with_intent("accent background color");
+    assert_eq!(ns.intent.value(), "accent background color");
+    assert_eq!(ns.screen, NamingScreen::Intent);
+}
+
+#[test]
+fn enter_on_intent_screen_advances_to_classification() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new_with_intent("background color");
+    ns.refresh_suggestions(&graph);
+    let event = ns.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, NamingEvent::Continue));
+    assert_eq!(ns.screen, NamingScreen::Classification);
+}
+
+#[test]
+fn enter_on_classification_screen_advances_to_result() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    let event = ns.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, NamingEvent::Continue));
+    assert_eq!(ns.screen, NamingScreen::Result);
+}
+
+#[test]
+fn c_on_result_screen_returns_copy_event() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // Tab to property field, then type.
+    ns.handle_key(key(KeyCode::Tab), &graph);
+    for c in "color".chars() {
+        ns.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    ns.handle_key(key(KeyCode::Enter), &graph); // advance to Result
+    assert_eq!(ns.screen, NamingScreen::Result);
+
+    let event = ns.handle_key(key(KeyCode::Char('c')), &graph);
+    assert!(matches!(event, NamingEvent::Copy(ref name) if name == "color"));
+}
+
+#[test]
+fn e_on_result_screen_goes_back_to_classification() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Result;
+    let event = ns.handle_key(key(KeyCode::Char('e')), &graph);
+    assert!(matches!(event, NamingEvent::Continue));
+    assert_eq!(ns.screen, NamingScreen::Classification);
+}
+
+#[test]
+fn esc_on_any_screen_cancels() {
+    let graph = make_graph();
+    for start_screen in [NamingScreen::Intent, NamingScreen::Classification, NamingScreen::Result] {
+        let mut ns = NamingWizardState::new();
+        ns.screen = start_screen;
+        let event = ns.handle_key(key(KeyCode::Esc), &graph);
+        assert!(matches!(event, NamingEvent::Cancel));
+    }
+}
+
+#[test]
+fn q_on_result_screen_cancels() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Result;
+    let event = ns.handle_key(key(KeyCode::Char('q')), &graph);
+    assert!(matches!(event, NamingEvent::Cancel));
+}
+
+#[test]
+fn layer_cycles_with_arrow_keys_on_classification() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // focused_field == 0 (layer), right cycles forward Foundation → Platform.
+    ns.handle_key(key(KeyCode::Right), &graph);
+    assert_eq!(ns.classification.layer, Layer::Platform);
+    ns.handle_key(key(KeyCode::Left), &graph);
+    assert_eq!(ns.classification.layer, Layer::Foundation);
+}
+
+// ── App-level integration tests ───────────────────────────────────────────────
+
+fn submit(app: &mut App, graph: &TokenGraph, cmd: &str) {
+    let ctx = SubmitContext::new(graph);
+    let chars: Vec<char> = cmd.chars().collect();
+    for c in chars {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    app.submit_palette(&ctx);
+}
+
+fn open_palette_cmd(app: &mut App) {
+    app.handle_key(key(KeyCode::Char(':')));
+}
+
+#[test]
+fn name_command_opens_naming_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name accent background");
+    assert!(matches!(app.modal, Some(Modal::Naming(_))));
+}
+
+#[test]
+fn name_command_no_args_opens_naming_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name");
+    assert!(matches!(app.modal, Some(Modal::Naming(_))));
+}
+
+#[test]
+fn name_command_seeds_intent_from_args() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name accent background");
+    if let Some(Modal::Naming(ref ns)) = app.modal {
+        assert_eq!(ns.intent.value(), "accent background");
+    } else {
+        panic!("expected Naming modal");
+    }
+}
+
+#[test]
+fn tab_autocompletes_name_command() {
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    // "na" is unambiguous — "name" is the only command with that prefix.
+    app.handle_key(key(KeyCode::Char('n')));
+    app.handle_key(key(KeyCode::Char('a')));
+    app.handle_key(key(KeyCode::Tab));
+    assert_eq!(app.palette_input.value(), "name ");
+}
+
+#[test]
+fn copy_event_sets_pending_yank_and_status() {
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name");
+
+    // Drive to result screen with a property typed.
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+
+    // Enter on intent screen → Classification.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // On Classification: Tab to property field, type "color", then Enter → Result.
+    app.handle_modal_key(key(KeyCode::Tab), &ctx);
+    for c in "color".chars() {
+        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+    }
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // On Result: press 'c' → Copy.
+    app.handle_modal_key(key(KeyCode::Char('c')), &ctx);
+
+    assert_eq!(app.pending_yank.as_deref(), Some("color"));
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
+}
+
+#[test]
+fn esc_in_naming_modal_closes_it() {
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "name");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+    app.handle_modal_key(key(KeyCode::Esc), &ctx);
+    assert!(app.modal.is_none());
+}


### PR DESCRIPTION
## Description

Adds a standalone query wizard launched via `:find [<intent>]` in the TUI palette. The wizard guides users through assembling a token-graph search without needing to know the query DSL, then hands off to the existing `ActiveView::Query` results view.

**Two-screen flow:**
1. **Filters** — property picklist (from `RegistryData` registry vocabulary, matching by substring as you type), component/variant/state free-text inputs, and an intent fallback (`suggest::suggest`-ranked results when no structured filter is set).
2. **Preview** — shows the assembled expression, match count, and up to 20 rows. `Enter` opens the full results table; `e` returns to Filters; `Esc`/`q` cancel.

The `:query` command (one-shot DSL path) is unchanged.

Also fixes a stale doc comment on `RegistryData::for_field` that incorrectly listed `property` as a field without a registry.

## Related Issue

Part of RFC #973 Q2 Track B. Track A (`:name`) shipped in #999.

## Motivation and Context

The existing `:query` command requires knowing the DSL syntax (`property=background-color,variant=accent`). New contributors don't. This wizard offers a guided path using the registered property vocabulary and free-text narrowing, with live match counts, without adding any new query engine or DSL extension.

Track B is also the third wizard-pattern data point needed before evaluating a `WizardChassis` trait extraction (D3 deferred from the RFC).

## How Has This Been Tested?

25 new tests in `sdk/tui/tests/find.rs`:
- `FindWizardState` state machine: screen transitions, `assemble_expr`, `refresh_preview` (both structured-filter and suggest-fallback paths), field cycling (Tab/BackTab), property autocomplete dropdown navigation.
- App-level integration: `:find` opens the modal, intent seeding from args, Tab autocomplete for `"find "`, Esc closes, accepting preview opens `ActiveView::Query` and clears the modal.

All 140 existing TUI tests pass. `cargo clippy --workspace -- -D warnings` clean.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)