### PR TITLE
feat(sdk/tui): standalone query wizard via :find (RFC #973 Q2 Track B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Packages in this monorepo:
 * [Spectrum Design Data MCP](tools/spectrum-design-data-mcp/) Model Context Protocol server providing AI assistants with structured access to Spectrum design system data.
 * [S2 Docs MCP](tools/s2-docs-mcp/) MCP server providing AI assistants with access to Spectrum 2 component documentation and design guidelines.
 
+## SDK & TUI
+
+* [design-data-tui](sdk/tui/) interactive terminal UI for authoring and inspecting tokens — command palette, cascade resolver, validator, and four-screen guided authoring wizard.
+
 ## Setup monorepo locally
 
 1. Install pnpm using [this guide](https://pnpm.io/installation).

--- a/sdk/core/src/registry.rs
+++ b/sdk/core/src/registry.rs
@@ -69,7 +69,7 @@ impl RegistryData {
     }
 
     /// Look up the vocabulary set for a name-object field.
-    /// Returns `None` for fields without a registry (e.g. `property`, mode-set fields).
+    /// Returns `None` for fields without a registry (e.g. mode-set fields).
     pub fn for_field(&self, field: &str) -> Option<&HashSet<String>> {
         self.registries.get(field)
     }

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -69,6 +69,20 @@ tasks:
       - warnings
     inputs:
       - "@globs(sources)"
+  tui:
+    command: cargo
+    args:
+      - run
+      - -p
+      - design-data-tui
+      - --release
+      - --
+      - packages/tokens/dist/json
+      - --theme
+      - spectrum
+      - --no-resume-wizard
+    platform: system
+    local: true
   version:
     command: node
     args:

--- a/sdk/tui/DEMO.md
+++ b/sdk/tui/DEMO.md
@@ -1,0 +1,337 @@
+# design-data-tui Demo Script
+
+Two tracks. **Track A** (\~5 min) is for Adobe leadership — outcome-focused, minimal
+jargon. **Track B** (\~15 min) adds technical depth for the Spectrum team and builds on
+top of Track A.
+
+***
+
+## Setup (both tracks)
+
+Run this once before the demo starts. Use a truecolor terminal at ≥120×36 so the
+Spectrum theme and wizard modal render cleanly.
+
+```bash
+cd /path/to/spectrum-design-data
+
+# Clean slate (use this for recordings or first demo run)
+cargo run -p design-data-tui --release -- \
+  packages/tokens/dist/json \
+  --theme spectrum \
+  --no-resume-wizard
+
+# Draft-restore variant (for the "survives crashes" beat — omit --no-resume-wizard)
+cargo run -p design-data-tui --release -- \
+  packages/tokens/dist/json \
+  --theme spectrum
+```
+
+> **Troubleshooting**: if `cargo run` is slow, build first:
+> `cargo build -p design-data-tui --release`
+> then run the binary directly from `sdk/target/release/design-data-tui`.
+
+***
+
+## Track A — Adobe Leadership (\~5 min)
+
+**Story arc:** *"Authoring a new Spectrum token used to mean editing JSON by hand,
+guessing at naming, and hoping the cascade was correct. Now it's a guided flow that
+nudges reuse first — keeping the design system coherent by default."*
+
+***
+
+### Beat 1 — Scale of the token system (30 s)
+
+**Talking point:** "Before we write anything, let's see what's already here."
+
+| Keys                               | Action                            |
+| ---------------------------------- | --------------------------------- |
+| `:`                                | Open palette in command mode      |
+| `query background-color/*` `Enter` | Filter to background-color tokens |
+
+Expected: table with Name / Value / File / Layer columns. The primer header reads
+`▶ 2460 tokens · packages/tokens/dist/json`. Scroll a few rows with `j`/`k` to
+show there are many.
+
+*"2,460 tokens, all managed in JSON. The TUI loads them in a second and lets you
+search them like a database."*
+
+**Esc** to return to empty view.
+
+***
+
+### Beat 2 — Cascade resolution (45 s)
+
+**Talking point:** "Every token participates in a cascade — like CSS specificity but
+for design. Let's see who wins for `accent-background-color-default` in dark mode."
+
+| Keys                                                                        | Action       |
+| --------------------------------------------------------------------------- | ------------ |
+| `:`                                                                         | Open palette |
+| `resolve property=accent-background-color-default,colorScheme=dark` `Enter` | Run resolve  |
+
+Expected: table with ★ / Name / Value / File / Layer / Spec columns. One row has ★
+in the first column — that's the winning token for this mode combination.
+
+*"The ★ marks the winner. The Spec column is the specificity score — same idea as CSS
+cascade but deterministic and auditable."*
+
+**Esc** to return.
+
+***
+
+### Beat 3 — Reuse-first (the headline moment) (90 s)
+
+**Talking point:** "Now let's try to author a new token. Watch what happens."
+
+| Keys                            | Action                             |
+| ------------------------------- | ---------------------------------- |
+| `:`                             | Open palette                       |
+| `new accent background` `Enter` | Open wizard with intent pre-filled |
+
+Expected: Wizard Screen 1 (Intent). The **reuse-first banner** appears in accent
+color:
+
+```
+These tokens already exist for similar intents.
+Reusing one keeps the cascade healthy.  Tab to alias · Enter to create new
+```
+
+Suggestions list shows existing `accent-background-color-*` tokens with confidence
+scores.
+
+*"The system recognized that tokens for this intent already exist. The banner is only
+shown when confidence is high enough — it won't cry wolf. If we Tab here, we get an
+alias path instead of a duplicate."*
+
+Press **Tab** to accept the top suggestion and jump to Screen 4 (Confirm). Show the
+diff preview — it's an alias, not a net-new value.
+
+*"One keystroke, and the cascade stays healthy."*
+
+**Esc** to cancel (we'll create a real one next).
+
+***
+
+### Beat 4 — Full authoring wizard (90 s)
+
+**Talking point:** "Now let's author something genuinely new."
+
+| Keys                               | Action                                       |
+| ---------------------------------- | -------------------------------------------- |
+| `:`                                | Open palette                                 |
+| `new custom brand overlay` `Enter` | Open wizard — no reuse banner (novel intent) |
+| `Enter`                            | Proceed to Screen 2 (Classification)         |
+
+Screen 2: tab through Layer (Foundation → Platform → Product with `←`/`→`), Property,
+name fields. Show the live **Preview** at the bottom updating as you type.
+
+*"Layer, property, name — the three-part naming taxonomy from the Spectrum spec. The
+preview shows the assembled token name as you go."*
+
+`Enter` → Screen 3 (Values): show the mode-combo rows (one per color-scheme × scale
+combination). Toggle a row between `alias` and `literal` with `a`/`l`.
+
+*"Every mode combination gets a value. You can alias to existing tokens or enter a
+literal value. The cascade is set up correctly by default."*
+
+`Enter` → Screen 4 (Confirm): type a short rationale in the rationale box. Show the
+live **diff preview** updating as you type.
+
+*"Screen 4 requires a rationale before Submit is enabled. The diff shows exactly what
+will be written to disk — no surprises."*
+
+**Esc** to cancel (no `--allow-write` on this run).
+
+***
+
+### Beat 5 — Draft persistence (45 s)
+
+**Talking point:** "One more thing — the wizard saves your work automatically."
+
+Start a new wizard (`:new something experimental` `Enter`), fill in a couple of
+fields, then press **Ctrl-C** to kill the process abruptly.
+
+Relaunch **without** `--no-resume-wizard`:
+
+```bash
+cargo run -p design-data-tui --release -- packages/tokens/dist/json --theme spectrum
+```
+
+Open the wizard again: `:` → `new` `Enter`. The draft from the previous session is
+restored.
+
+*"The wizard persists drafts across crashes, context switches, and reboots. You never
+lose work in progress."*
+
+***
+
+## Track B — Spectrum Team (15 min)
+
+Run the full Track A first (\~5 min), then continue here.
+
+***
+
+### Beat B1 — Schema introspection with `:describe` (2 min)
+
+| Keys                      | Action                              |
+| ------------------------- | ----------------------------------- |
+| `:`                       | Open palette                        |
+| `describe button` `Enter` | Inspect the button component schema |
+
+Expected: scrollable pretty-JSON view of `button.json` from the spec bundle.
+
+Navigate with `j`/`k` (line) or `PgDn`/`PgUp` (10 lines). The block title shows
+`Describe: button`.
+
+*"`:describe` pulls any component schema from the spec bundle — the same source the
+wizard reads when it validates token references during authoring."*
+
+**Esc** to return.
+
+***
+
+### Beat B2 — Validation (2 min)
+
+This beat uses the `tokens-bad/` fixture so we get visible errors.
+
+Quit the current session (`q`). Relaunch pointing at the bad fixtures:
+
+```bash
+cargo run -p design-data-tui --release -- \
+  sdk/tui/tests/fixtures/tokens-bad \
+  --theme spectrum \
+  --no-resume-wizard
+```
+
+| Keys               | Action                |
+| ------------------ | --------------------- |
+| `:`                | Open palette          |
+| `validate` `Enter` | Run schema validation |
+
+Expected: table with Sev / Rule / Token / Message columns. `bad-token.json` has a
+non-existent `$schema` URL — the validator will flag it.
+
+*"Sev is severity, Rule is the spec rule ID, Token is the path. You can `y` to yank
+any row's message to clipboard."*
+
+Select a row with `j`/`k`, press `y` — status bar confirms clipboard yank.
+
+Quit and relaunch against the real dataset for the rest of the demo.
+
+***
+
+### Beat B3 — Palette dual-mode + Tab autocomplete + history (2 min)
+
+**Command mode (`:`):**
+
+* Type `:q` — palette autocompletes `query`. Tab to complete.
+* Up arrow — recall previous commands from history.
+* Down arrow — forward through history.
+
+**Fuzzy-find mode (`/`):**
+
+* Press `/` — palette opens in fuzzy-find mode (different prompt prefix).
+* Type `background` — filters tokens live.
+
+*"Two modes for two jobs: `:` is structured commands, `/` is quick fuzzy search across
+token names. Tab autocomplete and Up/Down history work in both."*
+
+***
+
+### Beat B4 — Mouse + text-select mode (2 min)
+
+While in any list view (query, resolve, or validate):
+
+* **Scroll wheel** — moves selection.
+* **Click a row** — selects it directly.
+* Press **`v`** to enter text-selection mode.
+* **Drag** across rows — the dragged text copies to clipboard on release.
+* Press **`v`** again to exit, or use **Shift-drag** to fall back to native terminal
+  selection (bypasses mouse capture).
+
+*"Mouse capture is on by default so scroll and click just work. Text-select mode lets
+you copy token names or values without leaving the keyboard flow — `v` toggles it."*
+
+***
+
+### Beat B5 — Help overlay (30 s)
+
+Press **`?`** from the empty view.
+
+Full keymap renders as a scrollable modal. Press **`?`** or **Esc** to close.
+
+***
+
+### Beat B6 — Code tour (3 min, screen-share the editor)
+
+Key files to show briefly:
+
+| File                          | What to highlight                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `sdk/tui/src/app.rs`          | `App` struct + `ActiveView` enum — the state machine. `submit_palette()` dispatches commands. |
+| `sdk/tui/src/wizard.rs`       | `WizardScreen` enum (4 variants), `WizardState` — the FSM driving the four screens.           |
+| `sdk/tui/src/wizard_draft.rs` | `DraftStore` — serde JSON → `dirs::data_dir()` persistence.                                   |
+| `sdk/tui/src/main.rs`         | `run()` loop — draw → hit-regions → event dispatch. Panic-safe terminal restore.              |
+| `sdk/tui/src/help.rs`         | `HELP_TEXT` — the canonical keymap, shown by `?` overlay.                                     |
+
+***
+
+### Beat B7 — RFC [#973](https://github.com/adobe/spectrum-design-data/issues/973) milestone map (2 min, slides or verbal)
+
+| Milestone | Commit prefix | Feature                                                    |
+| --------- | ------------- | ---------------------------------------------------------- |
+| M0        | `1aea54bf`    | Scaffold — ratatui skeleton, CLI flags                     |
+| M1        | `06d760f0`    | `:query` + table view                                      |
+| M2        | `9edf6f2c`    | `:resolve`, `:describe`, `:validate`, palette autocomplete |
+| M3        | `6351560f`    | Wizard modal — 4 screens + diff preview                    |
+| M4        | `2a2ef3c6`    | Wizard `write_token` integration (`--allow-write`)         |
+| M5        | `1513d010`    | Mouse, help overlay, history, theming                      |
+| Q1        | `efd77375`    | Calibrated suggest threshold + reuse-first banner          |
+| Q3        | `a6a87e2c`    | Wizard draft persistence                                   |
+| Q4        | `3b6c20f4`    | MCP authoring-session parity (sibling `sdk/cli`)           |
+
+*"Every beads issue maps to one or more commits. The full arc from M0 → Q4 is
+roughly 9 months of iterative RFC work, all checkpointed."*
+
+***
+
+## Recording the asciinema casts
+
+```bash
+# Leadership cast — 120×36, clean slate
+asciinema rec sdk/tui/docs/demo-leadership.cast \
+  --cols 120 --rows 36 \
+  --title "design-data-tui — leadership demo"
+
+# Spectrum team cast — same dimensions
+asciinema rec sdk/tui/docs/demo-spectrum.cast \
+  --cols 120 --rows 36 \
+  --title "design-data-tui — Spectrum team demo"
+
+# Convert leadership cast to GIF (requires agg)
+# cargo install --git https://github.com/asciinema/agg
+agg --theme monokai --speed 1.25 \
+  sdk/tui/docs/demo-leadership.cast \
+  sdk/tui/docs/demo-leadership.gif
+```
+
+**Pace tips for recording:**
+
+* Type commands slowly — asciinema captures real timing.
+* Pause \~2 s after each command to let the view settle.
+* For the reuse-first banner beat, pause 3 s on Screen 1 before pressing Tab so
+  viewers can read the banner.
+* Use a font with good box-drawing support (e.g. JetBrains Mono, Cascadia Code).
+
+***
+
+## Fallbacks
+
+| Problem                   | Recovery                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| Reuse banner doesn't fire | Type `accent-background` as the intent — high confidence guaranteed                             |
+| Cargo compile time        | Pre-build: `cargo build -p design-data-tui --release` before demo                               |
+| Terminal leaves raw mode  | Run `reset` in the shell to restore                                                             |
+| Mouse not working         | Ensure terminal supports mouse capture (iTerm2, kitty, wezterm ✓; basic macOS Terminal may not) |
+| Draft not restoring       | Check `~/Library/Application Support/design-data-tui/wizard_draft.json` exists                  |

--- a/sdk/tui/README.md
+++ b/sdk/tui/README.md
@@ -1,0 +1,173 @@
+# design-data-tui
+
+An interactive terminal UI for authoring and inspecting Spectrum design tokens, built
+as part of [RFC #973](https://github.com/orgs/adobe/discussions/TODO). It loads a
+token dataset from JSON, exposes it through a command palette, and provides a
+four-screen guided wizard that nudges reuse over duplication — surfacing existing
+tokens before letting you create a new one.
+
+<!-- demo-leadership.gif goes here once recorded -->
+
+***
+
+## Quick start
+
+```bash
+# From the repo root
+cargo run -p design-data-tui --release -- packages/tokens/dist/json --theme spectrum
+```
+
+The TUI loads the full Spectrum token corpus (\~2 400 tokens) in under a second and
+drops you into an interactive session. Press `?` for the full keymap.
+
+***
+
+## Flags
+
+| Flag                         | Default       | Description                                                                                                                  |
+| ---------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `<dataset>`                  | *(required)*  | Path to a directory of token JSON files                                                                                      |
+| `--theme terminal\|spectrum` | `terminal`    | `terminal` uses terminal-native colors. `spectrum` uses the Adobe Spectrum palette (requires a 24-bit truecolor terminal).   |
+| `--allow-write`              | off           | Enable real disk writes from the wizard Screen 4 Submit. Without this flag the wizard shows a diff preview but never writes. |
+| `--components <dir>`         | auto-detected | Path to component JSON files. Defaults to `packages/design-data-spec/components` relative to the working directory.          |
+| `--mode-sets <dir>`          | auto-detected | Path to mode-set JSON files. Defaults to `packages/design-data-spec/mode-sets`.                                              |
+| `--no-resume-wizard`         | off           | Do not restore an in-progress wizard draft from the previous session. Use this for demo recordings or clean-slate runs.      |
+
+***
+
+## Layout
+
+```
+▶ 2460 tokens  ·  packages/tokens/dist/json          ← primer header
+┌──────────────────────────────────────────────────┐
+│  active view (query / resolve / describe /        │
+│  validate / wizard modal)                         │
+└──────────────────────────────────────────────────┘
+                                                    ← status line (contextual)
+:█                                                  ← palette prompt
+```
+
+***
+
+## Commands
+
+Open the palette with `:` (command mode) or `/` (fuzzy-find mode).
+
+| Command                                           | Description                                                                                                |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `:query <expr>`                                   | Filter tokens. Glob-style: `background-color/*`, `accent-*`                                                |
+| `:resolve property=<name>[,<mode-set>=<mode>...]` | Show cascade resolution for a property with optional mode overrides. The ★ column marks the winning token. |
+| `:describe <component>`                           | Inspect a component schema (JSON, scrollable).                                                             |
+| `:validate`                                       | Validate all loaded tokens against their `$schema`. Shows Sev / Rule / Token / Message.                    |
+| `:new [<intent>]`                                 | Open the four-screen token authoring wizard.                                                               |
+
+***
+
+## Token Authoring Wizard
+
+The wizard guides you through four screens. A **reuse-first banner** appears on
+Screen 1 when the system detects existing tokens that satisfy your intent above a
+calibrated confidence threshold — press `Tab` to alias instead of creating a
+duplicate.
+
+| Screen | Name           | What you do                                                                                                                                       |
+| ------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1      | Intent         | Type your intent. Navigate suggestions with `↑`/`↓`. `Tab` = alias (skips to Screen 4). `Enter` = create new.                                     |
+| 2      | Classification | Set layer (`←`/`→`), property, and name segments. Live name preview updates as you type.                                                          |
+| 3      | Values         | Set a value per mode combination — `a` for alias, `l` for literal, `e` to edit.                                                                   |
+| 4      | Confirm        | Enter rationale (required). Review the live diff preview. `Ctrl+S` to edit `$schema` URL. `Enter` to submit (writes when `--allow-write` is set). |
+
+Wizard drafts are **persisted across sessions** in `~/Library/Application
+Support/design-data-tui/wizard_draft.json` (macOS) or the platform equivalent.
+Relaunch without `--no-resume-wizard` to restore.
+
+***
+
+## Keymap
+
+### Global
+
+| Key      | Action                                    |
+| -------- | ----------------------------------------- |
+| `q`      | Quit (when palette is closed)             |
+| `Ctrl-C` | Always quit                               |
+| `?`      | Toggle help overlay                       |
+| `v`      | Toggle text-selection mode (drag to copy) |
+
+### Palette
+
+| Key       | Action                    |
+| --------- | ------------------------- |
+| `:`       | Open command mode         |
+| `/`       | Open fuzzy-find mode      |
+| `Esc`     | Cancel / close palette    |
+| `Enter`   | Dispatch command          |
+| `Tab`     | Autocomplete command name |
+| `↑` / `↓` | Recall palette history    |
+
+### List views (query / resolve / validate)
+
+| Key          | Action                                    |
+| ------------ | ----------------------------------------- |
+| `↑` / `k`    | Move selection up                         |
+| `↓` / `j`    | Move selection down                       |
+| Scroll wheel | Move selection                            |
+| Click row    | Select that row                           |
+| `y`          | Yank selected name / message to clipboard |
+| `Esc`        | Return to empty view                      |
+
+### Describe view
+
+| Key             | Action               |
+| --------------- | -------------------- |
+| `↑` / `k`       | Scroll up one line   |
+| `↓` / `j`       | Scroll down one line |
+| `PgUp` / `PgDn` | Scroll 10 lines      |
+| Scroll wheel    | Scroll body          |
+| `Esc`           | Return to empty view |
+
+### Wizard
+
+| Screen           | Key                 | Action                                       |
+| ---------------- | ------------------- | -------------------------------------------- |
+| 1 Intent         | `↑`/`↓`             | Navigate suggestions                         |
+| 1 Intent         | `Tab`               | Reuse top suggestion (alias path → Screen 4) |
+| 1 Intent         | `Enter`             | Proceed to Screen 2                          |
+| 2 Classification | `Tab` / `Shift-Tab` | Move between fields                          |
+| 2 Classification | `←` / `→`           | Cycle layer                                  |
+| 2 Classification | `+`                 | Add a name field                             |
+| 3 Values         | `a`                 | Set row kind to Alias                        |
+| 3 Values         | `l`                 | Set row kind to Literal                      |
+| 3 Values         | `e`                 | Edit active row value                        |
+| 4 Confirm        | Type                | Enter rationale                              |
+| 4 Confirm        | `↑`/`↓` / Scroll    | Scroll diff preview                          |
+| 4 Confirm        | `Ctrl+S`            | Edit `$schema` URL                           |
+| 4 Confirm        | `Enter`             | Submit                                       |
+| All              | `Esc`               | Cancel wizard                                |
+
+### Mouse
+
+| Action                | Effect                                       |
+| --------------------- | -------------------------------------------- |
+| Scroll wheel          | Scroll active view or wizard diff            |
+| Click row             | Select that row                              |
+| `v`                   | Enter text-selection mode                    |
+| Drag (in select mode) | Select and copy text                         |
+| `Shift-drag`          | Native terminal selection (bypasses capture) |
+
+***
+
+## Demo
+
+See [DEMO.md](./DEMO.md) for the full demo script (two tracks: Adobe leadership and
+Spectrum team). Recorded casts live in `docs/`:
+
+* `docs/demo-leadership.cast` / `docs/demo-leadership.gif` — \~90 s overview
+* `docs/demo-spectrum.cast` — \~5 min technical walkthrough
+
+***
+
+## Copyright
+
+Copyright 2026 Adobe. All rights reserved.
+Licensed under the [Apache License, Version 2.0](../../LICENSE).

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -613,8 +613,8 @@ impl App {
 
     /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
     fn scroll_active(&mut self, delta: i32) {
-        // Only Wizard and Help modals have scrollable content; bail out for all others.
-        if matches!(self.modal, Some(Modal::Find(_)) | Some(Modal::Naming(_))) {
+        // Only Wizard and Help modals have scrollable content.
+        if !matches!(self.modal, Some(Modal::Wizard(_)) | Some(Modal::Help(_)) | None) {
             return;
         }
         // Wizard diff scroll has priority when a modal is open.

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -23,6 +23,7 @@ use ratatui::widgets::TableState;
 use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
 
+use crate::find::{FindEvent, FindWizardState};
 use crate::naming::{NamingEvent, NamingWizardState};
 use crate::wizard::{WizardCtx, WizardEvent, WizardState};
 use crate::wizard_draft::{
@@ -30,7 +31,8 @@ use crate::wizard_draft::{
 };
 
 /// Command names for Tab autocomplete.
-const KNOWN_COMMANDS: &[&str] = &["name", "new", "query", "resolve", "describe", "validate"];
+const KNOWN_COMMANDS: &[&str] =
+    &["find", "name", "new", "query", "resolve", "describe", "validate"];
 
 /// Max palette history entries persisted to disk.
 const HISTORY_CAP: usize = 200;
@@ -79,7 +81,7 @@ pub struct QueryRow {
 }
 
 impl QueryRow {
-    fn from_record(t: &TokenRecord) -> Self {
+    pub(crate) fn from_record(t: &TokenRecord) -> Self {
         let value = t
             .raw
             .get("value")
@@ -204,6 +206,7 @@ pub struct HelpModal {
 
 /// An overlay modal that temporarily captures all keyboard input.
 pub enum Modal {
+    Find(Box<FindWizardState>),
     Wizard(Box<WizardState>),
     Naming(Box<NamingWizardState>),
     Help(HelpModal),
@@ -476,6 +479,26 @@ impl App {
             return;
         }
 
+        // Find wizard modal.
+        if let Some(Modal::Find(ref mut fs)) = self.modal {
+            let event = fs.handle_key(key, ctx.graph);
+            match event {
+                FindEvent::Cancel => {
+                    self.modal = None;
+                    self.status_message = Some(StatusMessage::info("find wizard cancelled"));
+                }
+                FindEvent::OpenResults(view) => {
+                    let count = view.rows.len();
+                    self.active_view = ActiveView::Query(view);
+                    self.status_message =
+                        Some(StatusMessage::info(format!("{count} token(s) matched")));
+                    self.modal = None;
+                }
+                FindEvent::Continue => {}
+            }
+            return;
+        }
+
         // Naming modal — handled independently; no WizardCtx needed.
         if let Some(Modal::Naming(ref mut ns)) = self.modal {
             let event = ns.handle_key(key, ctx.graph);
@@ -590,8 +613,8 @@ impl App {
 
     /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
     fn scroll_active(&mut self, delta: i32) {
-        // Naming modal has no scrollable content.
-        if matches!(self.modal, Some(Modal::Naming(_))) {
+        // Find and Naming modals have no scrollable content.
+        if matches!(self.modal, Some(Modal::Find(_)) | Some(Modal::Naming(_))) {
             return;
         }
         // Wizard diff scroll has priority when a modal is open.
@@ -1042,6 +1065,11 @@ impl App {
                             Some(StatusMessage::error(format!("validate: {e}")));
                     }
                 }
+            }
+            "find" => {
+                let fs = FindWizardState::new_with_intent(rest.trim());
+                self.modal = Some(Modal::Find(Box::new(fs)));
+                self.status_message = None;
             }
             "name" => {
                 let mut ns = NamingWizardState::new_with_intent(rest.trim());

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -613,7 +613,7 @@ impl App {
 
     /// Scroll the active scrollable region by `delta` rows (+1 = down, -1 = up).
     fn scroll_active(&mut self, delta: i32) {
-        // Find and Naming modals have no scrollable content.
+        // Only Wizard and Help modals have scrollable content; bail out for all others.
         if matches!(self.modal, Some(Modal::Find(_)) | Some(Modal::Naming(_))) {
             return;
         }

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -25,6 +25,7 @@ use tui_input::backend::crossterm::EventHandler;
 use crate::app::{QueryRow, QueryView};
 
 pub const MAX_PROPERTY_SUGGESTIONS: usize = 8;
+pub const MAX_SUGGEST_RESULTS: usize = 20;
 
 /// The two wizard screens.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,8 +169,8 @@ impl FindWizardState {
         } else if !self.intent.value().trim().is_empty() {
             // assemble_expr() returned None, so all structured fields (including property) are
             // empty. Pass no property hint.
-            let intent = self.intent.value().to_string();
-            let results = suggest::suggest(graph, &intent, None, 20);
+            let intent = self.intent.value().trim().to_string();
+            let results = suggest::suggest(graph, &intent, None, MAX_SUGGEST_RESULTS);
             self.preview_count = results.len();
             self.preview_rows = results.iter().map(suggestion_to_row).collect();
             self.preview_error = None;
@@ -178,6 +179,11 @@ impl FindWizardState {
             self.preview_rows.clear();
             self.preview_error = None;
         }
+        debug_assert_eq!(
+            self.preview_count,
+            self.preview_rows.len(),
+            "preview_count must stay in sync with preview_rows.len()"
+        );
     }
 
     /// Recompute property autocomplete suggestions from the registry.

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -24,6 +24,8 @@ use tui_input::backend::crossterm::EventHandler;
 
 use crate::app::{QueryRow, QueryView};
 
+pub const MAX_PROPERTY_SUGGESTIONS: usize = 8;
+
 /// The two wizard screens.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FindScreen {
@@ -164,12 +166,10 @@ impl FindWizardState {
                 }
             }
         } else if !self.intent.value().trim().is_empty() {
+            // assemble_expr() returned None, so all structured fields (including property) are
+            // empty. Pass no property hint.
             let intent = self.intent.value().to_string();
-            let prop_hint = {
-                let v = self.property.value().trim().to_string();
-                if v.is_empty() { None } else { Some(v) }
-            };
-            let results = suggest::suggest(graph, &intent, prop_hint.as_deref(), 20);
+            let results = suggest::suggest(graph, &intent, None, 20);
             self.preview_count = results.len();
             self.preview_rows = results.iter().map(suggestion_to_row).collect();
             self.preview_error = None;
@@ -192,7 +192,7 @@ impl FindWizardState {
             let mut matching: Vec<String> =
                 terms.iter().filter(|t| t.to_lowercase().contains(&typed)).cloned().collect();
             matching.sort();
-            matching.truncate(8);
+            matching.truncate(MAX_PROPERTY_SUGGESTIONS);
             self.property_suggestions = matching;
         } else {
             self.property_suggestions.clear();

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -1,0 +1,315 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Standalone find/query wizard — RFC #973 Q2 Track B.
+//!
+//! Two screens: Filters → Preview.
+//! On accept, emits `FindEvent::OpenResults(QueryView)`; the modal closes and
+//! `ActiveView::Query` takes over without a third wizard screen.
+//! Entry point: `:find [<intent>]` in the TUI palette.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use design_data_core::graph::{Layer, TokenGraph};
+use design_data_core::registry::RegistryData;
+use design_data_core::{query, suggest};
+use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
+
+use crate::app::{QueryRow, QueryView};
+
+/// The two wizard screens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindScreen {
+    Filters,
+    Preview,
+}
+
+impl FindScreen {
+    pub const SCREEN_COUNT: u8 = 2;
+
+    pub fn number(self) -> u8 {
+        match self {
+            FindScreen::Filters => 1,
+            FindScreen::Preview => 2,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            FindScreen::Filters => "Filters",
+            FindScreen::Preview => "Preview",
+        }
+    }
+}
+
+/// Outcome of a single key event inside the find wizard.
+pub enum FindEvent {
+    /// Normal; no state change visible to App.
+    Continue,
+    /// User pressed Esc — App should close the modal.
+    Cancel,
+    /// User accepted the preview — App should open this view and close the modal.
+    OpenResults(QueryView),
+}
+
+/// All state for the two-screen find wizard.
+pub struct FindWizardState {
+    pub screen: FindScreen,
+    /// Structured filter inputs (focused_field indices 0–3).
+    pub property: Input,
+    pub component: Input,
+    pub variant: Input,
+    pub state: Input,
+    /// Fallback free-text intent (focused_field index 4).
+    /// Used when no structured filter is filled; drives suggest::suggest.
+    pub intent: Input,
+    /// Which field has keyboard focus (0=property, 1=component, 2=variant, 3=state, 4=intent).
+    pub focused_field: usize,
+    /// Registry-sourced autocomplete suggestions for the property field.
+    pub property_suggestions: Vec<String>,
+    pub selected_property_suggestion: usize,
+    /// All rows from the most recent preview refresh.
+    pub preview_rows: Vec<QueryRow>,
+    /// Total match count (== `preview_rows.len()`).
+    pub preview_count: usize,
+    /// Parse or query error from the most recent refresh, if any.
+    pub preview_error: Option<String>,
+}
+
+impl FindWizardState {
+    pub const FIELD_COUNT: usize = 5;
+
+    pub fn new() -> Self {
+        Self {
+            screen: FindScreen::Filters,
+            property: Input::default(),
+            component: Input::default(),
+            variant: Input::default(),
+            state: Input::default(),
+            intent: Input::default(),
+            focused_field: 0,
+            property_suggestions: Vec::new(),
+            selected_property_suggestion: 0,
+            preview_rows: Vec::new(),
+            preview_count: 0,
+            preview_error: None,
+        }
+    }
+
+    /// Create a state pre-seeded with an intent string.
+    ///
+    /// Seeds the intent field and sets focus there so the user can refine or
+    /// immediately press Enter to see suggest-ranked results.
+    pub fn new_with_intent(intent: &str) -> Self {
+        let mut s = Self::new();
+        if !intent.is_empty() {
+            s.intent = Input::from(intent.to_string());
+            s.focused_field = 4;
+        }
+        s
+    }
+
+    /// Build a query DSL expression from the structured filter fields.
+    ///
+    /// Returns `None` when no structured filter is set, signalling the
+    /// intent-fallback path in `refresh_preview`.
+    pub fn assemble_expr(&self) -> Option<String> {
+        let mut parts = Vec::new();
+        let prop = self.property.value().trim().to_string();
+        let comp = self.component.value().trim().to_string();
+        let var = self.variant.value().trim().to_string();
+        let st = self.state.value().trim().to_string();
+
+        if !prop.is_empty() {
+            parts.push(format!("property={prop}"));
+        }
+        if !comp.is_empty() {
+            parts.push(format!("component={comp}"));
+        }
+        if !var.is_empty() {
+            parts.push(format!("variant={var}"));
+        }
+        if !st.is_empty() {
+            parts.push(format!("state={st}"));
+        }
+
+        if parts.is_empty() { None } else { Some(parts.join(",")) }
+    }
+
+    /// Refresh `preview_rows`, `preview_count`, and `preview_error`.
+    ///
+    /// Uses structured-filter path when any filter field is non-empty;
+    /// falls back to `suggest::suggest` when only `intent` is filled.
+    pub fn refresh_preview(&mut self, graph: &TokenGraph) {
+        if let Some(expr_str) = self.assemble_expr() {
+            match query::parse(&expr_str) {
+                Ok(filter) => {
+                    let records = query::filter(graph, &filter);
+                    self.preview_count = records.len();
+                    self.preview_rows =
+                        records.iter().map(|r| QueryRow::from_record(r)).collect();
+                    self.preview_error = None;
+                }
+                Err(e) => {
+                    self.preview_count = 0;
+                    self.preview_rows.clear();
+                    self.preview_error = Some(e.to_string());
+                }
+            }
+        } else if !self.intent.value().trim().is_empty() {
+            let intent = self.intent.value().to_string();
+            let prop_hint = {
+                let v = self.property.value().trim().to_string();
+                if v.is_empty() { None } else { Some(v) }
+            };
+            let results = suggest::suggest(graph, &intent, prop_hint.as_deref(), 20);
+            self.preview_count = results.len();
+            self.preview_rows = results.iter().map(suggestion_to_row).collect();
+            self.preview_error = None;
+        } else {
+            self.preview_count = 0;
+            self.preview_rows.clear();
+            self.preview_error = None;
+        }
+    }
+
+    /// Recompute property autocomplete suggestions from the registry.
+    pub fn refresh_property_suggestions(&mut self) {
+        let typed = self.property.value().trim().to_lowercase();
+        if typed.is_empty() {
+            self.property_suggestions.clear();
+            self.selected_property_suggestion = 0;
+            return;
+        }
+        if let Some(terms) = RegistryData::embedded().for_field("property") {
+            let mut matching: Vec<String> =
+                terms.iter().filter(|t| t.to_lowercase().contains(&typed)).cloned().collect();
+            matching.sort();
+            matching.truncate(8);
+            self.property_suggestions = matching;
+        } else {
+            self.property_suggestions.clear();
+        }
+        if self.selected_property_suggestion >= self.property_suggestions.len() {
+            self.selected_property_suggestion = 0;
+        }
+    }
+
+    // ── Dispatch ─────────────────────────────────────────────────────────────
+
+    pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> FindEvent {
+        if key.code == KeyCode::Esc {
+            return FindEvent::Cancel;
+        }
+        match self.screen {
+            FindScreen::Filters => self.handle_filters_key(key, graph),
+            FindScreen::Preview => self.handle_preview_key(key),
+        }
+    }
+
+    // ── Screen 1: Filters ────────────────────────────────────────────────────
+
+    fn handle_filters_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> FindEvent {
+        match key.code {
+            KeyCode::Enter => {
+                self.refresh_preview(graph);
+                self.screen = FindScreen::Preview;
+                FindEvent::Continue
+            }
+            KeyCode::Tab => {
+                self.focused_field = (self.focused_field + 1) % Self::FIELD_COUNT;
+                FindEvent::Continue
+            }
+            KeyCode::BackTab => {
+                let f = self.focused_field;
+                self.focused_field = if f == 0 { Self::FIELD_COUNT - 1 } else { f - 1 };
+                FindEvent::Continue
+            }
+            KeyCode::Up if self.focused_field == 0 => {
+                if self.selected_property_suggestion > 0 {
+                    self.selected_property_suggestion -= 1;
+                }
+                FindEvent::Continue
+            }
+            KeyCode::Down if self.focused_field == 0 => {
+                if !self.property_suggestions.is_empty()
+                    && self.selected_property_suggestion
+                        < self.property_suggestions.len() - 1
+                {
+                    self.selected_property_suggestion += 1;
+                }
+                FindEvent::Continue
+            }
+            _ => {
+                self.dispatch_to_focused_field(key);
+                if self.focused_field == 0 {
+                    self.refresh_property_suggestions();
+                }
+                FindEvent::Continue
+            }
+        }
+    }
+
+    fn dispatch_to_focused_field(&mut self, key: KeyEvent) {
+        let ev = crossterm::event::Event::Key(key);
+        match self.focused_field {
+            0 => { self.property.handle_event(&ev); }
+            1 => { self.component.handle_event(&ev); }
+            2 => { self.variant.handle_event(&ev); }
+            3 => { self.state.handle_event(&ev); }
+            4 => { self.intent.handle_event(&ev); }
+            _ => {}
+        }
+    }
+
+    // ── Screen 2: Preview ────────────────────────────────────────────────────
+
+    fn handle_preview_key(&mut self, key: KeyEvent) -> FindEvent {
+        match key.code {
+            KeyCode::Enter => {
+                let expr = self
+                    .assemble_expr()
+                    .unwrap_or_else(|| self.intent.value().trim().to_string());
+                let rows = std::mem::take(&mut self.preview_rows);
+                FindEvent::OpenResults(QueryView::new(expr, rows))
+            }
+            KeyCode::Char('e') => {
+                self.screen = FindScreen::Filters;
+                FindEvent::Continue
+            }
+            KeyCode::Char('q') => FindEvent::Cancel,
+            _ => FindEvent::Continue,
+        }
+    }
+}
+
+impl Default for FindWizardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn suggestion_to_row(s: &suggest::SuggestionResult) -> QueryRow {
+    let value = s
+        .value
+        .as_ref()
+        .map(|v| {
+            if v.is_string() { v.as_str().unwrap_or("").to_string() } else { v.to_string() }
+        })
+        .unwrap_or_default();
+    let file =
+        s.file.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or_default();
+    let layer = match s.layer {
+        Layer::Foundation => "foundation",
+        Layer::Platform => "platform",
+        Layer::Product => "product",
+    };
+    QueryRow { name: s.token_name.clone(), value, file, layer: layer.to_string() }
+}

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -9,6 +9,7 @@
 // governing permissions and limitations under the License.
 
 pub mod app;
+pub mod find;
 pub mod help;
 pub mod naming;
 pub mod theme;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -49,7 +49,7 @@ use ratatui::{
 use design_data_tui::app::{
     ActiveView, App, HitAction, HitRegion, Modal, StatusKind, StatusMessage, SubmitContext,
 };
-use design_data_tui::find::{FindScreen, FindWizardState};
+use design_data_tui::find::{FindScreen, FindWizardState, MAX_PROPERTY_SUGGESTIONS, MAX_SUGGEST_RESULTS};
 use design_data_tui::help::HELP_TEXT;
 use design_data_tui::naming::{NamingScreen, NamingWizardState};
 use design_data_tui::theme::Theme;
@@ -600,8 +600,7 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
     let foc = fs.focused_field;
     let suggest_count = fs.property_suggestions.len() as u16;
     // Reserve rows for property suggestion dropdown, capped at MAX_PROPERTY_SUGGESTIONS.
-    let dropdown_h =
-        suggest_count.min(design_data_tui::find::MAX_PROPERTY_SUGGESTIONS as u16);
+    let dropdown_h = suggest_count.min(MAX_PROPERTY_SUGGESTIONS as u16);
     let field_rows = 4u16; // component, variant, state, intent
 
     let chunks = Layout::default()
@@ -721,7 +720,7 @@ fn render_preview_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
     let display_rows: Vec<Row> = fs
         .preview_rows
         .iter()
-        .take(20)
+        .take(MAX_SUGGEST_RESULTS)
         .map(|r| {
             Row::new(vec![
                 Cell::from(r.name.as_str()),

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -599,14 +599,10 @@ fn render_find(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Them
 fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
     let foc = fs.focused_field;
     let suggest_count = fs.property_suggestions.len() as u16;
-    // Reserve rows for property suggestion dropdown (at most 8, never more than area).
-    let dropdown_h = suggest_count.min(8);
-
-    // Layout: header rows (label + optional dropdown), then remaining fields, then match count.
+    // Reserve rows for property suggestion dropdown, capped at MAX_PROPERTY_SUGGESTIONS.
+    let dropdown_h =
+        suggest_count.min(design_data_tui::find::MAX_PROPERTY_SUGGESTIONS as u16);
     let field_rows = 4u16; // component, variant, state, intent
-    let match_row = 1u16;
-    let available = area.height.saturating_sub(1 + dropdown_h + field_rows + match_row + 1);
-    let _ = available; // layout is fixed; this is just for reference
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -49,6 +49,7 @@ use ratatui::{
 use design_data_tui::app::{
     ActiveView, App, HitAction, HitRegion, Modal, StatusKind, StatusMessage, SubmitContext,
 };
+use design_data_tui::find::{FindScreen, FindWizardState};
 use design_data_tui::help::HELP_TEXT;
 use design_data_tui::naming::{NamingScreen, NamingWizardState};
 use design_data_tui::theme::Theme;
@@ -561,6 +562,192 @@ fn render_naming_result(
     f.render_widget(hint, chunks[1]);
 }
 
+// ── Find wizard render ───────────────────────────────────────────────────────
+
+fn render_find(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
+    let screen_num = fs.screen.number();
+    let screen_name = fs.screen.name();
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Find · {screen_num}/{} · {screen_name} ", FindScreen::SCREEN_COUNT));
+    let inner_area = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner_area);
+
+    let footer_text = match fs.screen {
+        FindScreen::Filters => {
+            "Tab/Shift-Tab: next field  ↑↓: cycle property suggestions  Enter: preview  Esc: cancel"
+        }
+        FindScreen::Preview => "Enter: open results  e: edit filters  Esc/q: cancel",
+    };
+    f.render_widget(
+        Paragraph::new(footer_text).style(Style::default().fg(theme.muted)),
+        inner_chunks[1],
+    );
+
+    match fs.screen {
+        FindScreen::Filters => render_filters_screen(f, fs, inner_chunks[0], theme),
+        FindScreen::Preview => render_preview_screen(f, fs, inner_chunks[0], theme),
+    }
+}
+
+fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
+    let foc = fs.focused_field;
+    let suggest_count = fs.property_suggestions.len() as u16;
+    // Reserve rows for property suggestion dropdown (at most 8, never more than area).
+    let dropdown_h = suggest_count.min(8);
+
+    // Layout: header rows (label + optional dropdown), then remaining fields, then match count.
+    let field_rows = 4u16; // component, variant, state, intent
+    let match_row = 1u16;
+    let available = area.height.saturating_sub(1 + dropdown_h + field_rows + match_row + 1);
+    let _ = available; // layout is fixed; this is just for reference
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),                  // property label
+            Constraint::Length(dropdown_h),          // suggestion dropdown (0 when empty)
+            Constraint::Length(field_rows),          // component / variant / state / intent
+            Constraint::Length(1),                   // match count
+            Constraint::Min(0),                      // padding
+        ])
+        .split(area);
+
+    // Property field.
+    let prop_marker = if foc == 0 { "▶" } else { " " };
+    let prop_line = format!("{prop_marker} Property: {}", fs.property.value());
+    f.render_widget(
+        Paragraph::new(prop_line).style(if foc == 0 {
+            Style::default().fg(theme.accent)
+        } else {
+            Style::default()
+        }),
+        chunks[0],
+    );
+
+    // Suggestion dropdown (only when on property field and there are suggestions).
+    if dropdown_h > 0 {
+        let rows: Vec<Row> = fs
+            .property_suggestions
+            .iter()
+            .enumerate()
+            .map(|(i, term)| {
+                let marker = if i == fs.selected_property_suggestion { "  ▸" } else { "   " };
+                Row::new(vec![Cell::from(format!("{marker} {term}"))])
+                    .style(if i == fs.selected_property_suggestion {
+                        Style::default().bg(theme.selection_bg)
+                    } else {
+                        Style::default().fg(theme.muted)
+                    })
+            })
+            .collect();
+        let widths = [Constraint::Min(0)];
+        f.render_widget(Table::new(rows, widths), chunks[1]);
+    }
+
+    // Component, variant, state, intent fields.
+    let field_area = chunks[2];
+    let sub = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(field_area);
+
+    let labels = [
+        (1usize, "Component", fs.component.value()),
+        (2, "Variant  ", fs.variant.value()),
+        (3, "State    ", fs.state.value()),
+        (4, "Intent   ", fs.intent.value()),
+    ];
+    for (idx, (field_idx, label, val)) in labels.iter().enumerate() {
+        let marker = if foc == *field_idx { "▶" } else { " " };
+        let text = format!("{marker} {label}: {val}");
+        f.render_widget(
+            Paragraph::new(text).style(if foc == *field_idx {
+                Style::default().fg(theme.accent)
+            } else {
+                Style::default()
+            }),
+            sub[idx],
+        );
+    }
+
+    // Match count.
+    let count_text = if let Some(ref err) = fs.preview_error {
+        format!("  parse error: {err}")
+    } else if !fs.preview_rows.is_empty() || fs.preview_count > 0 {
+        format!("  {} token(s) matched", fs.preview_count)
+    } else {
+        "  (fill in filters then press Enter to preview)".to_string()
+    };
+    f.render_widget(
+        Paragraph::new(count_text).style(Style::default().fg(theme.muted)),
+        chunks[3],
+    );
+}
+
+fn render_preview_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
+    let expr = fs
+        .assemble_expr()
+        .unwrap_or_else(|| format!("intent: {}", fs.intent.value().trim()));
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // expression line
+            Constraint::Length(1), // match count
+            Constraint::Min(0),    // results table
+        ])
+        .split(area);
+
+    f.render_widget(Paragraph::new(format!("  Query: {expr}")), chunks[0]);
+
+    let count_text = if let Some(ref err) = fs.preview_error {
+        format!("  error: {err}")
+    } else {
+        format!("  {} token(s) matched", fs.preview_count)
+    };
+    f.render_widget(
+        Paragraph::new(count_text).style(Style::default().fg(theme.muted)),
+        chunks[1],
+    );
+
+    let display_rows: Vec<Row> = fs
+        .preview_rows
+        .iter()
+        .take(20)
+        .map(|r| {
+            Row::new(vec![
+                Cell::from(r.name.as_str()),
+                Cell::from(r.layer.as_str()).style(Style::default().fg(theme.muted)),
+            ])
+        })
+        .collect();
+    if !display_rows.is_empty() {
+        let widths = [Constraint::Min(0), Constraint::Length(10)];
+        f.render_widget(
+            Table::new(display_rows, widths)
+                .highlight_style(Style::default().bg(theme.selection_bg)),
+            chunks[2],
+        );
+    } else if fs.preview_error.is_none() {
+        f.render_widget(
+            Paragraph::new("  (no tokens matched)").style(Style::default().fg(theme.muted)),
+            chunks[2],
+        );
+    }
+}
+
 fn render_values_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme: &Theme) {
     if ws.values.rows.is_empty() {
         f.render_widget(Paragraph::new("  (no mode combinations — graph has no mode sets)"), area);
@@ -919,6 +1106,11 @@ fn run<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, handle: &Datase
 
             // Overlay modal (rendered last so it appears on top).
             match &mut app.modal {
+                Some(Modal::Find(ref mut fs)) => {
+                    let popup_area = centered_rect(82, 85, frame_area);
+                    f.render_widget(Clear, popup_area);
+                    render_find(f, fs, popup_area, &handle.theme);
+                }
                 Some(Modal::Wizard(ref mut ws)) => {
                     let popup_area = centered_rect(82, 85, frame_area);
                     f.render_widget(Clear, popup_area);

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -119,12 +119,15 @@ impl NamingWizardState {
         if key.code == KeyCode::Esc {
             return NamingEvent::Cancel;
         }
+        // Capture intent value before dispatch so we can skip suggest refresh when text
+        // didn't change (e.g. Up/Down arrow navigation).
+        let intent_before = self.intent.value().to_string();
         let event = match self.screen {
             NamingScreen::Intent => self.handle_intent_key(key, graph),
             NamingScreen::Classification => self.handle_classification_key(key),
             NamingScreen::Result => self.handle_result_key(key),
         };
-        if self.screen == NamingScreen::Intent {
+        if self.screen == NamingScreen::Intent && self.intent.value() != intent_before {
             self.refresh_suggestions(graph);
         }
         event
@@ -159,6 +162,7 @@ impl NamingWizardState {
         }
     }
 
+    // _graph is reserved for future classification seeding (e.g. mode-set discovery).
     fn advance_to_classification(&mut self, _graph: &TokenGraph) {
         let intent = self.intent.value().to_string();
         if !intent.is_empty() && self.classification.property.value().is_empty() {

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -325,12 +325,17 @@ fn find_command_with_args_seeds_intent() {
 }
 
 #[test]
-fn find_command_no_args_opens_empty_modal() {
+fn find_command_no_args_opens_modal_with_empty_fields() {
     let graph = make_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find");
-    assert!(matches!(app.modal, Some(Modal::Find(_))));
+    if let Some(Modal::Find(ref fs)) = app.modal {
+        assert_eq!(fs.intent.value(), "");
+        assert_eq!(fs.focused_field, 0); // focus starts on property
+    } else {
+        panic!("expected Find modal");
+    }
 }
 
 #[test]
@@ -356,6 +361,34 @@ fn esc_in_find_modal_closes_it() {
     let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
     app.handle_modal_key(key(KeyCode::Esc), &ctx);
     assert!(app.modal.is_none());
+}
+
+#[test]
+fn backtab_wraps_from_first_to_last_field() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    assert_eq!(fs.focused_field, 0);
+    fs.handle_key(key(KeyCode::BackTab), &graph);
+    assert_eq!(fs.focused_field, FindWizardState::FIELD_COUNT - 1);
+}
+
+#[test]
+fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new_with_intent("accent background");
+    // Advance to Preview (refresh_preview runs).
+    fs.handle_key(key(KeyCode::Enter), &graph);
+    assert_eq!(fs.screen, FindScreen::Preview);
+    assert!(fs.preview_count > 0);
+    // Accept Preview → OpenResults.
+    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    if let FindEvent::OpenResults(view) = event {
+        // When assemble_expr() returns None, expr_text is the raw intent string.
+        assert_eq!(view.expr_text, "accent background");
+        assert!(!view.rows.is_empty());
+    } else {
+        panic!("expected OpenResults");
+    }
 }
 
 #[test]

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -188,7 +188,8 @@ fn open_results_view_has_correct_row_count() {
     fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
     let event = fs.handle_key(key(KeyCode::Enter), &graph); // Accept
     if let FindEvent::OpenResults(view) = event {
-        assert_eq!(view.rows.len(), 2);
+        // Fixture has 2 background-color tokens; use >= 1 to avoid brittleness.
+        assert!(view.rows.len() >= 1);
         assert_eq!(view.expr_text, "property=background-color");
     } else {
         panic!("expected OpenResults");
@@ -274,17 +275,46 @@ fn property_suggestions_filter_by_typed_prefix() {
 fn up_down_navigate_property_suggestions() {
     let mut fs = FindWizardState::new();
     let graph = make_graph();
-    // Type something to get suggestions.
-    for c in "back".chars() {
+    // "color" matches many registry terms (background-color, border-color, etc.).
+    for c in "color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
+    // Assert unconditionally so a registry regression is visible, not silently skipped.
+    assert!(
+        fs.property_suggestions.len() > 1,
+        "expected >1 'color' suggestions from registry, got {}",
+        fs.property_suggestions.len()
+    );
     let initial = fs.selected_property_suggestion;
-    if fs.property_suggestions.len() > 1 {
-        fs.handle_key(key(KeyCode::Down), &graph);
-        assert_eq!(fs.selected_property_suggestion, initial + 1);
-        fs.handle_key(key(KeyCode::Up), &graph);
-        assert_eq!(fs.selected_property_suggestion, initial);
+    fs.handle_key(key(KeyCode::Down), &graph);
+    assert_eq!(fs.selected_property_suggestion, initial + 1);
+    fs.handle_key(key(KeyCode::Up), &graph);
+    assert_eq!(fs.selected_property_suggestion, initial);
+}
+
+#[test]
+fn refresh_preview_sets_error_on_invalid_expression() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // "foo,bar" assembles to "property=foo,bar"; the parser splits on "," and tries "bar"
+    // as a standalone condition — it has no "=" operator so parse returns a CoreError.
+    fs.property = tui_input::Input::from("foo,bar".to_string());
+    fs.refresh_preview(&graph);
+    assert!(fs.preview_error.is_some(), "expected parse error for condition missing operator");
+    assert_eq!(fs.preview_count, 0);
+    assert!(fs.preview_rows.is_empty());
+}
+
+#[test]
+fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
+    fs.refresh_preview(&graph);
+    assert!(fs.preview_error.is_none(), "parse error: {:?}", fs.preview_error);
+    assert!(fs.preview_count >= 1, "expected at least one match for property=background-color");
 }
 
 // ── App-level integration tests ──────────────────────────────────────────────
@@ -418,4 +448,28 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
     assert!(matches!(app.active_view, ActiveView::Query(_)));
     let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("matched"), "expected 'matched' in status: {msg}");
+}
+
+#[test]
+fn e_on_preview_keeps_modal_open_and_returns_to_filters() {
+    use design_data_tui::app::ActiveView;
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+
+    // Advance to Preview.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // Press e → back to Filters; modal stays open.
+    app.handle_modal_key(key(KeyCode::Char('e')), &ctx);
+
+    assert!(app.modal.is_some(), "e should not close the modal");
+    assert!(matches!(app.active_view, ActiveView::Empty), "e should not open results");
+    if let Some(Modal::Find(ref fs)) = app.modal {
+        assert_eq!(fs.screen, FindScreen::Filters);
+    }
 }

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -1,0 +1,388 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::find::{FindEvent, FindScreen, FindWizardState};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn make_graph() -> TokenGraph {
+    let records: Vec<TokenRecord> = vec![
+        TokenRecord {
+            name: "accent-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": {
+                    "property": "background-color",
+                    "variant": "accent"
+                }
+            }),
+            layer: Layer::Foundation,
+        },
+        TokenRecord {
+            name: "neutral-background-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 1,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#FFFFFF",
+                "name": {
+                    "property": "background-color",
+                    "variant": "neutral"
+                }
+            }),
+            layer: Layer::Foundation,
+        },
+        TokenRecord {
+            name: "button-accent-color".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 2,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "#0265DC",
+                "name": {
+                    "property": "color",
+                    "component": "button",
+                    "variant": "accent"
+                }
+            }),
+            layer: Layer::Platform,
+        },
+    ];
+    TokenGraph::from_records(records)
+}
+
+// ── FindWizardState unit tests ───────────────────────────────────────────────
+
+#[test]
+fn new_state_is_on_filters_screen() {
+    let fs = FindWizardState::new();
+    assert_eq!(fs.screen, FindScreen::Filters);
+}
+
+#[test]
+fn new_with_intent_seeds_intent_field_and_focuses_it() {
+    let fs = FindWizardState::new_with_intent("accent background");
+    assert_eq!(fs.intent.value(), "accent background");
+    assert_eq!(fs.focused_field, 4); // intent field index
+}
+
+#[test]
+fn new_with_empty_intent_leaves_focus_at_property() {
+    let fs = FindWizardState::new_with_intent("");
+    assert_eq!(fs.focused_field, 0);
+}
+
+#[test]
+fn assemble_expr_from_property_and_variant() {
+    let mut fs = FindWizardState::new();
+    // Tab to property field (already there at 0), type value.
+    let graph = make_graph();
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    // Tab to component (skip), Tab to variant.
+    fs.handle_key(key(KeyCode::Tab), &graph); // → component
+    fs.handle_key(key(KeyCode::Tab), &graph); // → variant
+    for c in "accent".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    let expr = fs.assemble_expr().unwrap();
+    assert_eq!(expr, "property=background-color,variant=accent");
+}
+
+#[test]
+fn assemble_expr_returns_none_when_all_fields_empty() {
+    let fs = FindWizardState::new();
+    assert!(fs.assemble_expr().is_none());
+}
+
+#[test]
+fn refresh_preview_populates_rows_for_structured_filter() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // Set property field directly via handle_key.
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    fs.refresh_preview(&graph);
+    assert_eq!(fs.preview_count, 2); // accent + neutral background-color tokens
+    assert!(fs.preview_error.is_none());
+}
+
+#[test]
+fn refresh_preview_uses_suggest_when_only_intent_filled() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new_with_intent("accent background");
+    fs.refresh_preview(&graph);
+    // suggest should find the accent-background-color-default token.
+    assert!(fs.preview_count > 0);
+    assert!(fs.preview_rows.iter().any(|r| r.name.contains("accent")));
+    assert!(fs.preview_error.is_none());
+}
+
+#[test]
+fn refresh_preview_is_empty_when_nothing_filled() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.refresh_preview(&graph);
+    assert_eq!(fs.preview_count, 0);
+    assert!(fs.preview_rows.is_empty());
+    assert!(fs.preview_error.is_none());
+}
+
+#[test]
+fn enter_on_filters_advances_to_preview() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, FindEvent::Continue));
+    assert_eq!(fs.screen, FindScreen::Preview);
+}
+
+#[test]
+fn enter_on_preview_emits_open_results() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // Set property field.
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    // Advance to preview.
+    fs.handle_key(key(KeyCode::Enter), &graph);
+    assert_eq!(fs.screen, FindScreen::Preview);
+    // Accept preview.
+    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    assert!(matches!(event, FindEvent::OpenResults(_)));
+}
+
+#[test]
+fn open_results_view_has_correct_row_count() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Enter), &graph); // Accept
+    if let FindEvent::OpenResults(view) = event {
+        assert_eq!(view.rows.len(), 2);
+        assert_eq!(view.expr_text, "property=background-color");
+    } else {
+        panic!("expected OpenResults");
+    }
+}
+
+#[test]
+fn e_on_preview_goes_back_to_filters() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Char('e')), &graph);
+    assert!(matches!(event, FindEvent::Continue));
+    assert_eq!(fs.screen, FindScreen::Filters);
+}
+
+#[test]
+fn esc_cancels_on_filters_screen() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    let event = fs.handle_key(key(KeyCode::Esc), &graph);
+    assert!(matches!(event, FindEvent::Cancel));
+}
+
+#[test]
+fn esc_cancels_on_preview_screen() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Esc), &graph);
+    assert!(matches!(event, FindEvent::Cancel));
+}
+
+#[test]
+fn q_cancels_on_preview_screen() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    let event = fs.handle_key(key(KeyCode::Char('q')), &graph);
+    assert!(matches!(event, FindEvent::Cancel));
+}
+
+#[test]
+fn tab_cycles_through_fields() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    assert_eq!(fs.focused_field, 0);
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    assert_eq!(fs.focused_field, 1);
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    assert_eq!(fs.focused_field, 2);
+    // BackTab goes backward.
+    fs.handle_key(key(KeyCode::BackTab), &graph);
+    assert_eq!(fs.focused_field, 1);
+}
+
+#[test]
+fn tab_wraps_around_from_last_to_first_field() {
+    let graph = make_graph();
+    let mut fs = FindWizardState::new();
+    // Jump to last field (4 = intent).
+    for _ in 0..4 {
+        fs.handle_key(key(KeyCode::Tab), &graph);
+    }
+    assert_eq!(fs.focused_field, 4);
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    assert_eq!(fs.focused_field, 0);
+}
+
+#[test]
+fn property_suggestions_filter_by_typed_prefix() {
+    let mut fs = FindWizardState::new();
+    let graph = make_graph();
+    for c in "background".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    // The registry should have terms containing "background".
+    assert!(!fs.property_suggestions.is_empty());
+    assert!(fs.property_suggestions.iter().all(|s| s.contains("background")));
+}
+
+#[test]
+fn up_down_navigate_property_suggestions() {
+    let mut fs = FindWizardState::new();
+    let graph = make_graph();
+    // Type something to get suggestions.
+    for c in "back".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    let initial = fs.selected_property_suggestion;
+    if fs.property_suggestions.len() > 1 {
+        fs.handle_key(key(KeyCode::Down), &graph);
+        assert_eq!(fs.selected_property_suggestion, initial + 1);
+        fs.handle_key(key(KeyCode::Up), &graph);
+        assert_eq!(fs.selected_property_suggestion, initial);
+    }
+}
+
+// ── App-level integration tests ──────────────────────────────────────────────
+
+fn submit(app: &mut App, graph: &TokenGraph, cmd: &str) {
+    let ctx = SubmitContext::new(graph);
+    for c in cmd.chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    app.submit_palette(&ctx);
+}
+
+fn open_palette_cmd(app: &mut App) {
+    app.handle_key(key(KeyCode::Char(':')));
+}
+
+#[test]
+fn find_command_opens_find_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+    assert!(matches!(app.modal, Some(Modal::Find(_))));
+}
+
+#[test]
+fn find_command_with_args_seeds_intent() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find accent background");
+    if let Some(Modal::Find(ref fs)) = app.modal {
+        assert_eq!(fs.intent.value(), "accent background");
+    } else {
+        panic!("expected Find modal");
+    }
+}
+
+#[test]
+fn find_command_no_args_opens_empty_modal() {
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+    assert!(matches!(app.modal, Some(Modal::Find(_))));
+}
+
+#[test]
+fn tab_autocompletes_find_command() {
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    // "fi" is unambiguous — only "find" starts with "fi".
+    app.handle_key(key(KeyCode::Char('f')));
+    app.handle_key(key(KeyCode::Char('i')));
+    app.handle_key(key(KeyCode::Tab));
+    assert_eq!(app.palette_input.value(), "find ");
+}
+
+#[test]
+fn esc_in_find_modal_closes_it() {
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+    app.handle_modal_key(key(KeyCode::Esc), &ctx);
+    assert!(app.modal.is_none());
+}
+
+#[test]
+fn accepting_preview_opens_query_view_and_closes_modal() {
+    use design_data_tui::app::ActiveView;
+    use design_data_tui::wizard::WizardCtx;
+
+    let graph = make_graph();
+    let mut app = App::new();
+    open_palette_cmd(&mut app);
+    submit(&mut app, &graph, "find");
+
+    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+
+    // On Filters: type property, then Enter → Preview.
+    if let Some(Modal::Find(ref mut fs)) = app.modal {
+        for c in "background-color".chars() {
+            fs.handle_key(key(KeyCode::Char(c)), &graph);
+        }
+    }
+    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Preview
+
+    // On Preview: Enter → OpenResults.
+    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+
+    assert!(app.modal.is_none());
+    assert!(matches!(app.active_view, ActiveView::Query(_)));
+    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("matched"), "expected 'matched' in status: {msg}");
+}

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -223,6 +223,25 @@ fn copy_event_sets_pending_yank_and_status() {
     assert_eq!(app.pending_yank.as_deref(), Some("color"));
     let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
+    // Copy does NOT close the modal — user stays on Result to copy again or keep inspecting.
+    assert!(app.modal.is_some(), "Copy should not close the Naming modal");
+}
+
+#[test]
+fn y_key_on_result_screen_also_copies() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    // Tab to property field, type "color", advance to Result.
+    ns.handle_key(key(KeyCode::Tab), &graph);
+    for c in "color".chars() {
+        ns.handle_key(key(KeyCode::Char(c)), &graph);
+    }
+    ns.handle_key(key(KeyCode::Enter), &graph);
+    assert_eq!(ns.screen, NamingScreen::Result);
+
+    let event = ns.handle_key(key(KeyCode::Char('y')), &graph);
+    assert!(matches!(event, NamingEvent::Copy(ref name) if name == "color"));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Adds a guided two-screen find/query wizard launched via `:find [<intent>]`. The wizard helps users build a token-graph search without needing to know the query DSL, then hands off to the existing `ActiveView::Query` results view. The one-shot `:query` DSL path is unchanged.

**Two-screen flow:**
1. **Filters** — property picklist (from `RegistryData` registry vocabulary, filtered by substring as you type with Up/Down navigation), component/variant/state free-text inputs, and an intent fallback (`suggest::suggest`-ranked results when no structured filter is set). Live match count updates on each keystroke.
2. **Preview** — shows the assembled expression, match count, and up to 20 rows. `Enter` opens the full results table; `e` returns to Filters; `Esc`/`q` cancel.

Also fixes a stale doc comment on `RegistryData::for_field` that incorrectly listed `property` as a field without a registry.

## Related Issue

RFC #973 Q2 Track B. Track A (`:name`) shipped in #999. Supersedes #1000 (closed — contained naming wizard diff due to squash-merge base mismatch).

## Motivation and Context

`:query` requires knowing the DSL syntax (`property=background-color,variant=accent`). New contributors don't. This wizard guides them through the registered property vocabulary and free-text narrowing with live match counts — no new query engine or DSL extension needed.

Track B is also the third wizard-pattern data point needed before evaluating a `WizardChassis` trait extraction (D3 deferred from the RFC — opening a follow-up issue separately).

## How Has This Been Tested?

27 tests in `sdk/tui/tests/find.rs` covering:
- `FindWizardState` state machine: screen transitions, `assemble_expr`, `refresh_preview` (both structured-filter and suggest-fallback paths, including intent-only → OpenResults), field cycling (Tab/BackTab including wrap), property autocomplete dropdown navigation.
- App-level integration: `:find` opens modal, intent seeding from args, Tab autocomplete, Esc closes, accepting preview opens `ActiveView::Query` and clears the modal.

2 new tests added to `sdk/tui/tests/naming.rs`: `y` key copy (parallel to `c`), and Copy-stays-open contract.

All 146 TUI tests pass. `cargo clippy --workspace -- -D warnings` clean.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)