### PR TITLE
fix(site): add heading anchor IDs to published spec pages

### DIFF
--- a/.changeset/fix-spec-heading-anchors.md
+++ b/.changeset/fix-spec-heading-anchors.md
@@ -1,0 +1,9 @@
+---
+"site": patch
+---
+
+Fix broken heading anchors on published spec pages.
+
+- **docs/site/eleventy.config.js**: add `markdown-it-anchor` with a GitHub slugger; spec headings
+  now emit `id` attributes so fragment links like `#token-bindings` resolve.
+- **docs/site/package.json**: add `markdown-it-anchor` and `github-slugger`.

--- a/docs/site/eleventy.config.js
+++ b/docs/site/eleventy.config.js
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 
 import { HtmlBasePlugin } from "@11ty/eleventy";
+import markdownItAnchor from "markdown-it-anchor";
+import GithubSlugger from "github-slugger";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { siteName, siteDescription } from "./src/data/meta.js";
@@ -54,6 +56,22 @@ export default async function (eleventyConfig) {
   });
   eleventyConfig.addCollection("spec", function (api) {
     return api.getFilteredByGlob("src/spec/**/*.md");
+  });
+
+  // Add GitHub-compatible heading IDs so intra-page fragment links (#token-bindings, etc.) resolve.
+  // GithubSlugger is stateful; wrap md.render to reset it between pages so duplicate-heading
+  // disambiguation doesn't bleed across files.
+  eleventyConfig.amendLibrary("md", (md) => {
+    const slugger = new GithubSlugger();
+    const originalRender = md.render.bind(md);
+    md.render = (...args) => {
+      slugger.reset();
+      return originalRender(...args);
+    };
+    md.use(markdownItAnchor, {
+      slugify: (s) => slugger.slug(s),
+      tabIndex: false,
+    });
   });
 
   // Apply spectrum-Link to anchors in main article (body content) so links use Spectrum link styling

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -30,7 +30,9 @@
     "@spectrum-css/table": "^6.1.0",
     "@spectrum-css/tokens": "^16.0.2",
     "@spectrum-css/typography": "^8.1.0",
-    "markdown-it": "^14.0.0"
+    "github-slugger": "^2.0.0",
+    "markdown-it": "^14.0.0",
+    "markdown-it-anchor": "^9.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,15 @@ importers:
       "@spectrum-css/typography":
         specifier: ^8.1.0
         version: 8.2.0(@spectrum-css/tokens@16.0.2)
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       markdown-it:
         specifier: ^14.0.0
         version: 14.1.0
+      markdown-it-anchor:
+        specifier: ^9.2.0
+        version: 9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
     devDependencies:
       autoprefixer:
         specifier: ^10.4.21
@@ -2933,10 +2939,28 @@ packages:
         integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
       }
 
+  "@types/linkify-it@5.0.0":
+    resolution:
+      {
+        integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==,
+      }
+
+  "@types/markdown-it@14.1.2":
+    resolution:
+      {
+        integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==,
+      }
+
   "@types/mdast@4.0.4":
     resolution:
       {
         integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
+      }
+
+  "@types/mdurl@2.0.0":
+    resolution:
+      {
+        integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==,
       }
 
   "@types/ms@2.1.0":
@@ -5457,6 +5481,12 @@ packages:
     deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
+  github-slugger@2.0.0:
+    resolution:
+      {
+        integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==,
+      }
+
   glob-parent@5.1.2:
     resolution:
       {
@@ -6518,6 +6548,15 @@ packages:
         integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==,
       }
     engines: { node: ">=16" }
+
+  markdown-it-anchor@9.2.0:
+    resolution:
+      {
+        integrity: sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==,
+      }
+    peerDependencies:
+      "@types/markdown-it": "*"
+      markdown-it: "*"
 
   markdown-it@14.1.0:
     resolution:
@@ -11292,9 +11331,18 @@ snapshots:
 
   "@types/json-schema@7.0.15": {}
 
+  "@types/linkify-it@5.0.0": {}
+
+  "@types/markdown-it@14.1.2":
+    dependencies:
+      "@types/linkify-it": 5.0.0
+      "@types/mdurl": 2.0.0
+
   "@types/mdast@4.0.4":
     dependencies:
       "@types/unist": 3.0.3
+
+  "@types/mdurl@2.0.0": {}
 
   "@types/ms@2.1.0": {}
 
@@ -12971,6 +13019,8 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
+  github-slugger@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -13510,6 +13560,11 @@ snapshots:
       semver: 7.7.3
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it-anchor@9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
+    dependencies:
+      "@types/markdown-it": 14.1.2
+      markdown-it: 14.1.0
 
   markdown-it@14.1.0:
     dependencies:


### PR DESCRIPTION
## Description

Wire `markdown-it-anchor` with a GitHub-compatible slugger into the Eleventy build so spec headings emit `id` attributes. Fragment links like `#token-bindings` now resolve on the published site.

## Related Issue

Identified while answering a question about the component-format spec — the shared link `https://opensource.adobe.com/spectrum-design-data/spec/component-format/#token-bindings` didn't scroll to the heading because no heading IDs were being emitted.

## Motivation and Context

Eleventy's bundled markdown-it has no heading-anchor plugin by default. `docs/site/eleventy.config.js` never customised the markdown library, so every `<h2>` and `<h3>` in the rendered spec had no `id` attribute. Any fragment link shared externally or used in in-page navigation silently failed.

## How Has This Been Tested?

Built the site locally (`pnpm --filter site build`) and confirmed:

```
grep 'id="token-bindings"' site/spec/component-format/index.html  # ✓
grep 'id="options"'         site/spec/component-format/index.html  # ✓
grep 'id="anatomy-stub"'    site/spec/component-format/index.html  # ✓
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.