### PR TITLE
chore(demo): add verify-demo.sh preflight script + moon task

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -23,6 +23,7 @@ projects:
   s2-docs-mcp: "tools/s2-docs-mcp"
   component-options-editor: "tools/component-options-editor"
   token-naming-audit: "tools/token-naming-audit"
+  demo: "tools/demo"
 vcs:
   manager: "git"
   defaultBranch: "main"

--- a/tools/demo/README.md
+++ b/tools/demo/README.md
@@ -6,8 +6,19 @@ Self-contained demo assets. Print `scenarios.md`, keep it next to the laptop, co
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `scenarios.md`                     | The narration. Both demo flows with the exact commands and what to say at each step.                                                                                                                                |
 | `demo-commands.sh`                 | Copy-paste cheat sheet. Each command preceded by what to say. Not auto-executable — run commands one at a time so the audience can read the output.                                                                 |
+| `verify-demo.sh`                   | Auto-runnable preflight check. Builds the CLI, then exercises every shell command in the demo and asserts expected output. Run via `moon run demo:verify` before walking into the room.                             |
 | `clean-component-example.json`     | A minimal valid component declaration. Used to show the spec contract at its smallest: identity, anatomy, states (with accessibility-aware fields), top-level accessibility role + WCAG citations, document blocks. |
 | `broken-token-example.tokens.json` | A token file with a dangling alias `$ref` — triggers SPEC-001 (`alias-target-exists`). Used for the "validator catches mistakes live" moment.                                                                       |
 | `agent-questions.md`               | The prepared Claude Code question, exact wording, expected answer shape.                                                                                                                                            |
 
 Originally prepared for the May 15 2026 design director review; retained as general demo assets.
+
+## Verifying before a demo
+
+Run from the repo root:
+
+```bash
+moon run demo:verify
+```
+
+This builds the CLI in release mode and runs every automatable demo command (A2, A3, B2, B3, and the full-dataset bonus check). Manual steps — the S2 visualizer (A1), the Claude Code agent question (A4), and opening `clean-component-example.json` (B1) — are out of scope for the script; see `scenarios.md` for those.

--- a/tools/demo/moon.yml
+++ b/tools/demo/moon.yml
@@ -1,0 +1,13 @@
+type: tool
+language: bash
+
+tasks:
+  verify:
+    command: [bash, ./verify-demo.sh]
+    inputs:
+      - "verify-demo.sh"
+      - "demo-commands.sh"
+      - "broken-token-example.tokens.json"
+
+  ci:
+    deps: [verify]

--- a/tools/demo/moon.yml
+++ b/tools/demo/moon.yml
@@ -3,7 +3,9 @@ language: bash
 
 tasks:
   verify:
-    command: [bash, ./verify-demo.sh]
+    command: [bash, tools/demo/verify-demo.sh]
+    options:
+      runFromWorkspaceRoot: true
     inputs:
       - "verify-demo.sh"
       - "demo-commands.sh"

--- a/tools/demo/verify-demo.sh
+++ b/tools/demo/verify-demo.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+# Verify that every shell command in the demo still works.
+# Run from repo root:  bash tools/demo/verify-demo.sh
+# Or via moon:         moon run demo:verify
+#
+# Manual-only steps NOT covered here (see scenarios.md):
+#   A1  — S2 visualizer (browser required)
+#   A4  — Claude Code agent question (interactive MCP)
+#   B1  — open clean-component-example.json in editor
+
+set -euo pipefail
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+step() { echo -e "\n${BOLD}==> $*${RESET}"; }
+ok()   { echo -e "${GREEN}    ok${RESET}"; }
+fail() { echo -e "${RED}    FAIL: $*${RESET}"; exit 1; }
+
+# ─── Prerequisites ────────────────────────────────────────────────────────────
+
+step "Check: repo root"
+[[ -d "packages/design-data-spec/components" ]] \
+  || fail "Run this script from the spectrum-design-data repo root."
+ok
+
+step "Build: cargo build --release (design-data)"
+cargo build --release --manifest-path sdk/Cargo.toml --bin design-data
+ok
+
+CLI="sdk/target/release/design-data"
+[[ -x "$CLI" ]] || fail "Binary not found at $CLI after build."
+
+step "Check: packages/design-data-spec exists"
+[[ -d "packages/design-data-spec/components" ]] || fail "packages/design-data-spec/components not found."
+ok
+
+# ─── Demo A — Prototype against Spectrum ─────────────────────────────────────
+
+step "A2: design-data component button"
+output=$("$CLI" component button \
+  --components-dir packages/design-data-spec/components 2>&1)
+[[ "$output" == *"button"* ]] || fail "Expected 'button' in component output."
+ok
+
+step "A3: design-data query --filter component=button"
+"$CLI" query packages/design-data-spec --filter "component=button" > /dev/null
+ok
+
+# ─── Demo B — Blank design system ────────────────────────────────────────────
+
+step "B2: design-data validate broken-token-example.tokens.json (expect SPEC-001)"
+# Capture output; validate exits non-zero when errors are found — that's expected here.
+b2_output=$("$CLI" validate tools/demo/broken-token-example.tokens.json 2>&1 || true)
+[[ "$b2_output" == *"SPEC-001"* ]] \
+  || fail "Expected SPEC-001 in validation output — demo 'catches mistakes' moment is broken."
+ok
+
+step "B3: design-data primer packages/design-data-spec"
+"$CLI" primer packages/design-data-spec > /dev/null
+ok
+
+# ─── Bonus: full dataset runs without crashing ───────────────────────────────
+
+step "Bonus: design-data validate packages/design-data-spec --strict (runs without crashing)"
+# Exits non-zero when validation errors are present, which is normal for an in-progress system.
+# Assert it runs and produces output, not that the dataset is clean.
+bonus_output=$("$CLI" validate packages/design-data-spec --strict 2>&1 || true)
+[[ -n "$bonus_output" ]] \
+  || fail "Expected validation output for full dataset — command may have crashed silently."
+ok
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo -e "\n${GREEN}${BOLD}==> All demo commands verified.${RESET}"


### PR DESCRIPTION
## Description

Adds an auto-runnable preflight script (`tools/demo/verify-demo.sh`) that builds the CLI and exercises every shell-automatable demo command before a live demo. Also wires it up as `moon run demo:verify`.

## Related Issue

N/A — follow-up to the demo materials refresh in #1005.

## Motivation and Context

Manual pre-demo checks were error-prone. This script catches broken CLI commands, missing binaries, or spec path regressions before walking into the room.

## How Has This Been Tested?

- Ran `moon run demo:verify` locally against `packages/design-data-spec`.
- Script exercises steps A2, A3, B2, B3, and the full-dataset bonus check.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.