### PR TITLE
test(tui): shared tests/common/mod.rs harness (#1016)

### DIFF
--- a/sdk/tui/tests/autocomplete.rs
+++ b/sdk/tui/tests/autocomplete.rs
@@ -8,12 +8,11 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use design_data_tui::app::App;
+mod common;
+use common::key;
 
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
+use crossterm::event::KeyCode;
+use design_data_tui::app::App;
 
 fn open_palette(app: &mut App) {
     app.handle_key(key(KeyCode::Char(':')));

--- a/sdk/tui/tests/common/mod.rs
+++ b/sdk/tui/tests/common/mod.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
+};
+use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_tui::app::App;
+use design_data_tui::theme::Theme;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::Terminal;
+use serde_json::json;
+use std::path::PathBuf;
+
+/// Build a `KeyEvent` (Press, no modifiers) for the given key code.
+pub fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }
+}
+
+/// Build a mouse event at the given terminal cell.
+pub fn mouse(kind: MouseEventKind, row: u16, col: u16) -> MouseEvent {
+    MouseEvent { kind, row, column: col, modifiers: KeyModifiers::NONE }
+}
+
+/// Standard 2-token graph used across most test suites.
+pub fn make_graph() -> TokenGraph {
+    make_graph_with_tokens(&["accent-background-color-default", "neutral-background-color-default"])
+}
+
+/// Build a graph from a list of token names. Each token gets `value = "red"` and
+/// a `name.property` field matching the name itself, so `property=<name>` queries work.
+pub fn make_graph_with_tokens(names: &[&str]) -> TokenGraph {
+    let records: Vec<TokenRecord> = names
+        .iter()
+        .enumerate()
+        .map(|(i, &name)| TokenRecord {
+            name: name.to_string(),
+            file: PathBuf::from("test.json"),
+            index: i,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({
+                "value": "red",
+                "name": { "property": name }
+            }),
+            layer: Layer::Foundation,
+        })
+        .collect();
+    TokenGraph::from_records(records)
+}
+
+/// Empty graph — useful for testing empty-state rendering and error paths.
+pub fn empty_graph() -> TokenGraph {
+    make_graph_with_tokens(&[])
+}
+
+/// Primer line shown in the header during test renders.
+pub const TEST_PRIMER: &str = "test · 0 tokens";
+
+/// Render `app` via `design_data_tui::draw` into a `TestBackend` and return the `Buffer`.
+pub fn render_to_buffer(app: &mut App, w: u16, h: u16) -> Buffer {
+    let backend = TestBackend::new(w, h);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| design_data_tui::draw(app, f, &Theme::terminal(), TEST_PRIMER))
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+#[test]
+fn render_to_buffer_does_not_panic_on_empty_app() {
+    let mut app = App::new();
+    let buf = render_to_buffer(&mut app, 80, 24);
+    assert_eq!(buf.area().width, 80);
+    assert_eq!(buf.area().height, 24);
+}

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -8,15 +8,14 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+mod common;
+use common::key;
+
+use crossterm::event::KeyCode;
 use design_data_core::graph::{ComponentRecord, TokenGraph};
 use design_data_tui::app::{ActiveView, App, SubmitContext};
 use serde_json::json;
 use std::path::PathBuf;
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
 
 fn fixtures_components_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/components")

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -8,18 +8,17 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+mod common;
+use common::key;
+
+use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_tui::app::{App, Modal, SubmitContext};
 use design_data_tui::find::{FindEvent, FindScreen, FindWizardState};
 use serde_json::json;
 use std::path::PathBuf;
 
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
-
-fn make_graph() -> TokenGraph {
+fn make_find_graph() -> TokenGraph {
     let records: Vec<TokenRecord> = vec![
         TokenRecord {
             name: "accent-background-color-default".into(),
@@ -99,7 +98,7 @@ fn new_with_empty_intent_leaves_focus_at_property() {
 fn assemble_expr_from_property_and_variant() {
     let mut fs = FindWizardState::new();
     // Tab to property field (already there at 0), type value.
-    let graph = make_graph();
+    let graph = make_find_graph();
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
@@ -121,7 +120,7 @@ fn assemble_expr_returns_none_when_all_fields_empty() {
 
 #[test]
 fn refresh_preview_populates_rows_for_structured_filter() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     // Set property field directly via handle_key.
     for c in "background-color".chars() {
@@ -134,7 +133,7 @@ fn refresh_preview_populates_rows_for_structured_filter() {
 
 #[test]
 fn refresh_preview_uses_suggest_when_only_intent_filled() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new_with_intent("accent background");
     fs.refresh_preview(&graph);
     // suggest should find the accent-background-color-default token.
@@ -145,7 +144,7 @@ fn refresh_preview_uses_suggest_when_only_intent_filled() {
 
 #[test]
 fn refresh_preview_is_empty_when_nothing_filled() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     fs.refresh_preview(&graph);
     assert_eq!(fs.preview_count, 0);
@@ -155,7 +154,7 @@ fn refresh_preview_is_empty_when_nothing_filled() {
 
 #[test]
 fn enter_on_filters_advances_to_preview() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     let event = fs.handle_key(key(KeyCode::Enter), &graph);
     assert!(matches!(event, FindEvent::Continue));
@@ -164,7 +163,7 @@ fn enter_on_filters_advances_to_preview() {
 
 #[test]
 fn enter_on_preview_emits_open_results() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     // Set property field.
     for c in "background-color".chars() {
@@ -180,7 +179,7 @@ fn enter_on_preview_emits_open_results() {
 
 #[test]
 fn open_results_view_has_correct_row_count() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
@@ -198,7 +197,7 @@ fn open_results_view_has_correct_row_count() {
 
 #[test]
 fn e_on_preview_goes_back_to_filters() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
     let event = fs.handle_key(key(KeyCode::Char('e')), &graph);
@@ -208,7 +207,7 @@ fn e_on_preview_goes_back_to_filters() {
 
 #[test]
 fn esc_cancels_on_filters_screen() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     let event = fs.handle_key(key(KeyCode::Esc), &graph);
     assert!(matches!(event, FindEvent::Cancel));
@@ -216,7 +215,7 @@ fn esc_cancels_on_filters_screen() {
 
 #[test]
 fn esc_cancels_on_preview_screen() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
     let event = fs.handle_key(key(KeyCode::Esc), &graph);
@@ -225,7 +224,7 @@ fn esc_cancels_on_preview_screen() {
 
 #[test]
 fn q_cancels_on_preview_screen() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
     let event = fs.handle_key(key(KeyCode::Char('q')), &graph);
@@ -234,7 +233,7 @@ fn q_cancels_on_preview_screen() {
 
 #[test]
 fn tab_cycles_through_fields() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     assert_eq!(fs.focused_field, 0);
     fs.handle_key(key(KeyCode::Tab), &graph);
@@ -248,7 +247,7 @@ fn tab_cycles_through_fields() {
 
 #[test]
 fn tab_wraps_around_from_last_to_first_field() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     // Jump to last field (4 = intent).
     for _ in 0..4 {
@@ -262,7 +261,7 @@ fn tab_wraps_around_from_last_to_first_field() {
 #[test]
 fn property_suggestions_filter_by_typed_prefix() {
     let mut fs = FindWizardState::new();
-    let graph = make_graph();
+    let graph = make_find_graph();
     for c in "background".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
@@ -274,7 +273,7 @@ fn property_suggestions_filter_by_typed_prefix() {
 #[test]
 fn up_down_navigate_property_suggestions() {
     let mut fs = FindWizardState::new();
-    let graph = make_graph();
+    let graph = make_find_graph();
     // "color" matches many registry terms (background-color, border-color, etc.).
     for c in "color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
@@ -294,7 +293,7 @@ fn up_down_navigate_property_suggestions() {
 
 #[test]
 fn refresh_preview_sets_error_on_invalid_expression() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     // "foo,bar" assembles to "property=foo,bar"; the parser splits on "," and tries "bar"
     // as a standalone condition — it has no "=" operator so parse returns a CoreError.
@@ -307,7 +306,7 @@ fn refresh_preview_sets_error_on_invalid_expression() {
 
 #[test]
 fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
@@ -334,7 +333,7 @@ fn open_palette_cmd(app: &mut App) {
 
 #[test]
 fn find_command_opens_find_modal() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find");
@@ -343,7 +342,7 @@ fn find_command_opens_find_modal() {
 
 #[test]
 fn find_command_with_args_seeds_intent() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find accent background");
@@ -356,7 +355,7 @@ fn find_command_with_args_seeds_intent() {
 
 #[test]
 fn find_command_no_args_opens_modal_with_empty_fields() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find");
@@ -383,7 +382,7 @@ fn tab_autocompletes_find_command() {
 fn esc_in_find_modal_closes_it() {
     use design_data_tui::wizard::WizardCtx;
 
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find");
@@ -395,7 +394,7 @@ fn esc_in_find_modal_closes_it() {
 
 #[test]
 fn backtab_wraps_from_first_to_last_field() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new();
     assert_eq!(fs.focused_field, 0);
     fs.handle_key(key(KeyCode::BackTab), &graph);
@@ -404,7 +403,7 @@ fn backtab_wraps_from_first_to_last_field() {
 
 #[test]
 fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut fs = FindWizardState::new_with_intent("accent background");
     // Advance to Preview (refresh_preview runs).
     fs.handle_key(key(KeyCode::Enter), &graph);
@@ -426,7 +425,7 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
     use design_data_tui::app::ActiveView;
     use design_data_tui::wizard::WizardCtx;
 
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find");
@@ -455,7 +454,7 @@ fn e_on_preview_keeps_modal_open_and_returns_to_filters() {
     use design_data_tui::app::ActiveView;
     use design_data_tui::wizard::WizardCtx;
 
-    let graph = make_graph();
+    let graph = make_find_graph();
     let mut app = App::new();
     open_palette_cmd(&mut app);
     submit(&mut app, &graph, "find");

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -13,31 +13,16 @@
 use std::env;
 use std::sync::Mutex;
 
-use crossterm::event::{
-    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
-    MouseEventKind,
-};
+mod common;
+use common::{key, mouse};
+
+use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
 use design_data_core::graph::TokenGraph;
 use design_data_tui::app::{App, HitAction, HitRegion, Modal};
 use design_data_tui::theme::Theme;
 use design_data_tui::wizard::WizardCtx;
 use ratatui::layout::Rect;
 use tempfile::TempDir;
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent {
-        code,
-        modifiers: KeyModifiers::NONE,
-        kind: KeyEventKind::Press,
-        state: KeyEventState::NONE,
-    }
-}
-
-fn mouse(kind: MouseEventKind, row: u16, col: u16) -> MouseEvent {
-    MouseEvent { kind, row, column: col, modifiers: KeyModifiers::NONE }
-}
 
 fn empty_ctx(graph: &TokenGraph) -> WizardCtx<'_> {
     WizardCtx { graph, dataset_path: None, schema_registry: None, allow_write: false }

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -8,34 +8,16 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+mod common;
+use common::{key, make_graph_with_tokens};
+
+use crossterm::event::KeyCode;
+use design_data_core::graph::{Layer, TokenGraph};
 use design_data_tui::app::{App, Modal, SubmitContext};
 use design_data_tui::naming::{NamingEvent, NamingScreen, NamingWizardState};
-use serde_json::json;
-use std::path::PathBuf;
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
 
 fn make_graph() -> TokenGraph {
-    let records: Vec<TokenRecord> = vec![
-        TokenRecord {
-            name: "accent-background-color-default".into(),
-            file: PathBuf::from("tokens.json"),
-            index: 0,
-            schema_url: None,
-            uuid: None,
-            alias_target: None,
-            raw: json!({
-                "value": "#0265DC",
-                "name": { "property": "background-color", "variant": "accent" }
-            }),
-            layer: Layer::Foundation,
-        },
-    ];
-    TokenGraph::from_records(records)
+    make_graph_with_tokens(&["accent-background-color-default"])
 }
 
 // ── NamingWizardState unit tests ─────────────────────────────────────────────

--- a/sdk/tui/tests/palette.rs
+++ b/sdk/tui/tests/palette.rs
@@ -8,12 +8,11 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
+mod common;
+use common::key;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use design_data_tui::app::{App, PaletteMode};
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
 
 fn ctrl(c: char) -> KeyEvent {
     KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -8,42 +8,11 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+mod common;
+use common::{empty_graph, key, make_graph_with_tokens};
+
+use crossterm::event::KeyCode;
 use design_data_tui::app::{ActiveView, App, SubmitContext};
-use serde_json::json;
-use std::path::PathBuf;
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
-
-fn make_graph_with_tokens(names: &[&str]) -> TokenGraph {
-    let records: Vec<TokenRecord> = names
-        .iter()
-        .enumerate()
-        .map(|(i, &name)| TokenRecord {
-            name: name.to_string(),
-            file: PathBuf::from("test.json"),
-            index: i,
-            schema_url: None,
-            uuid: None,
-            alias_target: None,
-            // Include name.property so property=* queries match.
-            raw: json!({
-                "value": "red",
-                "$schema": "https://example.com",
-                "name": { "property": name }
-            }),
-            layer: Layer::Foundation,
-        })
-        .collect();
-    TokenGraph::from_records(records)
-}
-
-fn empty_graph() -> TokenGraph {
-    make_graph_with_tokens(&[])
-}
 
 #[test]
 fn submit_valid_query_populates_query_view() {

--- a/sdk/tui/tests/resolve.rs
+++ b/sdk/tui/tests/resolve.rs
@@ -8,15 +8,14 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+mod common;
+use common::key;
+
+use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
 use design_data_tui::app::{ActiveView, App, SubmitContext};
 use serde_json::json;
 use std::path::PathBuf;
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
 
 fn make_resolve_graph() -> TokenGraph {
     // Three tokens for "background-color":

--- a/sdk/tui/tests/validate.rs
+++ b/sdk/tui/tests/validate.rs
@@ -8,15 +8,14 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+mod common;
+use common::key;
+
+use crossterm::event::KeyCode;
 use design_data_core::graph::TokenGraph;
 use design_data_core::schema::SchemaRegistry;
 use design_data_tui::app::{ActiveView, App, SubmitContext};
 use std::path::PathBuf;
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
 
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -8,49 +8,14 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
+mod common;
+use common::{key, make_graph};
+
+use crossterm::event::KeyCode;
+use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
 use design_data_tui::app::{App, Modal, SubmitContext};
 use design_data_tui::wizard::{ValueKind, WizardCtx, WizardPath, WizardScreen};
-use serde_json::json;
 use std::path::PathBuf;
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
-
-/// Simple graph with a few color tokens.
-fn make_graph() -> TokenGraph {
-    let records: Vec<TokenRecord> = vec![
-        TokenRecord {
-            name: "accent-background-color-default".into(),
-            file: PathBuf::from("tokens.json"),
-            index: 0,
-            schema_url: None,
-            uuid: None,
-            alias_target: None,
-            raw: json!({
-                "value": "#0265DC",
-                "name": { "property": "background-color", "variant": "accent" }
-            }),
-            layer: Layer::Foundation,
-        },
-        TokenRecord {
-            name: "neutral-background-color-default".into(),
-            file: PathBuf::from("tokens.json"),
-            index: 1,
-            schema_url: None,
-            uuid: None,
-            alias_target: None,
-            raw: json!({
-                "value": "#F5F5F5",
-                "name": { "property": "background-color", "variant": "neutral" }
-            }),
-            layer: Layer::Foundation,
-        },
-    ];
-    TokenGraph::from_records(records)
-}
 
 /// Graph with a colorScheme mode set — used for Screen 3 tests.
 fn make_graph_with_modes() -> TokenGraph {

--- a/sdk/tui/tests/wizard_persistence.rs
+++ b/sdk/tui/tests/wizard_persistence.rs
@@ -13,7 +13,10 @@
 use std::env;
 use std::sync::Mutex;
 
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+mod common;
+use common::key;
+
+use crossterm::event::KeyCode;
 use design_data_core::graph::TokenGraph;
 use design_data_tui::app::{App, Modal};
 use design_data_tui::wizard::{WizardCtx, WizardScreen, WizardState};
@@ -21,17 +24,6 @@ use design_data_tui::wizard_draft::{
     from_draft, load_wizard_draft, save_wizard_draft, to_draft, wizard_draft_path,
 };
 use tempfile::TempDir;
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent {
-        code,
-        modifiers: KeyModifiers::NONE,
-        kind: KeyEventKind::Press,
-        state: KeyEventState::NONE,
-    }
-}
 
 fn empty_ctx(graph: &TokenGraph) -> WizardCtx<'_> {
     WizardCtx { graph, dataset_path: None, schema_registry: None, allow_write: false }

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -16,19 +16,16 @@
 
 use std::path::PathBuf;
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+mod common;
+use common::key;
+
+use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_core::schema::SchemaRegistry;
 use design_data_tui::app::{App, SubmitContext};
 use design_data_tui::wizard::{ValueKind, ValueRow, WizardCtx, WizardState};
 use serde_json::json;
 use tui_input::Input;
-
-// ── Fixtures ──────────────────────────────────────────────────────────────────
-
-fn key(code: KeyCode) -> KeyEvent {
-    KeyEvent::new(code, KeyModifiers::NONE)
-}
 
 /// Valid color schema URL from the real registry.
 const COLOR_SCHEMA: &str =


### PR DESCRIPTION
## Description

Extract the helpers duplicated across all 12 test files into a new `tests/common/mod.rs` module, and add the `render_to_buffer` helper that backs render testing in #1017.

**New `tests/common/mod.rs` exports:**
- `key(code) -> KeyEvent` — explicit Press form, replaces 12 identical local declarations
- `mouse(kind, row, col) -> MouseEvent` — moved from m5.rs only
- `make_graph() -> TokenGraph` — standard 2-token graph for most test suites
- `make_graph_with_tokens(names) -> TokenGraph` — parametric version from query.rs
- `empty_graph() -> TokenGraph` — zero-token graph for error-path tests
- `render_to_buffer(app, w, h) -> Buffer` — new; calls `lib::draw` via `TestBackend`

**Each of the 12 test files** now imports from `common` instead of declaring its own `key()`. Files with test-specific graph data (`find.rs`, `write.rs`, `describe.rs`) keep local builder fns but import `key` from common.

## Related Issue

Closes #1016. Part of TUI v2 epic #1014. Unblocks #1017 (render snapshot tests).

## Motivation and Context

Every test file redeclared identical helpers, making any change require 12-file edits. `render_to_buffer` specifically unlocks Buffer-cell render assertions without any extra dep.

## How Has This Been Tested?

All 146+ existing tests pass (`cargo test`). No behavior change.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.