### PR TITLE
test(tui): first render snapshot tests — Buffer-cell assertions (#1017)

### DIFF
--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -1,0 +1,184 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Buffer-cell render tests (GH #1017).
+//!
+//! Pattern: build App state, call render_to_buffer, assert specific cells.
+//! No snapshot deps — assertions are direct `buf.cell((x, y)).symbol()` checks.
+
+mod common;
+use common::{key, make_graph_with_tokens, render_to_buffer, TEST_PRIMER};
+
+use crossterm::event::KeyCode;
+use design_data_tui::app::{App, SubmitContext};
+use ratatui::buffer::Buffer;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const W: u16 = 80;
+const H: u16 = 24;
+
+/// Collect a single row of the buffer as a `String`.
+fn row_str(buf: &Buffer, y: u16, w: u16) -> String {
+    (0..w).map(|x| buf.cell((x, y)).unwrap().symbol().to_string()).collect()
+}
+
+/// Scan all rows for the first one whose text contains `needle`. Returns that
+/// row's content as a String, or panics with a helpful message if not found.
+fn find_row_containing<'a>(buf: &Buffer, needle: &str, w: u16, h: u16) -> String {
+    for y in 0..h {
+        let row = row_str(buf, y, w);
+        if row.contains(needle) {
+            return row;
+        }
+    }
+    panic!("no row contains '{needle}' in {w}×{h} buffer");
+}
+
+/// Open command palette, type `cmd`, submit. Returns the updated app.
+fn submit_query(app: &mut App, graph: &design_data_core::graph::TokenGraph, cmd: &str) {
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in cmd.chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&SubmitContext::new(graph));
+}
+
+// ── Empty / initial view ───────────────────────────────────────────────────────
+
+#[test]
+fn empty_app_renders_primer_arrow() {
+    let mut app = App::new();
+    let buf = render_to_buffer(&mut app, W, H);
+    // Row 0 is always the primer header; the arrow marker is the first character.
+    assert_eq!(buf.cell((0, 0)).unwrap().symbol(), "▶");
+}
+
+#[test]
+fn empty_app_renders_primer_text() {
+    let mut app = App::new();
+    let buf = render_to_buffer(&mut app, W, H);
+    // TEST_PRIMER starts at col 2 (after "▶ ").
+    let row = row_str(&buf, 0, W);
+    assert!(
+        row.contains(TEST_PRIMER),
+        "primer row should contain '{TEST_PRIMER}', got: {row}"
+    );
+}
+
+#[test]
+fn empty_app_renders_active_view_border() {
+    let mut app = App::new();
+    let buf = render_to_buffer(&mut app, W, H);
+    // Scan rows 1..H for the top-left border corner "┌" — layout-agnostic.
+    let border_row = (1..H).find(|&y| buf.cell((0, y)).unwrap().symbol() == "┌");
+    assert!(border_row.is_some(), "expected a '┌' border somewhere in rows 1..{H}");
+}
+
+#[test]
+fn empty_app_palette_prompt_row_is_last() {
+    let mut app = App::new();
+    let buf = render_to_buffer(&mut app, W, H);
+    // Last row (H-1) is the palette prompt — empty when palette is closed.
+    let last_row = row_str(&buf, H - 1, W);
+    assert!(
+        last_row.trim().is_empty(),
+        "palette row should be empty when closed, got: '{last_row}'"
+    );
+}
+
+// ── Query view ────────────────────────────────────────────────────────────────
+
+#[test]
+fn query_view_renders_column_headers() {
+    let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
+    let mut app = App::new();
+    submit_query(&mut app, &graph, "query property=accent-color");
+
+    let buf = render_to_buffer(&mut app, W, H);
+    // Scan for the row that contains "Name" — the table header row.
+    let header_row = find_row_containing(&buf, "Name", W, H);
+    assert!(header_row.contains("Value"), "header should also contain 'Value': {header_row}");
+}
+
+#[test]
+fn query_view_renders_token_name_in_data_row() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let mut app = App::new();
+    submit_query(&mut app, &graph, "query property=accent-color");
+
+    let buf = render_to_buffer(&mut app, W, H);
+    // Scan for the row that contains the token name — layout-agnostic.
+    find_row_containing(&buf, "accent-color", W, H);
+}
+
+// ── Help modal ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn help_modal_renders_title() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('?')));
+    let buf = render_to_buffer(&mut app, W, H);
+    // Scan for any row containing "Help" — the modal title bar.
+    find_row_containing(&buf, "Help", W, H);
+}
+
+// ── Palette prompt ─────────────────────────────────────────────────────────────
+
+#[test]
+fn open_palette_renders_colon_on_last_row() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char(':')));
+    let buf = render_to_buffer(&mut app, W, H);
+    assert_eq!(
+        buf.cell((0, H - 1)).unwrap().symbol(),
+        ":",
+        "palette prompt should start with ':' in command mode"
+    );
+}
+
+#[test]
+fn fuzzy_palette_renders_slash_on_last_row() {
+    let mut app = App::new();
+    app.handle_key(key(KeyCode::Char('/')));
+    let buf = render_to_buffer(&mut app, W, H);
+    assert_eq!(
+        buf.cell((0, H - 1)).unwrap().symbol(),
+        "/",
+        "palette prompt should start with '/' in fuzzy mode"
+    );
+}
+
+// ── Determinism ───────────────────────────────────────────────────────────────
+
+#[test]
+fn two_consecutive_renders_are_identical() {
+    let mut app = App::new();
+    let buf1 = render_to_buffer(&mut app, W, H);
+    let buf2 = render_to_buffer(&mut app, W, H);
+    assert!(
+        buf1 == buf2,
+        "draw must be deterministic — two renders of the same state must be identical"
+    );
+}
+
+// ── Panic safety ──────────────────────────────────────────────────────────────
+
+#[test]
+fn draw_does_not_panic_on_1x1_terminal() {
+    let mut app = App::new();
+    render_to_buffer(&mut app, 1, 1);
+}
+
+#[test]
+fn draw_does_not_panic_on_narrow_terminal() {
+    let mut app = App::new();
+    render_to_buffer(&mut app, 10, 5);
+}


### PR DESCRIPTION
## Description

New `tests/render.rs` with 13 Buffer-cell render tests. Direct `buf.cell((x,y)).symbol()` assertions, no snapshot dep.

**Tests added:**
- `empty_app_renders_primer_arrow` — row 0, col 0 is `▶`
- `empty_app_renders_primer_text` — primer row starts with `TEST_PRIMER`
- `empty_app_renders_active_view_border` — top-left of active view block is `┌`
- `empty_app_palette_prompt_row_is_last` — last row empty when palette closed
- `query_view_renders_column_headers` — header row contains Name/Value
- `query_view_renders_token_name_in_data_row` — first data row has token name
- `help_modal_renders_title` — `?` key produces a frame containing "Help"
- `open_palette_renders_colon_on_last_row` — `:` opens command mode prompt
- `fuzzy_palette_renders_slash_on_last_row` — `/` opens fuzzy mode prompt
- `two_consecutive_renders_are_identical` — determinism check
- `draw_does_not_panic_on_1x1_terminal` — panic-safety
- `draw_does_not_panic_on_narrow_terminal` — panic-safety (10×5)
- `common::render_to_buffer_does_not_panic_on_empty_app` — smoke test from #1016

## Related Issue

Closes #1017. Part of TUI v2 epic #1014. Completes Phase A (Foundation).

## How Has This Been Tested?

`cargo test --test render` — 13 passed. Full `cargo test` — all 159+ tests pass.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.