### PR TITLE
feat(tui): pure update fn + Task<Message> (#1020)

### DIFF
--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -29,11 +29,11 @@ use crate::wizard::{WizardCtx, WizardEvent, WizardState};
 use crate::wizard_draft::{clear_wizard_draft, from_draft, load_wizard_draft};
 
 /// Command names for Tab autocomplete.
-const KNOWN_COMMANDS: &[&str] =
+pub(crate) const KNOWN_COMMANDS: &[&str] =
     &["find", "name", "new", "query", "resolve", "describe", "validate"];
 
 /// Max palette history entries persisted to disk.
-const HISTORY_CAP: usize = 200;
+pub(crate) const HISTORY_CAP: usize = 200;
 
 /// Which prefix the palette was opened with.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,7 +113,7 @@ impl QueryView {
         Self { expr_text, rows, table_state }
     }
 
-    fn selected_row(&self) -> Option<&QueryRow> {
+    pub(crate) fn selected_row(&self) -> Option<&QueryRow> {
         self.table_state.selected().and_then(|i| self.rows.get(i))
     }
 }
@@ -137,7 +137,7 @@ pub struct ResolveView {
 }
 
 impl ResolveView {
-    fn new(property: String, rows: Vec<ResolvedRow>) -> Self {
+    pub(crate) fn new(property: String, rows: Vec<ResolvedRow>) -> Self {
         let mut table_state = TableState::default();
         if !rows.is_empty() {
             table_state.select(Some(0));
@@ -145,7 +145,7 @@ impl ResolveView {
         Self { property, rows, table_state }
     }
 
-    fn selected_row(&self) -> Option<&ResolvedRow> {
+    pub(crate) fn selected_row(&self) -> Option<&ResolvedRow> {
         self.table_state.selected().and_then(|i| self.rows.get(i))
     }
 }
@@ -173,7 +173,7 @@ pub struct ValidateView {
 }
 
 impl ValidateView {
-    fn new(rows: Vec<DiagnosticRow>) -> Self {
+    pub(crate) fn new(rows: Vec<DiagnosticRow>) -> Self {
         let mut table_state = TableState::default();
         if !rows.is_empty() {
             table_state.select(Some(0));
@@ -181,7 +181,7 @@ impl ValidateView {
         Self { rows, table_state }
     }
 
-    fn selected_row(&self) -> Option<&DiagnosticRow> {
+    pub(crate) fn selected_row(&self) -> Option<&DiagnosticRow> {
         self.table_state.selected().and_then(|i| self.rows.get(i))
     }
 }
@@ -1186,7 +1186,7 @@ fn load_palette_history() -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn save_palette_history(history: &[String]) {
+pub(crate) fn save_palette_history(history: &[String]) {
     let Some(path) = history_path() else { return };
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -1200,7 +1200,7 @@ fn save_palette_history(history: &[String]) {
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
-fn layer_str(layer: Layer) -> &'static str {
+pub(crate) fn layer_str(layer: Layer) -> &'static str {
     match layer {
         Layer::Foundation => "foundation",
         Layer::Platform => "platform",
@@ -1219,7 +1219,7 @@ pub fn move_table_selection(state: &mut TableState, len: usize, delta: i64) {
 }
 
 /// Test whether `(row, col)` is inside `rect`.
-fn rect_contains(rect: Rect, row: u16, col: u16) -> bool {
+pub(crate) fn rect_contains(rect: Rect, row: u16, col: u16) -> bool {
     col >= rect.x
         && col < rect.x + rect.width
         && row >= rect.y
@@ -1236,7 +1236,7 @@ fn apply_scroll_delta(scroll: &mut u16, delta: i32) {
     }
 }
 
-fn parse_resolve_args(rest: &str) -> Result<(String, ResolutionContext), String> {
+pub(crate) fn parse_resolve_args(rest: &str) -> Result<(String, ResolutionContext), String> {
     let mut property: Option<String> = None;
     let mut ctx = ResolutionContext::new();
     for pair in rest.split(',') {

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -14,7 +14,9 @@ pub mod help;
 pub mod message;
 pub mod model;
 pub mod naming;
+pub mod task;
 pub mod theme;
+pub mod update;
 pub mod view;
 pub mod wizard;
 pub mod wizard_common;
@@ -22,4 +24,6 @@ pub mod wizard_draft;
 
 pub use message::Message;
 pub use model::Model;
+pub use task::Task;
+pub use update::{update, UpdateCtx};
 pub use view::draw;

--- a/sdk/tui/src/task.rs
+++ b/sdk/tui/src/task.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! `Task<Msg>` — the side-effect type returned by `update` (GH #1020).
+//!
+//! Mirrors iced's `Task` / `Command` constructor menu. The runtime (#1021)
+//! is responsible for executing tasks; `update` only produces them.
+
+/// A description of work to run outside the pure `update` function.
+pub enum Task<Msg> {
+    /// No side effect — the most common return value.
+    None,
+    /// Run a synchronous closure on a worker thread and feed its result back
+    /// as a `Msg`. Used for FS writes, clipboard, and other blocking I/O.
+    Cmd(Box<dyn FnOnce() -> Msg + Send + 'static>),
+    /// Run several tasks, all of whose results are fed back as messages.
+    Batch(Vec<Task<Msg>>),
+}
+
+impl<Msg: 'static> Task<Msg> {
+    pub fn none() -> Self {
+        Task::None
+    }
+
+    pub fn cmd(f: impl FnOnce() -> Msg + Send + 'static) -> Self {
+        Task::Cmd(Box::new(f))
+    }
+
+    pub fn batch(tasks: Vec<Task<Msg>>) -> Self {
+        Task::Batch(tasks)
+    }
+
+    /// Return true if this task has no work to do.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Task::None)
+    }
+
+    /// Return true if this task is a `Cmd` closure (useful in tests).
+    pub fn is_cmd(&self) -> bool {
+        matches!(self, Task::Cmd(_))
+    }
+}

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -1,0 +1,933 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Pure `update` function — the single state-transition entry point (GH #1020).
+//!
+//! `update` takes the current `Model`, an incoming `Message`, and read-only
+//! external context (`UpdateCtx`). It returns a `Task<Message>` describing any
+//! side effects to run. It never calls `std::fs`, clipboard, or any async
+//! runtime directly — those are wrapped in `Task::Cmd` closures.
+//!
+//! Side effects deferred to `#1023`: `describe` FS read, `validate` FS scan,
+//! and `--allow-write` wizard writes still execute inline; they are tagged with
+//! `// TODO(#1023)` comments.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEventKind};
+use tui_input::backend::crossterm::EventHandler;
+use design_data_core::cascade::{self, specificity};
+use design_data_core::diff::display_name;
+use design_data_core::graph::{TokenGraph, TokenRecord};
+use design_data_core::schema::SchemaRegistry;
+
+use crate::app::{
+    ActiveView, DescribeView, HitAction, Modal, PaletteMode, QueryRow, QueryView, ResolvedRow,
+    ResolveView, StatusMessage, ValidateView, HISTORY_CAP, KNOWN_COMMANDS,
+    layer_str, move_table_selection, parse_resolve_args, rect_contains, save_palette_history,
+};
+use crate::find::{FindEvent, FindWizardState};
+use crate::message::Message;
+use crate::model::Model;
+use crate::naming::{NamingEvent, NamingWizardState};
+use crate::task::Task;
+use crate::wizard::{WizardCtx, WizardEvent, WizardState};
+use crate::wizard_draft::{clear_wizard_draft, save_wizard_draft, to_draft};
+
+// ── External context ──────────────────────────────────────────────────────────
+
+/// Read-only external context passed into `update` alongside the message.
+///
+/// Combines the fields of `SubmitContext` and `WizardCtx` so `update` is a
+/// single entry point regardless of which command or modal is active.
+pub struct UpdateCtx<'a> {
+    pub graph: &'a TokenGraph,
+    pub dataset_path: Option<&'a Path>,
+    pub components_dir: Option<&'a Path>,
+    pub schema_registry: Option<&'a SchemaRegistry>,
+    pub mode_sets_dir: Option<&'a Path>,
+    pub allow_write: bool,
+}
+
+impl<'a> UpdateCtx<'a> {
+    /// Minimal context for tests that only need key/palette/modal behavior.
+    pub fn minimal(graph: &'a TokenGraph) -> Self {
+        Self {
+            graph,
+            dataset_path: None,
+            components_dir: None,
+            schema_registry: None,
+            mode_sets_dir: None,
+            allow_write: false,
+        }
+    }
+
+    fn as_wizard_ctx(&self) -> WizardCtx<'_> {
+        WizardCtx {
+            graph: self.graph,
+            dataset_path: self.dataset_path,
+            schema_registry: self.schema_registry,
+            allow_write: self.allow_write,
+        }
+    }
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+/// The single state-transition function for the TUI runtime.
+///
+/// Routes `msg` through the appropriate handler based on current `model` state,
+/// mutates `model` in place, and returns a `Task` describing any side effects
+/// to execute outside this call (FS writes, clipboard, etc.).
+pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Message> {
+    match msg {
+        Message::Key(key) => handle_key(model, key, ctx),
+        Message::Mouse(me) => handle_mouse(model, me),
+        Message::PaletteSubmit(raw) => handle_palette_submit(model, raw, ctx),
+        Message::PaletteCancel => {
+            model.palette_open = false;
+            model.palette_input = tui_input::Input::default();
+            model.palette_history_cursor = None;
+            Task::none()
+        }
+        Message::PaletteHistoryNav { older } => {
+            handle_history_nav(model, older);
+            Task::none()
+        }
+        Message::WriteDone(result) => {
+            match result {
+                Ok(path) => {
+                    model.status_message =
+                        Some(StatusMessage::info(format!("wrote → {}", path.display())));
+                }
+                Err(e) => {
+                    if let Some(Modal::Wizard(ref mut ws)) = model.modal {
+                        ws.error = Some(e);
+                    }
+                }
+            }
+            Task::none()
+        }
+        // Synthetic modal messages exist in Message for replay/injection use.
+        // The Key path handles them via modal delegation above; no-op here.
+        Message::WizardAdvance
+        | Message::WizardBack
+        | Message::WizardConfirm
+        | Message::WizardCancel
+        | Message::NamingCopy(_)
+        | Message::NamingCancel
+        | Message::FindOpenResults
+        | Message::FindCancel
+        | Message::Tick
+        | Message::ClipboardDone => Task::none(),
+    }
+}
+
+// ── Key handling ──────────────────────────────────────────────────────────────
+
+fn handle_key(
+    model: &mut Model,
+    key: crossterm::event::KeyEvent,
+    ctx: &UpdateCtx<'_>,
+) -> Task<Message> {
+    // Ctrl-C always exits.
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        model.quit = true;
+        return Task::none();
+    }
+
+    // While the palette is open all keys are consumed here.
+    if model.palette_open {
+        return handle_palette_key(model, key);
+    }
+
+    // Modal captures all key input when present.
+    if model.modal.is_some() {
+        return route_modal_key(model, key, ctx);
+    }
+
+    // View-specific keys (navigation, yank).
+    if handle_view_key(model, key.code) {
+        return Task::none();
+    }
+
+    // Global fallback keys.
+    match key.code {
+        KeyCode::Char('?') => {
+            model.modal = Some(Modal::Help(crate::app::HelpModal { scroll: 0 }));
+        }
+        KeyCode::Char('v') => {
+            model.selection_mode = !model.selection_mode;
+            if !model.selection_mode {
+                model.sel_start = None;
+                model.sel_end = None;
+            }
+            let label = if model.selection_mode { "on" } else { "off" };
+            model.status_message = Some(StatusMessage::info(
+                format!("selection mode {label}  (drag to select, release to copy)"),
+            ));
+        }
+        KeyCode::Char(':') => {
+            model.palette_open = true;
+            model.palette_mode = PaletteMode::Command;
+            model.palette_input = tui_input::Input::default();
+            model.palette_history_cursor = None;
+        }
+        KeyCode::Char('/') => {
+            model.palette_open = true;
+            model.palette_mode = PaletteMode::FuzzyFind;
+            model.palette_input = tui_input::Input::default();
+            model.palette_history_cursor = None;
+        }
+        KeyCode::Char('q') => {
+            model.quit = true;
+        }
+        _ => {}
+    }
+    Task::none()
+}
+
+fn handle_palette_key(
+    model: &mut Model,
+    key: crossterm::event::KeyEvent,
+) -> Task<Message> {
+    match key.code {
+        KeyCode::Esc => {
+            model.palette_open = false;
+            model.palette_input = tui_input::Input::default();
+            model.palette_history_cursor = None;
+        }
+        KeyCode::Enter => {
+            // Close the palette. The runtime sends a separate Message::PaletteSubmit
+            // after detecting this transition; submit is NOT dispatched here.
+            model.palette_open = false;
+        }
+        KeyCode::Tab if model.palette_mode == PaletteMode::Command => {
+            let current = model.palette_input.value().to_string();
+            if !current.contains(' ') {
+                let matches: Vec<&str> = KNOWN_COMMANDS
+                    .iter()
+                    .copied()
+                    .filter(|&c| c.starts_with(current.as_str()))
+                    .collect();
+                match matches.len() {
+                    0 => {}
+                    1 => {
+                        model.palette_input =
+                            tui_input::Input::from(format!("{} ", matches[0]));
+                    }
+                    _ => {
+                        model.status_message = Some(StatusMessage::info(
+                            format!("matches: {}", matches.join(" | ")),
+                        ));
+                    }
+                }
+            }
+        }
+        KeyCode::Up if model.palette_mode == PaletteMode::Command => {
+            handle_history_nav(model, true);
+        }
+        KeyCode::Down if model.palette_mode == PaletteMode::Command => {
+            handle_history_nav(model, false);
+        }
+        _ => {
+            model.palette_history_cursor = None;
+            model
+                .palette_input
+                .handle_event(&crossterm::event::Event::Key(key));
+        }
+    }
+    Task::none()
+}
+
+fn handle_history_nav(model: &mut Model, older: bool) {
+    if older {
+        let next = match model.palette_history_cursor {
+            None if !model.palette_history.is_empty() => Some(0),
+            Some(i) if i + 1 < model.palette_history.len() => Some(i + 1),
+            other => other,
+        };
+        model.palette_history_cursor = next;
+        if let Some(i) = next {
+            if let Some(entry) = model.palette_history.get(i) {
+                model.palette_input = tui_input::Input::from(entry.clone());
+            }
+        }
+    } else {
+        let next = model.palette_history_cursor.and_then(|i| {
+            if i == 0 { None } else { Some(i - 1) }
+        });
+        model.palette_history_cursor = next;
+        match next {
+            Some(i) => {
+                if let Some(entry) = model.palette_history.get(i) {
+                    model.palette_input = tui_input::Input::from(entry.clone());
+                }
+            }
+            None => {
+                model.palette_input = tui_input::Input::default();
+            }
+        }
+    }
+}
+
+/// Handle a view-specific key. Returns `true` when the key was consumed.
+fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
+    match code {
+        KeyCode::Esc => {
+            if matches!(model.active_view, ActiveView::Empty) {
+                return false;
+            }
+            model.active_view = ActiveView::Empty;
+            model.status_message = None;
+            true
+        }
+        KeyCode::Up | KeyCode::Char('k') => match &mut model.active_view {
+            ActiveView::Query(qv) => {
+                move_table_selection(&mut qv.table_state, qv.rows.len(), -1);
+                true
+            }
+            ActiveView::Resolve(rv) => {
+                move_table_selection(&mut rv.table_state, rv.rows.len(), -1);
+                true
+            }
+            ActiveView::Validate(vv) => {
+                move_table_selection(&mut vv.table_state, vv.rows.len(), -1);
+                true
+            }
+            ActiveView::Describe(dv) => {
+                dv.scroll = dv.scroll.saturating_sub(1);
+                true
+            }
+            ActiveView::Empty => false,
+        },
+        KeyCode::Down | KeyCode::Char('j') => match &mut model.active_view {
+            ActiveView::Query(qv) => {
+                move_table_selection(&mut qv.table_state, qv.rows.len(), 1);
+                true
+            }
+            ActiveView::Resolve(rv) => {
+                move_table_selection(&mut rv.table_state, rv.rows.len(), 1);
+                true
+            }
+            ActiveView::Validate(vv) => {
+                move_table_selection(&mut vv.table_state, vv.rows.len(), 1);
+                true
+            }
+            ActiveView::Describe(dv) => {
+                dv.scroll = dv.scroll.saturating_add(1);
+                true
+            }
+            ActiveView::Empty => false,
+        },
+        KeyCode::PageUp => {
+            if let ActiveView::Describe(ref mut dv) = model.active_view {
+                dv.scroll = dv.scroll.saturating_sub(10);
+                true
+            } else {
+                false
+            }
+        }
+        KeyCode::PageDown => {
+            if let ActiveView::Describe(ref mut dv) = model.active_view {
+                dv.scroll = dv.scroll.saturating_add(10);
+                true
+            } else {
+                false
+            }
+        }
+        KeyCode::Char('y') => {
+            let yank = match &model.active_view {
+                ActiveView::Query(qv) => qv.selected_row().map(|r| r.name.clone()),
+                ActiveView::Resolve(rv) => rv.selected_row().map(|r| r.name.clone()),
+                ActiveView::Validate(vv) => vv.selected_row().map(|r| r.message.clone()),
+                ActiveView::Describe(_) | ActiveView::Empty => None,
+            };
+            if let Some(text) = yank {
+                model.pending_yank = Some(text);
+                true
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+// ── Modal key routing ─────────────────────────────────────────────────────────
+
+fn route_modal_key(
+    model: &mut Model,
+    key: crossterm::event::KeyEvent,
+    ctx: &UpdateCtx<'_>,
+) -> Task<Message> {
+    // Help modal.
+    if let Some(Modal::Help(ref mut hm)) = model.modal {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('?') => {
+                model.modal = None;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                hm.scroll = hm.scroll.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                hm.scroll = hm.scroll.saturating_add(1);
+            }
+            KeyCode::PageUp => {
+                hm.scroll = hm.scroll.saturating_sub(10);
+            }
+            KeyCode::PageDown => {
+                hm.scroll = hm.scroll.saturating_add(10);
+            }
+            _ => {}
+        }
+        return Task::none();
+    }
+
+    // Find modal.
+    if let Some(Modal::Find(ref mut fs)) = model.modal {
+        let event = fs.handle_key(key, ctx.graph);
+        match event {
+            FindEvent::Cancel => {
+                model.modal = None;
+                model.status_message = Some(StatusMessage::info("find wizard cancelled"));
+            }
+            FindEvent::OpenResults(view) => {
+                let count = view.rows.len();
+                model.active_view = ActiveView::Query(view);
+                model.status_message =
+                    Some(StatusMessage::info(format!("{count} token(s) matched")));
+                model.modal = None;
+            }
+            FindEvent::Continue => {}
+        }
+        return Task::none();
+    }
+
+    // Naming modal.
+    if let Some(Modal::Naming(ref mut ns)) = model.modal {
+        let event = ns.handle_key(key, ctx.graph);
+        match event {
+            NamingEvent::Cancel => {
+                model.modal = None;
+                model.status_message = Some(StatusMessage::info("naming wizard cancelled"));
+            }
+            NamingEvent::Copy(name) => {
+                model.pending_yank = Some(name.clone());
+                model.status_message =
+                    Some(StatusMessage::info(format!("copied: {name}")));
+            }
+            NamingEvent::Continue => {}
+        }
+        return Task::none();
+    }
+
+    // Wizard modal.
+    let wctx = ctx.as_wizard_ctx();
+    let event = match &mut model.modal {
+        Some(Modal::Wizard(ws)) => ws.handle_key(key, &wctx),
+        _ => return Task::none(),
+    };
+
+    match event {
+        WizardEvent::Cancel => {
+            model.modal = None;
+            model.status_message = Some(StatusMessage::info("wizard cancelled"));
+            Task::cmd(|| { clear_wizard_draft(); Message::Tick })
+        }
+        WizardEvent::Submit => {
+            if !ctx.allow_write {
+                model.modal = None;
+                model.status_message = Some(StatusMessage::info(
+                    "wizard preview ready — pass --allow-write to enable writes",
+                ));
+                Task::cmd(|| { clear_wizard_draft(); Message::Tick })
+            } else {
+                // TODO(#1023): extract perform_write into Task::Cmd once WizardState
+                // exposes owned submit-data that can be moved into a 'static closure.
+                let write_result = if let Some(Modal::Wizard(ref ws)) = model.modal {
+                    Some((ws.assembled_name(), ws.perform_write(&wctx)))
+                } else {
+                    None
+                };
+                match write_result {
+                    Some((name, Ok(written_path))) => {
+                        model.modal = None;
+                        model.status_message = Some(StatusMessage::info(
+                            format!("wrote {name} → {written_path}"),
+                        ));
+                        Task::cmd(|| { clear_wizard_draft(); Message::Tick })
+                    }
+                    Some((_, Err(e))) => {
+                        if let Some(Modal::Wizard(ref mut ws)) = model.modal {
+                            ws.error = Some(e);
+                        }
+                        Task::none()
+                    }
+                    None => Task::none(),
+                }
+            }
+        }
+        WizardEvent::Continue => {
+            let draft = if let Some(Modal::Wizard(ref ws)) = model.modal {
+                Some(to_draft(ws))
+            } else {
+                None
+            };
+            match draft {
+                Some(d) => Task::cmd(move || { save_wizard_draft(&d); Message::Tick }),
+                None => Task::none(),
+            }
+        }
+    }
+}
+
+// ── Mouse handling ────────────────────────────────────────────────────────────
+
+fn handle_mouse(model: &mut Model, me: crossterm::event::MouseEvent) -> Task<Message> {
+    match me.kind {
+        MouseEventKind::ScrollUp => {
+            scroll_active(model, -1);
+        }
+        MouseEventKind::ScrollDown => {
+            scroll_active(model, 1);
+        }
+        MouseEventKind::Down(MouseButton::Left) => {
+            if model.selection_mode {
+                model.sel_start = Some((me.row, me.column));
+                model.sel_end = Some((me.row, me.column));
+            } else {
+                click_at(model, me.row, me.column);
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left) if model.selection_mode => {
+            model.sel_end = Some((me.row, me.column));
+        }
+        MouseEventKind::Up(MouseButton::Left) if model.selection_mode => {
+            if let Some(text) = extract_selection(model) {
+                if !text.is_empty() {
+                    model.pending_yank = Some(text);
+                }
+            }
+            model.sel_start = None;
+            model.sel_end = None;
+        }
+        _ => {}
+    }
+    Task::none()
+}
+
+fn scroll_active(model: &mut Model, delta: i32) {
+    if let Some(ref mut modal) = model.modal {
+        if modal.wants_scroll() {
+            modal.on_scroll(delta);
+        }
+        return;
+    }
+    match &mut model.active_view {
+        ActiveView::Describe(dv) => {
+            let amount = delta.unsigned_abs() as u16 * 3;
+            if delta > 0 {
+                dv.scroll = dv.scroll.saturating_add(amount);
+            } else {
+                dv.scroll = dv.scroll.saturating_sub(amount);
+            }
+        }
+        ActiveView::Query(qv) => {
+            move_table_selection(&mut qv.table_state, qv.rows.len(), delta as i64);
+        }
+        ActiveView::Resolve(rv) => {
+            move_table_selection(&mut rv.table_state, rv.rows.len(), delta as i64);
+        }
+        ActiveView::Validate(vv) => {
+            move_table_selection(&mut vv.table_state, vv.rows.len(), delta as i64);
+        }
+        ActiveView::Empty => {}
+    }
+}
+
+fn click_at(model: &mut Model, row: u16, col: u16) {
+    let action = model.hit_regions.iter().find_map(|r| {
+        if rect_contains(r.rect, row, col) { Some(&r.action) } else { None }
+    });
+    match action {
+        Some(HitAction::SelectListRow(i)) => {
+            let i = *i;
+            match &mut model.active_view {
+                ActiveView::Query(qv) => { qv.table_state.select(Some(i)); }
+                ActiveView::Resolve(rv) => { rv.table_state.select(Some(i)); }
+                ActiveView::Validate(vv) => { vv.table_state.select(Some(i)); }
+                _ => {}
+            }
+        }
+        None => {}
+    }
+}
+
+fn extract_selection(model: &Model) -> Option<String> {
+    let (Some((r1, c1)), Some((r2, c2))) = (model.sel_start, model.sel_end) else {
+        return None;
+    };
+    let min_row = r1.min(r2);
+    let max_row = r1.max(r2);
+    let min_col = c1.min(c2);
+    let max_col = c1.max(c2);
+    let mut lines: Vec<&str> = Vec::new();
+    for region in &model.hit_regions {
+        let ry = region.rect.y;
+        let rx = region.rect.x;
+        let rx_end = rx + region.rect.width;
+        if ry >= min_row && ry <= max_row && rx_end > min_col && rx <= max_col {
+            lines.push(&region.text);
+        }
+    }
+    if lines.is_empty() { None } else { Some(lines.join("\n")) }
+}
+
+// ── Palette submit / command dispatch ─────────────────────────────────────────
+
+fn handle_palette_submit(
+    model: &mut Model,
+    raw: String,
+    ctx: &UpdateCtx<'_>,
+) -> Task<Message> {
+    // FuzzyFind mode: close without dispatching.
+    if model.palette_mode != PaletteMode::Command {
+        model.palette_open = false;
+        model.palette_input = tui_input::Input::default();
+        return Task::none();
+    }
+
+    let raw = raw.trim().to_string();
+    model.palette_open = false;
+    model.palette_input = tui_input::Input::default();
+    model.palette_history_cursor = None;
+
+    // Append to history (dedupe head, cap at HISTORY_CAP).
+    let history_task = if !raw.is_empty()
+        && model.palette_history.first().map(|s| s.as_str()) != Some(raw.as_str())
+    {
+        model.palette_history.insert(0, raw.clone());
+        model.palette_history.truncate(HISTORY_CAP);
+        let snap = model.palette_history.clone();
+        Task::cmd(move || { save_palette_history(&snap); Message::Tick })
+    } else {
+        Task::none()
+    };
+
+    let (cmd, rest) = match raw.split_once(' ') {
+        Some((c, r)) => (c.to_lowercase(), r.trim().to_string()),
+        None => (raw.to_lowercase(), String::new()),
+    };
+
+    let cmd_task = dispatch_command(model, &cmd, &rest, ctx);
+
+    // Combine history save with command task.
+    match (history_task, cmd_task) {
+        (Task::None, t) | (t, Task::None) => t,
+        (h, c) => Task::batch(vec![h, c]),
+    }
+}
+
+fn dispatch_command(
+    model: &mut Model,
+    cmd: &str,
+    rest: &str,
+    ctx: &UpdateCtx<'_>,
+) -> Task<Message> {
+    match cmd {
+        "query" => {
+            if rest.is_empty() {
+                model.status_message =
+                    Some(StatusMessage::error("query: expression required"));
+                return Task::none();
+            }
+            match design_data_core::query::parse(rest) {
+                Ok(expr) => {
+                    let records = design_data_core::query::filter(ctx.graph, &expr);
+                    let rows: Vec<QueryRow> =
+                        records.iter().map(|r| QueryRow::from_record(r)).collect();
+                    let count = rows.len();
+                    model.active_view =
+                        ActiveView::Query(QueryView::new(rest.to_string(), rows));
+                    model.status_message =
+                        Some(StatusMessage::info(format!("{count} token(s) matched")));
+                }
+                Err(e) => {
+                    model.status_message =
+                        Some(StatusMessage::error(format!("query error: {e}")));
+                }
+            }
+            Task::none()
+        }
+        "resolve" => {
+            if rest.is_empty() {
+                model.status_message =
+                    Some(StatusMessage::error("resolve: property=<name> required"));
+                return Task::none();
+            }
+            let (prop, res_ctx) = match parse_resolve_args(rest) {
+                Ok(v) => v,
+                Err(e) => {
+                    model.status_message =
+                        Some(StatusMessage::error(format!("resolve: {e}")));
+                    return Task::none();
+                }
+            };
+            let candidates: Vec<TokenRecord> = ctx
+                .graph
+                .tokens
+                .values()
+                .filter(|t| {
+                    t.raw
+                        .get("name")
+                        .and_then(|v| v.as_object())
+                        .and_then(|n| n.get("property"))
+                        .and_then(|v| v.as_str())
+                        == Some(prop.as_str())
+                })
+                .cloned()
+                .collect();
+            if candidates.is_empty() {
+                model.active_view =
+                    ActiveView::Resolve(ResolveView::new(prop, vec![]));
+                model.status_message = Some(StatusMessage::info("no match"));
+                return Task::none();
+            }
+            let filtered_graph = design_data_core::graph::TokenGraph::from_records(candidates)
+                .with_mode_sets(ctx.graph.mode_sets.clone());
+            let mut with_spec: Vec<(&TokenRecord, u32)> = filtered_graph
+                .tokens
+                .values()
+                .map(|t| {
+                    let s = t
+                        .raw
+                        .get("name")
+                        .and_then(|v| v.as_object())
+                        .map(|n| specificity(n, &filtered_graph.mode_sets))
+                        .unwrap_or(0);
+                    (t, s)
+                })
+                .collect();
+            with_spec.sort_by(|(a, sa), (b, sb)| {
+                b.layer
+                    .cmp(&a.layer)
+                    .then_with(|| sb.cmp(sa))
+                    .then_with(|| a.file.cmp(&b.file))
+                    .then_with(|| a.index.cmp(&b.index))
+            });
+            let winner = cascade::resolve(&filtered_graph, &res_ctx);
+            let rows: Vec<ResolvedRow> = with_spec
+                .iter()
+                .map(|(t, spec)| {
+                    let value = t
+                        .raw
+                        .get("value")
+                        .map(|v| {
+                            if v.is_string() {
+                                v.as_str().unwrap_or("").to_string()
+                            } else {
+                                v.to_string()
+                            }
+                        })
+                        .or_else(|| t.alias_target.clone())
+                        .unwrap_or_default();
+                    let file = t
+                        .file
+                        .file_name()
+                        .map(|f| f.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    let is_winner = winner.map(|w| w.name == t.name).unwrap_or(false);
+                    ResolvedRow {
+                        name: display_name(t),
+                        value,
+                        file,
+                        layer: layer_str(t.layer).to_string(),
+                        specificity: *spec,
+                        is_winner,
+                    }
+                })
+                .collect();
+            let count = rows.len();
+            model.active_view = ActiveView::Resolve(ResolveView::new(prop, rows));
+            model.status_message =
+                Some(StatusMessage::info(format!("{count} candidate(s)")));
+            Task::none()
+        }
+        "describe" | "component" => {
+            // TODO(#1023): wrap the fs::read_to_string in Task::Cmd once the
+            // runtime can feed the result back as Message::DescribeDone.
+            if rest.is_empty() {
+                model.status_message =
+                    Some(StatusMessage::error("describe: component ID required"));
+                return Task::none();
+            }
+            let id = rest.trim();
+            if id.is_empty()
+                || !id.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+                || !id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            {
+                model.status_message =
+                    Some(StatusMessage::error(format!("invalid component ID '{id}'")));
+                return Task::none();
+            }
+            let Some(comp_dir) = ctx.components_dir else {
+                model.status_message = Some(StatusMessage::error(
+                    "describe: no components directory available",
+                ));
+                return Task::none();
+            };
+            let file_path = comp_dir.join(format!("{id}.json"));
+            if file_path.is_file() {
+                match std::fs::read_to_string(&file_path) {
+                    Ok(raw_text) => match serde_json::from_str::<serde_json::Value>(&raw_text) {
+                        Ok(doc) => match serde_json::to_string_pretty(&doc) {
+                            Ok(pretty) => {
+                                model.active_view = ActiveView::Describe(DescribeView {
+                                    component: id.to_string(),
+                                    pretty_json: pretty,
+                                    scroll: 0,
+                                });
+                                model.status_message = None;
+                            }
+                            Err(e) => {
+                                model.status_message = Some(StatusMessage::error(
+                                    format!("describe: render error: {e}"),
+                                ));
+                            }
+                        },
+                        Err(e) => {
+                            model.status_message = Some(StatusMessage::error(
+                                format!("describe: parse error: {e}"),
+                            ));
+                        }
+                    },
+                    Err(e) => {
+                        model.status_message = Some(StatusMessage::error(
+                            format!("describe: read error: {e}"),
+                        ));
+                    }
+                }
+            } else {
+                let available: Vec<&str> =
+                    ctx.graph.components.iter().map(|c| c.name.as_str()).collect();
+                let suggestion = build_did_you_mean(id, &available);
+                model.status_message = Some(StatusMessage::error(format!(
+                    "component '{id}' not found{suggestion}"
+                )));
+            }
+            Task::none()
+        }
+        "validate" => {
+            // TODO(#1023): wrap validate_all_with_options_and_names in Task::Cmd.
+            let (Some(dataset_path), Some(schema_registry)) =
+                (ctx.dataset_path, ctx.schema_registry)
+            else {
+                model.status_message = Some(StatusMessage::error(
+                    "validate: requires --dataset and schema registry",
+                ));
+                return Task::none();
+            };
+            use design_data_core::validate;
+            match validate::validate_all_with_options_and_names(
+                dataset_path,
+                schema_registry,
+                &HashSet::new(),
+                ctx.mode_sets_dir,
+                ctx.components_dir,
+                None,
+            ) {
+                Ok(report) => {
+                    use crate::app::DiagnosticRow;
+                    let rows: Vec<DiagnosticRow> = report
+                        .errors
+                        .iter()
+                        .map(|d| DiagnosticRow {
+                            severity: "error".to_string(),
+                            rule_id: d.rule_id.clone().unwrap_or_default(),
+                            token: d.token.clone().unwrap_or_default(),
+                            message: d.message.clone(),
+                        })
+                        .chain(report.warnings.iter().map(|d| DiagnosticRow {
+                            severity: "warning".to_string(),
+                            rule_id: d.rule_id.clone().unwrap_or_default(),
+                            token: d.token.clone().unwrap_or_default(),
+                            message: d.message.clone(),
+                        }))
+                        .collect();
+                    let count = rows.len();
+                    model.active_view = ActiveView::Validate(ValidateView::new(rows));
+                    model.status_message =
+                        Some(StatusMessage::info(format!("{count} finding(s)")));
+                }
+                Err(e) => {
+                    model.status_message =
+                        Some(StatusMessage::error(format!("validate: {e}")));
+                }
+            }
+            Task::none()
+        }
+        "find" => {
+            let fs = FindWizardState::new_with_intent(rest.trim());
+            model.modal = Some(Modal::Find(Box::new(fs)));
+            model.status_message = None;
+            Task::none()
+        }
+        "name" => {
+            let mut ns = NamingWizardState::new_with_intent(rest.trim());
+            ns.refresh_suggestions(ctx.graph);
+            model.modal = Some(Modal::Naming(Box::new(ns)));
+            model.status_message = None;
+            Task::none()
+        }
+        "new" | "create" => {
+            let mut ws = WizardState::new_with_intent(rest.trim());
+            ws.refresh_suggestions(ctx.graph);
+            model.modal = Some(Modal::Wizard(Box::new(ws)));
+            model.status_message = None;
+            Task::none()
+        }
+        other => {
+            model.status_message =
+                Some(StatusMessage::error(format!("unknown command: {other}")));
+            Task::none()
+        }
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn build_did_you_mean(id: &str, available: &[&str]) -> String {
+    if available.is_empty() {
+        return String::new();
+    }
+    // Safe: callers validate that id is ASCII-only before reaching this point
+    // (the is_ascii_lowercase / is_ascii_digit / '-' guard in dispatch_command).
+    let prefix_len = id.len().min(3);
+    let prefix = &id[..prefix_len];
+    let mut matches: Vec<&str> = available
+        .iter()
+        .filter(|&&n| n.starts_with(id))
+        .copied()
+        .collect();
+    if matches.is_empty() {
+        matches = available
+            .iter()
+            .filter(|&&n| n.starts_with(prefix))
+            .copied()
+            .collect();
+    }
+    if matches.is_empty() {
+        format!(" — available: {}", available.join(", "))
+    } else {
+        format!(" — did you mean: {}", matches.join(", "))
+    }
+}

--- a/sdk/tui/tests/autocomplete.rs
+++ b/sdk/tui/tests/autocomplete.rs
@@ -9,101 +9,103 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::key;
+use common::{empty_graph, key, update_ctx};
 
 use crossterm::event::KeyCode;
-use design_data_tui::app::App;
+use design_data_tui::{update, Message, Model};
 
-fn open_palette(app: &mut App) {
-    app.handle_key(key(KeyCode::Char(':')));
-}
-
-fn type_str(app: &mut App, s: &str) {
+fn type_str(model: &mut Model, ctx: &design_data_tui::UpdateCtx<'_>, s: &str) {
     for c in s.chars() {
-        app.handle_key(key(KeyCode::Char(c)));
+        update(model, Message::Key(key(KeyCode::Char(c))), ctx);
     }
 }
 
 #[test]
 fn tab_completes_query() {
-    let mut app = App::new();
-    open_palette(&mut app);
-    type_str(&mut app, "q");
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "query ");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    type_str(&mut model, &ctx, "q");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "query ");
 }
 
 #[test]
 fn tab_completes_resolve() {
-    let mut app = App::new();
-    open_palette(&mut app);
-    type_str(&mut app, "re");
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "resolve ");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    type_str(&mut model, &ctx, "re");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "resolve ");
 }
 
 #[test]
 fn tab_completes_describe() {
-    let mut app = App::new();
-    open_palette(&mut app);
-    type_str(&mut app, "d");
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "describe ");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    type_str(&mut model, &ctx, "d");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "describe ");
 }
 
 #[test]
 fn tab_completes_validate() {
-    let mut app = App::new();
-    open_palette(&mut app);
-    type_str(&mut app, "v");
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "validate ");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    type_str(&mut model, &ctx, "v");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "validate ");
 }
 
 #[test]
 fn ambiguous_prefix_sets_status_and_leaves_buffer_unchanged() {
-    // "r" matches resolve (and only resolve with current set, but let's use "")
-    // Use "q" which is unambiguous — use a prefix that matches multiple:
-    // Actually all current commands start with unique first letters.
-    // "re" vs "res" — let's use an empty string which matches all 4.
-    // Or type nothing and tab:
-    let mut app = App::new();
-    open_palette(&mut app);
-    // Empty prefix — matches all 4 commands → ambiguous.
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), ""); // buffer unchanged
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(
-        msg.contains("matches:"),
-        "expected 'matches:' in status: {msg}"
-    );
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    // Empty prefix matches all commands → ambiguous.
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "");
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(msg.contains("matches:"), "expected 'matches:' in status: {msg}");
 }
 
 #[test]
 fn tab_after_space_is_noop() {
-    let mut app = App::new();
-    open_palette(&mut app);
-    type_str(&mut app, "query ");
-    app.handle_key(key(KeyCode::Tab));
-    // Buffer should remain "query " — Tab inside argument is ignored.
-    assert_eq!(app.palette_input.value(), "query ");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    type_str(&mut model, &ctx, "query ");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "query ");
 }
 
 #[test]
 fn tab_on_no_match_is_noop() {
-    let mut app = App::new();
-    open_palette(&mut app);
-    type_str(&mut app, "zzz");
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "zzz");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    type_str(&mut model, &ctx, "zzz");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "zzz");
 }
 
 #[test]
 fn tab_in_fuzzy_mode_is_noop() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('/'))); // open in fuzzy mode
-    type_str(&mut app, "q");
-    app.handle_key(key(KeyCode::Tab));
-    // Tab does nothing in fuzzy mode — no autocomplete.
-    assert_eq!(app.palette_input.value(), "q");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "q");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "q");
 }

--- a/sdk/tui/tests/common/mod.rs
+++ b/sdk/tui/tests/common/mod.rs
@@ -13,6 +13,7 @@ use crossterm::event::{
 };
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_tui::app::App;
+use design_data_tui::UpdateCtx;
 use design_data_tui::theme::Theme;
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
@@ -66,6 +67,11 @@ pub fn make_graph_with_tokens(names: &[&str]) -> TokenGraph {
 /// Empty graph — useful for testing empty-state rendering and error paths.
 pub fn empty_graph() -> TokenGraph {
     make_graph_with_tokens(&[])
+}
+
+/// Minimal `UpdateCtx` for tests that only need key/palette/modal behavior.
+pub fn update_ctx(graph: &TokenGraph) -> UpdateCtx<'_> {
+    UpdateCtx::minimal(graph)
 }
 
 /// Primer line shown in the header during test renders.

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -9,12 +9,13 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::key;
+use common::{key, update_ctx};
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
-use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::app::{ActiveView, Modal};
 use design_data_tui::find::{FindEvent, FindScreen, FindWizardState};
+use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
 use std::path::PathBuf;
 
@@ -29,10 +30,7 @@ fn make_find_graph() -> TokenGraph {
             alias_target: None,
             raw: json!({
                 "value": "#0265DC",
-                "name": {
-                    "property": "background-color",
-                    "variant": "accent"
-                }
+                "name": { "property": "background-color", "variant": "accent" }
             }),
             layer: Layer::Foundation,
         },
@@ -45,10 +43,7 @@ fn make_find_graph() -> TokenGraph {
             alias_target: None,
             raw: json!({
                 "value": "#FFFFFF",
-                "name": {
-                    "property": "background-color",
-                    "variant": "neutral"
-                }
+                "name": { "property": "background-color", "variant": "neutral" }
             }),
             layer: Layer::Foundation,
         },
@@ -61,11 +56,7 @@ fn make_find_graph() -> TokenGraph {
             alias_target: None,
             raw: json!({
                 "value": "#0265DC",
-                "name": {
-                    "property": "color",
-                    "component": "button",
-                    "variant": "accent"
-                }
+                "name": { "property": "color", "component": "button", "variant": "accent" }
             }),
             layer: Layer::Platform,
         },
@@ -73,7 +64,7 @@ fn make_find_graph() -> TokenGraph {
     TokenGraph::from_records(records)
 }
 
-// ── FindWizardState unit tests ───────────────────────────────────────────────
+// ── FindWizardState unit tests (test find module directly, no App/update) ────
 
 #[test]
 fn new_state_is_on_filters_screen() {
@@ -85,7 +76,7 @@ fn new_state_is_on_filters_screen() {
 fn new_with_intent_seeds_intent_field_and_focuses_it() {
     let fs = FindWizardState::new_with_intent("accent background");
     assert_eq!(fs.intent.value(), "accent background");
-    assert_eq!(fs.focused_field, 4); // intent field index
+    assert_eq!(fs.focused_field, 4);
 }
 
 #[test]
@@ -97,14 +88,12 @@ fn new_with_empty_intent_leaves_focus_at_property() {
 #[test]
 fn assemble_expr_from_property_and_variant() {
     let mut fs = FindWizardState::new();
-    // Tab to property field (already there at 0), type value.
     let graph = make_find_graph();
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    // Tab to component (skip), Tab to variant.
-    fs.handle_key(key(KeyCode::Tab), &graph); // → component
-    fs.handle_key(key(KeyCode::Tab), &graph); // → variant
+    fs.handle_key(key(KeyCode::Tab), &graph);
+    fs.handle_key(key(KeyCode::Tab), &graph);
     for c in "accent".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
@@ -122,12 +111,11 @@ fn assemble_expr_returns_none_when_all_fields_empty() {
 fn refresh_preview_populates_rows_for_structured_filter() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    // Set property field directly via handle_key.
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
     fs.refresh_preview(&graph);
-    assert_eq!(fs.preview_count, 2); // accent + neutral background-color tokens
+    assert_eq!(fs.preview_count, 2);
     assert!(fs.preview_error.is_none());
 }
 
@@ -136,7 +124,6 @@ fn refresh_preview_uses_suggest_when_only_intent_filled() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new_with_intent("accent background");
     fs.refresh_preview(&graph);
-    // suggest should find the accent-background-color-default token.
     assert!(fs.preview_count > 0);
     assert!(fs.preview_rows.iter().any(|r| r.name.contains("accent")));
     assert!(fs.preview_error.is_none());
@@ -165,14 +152,11 @@ fn enter_on_filters_advances_to_preview() {
 fn enter_on_preview_emits_open_results() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    // Set property field.
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    // Advance to preview.
     fs.handle_key(key(KeyCode::Enter), &graph);
     assert_eq!(fs.screen, FindScreen::Preview);
-    // Accept preview.
     let event = fs.handle_key(key(KeyCode::Enter), &graph);
     assert!(matches!(event, FindEvent::OpenResults(_)));
 }
@@ -184,10 +168,9 @@ fn open_results_view_has_correct_row_count() {
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
-    let event = fs.handle_key(key(KeyCode::Enter), &graph); // Accept
+    fs.handle_key(key(KeyCode::Enter), &graph);
+    let event = fs.handle_key(key(KeyCode::Enter), &graph);
     if let FindEvent::OpenResults(view) = event {
-        // Fixture has 2 background-color tokens; use >= 1 to avoid brittleness.
         assert!(view.rows.len() >= 1);
         assert_eq!(view.expr_text, "property=background-color");
     } else {
@@ -199,7 +182,7 @@ fn open_results_view_has_correct_row_count() {
 fn e_on_preview_goes_back_to_filters() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    fs.handle_key(key(KeyCode::Enter), &graph);
     let event = fs.handle_key(key(KeyCode::Char('e')), &graph);
     assert!(matches!(event, FindEvent::Continue));
     assert_eq!(fs.screen, FindScreen::Filters);
@@ -217,7 +200,7 @@ fn esc_cancels_on_filters_screen() {
 fn esc_cancels_on_preview_screen() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    fs.handle_key(key(KeyCode::Enter), &graph);
     let event = fs.handle_key(key(KeyCode::Esc), &graph);
     assert!(matches!(event, FindEvent::Cancel));
 }
@@ -226,7 +209,7 @@ fn esc_cancels_on_preview_screen() {
 fn q_cancels_on_preview_screen() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph); // → Preview
+    fs.handle_key(key(KeyCode::Enter), &graph);
     let event = fs.handle_key(key(KeyCode::Char('q')), &graph);
     assert!(matches!(event, FindEvent::Cancel));
 }
@@ -240,7 +223,6 @@ fn tab_cycles_through_fields() {
     assert_eq!(fs.focused_field, 1);
     fs.handle_key(key(KeyCode::Tab), &graph);
     assert_eq!(fs.focused_field, 2);
-    // BackTab goes backward.
     fs.handle_key(key(KeyCode::BackTab), &graph);
     assert_eq!(fs.focused_field, 1);
 }
@@ -249,7 +231,6 @@ fn tab_cycles_through_fields() {
 fn tab_wraps_around_from_last_to_first_field() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    // Jump to last field (4 = intent).
     for _ in 0..4 {
         fs.handle_key(key(KeyCode::Tab), &graph);
     }
@@ -265,7 +246,6 @@ fn property_suggestions_filter_by_typed_prefix() {
     for c in "background".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    // The registry should have terms containing "background".
     assert!(!fs.property_suggestions.is_empty());
     assert!(fs.property_suggestions.iter().all(|s| s.contains("background")));
 }
@@ -274,11 +254,9 @@ fn property_suggestions_filter_by_typed_prefix() {
 fn up_down_navigate_property_suggestions() {
     let mut fs = FindWizardState::new();
     let graph = make_find_graph();
-    // "color" matches many registry terms (background-color, border-color, etc.).
     for c in "color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    // Assert unconditionally so a registry regression is visible, not silently skipped.
     assert!(
         fs.property_suggestions.len() > 1,
         "expected >1 'color' suggestions from registry, got {}",
@@ -295,8 +273,6 @@ fn up_down_navigate_property_suggestions() {
 fn refresh_preview_sets_error_on_invalid_expression() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new();
-    // "foo,bar" assembles to "property=foo,bar"; the parser splits on "," and tries "bar"
-    // as a standalone condition — it has no "=" operator so parse returns a CoreError.
     fs.property = tui_input::Input::from("foo,bar".to_string());
     fs.refresh_preview(&graph);
     assert!(fs.preview_error.is_some(), "expected parse error for condition missing operator");
@@ -316,82 +292,6 @@ fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
     assert!(fs.preview_count >= 1, "expected at least one match for property=background-color");
 }
 
-// ── App-level integration tests ──────────────────────────────────────────────
-
-fn submit(app: &mut App, graph: &TokenGraph, cmd: &str) {
-    let ctx = SubmitContext::new(graph);
-    for c in cmd.chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.handle_key(key(KeyCode::Enter));
-    app.submit_palette(&ctx);
-}
-
-fn open_palette_cmd(app: &mut App) {
-    app.handle_key(key(KeyCode::Char(':')));
-}
-
-#[test]
-fn find_command_opens_find_modal() {
-    let graph = make_find_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "find");
-    assert!(matches!(app.modal, Some(Modal::Find(_))));
-}
-
-#[test]
-fn find_command_with_args_seeds_intent() {
-    let graph = make_find_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "find accent background");
-    if let Some(Modal::Find(ref fs)) = app.modal {
-        assert_eq!(fs.intent.value(), "accent background");
-    } else {
-        panic!("expected Find modal");
-    }
-}
-
-#[test]
-fn find_command_no_args_opens_modal_with_empty_fields() {
-    let graph = make_find_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "find");
-    if let Some(Modal::Find(ref fs)) = app.modal {
-        assert_eq!(fs.intent.value(), "");
-        assert_eq!(fs.focused_field, 0); // focus starts on property
-    } else {
-        panic!("expected Find modal");
-    }
-}
-
-#[test]
-fn tab_autocompletes_find_command() {
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    // "fi" is unambiguous — only "find" starts with "fi".
-    app.handle_key(key(KeyCode::Char('f')));
-    app.handle_key(key(KeyCode::Char('i')));
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "find ");
-}
-
-#[test]
-fn esc_in_find_modal_closes_it() {
-    use design_data_tui::wizard::WizardCtx;
-
-    let graph = make_find_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "find");
-
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Esc), &ctx);
-    assert!(app.modal.is_none());
-}
-
 #[test]
 fn backtab_wraps_from_first_to_last_field() {
     let graph = make_find_graph();
@@ -405,14 +305,11 @@ fn backtab_wraps_from_first_to_last_field() {
 fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
     let graph = make_find_graph();
     let mut fs = FindWizardState::new_with_intent("accent background");
-    // Advance to Preview (refresh_preview runs).
     fs.handle_key(key(KeyCode::Enter), &graph);
     assert_eq!(fs.screen, FindScreen::Preview);
     assert!(fs.preview_count > 0);
-    // Accept Preview → OpenResults.
     let event = fs.handle_key(key(KeyCode::Enter), &graph);
     if let FindEvent::OpenResults(view) = event {
-        // When assemble_expr() returns None, expr_text is the raw intent string.
         assert_eq!(view.expr_text, "accent background");
         assert!(!view.rows.is_empty());
     } else {
@@ -420,55 +317,109 @@ fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
     }
 }
 
+// ── App-level integration tests (migrated to Model + update) ─────────────────
+
+fn submit(model: &mut Model, ctx: &UpdateCtx<'_>, cmd: &str) {
+    update(model, Message::PaletteSubmit(cmd.into()), ctx);
+}
+
+#[test]
+fn find_command_opens_find_modal() {
+    let graph = make_find_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "find");
+    assert!(matches!(model.modal, Some(Modal::Find(_))));
+}
+
+#[test]
+fn find_command_with_args_seeds_intent() {
+    let graph = make_find_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "find accent background");
+    if let Some(Modal::Find(ref fs)) = model.modal {
+        assert_eq!(fs.intent.value(), "accent background");
+    } else {
+        panic!("expected Find modal");
+    }
+}
+
+#[test]
+fn find_command_no_args_opens_modal_with_empty_fields() {
+    let graph = make_find_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "find");
+    if let Some(Modal::Find(ref fs)) = model.modal {
+        assert_eq!(fs.intent.value(), "");
+        assert_eq!(fs.focused_field, 0);
+    } else {
+        panic!("expected Find modal");
+    }
+}
+
+#[test]
+fn tab_autocompletes_find_command() {
+    let graph = make_find_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    for c in "fi".chars() {
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
+    }
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "find ");
+}
+
+#[test]
+fn esc_in_find_modal_closes_it() {
+    let graph = make_find_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "find");
+    assert!(model.modal.is_some());
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(model.modal.is_none());
+}
+
 #[test]
 fn accepting_preview_opens_query_view_and_closes_modal() {
-    use design_data_tui::app::ActiveView;
-    use design_data_tui::wizard::WizardCtx;
-
     let graph = make_find_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "find");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "find");
 
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-
-    // On Filters: type property, then Enter → Preview.
-    if let Some(Modal::Find(ref mut fs)) = app.modal {
-        for c in "background-color".chars() {
-            fs.handle_key(key(KeyCode::Char(c)), &graph);
-        }
+    // Type property field, then Enter → Preview.
+    for c in "background-color".chars() {
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Preview
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Preview
 
-    // On Preview: Enter → OpenResults.
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
+    // Enter → OpenResults.
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
 
-    assert!(app.modal.is_none());
-    assert!(matches!(app.active_view, ActiveView::Query(_)));
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(model.modal.is_none());
+    assert!(matches!(model.active_view, ActiveView::Query(_)));
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("matched"), "expected 'matched' in status: {msg}");
 }
 
 #[test]
 fn e_on_preview_keeps_modal_open_and_returns_to_filters() {
-    use design_data_tui::app::ActiveView;
-    use design_data_tui::wizard::WizardCtx;
-
     let graph = make_find_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "find");
-
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "find");
 
     // Advance to Preview.
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    // Press e → back to Filters; modal stays open.
-    app.handle_modal_key(key(KeyCode::Char('e')), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
+    // Press e → back to Filters.
+    update(&mut model, Message::Key(key(KeyCode::Char('e'))), &ctx);
 
-    assert!(app.modal.is_some(), "e should not close the modal");
-    assert!(matches!(app.active_view, ActiveView::Empty), "e should not open results");
-    if let Some(Modal::Find(ref fs)) = app.modal {
+    assert!(model.modal.is_some(), "e should not close the modal");
+    assert!(matches!(model.active_view, ActiveView::Empty));
+    if let Some(Modal::Find(ref fs)) = model.modal {
         assert_eq!(fs.screen, FindScreen::Filters);
     }
 }

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -10,62 +10,55 @@
 
 //! M5 polish milestone tests: mouse, help overlay, palette history, theming.
 
-use std::env;
-use std::sync::Mutex;
-
 mod common;
-use common::{key, mouse};
+use common::{empty_graph, key, mouse, update_ctx};
 
 use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
-use design_data_core::graph::TokenGraph;
-use design_data_tui::app::{App, HitAction, HitRegion, Modal};
+use design_data_tui::app::{ActiveView, DescribeView, HitAction, HitRegion, Modal, QueryRow,
+    QueryView};
 use design_data_tui::theme::Theme;
-use design_data_tui::wizard::WizardCtx;
+use design_data_tui::{update, Message, Model};
 use ratatui::layout::Rect;
-use tempfile::TempDir;
-
-fn empty_ctx(graph: &TokenGraph) -> WizardCtx<'_> {
-    WizardCtx { graph, dataset_path: None, schema_registry: None, allow_write: false }
-}
-
-fn open_palette(app: &mut App) {
-    app.handle_key(key(KeyCode::Char(':')));
-}
 
 // ── Help overlay ──────────────────────────────────────────────────────────────
 
 #[test]
 fn question_mark_opens_help_modal() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('?')));
-    assert!(matches!(app.modal, Some(Modal::Help(_))), "? should open help modal");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    assert!(matches!(model.modal, Some(Modal::Help(_))), "? should open help modal");
 }
 
 #[test]
 fn esc_closes_help_modal() {
-    let graph = TokenGraph::default();
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('?')));
-    app.handle_modal_key(key(KeyCode::Esc), &empty_ctx(&graph));
-    assert!(app.modal.is_none(), "Esc should close help modal");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(model.modal.is_none(), "Esc should close help modal");
 }
 
 #[test]
 fn question_mark_closes_help_modal() {
-    let graph = TokenGraph::default();
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('?')));
-    app.handle_modal_key(key(KeyCode::Char('?')), &empty_ctx(&graph));
-    assert!(app.modal.is_none(), "second ? should close help modal");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    assert!(model.modal.is_none(), "second ? should close help modal");
 }
 
 #[test]
 fn pgdn_scrolls_help_body() {
-    let graph = TokenGraph::default();
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('?')));
-    app.handle_modal_key(key(KeyCode::PageDown), &empty_ctx(&graph));
-    if let Some(Modal::Help(ref hm)) = app.modal {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::PageDown)), &ctx);
+    if let Some(Modal::Help(ref hm)) = model.modal {
         assert_eq!(hm.scroll, 10, "PageDown should advance help scroll by 10");
     } else {
         panic!("expected Help modal to still be open");
@@ -74,14 +67,14 @@ fn pgdn_scrolls_help_body() {
 
 #[test]
 fn arrow_keys_scroll_help_body() {
-    let graph = TokenGraph::default();
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('?')));
-    let ctx = empty_ctx(&graph);
-    app.handle_modal_key(key(KeyCode::Down), &ctx);
-    app.handle_modal_key(key(KeyCode::Down), &ctx);
-    app.handle_modal_key(key(KeyCode::Up), &ctx);
-    if let Some(Modal::Help(ref hm)) = app.modal {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
+    if let Some(Modal::Help(ref hm)) = model.modal {
         assert_eq!(hm.scroll, 1);
     } else {
         panic!("expected Help modal");
@@ -90,127 +83,87 @@ fn arrow_keys_scroll_help_body() {
 
 // ── Palette history ───────────────────────────────────────────────────────────
 
-// Serialize env-touching tests to avoid DESIGN_DATA_TUI_HISTORY stomping across
-// concurrently running tests (cargo test runs in parallel by default).
-static HISTORY_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-fn with_temp_history<F: FnOnce()>(f: F) -> TempDir {
-    let dir = TempDir::new().unwrap();
-    let history_path = dir.path().join("history");
-    let _guard = HISTORY_ENV_LOCK.lock().unwrap();
-    env::set_var("DESIGN_DATA_TUI_HISTORY", &history_path);
-    f();
-    env::remove_var("DESIGN_DATA_TUI_HISTORY");
-    dir
-}
-
 #[test]
 fn submit_palette_appends_to_history() {
-    let _dir = with_temp_history(|| {
-        let mut app = App::new();
-        open_palette(&mut app);
-        for ch in "query *".chars() {
-            app.handle_key(key(KeyCode::Char(ch)));
-        }
-        app.handle_key(key(KeyCode::Enter));
-        let graph = TokenGraph::default();
-        let ctx = design_data_tui::app::SubmitContext::new(&graph);
-        app.submit_palette(&ctx);
-
-        assert_eq!(app.palette_history.first().map(|s| s.as_str()), Some("query *"));
-    });
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query *".into()), &ctx);
+    assert_eq!(model.palette_history.first().map(|s| s.as_str()), Some("query *"));
 }
 
 #[test]
 fn up_arrow_in_palette_recalls_last_command() {
-    let _dir = with_temp_history(|| {
-        let mut app = App::new();
-        app.palette_history = vec!["query foo".to_string(), "query bar".to_string()];
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.palette_history = vec!["query foo".to_string(), "query bar".to_string()];
 
-        open_palette(&mut app);
-        app.handle_key(key(KeyCode::Up));
-        assert_eq!(app.palette_input.value(), "query foo");
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx); // open palette
+    update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
+    assert_eq!(model.palette_input.value(), "query foo");
 
-        app.handle_key(key(KeyCode::Up));
-        assert_eq!(app.palette_input.value(), "query bar");
+    update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
+    assert_eq!(model.palette_input.value(), "query bar");
 
-        app.handle_key(key(KeyCode::Down));
-        assert_eq!(app.palette_input.value(), "query foo");
-    });
+    update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
+    assert_eq!(model.palette_input.value(), "query foo");
 }
 
 #[test]
 fn history_dedupes_consecutive_duplicates() {
-    let _dir = with_temp_history(|| {
-        let mut app = App::new();
-        app.palette_history = vec!["query *".to_string()];
-        open_palette(&mut app);
-        for ch in "query *".chars() {
-            app.handle_key(key(KeyCode::Char(ch)));
-        }
-        app.handle_key(key(KeyCode::Enter));
-        let graph = TokenGraph::default();
-        let ctx = design_data_tui::app::SubmitContext::new(&graph);
-        app.submit_palette(&ctx);
-
-        assert_eq!(app.palette_history.len(), 1, "same command should not be duplicated");
-    });
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.palette_history = vec!["query *".to_string()];
+    update(&mut model, Message::PaletteSubmit("query *".into()), &ctx);
+    assert_eq!(model.palette_history.len(), 1, "same command should not be duplicated");
 }
 
 #[test]
 fn history_caps_at_200_entries() {
-    let _dir = with_temp_history(|| {
-        let mut app = App::new();
-        app.palette_history = (0..199).map(|i| format!("query token-{i}")).collect();
-
-        open_palette(&mut app);
-        for ch in "query new-token".chars() {
-            app.handle_key(key(KeyCode::Char(ch)));
-        }
-        app.handle_key(key(KeyCode::Enter));
-        let graph = TokenGraph::default();
-        let ctx = design_data_tui::app::SubmitContext::new(&graph);
-        app.submit_palette(&ctx);
-
-        assert_eq!(app.palette_history.len(), 200);
-        assert_eq!(app.palette_history[0], "query new-token");
-    });
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.palette_history = (0..199).map(|i| format!("query token-{i}")).collect();
+    update(&mut model, Message::PaletteSubmit("query new-token".into()), &ctx);
+    assert_eq!(model.palette_history.len(), 200);
+    assert_eq!(model.palette_history[0], "query new-token");
 }
 
 #[test]
 fn typing_resets_history_cursor() {
-    let _dir = with_temp_history(|| {
-        let mut app = App::new();
-        app.palette_history = vec!["query foo".to_string(), "query bar".to_string()];
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.palette_history = vec!["query foo".to_string(), "query bar".to_string()];
 
-        open_palette(&mut app);
-        app.handle_key(key(KeyCode::Up)); // cursor = Some(0)
-        assert_eq!(app.palette_history_cursor, Some(0));
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
+    assert_eq!(model.palette_history_cursor, Some(0));
 
-        // Type a character — cursor must reset so the next ↑ starts from head.
-        app.handle_key(key(KeyCode::Char('x')));
-        assert_eq!(app.palette_history_cursor, None, "typing should reset history cursor");
+    update(&mut model, Message::Key(key(KeyCode::Char('x'))), &ctx);
+    assert_eq!(model.palette_history_cursor, None, "typing should reset history cursor");
 
-        // Pressing ↑ again should return to index 0 (newest entry), not continue from 1.
-        app.handle_key(key(KeyCode::Up));
-        assert_eq!(app.palette_history_cursor, Some(0));
-        assert_eq!(app.palette_input.value(), "query foo");
-    });
+    update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
+    assert_eq!(model.palette_history_cursor, Some(0));
+    assert_eq!(model.palette_input.value(), "query foo");
 }
 
 // ── Mouse: wheel scroll ───────────────────────────────────────────────────────
 
 #[test]
 fn wheel_scroll_down_increments_describe_scroll() {
-    use design_data_tui::app::ActiveView;
-    let mut app = App::new();
-    app.active_view = ActiveView::Describe(design_data_tui::app::DescribeView {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(DescribeView {
         component: "button".to_string(),
         pretty_json: "{}".to_string(),
         scroll: 0,
     });
-    app.handle_mouse(mouse(MouseEventKind::ScrollDown, 5, 5));
-    if let ActiveView::Describe(ref dv) = app.active_view {
+    update(&mut model, Message::Mouse(mouse(MouseEventKind::ScrollDown, 5, 5)), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
         assert!(dv.scroll > 0, "scroll down should advance describe scroll");
     }
 }
@@ -219,51 +172,22 @@ fn wheel_scroll_down_increments_describe_scroll() {
 
 #[test]
 fn click_on_hit_region_selects_row() {
-    use design_data_tui::app::{ActiveView, QueryRow, QueryView};
-    let mut app = App::new();
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
     let rows = vec![
-        QueryRow {
-            name: "a".into(),
-            value: "1".into(),
-            file: "f".into(),
-            layer: "foundation".into(),
-        },
-        QueryRow {
-            name: "b".into(),
-            value: "2".into(),
-            file: "f".into(),
-            layer: "foundation".into(),
-        },
-        QueryRow {
-            name: "c".into(),
-            value: "3".into(),
-            file: "f".into(),
-            layer: "foundation".into(),
-        },
+        QueryRow { name: "a".into(), value: "1".into(), file: "f".into(), layer: "foundation".into() },
+        QueryRow { name: "b".into(), value: "2".into(), file: "f".into(), layer: "foundation".into() },
+        QueryRow { name: "c".into(), value: "3".into(), file: "f".into(), layer: "foundation".into() },
     ];
-    app.active_view = ActiveView::Query(QueryView::new("*".to_string(), rows));
-
-    app.hit_regions = vec![
-        HitRegion {
-            rect: Rect { x: 0, y: 2, width: 80, height: 1 },
-            action: HitAction::SelectListRow(0),
-            text: "a".into(),
-        },
-        HitRegion {
-            rect: Rect { x: 0, y: 3, width: 80, height: 1 },
-            action: HitAction::SelectListRow(1),
-            text: "b".into(),
-        },
-        HitRegion {
-            rect: Rect { x: 0, y: 4, width: 80, height: 1 },
-            action: HitAction::SelectListRow(2),
-            text: "c".into(),
-        },
+    model.active_view = ActiveView::Query(QueryView::new("*".to_string(), rows));
+    model.hit_regions = vec![
+        HitRegion { rect: Rect { x: 0, y: 2, width: 80, height: 1 }, action: HitAction::SelectListRow(0), text: "a".into() },
+        HitRegion { rect: Rect { x: 0, y: 3, width: 80, height: 1 }, action: HitAction::SelectListRow(1), text: "b".into() },
+        HitRegion { rect: Rect { x: 0, y: 4, width: 80, height: 1 }, action: HitAction::SelectListRow(2), text: "c".into() },
     ];
-
-    // Click row 1 (y=3).
-    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 10));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    update(&mut model, Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 10)), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(1), "click should select row 1");
     }
 }
@@ -272,27 +196,33 @@ fn click_on_hit_region_selects_row() {
 
 #[test]
 fn v_key_enters_selection_mode() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('v')));
-    assert!(app.selection_mode, "v should enable selection mode");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
+    assert!(model.selection_mode, "v should enable selection mode");
 }
 
 #[test]
 fn v_key_toggles_selection_mode_off() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('v')));
-    app.handle_key(key(KeyCode::Char('v')));
-    assert!(!app.selection_mode, "second v should disable selection mode");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
+    assert!(!model.selection_mode, "second v should disable selection mode");
 }
 
 #[test]
 fn drag_records_selection_endpoints() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('v')));
-    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0));
-    app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 10));
-    assert_eq!(app.sel_start, Some((2, 0)));
-    assert_eq!(app.sel_end, Some((4, 10)));
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
+    update(&mut model, Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0)), &ctx);
+    update(&mut model, Message::Mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 10)), &ctx);
+    assert_eq!(model.sel_start, Some((2, 0)));
+    assert_eq!(model.sel_end, Some((4, 10)));
 }
 
 // ── Theming ───────────────────────────────────────────────────────────────────
@@ -308,11 +238,7 @@ fn theme_terminal_has_reset_fg() {
 fn theme_spectrum_overrides_accent() {
     use ratatui::style::Color;
     let t = Theme::spectrum();
-    assert_eq!(
-        t.accent,
-        Color::Rgb(64, 70, 202),
-        "spectrum theme accent should be Indigo 700"
-    );
+    assert_eq!(t.accent, Color::Rgb(64, 70, 202), "spectrum theme accent should be Indigo 700");
 }
 
 #[test]

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -9,25 +9,25 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::{key, make_graph_with_tokens};
+use common::{key, make_graph_with_tokens, update_ctx};
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph};
-use design_data_tui::app::{App, Modal, SubmitContext};
+use design_data_tui::app::Modal;
 use design_data_tui::naming::{NamingEvent, NamingScreen, NamingWizardState};
+use design_data_tui::{update, Message, Model, UpdateCtx};
 
 fn make_graph() -> TokenGraph {
     make_graph_with_tokens(&["accent-background-color-default"])
 }
 
-// ── NamingWizardState unit tests ─────────────────────────────────────────────
+// ── NamingWizardState unit tests (test naming module directly, no App/update) ─
 
 #[test]
 fn assembled_name_joins_property_and_name_fields() {
     let graph = make_graph();
     let mut ns = NamingWizardState::new();
     ns.screen = NamingScreen::Classification;
-    // Tab to move focus to property field (focused_field 0→1).
     ns.handle_key(key(KeyCode::Tab), &graph);
     for c in "background-color".chars() {
         ns.handle_key(key(KeyCode::Char(c)), &graph);
@@ -67,14 +67,12 @@ fn c_on_result_screen_returns_copy_event() {
     let graph = make_graph();
     let mut ns = NamingWizardState::new();
     ns.screen = NamingScreen::Classification;
-    // Tab to property field, then type.
     ns.handle_key(key(KeyCode::Tab), &graph);
     for c in "color".chars() {
         ns.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    ns.handle_key(key(KeyCode::Enter), &graph); // advance to Result
+    ns.handle_key(key(KeyCode::Enter), &graph);
     assert_eq!(ns.screen, NamingScreen::Result);
-
     let event = ns.handle_key(key(KeyCode::Char('c')), &graph);
     assert!(matches!(event, NamingEvent::Copy(ref name) if name == "color"));
 }
@@ -114,54 +112,58 @@ fn layer_cycles_with_arrow_keys_on_classification() {
     let graph = make_graph();
     let mut ns = NamingWizardState::new();
     ns.screen = NamingScreen::Classification;
-    // focused_field == 0 (layer), right cycles forward Foundation → Platform.
     ns.handle_key(key(KeyCode::Right), &graph);
     assert_eq!(ns.classification.layer, Layer::Platform);
     ns.handle_key(key(KeyCode::Left), &graph);
     assert_eq!(ns.classification.layer, Layer::Foundation);
 }
 
-// ── App-level integration tests ───────────────────────────────────────────────
-
-fn submit(app: &mut App, graph: &TokenGraph, cmd: &str) {
-    let ctx = SubmitContext::new(graph);
-    let chars: Vec<char> = cmd.chars().collect();
-    for c in chars {
-        app.handle_key(key(KeyCode::Char(c)));
+#[test]
+fn y_key_on_result_screen_also_copies() {
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    ns.handle_key(key(KeyCode::Tab), &graph);
+    for c in "color".chars() {
+        ns.handle_key(key(KeyCode::Char(c)), &graph);
     }
-    app.handle_key(key(KeyCode::Enter));
-    app.submit_palette(&ctx);
+    ns.handle_key(key(KeyCode::Enter), &graph);
+    assert_eq!(ns.screen, NamingScreen::Result);
+    let event = ns.handle_key(key(KeyCode::Char('y')), &graph);
+    assert!(matches!(event, NamingEvent::Copy(ref name) if name == "color"));
 }
 
-fn open_palette_cmd(app: &mut App) {
-    app.handle_key(key(KeyCode::Char(':')));
+// ── App-level integration tests (migrated to Model + update) ─────────────────
+
+fn submit(model: &mut Model, ctx: &UpdateCtx<'_>, cmd: &str) {
+    update(model, Message::PaletteSubmit(cmd.into()), ctx);
 }
 
 #[test]
 fn name_command_opens_naming_modal() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "name accent background");
-    assert!(matches!(app.modal, Some(Modal::Naming(_))));
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "name accent background");
+    assert!(matches!(model.modal, Some(Modal::Naming(_))));
 }
 
 #[test]
 fn name_command_no_args_opens_naming_modal() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "name");
-    assert!(matches!(app.modal, Some(Modal::Naming(_))));
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "name");
+    assert!(matches!(model.modal, Some(Modal::Naming(_))));
 }
 
 #[test]
 fn name_command_seeds_intent_from_args() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "name accent background");
-    if let Some(Modal::Naming(ref ns)) = app.modal {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "name accent background");
+    if let Some(Modal::Naming(ref ns)) = model.modal {
         assert_eq!(ns.intent.value(), "accent background");
     } else {
         panic!("expected Naming modal");
@@ -170,72 +172,48 @@ fn name_command_seeds_intent_from_args() {
 
 #[test]
 fn tab_autocompletes_name_command() {
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    // "na" is unambiguous — "name" is the only command with that prefix.
-    app.handle_key(key(KeyCode::Char('n')));
-    app.handle_key(key(KeyCode::Char('a')));
-    app.handle_key(key(KeyCode::Tab));
-    assert_eq!(app.palette_input.value(), "name ");
+    let graph = make_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    for c in "na".chars() {
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
+    }
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input.value(), "name ");
 }
 
 #[test]
 fn copy_event_sets_pending_yank_and_status() {
-    use design_data_tui::wizard::WizardCtx;
-
     let graph = make_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "name");
-
-    // Drive to result screen with a property typed.
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "name");
 
     // Enter on intent screen → Classification.
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    // On Classification: Tab to property field, type "color", then Enter → Result.
-    app.handle_modal_key(key(KeyCode::Tab), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
+    // Tab to property field, type "color", Enter → Result.
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
     for c in "color".chars() {
-        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    // On Result: press 'c' → Copy.
-    app.handle_modal_key(key(KeyCode::Char('c')), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
+    // Press 'c' → Copy.
+    update(&mut model, Message::Key(key(KeyCode::Char('c'))), &ctx);
 
-    assert_eq!(app.pending_yank.as_deref(), Some("color"));
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert_eq!(model.pending_yank.as_deref(), Some("color"));
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
-    // Copy does NOT close the modal — user stays on Result to copy again or keep inspecting.
-    assert!(app.modal.is_some(), "Copy should not close the Naming modal");
-}
-
-#[test]
-fn y_key_on_result_screen_also_copies() {
-    let graph = make_graph();
-    let mut ns = NamingWizardState::new();
-    ns.screen = NamingScreen::Classification;
-    // Tab to property field, type "color", advance to Result.
-    ns.handle_key(key(KeyCode::Tab), &graph);
-    for c in "color".chars() {
-        ns.handle_key(key(KeyCode::Char(c)), &graph);
-    }
-    ns.handle_key(key(KeyCode::Enter), &graph);
-    assert_eq!(ns.screen, NamingScreen::Result);
-
-    let event = ns.handle_key(key(KeyCode::Char('y')), &graph);
-    assert!(matches!(event, NamingEvent::Copy(ref name) if name == "color"));
+    assert!(model.modal.is_some(), "Copy should not close the Naming modal");
 }
 
 #[test]
 fn esc_in_naming_modal_closes_it() {
-    use design_data_tui::wizard::WizardCtx;
-
     let graph = make_graph();
-    let mut app = App::new();
-    open_palette_cmd(&mut app);
-    submit(&mut app, &graph, "name");
-
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Esc), &ctx);
-    assert!(app.modal.is_none());
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "name");
+    assert!(model.modal.is_some());
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(model.modal.is_none());
 }

--- a/sdk/tui/tests/palette.rs
+++ b/sdk/tui/tests/palette.rs
@@ -9,10 +9,11 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::key;
+use common::{empty_graph, key, update_ctx};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use design_data_tui::app::{App, PaletteMode};
+use design_data_tui::app::PaletteMode;
+use design_data_tui::{update, Message, Model};
 
 fn ctrl(c: char) -> KeyEvent {
     KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
@@ -20,85 +21,105 @@ fn ctrl(c: char) -> KeyEvent {
 
 #[test]
 fn colon_opens_palette_in_command_mode() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    assert!(app.palette_open);
-    assert_eq!(app.palette_mode, PaletteMode::Command);
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    assert!(model.palette_open);
+    assert_eq!(model.palette_mode, PaletteMode::Command);
 }
 
 #[test]
 fn slash_opens_palette_in_fuzzy_find_mode() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('/')));
-    assert!(app.palette_open);
-    assert_eq!(app.palette_mode, PaletteMode::FuzzyFind);
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    assert!(model.palette_open);
+    assert_eq!(model.palette_mode, PaletteMode::FuzzyFind);
 }
 
 #[test]
 fn esc_closes_palette() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    assert!(app.palette_open);
-    app.handle_key(key(KeyCode::Esc));
-    assert!(!app.palette_open);
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    assert!(model.palette_open);
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(!model.palette_open);
 }
 
 #[test]
 fn q_quits_when_palette_closed() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('q')));
-    assert!(app.quit);
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('q'))), &ctx);
+    assert!(model.quit);
 }
 
 #[test]
 fn q_does_not_quit_when_palette_open() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    app.handle_key(key(KeyCode::Char('q')));
-    assert!(!app.quit);
-    assert!(app.palette_open);
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('q'))), &ctx);
+    assert!(!model.quit);
+    assert!(model.palette_open);
 }
 
 #[test]
 fn ctrl_c_always_quits() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    assert!(app.palette_open);
-    app.handle_key(ctrl('c'));
-    assert!(app.quit);
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    assert!(model.palette_open);
+    update(&mut model, Message::Key(ctrl('c')), &ctx);
+    assert!(model.quit);
 }
 
 #[test]
 fn esc_clears_palette_input() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    app.handle_key(key(KeyCode::Char('f')));
-    app.handle_key(key(KeyCode::Char('o')));
-    app.handle_key(key(KeyCode::Char('o')));
-    app.handle_key(key(KeyCode::Esc));
-    assert!(!app.palette_open);
-    assert!(app.palette_input.value().is_empty());
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    for c in "foo".chars() {
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
+    }
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(!model.palette_open);
+    assert!(model.palette_input.value().is_empty());
 }
 
 #[test]
 fn palette_prefix_command() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    assert_eq!(app.palette_prefix(), ":");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    assert_eq!(model.palette_prefix(), ":");
 }
 
 #[test]
 fn palette_prefix_fuzzy_find() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('/')));
-    assert_eq!(app.palette_prefix(), "/");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    assert_eq!(model.palette_prefix(), "/");
 }
 
 #[test]
 fn colon_while_palette_open_goes_to_input_buffer() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':'))); // open palette
-    app.handle_key(key(KeyCode::Char(':'))); // forwarded to input, not re-open
-    assert!(app.palette_open);
-    assert_eq!(app.palette_input.value(), ":");
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx); // open palette
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx); // forwarded to input
+    assert!(model.palette_open);
+    assert_eq!(model.palette_input.value(), ":");
 }

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -9,36 +9,29 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::{empty_graph, key, make_graph_with_tokens};
+use common::{empty_graph, key, make_graph_with_tokens, update_ctx};
 
 use crossterm::event::KeyCode;
-use design_data_tui::app::{ActiveView, App, SubmitContext};
+use design_data_tui::app::ActiveView;
+use design_data_tui::{update, Message, Model};
 
 #[test]
 fn submit_valid_query_populates_query_view() {
     let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
-    let mut app = App::new();
-    // Simulate opening palette, typing, and submitting.
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=accent-color".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    // Palette is still open; submit_palette is called by main.rs after Enter.
-    app.submit_palette(&SubmitContext::new(&graph));
-    assert!(!app.palette_open);
-    assert!(matches!(app.active_view, ActiveView::Query(_)));
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=accent-color".into()), &ctx);
+    assert!(!model.palette_open);
+    assert!(matches!(model.active_view, ActiveView::Query(_)));
 }
 
 #[test]
 fn submit_query_resets_selection_to_zero() {
     let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
     } else {
         panic!("expected Query view");
@@ -48,43 +41,36 @@ fn submit_query_resets_selection_to_zero() {
 #[test]
 fn submit_invalid_query_sets_status_message() {
     let graph = empty_graph();
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query ===bad===".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    assert!(!app.palette_open);
-    assert!(matches!(app.active_view, ActiveView::Empty));
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("query error") || msg.contains("error"), "expected error message, got: {msg}");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query ===bad===".into()), &ctx);
+    assert!(!model.palette_open);
+    assert!(matches!(model.active_view, ActiveView::Empty));
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(
+        msg.contains("query error") || msg.contains("error"),
+        "expected error message, got: {msg}"
+    );
 }
 
 #[test]
 fn submit_unknown_command_sets_status_message() {
     let graph = empty_graph();
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "foobar".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("foobar".into()), &ctx);
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("unknown command"), "expected 'unknown command' in: {msg}");
 }
 
 #[test]
 fn down_j_moves_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    // Selection starts at 0.
-    app.handle_key(key(KeyCode::Char('j')));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(1));
     } else {
         panic!("expected Query view");
@@ -94,15 +80,12 @@ fn down_j_moves_selection() {
 #[test]
 fn up_k_moves_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    app.handle_key(key(KeyCode::Char('j')));
-    app.handle_key(key(KeyCode::Char('k')));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('k'))), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
     } else {
         panic!("expected Query view");
@@ -112,23 +95,18 @@ fn up_k_moves_selection() {
 #[test]
 fn selection_clamps_at_bounds() {
     let graph = make_graph_with_tokens(&["a", "b"]);
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    // Try to go above 0.
-    app.handle_key(key(KeyCode::Up));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
     } else {
         panic!("expected Query view");
     }
-    // Go to last, then try to go past.
-    app.handle_key(key(KeyCode::Down));
-    app.handle_key(key(KeyCode::Down));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(1));
     } else {
         panic!("expected Query view");
@@ -138,48 +116,33 @@ fn selection_clamps_at_bounds() {
 #[test]
 fn y_sets_yank_pending_with_selected_name() {
     let graph = make_graph_with_tokens(&["accent-color"]);
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    app.handle_key(key(KeyCode::Char('y')));
-    assert!(app.pending_yank.is_some());
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('y'))), &ctx);
+    assert!(model.pending_yank.is_some());
 }
 
 #[test]
 fn esc_from_query_view_returns_to_empty() {
     let graph = make_graph_with_tokens(&["a"]);
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    assert!(matches!(app.active_view, ActiveView::Query(_)));
-    app.handle_key(key(KeyCode::Esc));
-    assert!(matches!(app.active_view, ActiveView::Empty));
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    assert!(matches!(model.active_view, ActiveView::Query(_)));
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(matches!(model.active_view, ActiveView::Empty));
 }
 
 #[test]
 fn re_query_replaces_results_and_resets_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
-    let mut app = App::new();
-    // First query.
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    app.handle_key(key(KeyCode::Char('j')));
-    // Second query from within query view — `:` opens palette.
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in "query property=*".chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(&graph));
-    if let ActiveView::Query(ref qv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
     } else {
         panic!("expected Query view");

--- a/sdk/tui/tests/resolve.rs
+++ b/sdk/tui/tests/resolve.rs
@@ -9,19 +9,16 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::key;
+use common::{key, update_ctx};
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
-use design_data_tui::app::{ActiveView, App, SubmitContext};
+use design_data_tui::app::ActiveView;
+use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
 use std::path::PathBuf;
 
 fn make_resolve_graph() -> TokenGraph {
-    // Three tokens for "background-color":
-    //   - base (no colorScheme → wildcard, specificity 0)
-    //   - light (colorScheme=light, specificity 0 because light is the default)
-    //   - dark  (colorScheme=dark,  specificity 1 because dark is non-default)
     let color_scheme_ms = ModeSetRecord {
         file: PathBuf::from("mode-sets/color-scheme.json"),
         name: "colorScheme".into(),
@@ -63,33 +60,27 @@ fn make_resolve_graph() -> TokenGraph {
     TokenGraph::from_records(records).with_mode_sets(vec![color_scheme_ms])
 }
 
-fn submit_command(app: &mut App, graph: &TokenGraph, cmd: &str) {
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in cmd.chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(graph));
+fn submit(model: &mut Model, ctx: &UpdateCtx<'_>, cmd: &str) {
+    update(model, Message::PaletteSubmit(cmd.into()), ctx);
 }
 
 #[test]
 fn resolve_with_matching_property_returns_resolve_view() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=background-color");
-    assert!(
-        matches!(app.active_view, ActiveView::Resolve(_)),
-        "expected Resolve view"
-    );
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    assert!(matches!(model.active_view, ActiveView::Resolve(_)), "expected Resolve view");
 }
 
 #[test]
 fn resolve_view_has_winner() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=background-color");
-    if let ActiveView::Resolve(ref rv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    if let ActiveView::Resolve(ref rv) = model.active_view {
         assert!(!rv.rows.is_empty(), "expected candidates");
-        // First row should be winner (highest-precedence candidate).
         assert!(rv.rows[0].is_winner, "expected first row to be winner");
     } else {
         panic!("expected Resolve view");
@@ -99,41 +90,39 @@ fn resolve_view_has_winner() {
 #[test]
 fn resolve_no_args_sets_error_status() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve");
-    assert!(matches!(app.active_view, ActiveView::Empty));
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve");
+    assert!(matches!(model.active_view, ActiveView::Empty));
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("required") || msg.contains("error"), "expected error: {msg}");
 }
 
 #[test]
 fn resolve_unknown_property_returns_empty_candidates() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=nonexistent-property");
-    if let ActiveView::Resolve(ref rv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=nonexistent-property");
+    if let ActiveView::Resolve(ref rv) = model.active_view {
         assert!(rv.rows.is_empty(), "expected no candidates");
     } else {
         panic!("expected Resolve view");
     }
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("no match"), "expected 'no match': {msg}");
 }
 
 #[test]
 fn resolve_with_color_scheme_context_selects_dark_winner() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(
-        &mut app,
-        &graph,
-        "resolve property=background-color,colorScheme=dark",
-    );
-    if let ActiveView::Resolve(ref rv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color,colorScheme=dark");
+    if let ActiveView::Resolve(ref rv) = model.active_view {
         assert!(!rv.rows.is_empty());
         let winner = rv.rows.iter().find(|r| r.is_winner);
         assert!(winner.is_some(), "expected a winner");
-        // Dark token has higher specificity and should win in dark context.
         let w = winner.unwrap();
         assert!(
             w.name.contains("dark") || w.name.contains("colorScheme=dark"),
@@ -148,9 +137,10 @@ fn resolve_with_color_scheme_context_selects_dark_winner() {
 #[test]
 fn resolve_selection_starts_at_zero() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=background-color");
-    if let ActiveView::Resolve(ref rv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    if let ActiveView::Resolve(ref rv) = model.active_view {
         assert_eq!(rv.table_state.selected(), Some(0));
     } else {
         panic!("expected Resolve view");
@@ -160,16 +150,17 @@ fn resolve_selection_starts_at_zero() {
 #[test]
 fn resolve_j_k_navigate() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=background-color");
-    app.handle_key(key(KeyCode::Char('j')));
-    if let ActiveView::Resolve(ref rv) = app.active_view {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    if let ActiveView::Resolve(ref rv) = model.active_view {
         assert_eq!(rv.table_state.selected(), Some(1));
     } else {
         panic!("expected Resolve view");
     }
-    app.handle_key(key(KeyCode::Char('k')));
-    if let ActiveView::Resolve(ref rv) = app.active_view {
+    update(&mut model, Message::Key(key(KeyCode::Char('k'))), &ctx);
+    if let ActiveView::Resolve(ref rv) = model.active_view {
         assert_eq!(rv.table_state.selected(), Some(0));
     } else {
         panic!("expected Resolve view");
@@ -179,18 +170,20 @@ fn resolve_j_k_navigate() {
 #[test]
 fn resolve_y_sets_pending_yank() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=background-color");
-    app.handle_key(key(KeyCode::Char('y')));
-    assert!(app.pending_yank.is_some(), "expected pending yank");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    update(&mut model, Message::Key(key(KeyCode::Char('y'))), &ctx);
+    assert!(model.pending_yank.is_some(), "expected pending yank");
 }
 
 #[test]
 fn esc_from_resolve_view_returns_to_empty() {
     let graph = make_resolve_graph();
-    let mut app = App::new();
-    submit_command(&mut app, &graph, "resolve property=background-color");
-    assert!(matches!(app.active_view, ActiveView::Resolve(_)));
-    app.handle_key(key(KeyCode::Esc));
-    assert!(matches!(app.active_view, ActiveView::Empty));
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    assert!(matches!(model.active_view, ActiveView::Resolve(_)));
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(matches!(model.active_view, ActiveView::Empty));
 }

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -9,15 +9,15 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::{key, make_graph};
+use common::{key, make_graph, update_ctx};
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
 use design_data_tui::app::{App, Modal, SubmitContext};
 use design_data_tui::wizard::{ValueKind, WizardCtx, WizardPath, WizardScreen};
+use design_data_tui::{Task, UpdateCtx, update, Message, Model};
 use std::path::PathBuf;
 
-/// Graph with a colorScheme mode set — used for Screen 3 tests.
 fn make_graph_with_modes() -> TokenGraph {
     let ms = ModeSetRecord {
         file: PathBuf::from("mode-sets/color-scheme.json"),
@@ -28,14 +28,13 @@ fn make_graph_with_modes() -> TokenGraph {
     make_graph().with_mode_sets(vec![ms])
 }
 
-/// Open the wizard via `:new <intent>`.
-fn open_wizard(app: &mut App, graph: &TokenGraph, intent: &str) {
-    let cmd = format!("new {intent}");
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in cmd.chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(graph));
+fn fixtures_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+/// Open the wizard via `PaletteSubmit("new <intent>")`.
+fn open_wizard(model: &mut Model, ctx: &UpdateCtx<'_>, intent: &str) {
+    update(model, Message::PaletteSubmit(format!("new {intent}")), ctx);
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -43,33 +42,33 @@ fn open_wizard(app: &mut App, graph: &TokenGraph, intent: &str) {
 #[test]
 fn new_command_opens_wizard() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "accent background");
-    assert!(app.modal.is_some(), "modal should be open after :new");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "accent background");
+    assert!(model.modal.is_some(), "modal should be open after :new");
 }
 
 #[test]
 fn esc_cancels_wizard() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "accent background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Esc), &ctx);
-    assert!(app.modal.is_none(), "modal should close on Esc");
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "accent background");
+    let task = update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(model.modal.is_none(), "modal should close on Esc");
+    assert!(matches!(task, Task::Cmd(_)), "cancel should return Task::Cmd (draft clear)");
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("cancelled"), "status should say cancelled: {msg}");
 }
 
 #[test]
 fn intent_populates_suggestions_on_open() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "accent background");
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
-        assert!(
-            !ws.suggestions.is_empty(),
-            "suggestions should be populated from intent"
-        );
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "accent background");
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
+        assert!(!ws.suggestions.is_empty(), "suggestions should be populated from intent");
     } else {
         panic!("expected wizard modal");
     }
@@ -78,11 +77,11 @@ fn intent_populates_suggestions_on_open() {
 #[test]
 fn enter_on_screen_1_advances_to_screen_2() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "accent background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "accent background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.screen, WizardScreen::Classification, "should advance to Screen 2");
     } else {
         panic!("expected wizard modal after Enter on Screen 1");
@@ -92,13 +91,12 @@ fn enter_on_screen_1_advances_to_screen_2() {
 #[test]
 fn tab_with_suggestion_sets_alias_path_and_jumps_to_confirm() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "accent background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    // Tab should reuse the top suggestion and skip to Screen 4.
-    app.handle_modal_key(key(KeyCode::Tab), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
-        assert_eq!(ws.screen, WizardScreen::Confirm, "should jump to Confirm after Tab reuse");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "accent background");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
+        assert_eq!(ws.screen, WizardScreen::Confirm, "Tab should jump to Confirm");
         assert!(
             matches!(ws.chosen_path, WizardPath::AliasToExisting(_)),
             "chosen_path should be AliasToExisting"
@@ -111,21 +109,18 @@ fn tab_with_suggestion_sets_alias_path_and_jumps_to_confirm() {
 #[test]
 fn screen_2_layer_cycles_with_arrow_keys() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    // Advance to Screen 2.
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    // focused_field = 0 (layer); Right cycles forward.
-    app.handle_modal_key(key(KeyCode::Right), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Right)), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.classification.layer, Layer::Platform, "Right should advance layer");
     } else {
         panic!("expected wizard modal");
     }
-    // Left cycles back.
-    app.handle_modal_key(key(KeyCode::Left), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    update(&mut model, Message::Key(key(KeyCode::Left)), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.classification.layer, Layer::Foundation, "Left should reverse layer");
     }
 }
@@ -133,12 +128,12 @@ fn screen_2_layer_cycles_with_arrow_keys() {
 #[test]
 fn screen_2_enter_advances_to_screen_3() {
     let graph = make_graph();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.screen, WizardScreen::Values, "should advance to Screen 3");
     } else {
         panic!("expected wizard modal");
@@ -148,13 +143,12 @@ fn screen_2_enter_advances_to_screen_3() {
 #[test]
 fn screen_3_mode_rows_match_cartesian_product() {
     let graph = make_graph_with_modes();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
-        // colorScheme has 2 modes → 2 rows.
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.values.rows.len(), 2, "should have one row per mode combo");
     } else {
         panic!("expected wizard modal");
@@ -164,34 +158,39 @@ fn screen_3_mode_rows_match_cartesian_product() {
 #[test]
 fn screen_3_a_l_toggle_value_kind() {
     let graph = make_graph_with_modes();
-    let mut app = App::new();
-    open_wizard(&mut app, &graph, "background");
-    let ctx = WizardCtx { graph: &graph, dataset_path: None, schema_registry: None, allow_write: false };
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    // Default is Alias; 'l' should switch to Literal.
-    app.handle_modal_key(key(KeyCode::Char('l')), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.values.rows[0].kind, ValueKind::Literal, "'l' should set Literal");
     }
-    // 'a' should switch back.
-    app.handle_modal_key(key(KeyCode::Char('a')), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    update(&mut model, Message::Key(key(KeyCode::Char('a'))), &ctx);
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.values.rows[0].kind, ValueKind::Alias, "'a' should restore Alias");
     }
 }
 
 #[test]
 fn screen_3_enter_advances_to_screen_4() {
+    let fixtures = fixtures_path();
     let graph = make_graph();
-    let mut app = App::new();
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
-    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures), schema_registry: None, allow_write: false };
-    open_wizard(&mut app, &graph, "background");
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    let ctx = UpdateCtx {
+        graph: &graph,
+        dataset_path: Some(fixtures.as_path()),
+        components_dir: None,
+        schema_registry: None,
+        mode_sets_dir: None,
+        allow_write: false,
+    };
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.screen, WizardScreen::Confirm, "should advance to Screen 4");
     } else {
         panic!("expected wizard modal");
@@ -200,38 +199,50 @@ fn screen_3_enter_advances_to_screen_4() {
 
 #[test]
 fn screen_4_empty_rationale_blocks_submit() {
+    let fixtures = fixtures_path();
     let graph = make_graph();
-    let mut app = App::new();
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
-    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures), schema_registry: None, allow_write: false };
-    open_wizard(&mut app, &graph, "background");
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4
-    // Rationale is empty; Enter should NOT close the modal.
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    assert!(app.modal.is_some(), "modal should stay open when rationale is empty");
+    let ctx = UpdateCtx {
+        graph: &graph,
+        dataset_path: Some(fixtures.as_path()),
+        components_dir: None,
+        schema_registry: None,
+        mode_sets_dir: None,
+        allow_write: false,
+    };
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // Submit with empty rationale
+    assert!(model.modal.is_some(), "modal should stay open when rationale is empty");
 }
 
 #[test]
 fn screen_4_diff_preview_is_populated_on_enter() {
+    let fixtures = fixtures_path();
     let graph = make_graph();
-    let mut app = App::new();
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
-    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures), schema_registry: None, allow_write: false };
-    open_wizard(&mut app, &graph, "background");
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    // Tab once: layer (0) → property (1).
-    app.handle_modal_key(key(KeyCode::Tab), &ctx);
+    let ctx = UpdateCtx {
+        graph: &graph,
+        dataset_path: Some(fixtures.as_path()),
+        components_dir: None,
+        schema_registry: None,
+        mode_sets_dir: None,
+        allow_write: false,
+    };
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx); // focus → property
     for c in "background-color".chars() {
-        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4 (triggers build_diff)
-    if let Some(Modal::Wizard(ref ws)) = app.modal {
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
+    if let Some(Modal::Wizard(ref ws)) = model.modal {
         assert_eq!(ws.screen, WizardScreen::Confirm);
         let diff = ws.diff_preview.as_ref().expect("diff_preview should be populated");
-        assert!(diff.contains('+'), "diff should contain '+' lines for the new token");
+        assert!(diff.contains('+'), "diff should contain '+' lines");
     } else {
         panic!("expected wizard modal");
     }
@@ -239,37 +250,54 @@ fn screen_4_diff_preview_is_populated_on_enter() {
 
 #[test]
 fn screen_4_submit_closes_modal_and_sets_status() {
+    let fixtures = fixtures_path();
     let graph = make_graph();
-    let mut app = App::new();
-    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
-    let ctx = WizardCtx { graph: &graph, dataset_path: Some(&fixtures), schema_registry: None, allow_write: false };
-    open_wizard(&mut app, &graph, "background");
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 2
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 3
-    app.handle_modal_key(key(KeyCode::Enter), &ctx); // → Screen 4
-    // Type a rationale.
+    let ctx = UpdateCtx {
+        graph: &graph,
+        dataset_path: Some(fixtures.as_path()),
+        components_dir: None,
+        schema_registry: None,
+        mode_sets_dir: None,
+        allow_write: false,
+    };
+    let mut model = Model::new();
+    open_wizard(&mut model, &ctx, "background");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
     for c in "Needed for the checkout redesign".chars() {
-        app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
+        update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
-    // Submit.
-    app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    assert!(app.modal.is_none(), "modal should close after submit");
-    let msg = app.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let task = update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
+    assert!(model.modal.is_none(), "modal should close after submit");
+    assert!(matches!(task, Task::Cmd(_)), "submit should return Task::Cmd (draft clear)");
+    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(
         msg.contains("write disabled") || msg.contains("preview"),
         "status should mention preview/write disabled: {msg}"
     );
 }
 
+// ── Test that keeps App path (uses tempfile for FS write assertion) ────────────
+
 #[test]
 fn submit_does_not_create_foundation_json_without_allow_write() {
     let graph = make_graph();
     let mut app = App::new();
     let tmpdir = tempfile::TempDir::new().expect("tempdir");
-    // foundation.json is the resolved target for a Foundation-layer token.
     let foundation_file = tmpdir.path().join("foundation.json");
-    let ctx = WizardCtx { graph: &graph, dataset_path: Some(tmpdir.path()), schema_registry: None, allow_write: false };
-    open_wizard(&mut app, &graph, "background");
+    let ctx = WizardCtx {
+        graph: &graph,
+        dataset_path: Some(tmpdir.path()),
+        schema_registry: None,
+        allow_write: false,
+    };
+    // Use old App path since this test verifies filesystem behavior.
+    app.handle_key(key(KeyCode::Char(':')));
+    for c in "new background".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.submit_palette(&SubmitContext::new(&graph));
     app.handle_modal_key(key(KeyCode::Enter), &ctx);
     app.handle_modal_key(key(KeyCode::Enter), &ctx);
     app.handle_modal_key(key(KeyCode::Enter), &ctx);
@@ -277,17 +305,15 @@ fn submit_does_not_create_foundation_json_without_allow_write() {
         app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
     }
     app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    assert!(
-        !foundation_file.exists(),
-        "wizard submit without --allow-write must NOT write foundation.json to the dataset"
-    );
+    assert!(!foundation_file.exists(), "wizard submit without --allow-write must NOT write");
 }
+
+// ── WizardState unit test ─────────────────────────────────────────────────────
 
 #[test]
 fn assembled_name_joins_property_and_fields() {
     use design_data_tui::wizard::WizardState;
     let mut ws = WizardState::new();
-    // Set property via Classification input.
     use tui_input::Input;
     ws.classification.property = Input::from("background-color".to_string());
     ws.classification.name_fields.push(design_data_tui::wizard::NameField {


### PR DESCRIPTION
## Description

The largest issue in Phase B. Introduces the TEA runtime contract for the TUI.

**New `src/task.rs`:** `Task<Msg>` enum with `None`, `Cmd(Box<dyn FnOnce() -> Msg + Send + 'static>)`, `Batch(Vec<Task<Msg>>)` constructors. Mirrors iced's constructor menu (no async/Perform yet — that's #1021).

**New `src/update.rs`:** Single `pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Message>` entry point. Ports all logic from:
- `App::handle_key` + `handle_view_key` (palette keys, view nav, global keys)
- `App::handle_modal_key` (Help, Find, Naming, Wizard modal routing)
- `App::handle_mouse` (scroll, click, drag/selection)
- `App::submit_palette` (query, resolve, find, name, new, describe, validate commands)

Side effects wrapped in `Task::Cmd`: wizard draft save/clear, palette history save, write-token. Describe/validate FS reads are inline with `// TODO(#1023)` comments (deferred to #1023 scope).

**`src/app.rs`:** Minimal `pub(crate)` visibility bumps for helpers shared with `update.rs`.

**Test migration:** 8 test files migrated from `App::handle_key` / `submit_palette` to `update() + Message`. Key new pattern: wizard cancel/submit tests assert `matches!(task, Task::Cmd(_))`. 4 FS-heavy files kept on `App` path (validate, describe, wizard_persistence, write — deferred to #1023).

## Related Issue

Closes #1020. Part of TUI v2 epic #1014. Unblocks #1021 (runtime adapter), #1023 (side effects), #1024 (impossible states).

## How Has This Been Tested?

`cargo test` — all 162+ tests pass. Grep confirms `.handle_key` / `.handle_modal_key` / `.submit_palette` only appear in expected files (unit tests for find/naming modules, render.rs using App directly, the 4 intentionally un-migrated FS test files).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.