### PR TITLE
feat(tui): runtime adapter — crossterm event loop driving update (#1021)

### DIFF
--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -1174,7 +1174,7 @@ pub fn history_path() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join("design-data-tui").join("history"))
 }
 
-fn load_palette_history() -> Vec<String> {
+pub(crate) fn load_palette_history() -> Vec<String> {
     let Some(path) = history_path() else { return Vec::new() };
     std::fs::read_to_string(&path)
         .map(|s| {

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -14,6 +14,7 @@ pub mod help;
 pub mod message;
 pub mod model;
 pub mod naming;
+pub mod runtime;
 pub mod task;
 pub mod theme;
 pub mod update;
@@ -24,6 +25,7 @@ pub mod wizard_draft;
 
 pub use message::Message;
 pub use model::Model;
+pub use runtime::run;
 pub use task::Task;
 pub use update::{update, UpdateCtx};
 pub use view::draw;

--- a/sdk/tui/src/main.rs
+++ b/sdk/tui/src/main.rs
@@ -24,28 +24,22 @@
 //! - `?` opens the help overlay; Esc or `?` closes it.
 //! - `v` toggles text-selection mode; drag to copy.
 
-use std::io::{Write, stderr};
+use std::io::stderr;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
 
 use clap::{Parser, ValueEnum};
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use design_data_core::graph::TokenGraph;
 use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
-use ratatui::{
-    Terminal,
-    backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout, Rect},
-};
+use ratatui::{Terminal, backend::CrosstermBackend};
 
-use design_data_tui::app::{ActiveView, App, HitAction, HitRegion, StatusMessage, SubmitContext};
 use design_data_tui::theme::Theme;
-use design_data_tui::wizard::WizardCtx;
+use design_data_tui::{Model, UpdateCtx};
 
 /// Which visual palette to use.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -133,21 +127,13 @@ impl DatasetHandle {
         )
     }
 
-    fn submit_context(&self) -> SubmitContext<'_> {
-        SubmitContext {
+    fn update_ctx(&self) -> UpdateCtx<'_> {
+        UpdateCtx {
             graph: &self.graph,
             dataset_path: Some(&self.dataset_path),
             components_dir: self.components_dir.as_deref(),
             schema_registry: self.schema_registry.as_ref(),
             mode_sets_dir: self.mode_sets_dir.as_deref(),
-        }
-    }
-
-    fn wizard_ctx(&self) -> WizardCtx<'_> {
-        WizardCtx {
-            graph: &self.graph,
-            dataset_path: Some(&self.dataset_path),
-            schema_registry: self.schema_registry.as_ref(),
             allow_write: self.allow_write,
         }
     }
@@ -205,37 +191,6 @@ struct Cli {
     no_resume_wizard: bool,
 }
 
-/// Write `text` to the system clipboard.
-///
-/// - macOS: `pbcopy`
-/// - Linux: `xclip -selection clipboard`
-/// - Windows: not supported; returns an error that main.rs surfaces in the status bar.
-fn write_clipboard(text: &str) -> std::io::Result<()> {
-    #[cfg(target_os = "macos")]
-    let mut child = Command::new("pbcopy").stdin(Stdio::piped()).spawn()?;
-
-    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-    let mut child = Command::new("xclip")
-        .args(["-selection", "clipboard"])
-        .stdin(Stdio::piped())
-        .spawn()?;
-
-    #[cfg(target_os = "windows")]
-    return Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "clipboard yank is not supported on Windows",
-    ));
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(text.as_bytes())?;
-        }
-        child.wait()?;
-        Ok(())
-    }
-}
-
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let theme = match cli.theme {
@@ -271,131 +226,12 @@ fn main() -> Result<()> {
     result
 }
 
-/// Rebuild hit regions after a draw, mirroring the layout computed inside `view::draw`.
-///
-/// SYNC WITH view::draw layout: the constraint array below must stay identical to the
-/// one in `view::draw`. If a chunk is added or reordered there, update this function to
-/// match or click targets will silently drift.
-fn compute_hit_regions(app: &App, status_height: u16, frame_area: Rect) -> Vec<HitRegion> {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),             // primer header  ← SYNC WITH view::draw
-            Constraint::Min(0),                // active view    ← SYNC WITH view::draw
-            Constraint::Length(status_height), // status message ← SYNC WITH view::draw
-            Constraint::Length(1),             // palette prompt ← SYNC WITH view::draw
-        ])
-        .split(frame_area);
-
-    let view_area = chunks[1];
-    // Tables have a top border (1) + header row (1) before data rows start.
-    let data_y = view_area.y + 2;
-    let data_height = view_area.height.saturating_sub(2);
-
-    let mut regions = Vec::new();
-    match &app.active_view {
-        ActiveView::Query(qv) => {
-            for (i, row) in qv.rows.iter().enumerate() {
-                let y = data_y + i as u16;
-                if i as u16 >= data_height {
-                    break;
-                }
-                regions.push(HitRegion {
-                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
-                    action: HitAction::SelectListRow(i),
-                    text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
-                });
-            }
-        }
-        ActiveView::Resolve(rv) => {
-            for (i, row) in rv.rows.iter().enumerate() {
-                let y = data_y + i as u16;
-                if i as u16 >= data_height {
-                    break;
-                }
-                regions.push(HitRegion {
-                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
-                    action: HitAction::SelectListRow(i),
-                    text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
-                });
-            }
-        }
-        ActiveView::Validate(vv) => {
-            for (i, row) in vv.rows.iter().enumerate() {
-                let y = data_y + i as u16;
-                if i as u16 >= data_height {
-                    break;
-                }
-                regions.push(HitRegion {
-                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
-                    action: HitAction::SelectListRow(i),
-                    text: format!(
-                        "{}\t{}\t{}\t{}",
-                        row.severity, row.rule_id, row.token, row.message
-                    ),
-                });
-            }
-        }
-        ActiveView::Empty | ActiveView::Describe(_) => {}
-    }
-    regions
-}
-
 fn run<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     handle: &DatasetHandle,
     resume_wizard: bool,
 ) -> Result<()> {
-    let mut app = App::new_with_options(resume_wizard);
-
-    loop {
-        let mut frame_area = Rect::default();
-        let status_height = u16::from(app.status_message.is_some());
-
-        terminal.draw(|f| {
-            frame_area = f.area();
-            design_data_tui::draw(&mut app, f, &handle.theme, &handle.primer_line());
-        }).into_diagnostic()?;
-
-        // Rebuild hit regions from the frame geometry computed during draw.
-        app.hit_regions = compute_hit_regions(&app, status_height, frame_area);
-
-        // Copy to clipboard outside the draw closure (needs mutable app).
-        if let Some(text) = app.take_pending_yank() {
-            if let Err(e) = write_clipboard(&text) {
-                app.status_message =
-                    Some(StatusMessage::error(format!("clipboard unavailable: {e}")));
-            }
-        }
-
-        if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
-            match event::read().into_diagnostic()? {
-                Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    if app.modal.is_some() {
-                        // Modal captures all input; palette is suppressed.
-                        app.handle_modal_key(key, &handle.wizard_ctx());
-                    } else {
-                        let was_open = app.palette_open;
-                        app.handle_key(key);
-                        // Palette just closed via Enter — dispatch command.
-                        if was_open && !app.palette_open && key.code == KeyCode::Enter {
-                            app.submit_palette(&handle.submit_context());
-                        }
-                    }
-                }
-                Event::Key(_) => {}
-                Event::Mouse(me) => {
-                    // handle_mouse sets pending_yank; it is drained above next frame.
-                    app.handle_mouse(me);
-                }
-                _ => {}
-            }
-        }
-
-        if app.quit {
-            break;
-        }
-    }
-
-    Ok(())
+    let model = Model::new_with_options(resume_wizard);
+    let ctx = handle.update_ctx();
+    design_data_tui::run(terminal, model, &ctx, &handle.theme, &handle.primer_line())
 }

--- a/sdk/tui/src/model.rs
+++ b/sdk/tui/src/model.rs
@@ -41,6 +41,23 @@ pub struct Model {
 }
 
 impl Model {
+    /// Create the model for a real session, loading palette history from disk and
+    /// optionally restoring an in-progress wizard draft.
+    pub fn new_with_options(resume_wizard: bool) -> Self {
+        use crate::app::Modal;
+        use crate::wizard_draft::{from_draft, load_wizard_draft};
+        let modal = if resume_wizard {
+            load_wizard_draft().map(|d| Modal::Wizard(Box::new(from_draft(d))))
+        } else {
+            None
+        };
+        Self {
+            palette_history: crate::app::load_palette_history(),
+            modal,
+            ..Self::new()
+        }
+    }
+
     pub fn new() -> Self {
         Self {
             palette_open: false,

--- a/sdk/tui/src/runtime.rs
+++ b/sdk/tui/src/runtime.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Crossterm event loop — the runtime adapter (GH #1021).
+//!
+//! `run` pumps crossterm events through `update`, executes returned `Task::Cmd`
+//! closures synchronously, calls `draw` each frame, and rebuilds hit regions.
+//! `main.rs` is now a thin CLI entry point that delegates entirely to this function.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use miette::{IntoDiagnostic, Result};
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Direction, Layout, Rect},
+};
+
+use crate::app::{ActiveView, HitAction, HitRegion, StatusMessage};
+use crate::message::Message;
+use crate::model::Model;
+use crate::task::Task;
+use crate::theme::Theme;
+use crate::update::{update, UpdateCtx};
+use crate::view::draw;
+
+/// Run the TUI event loop until the user quits.
+///
+/// Pumps crossterm events → `Message` → `update` → `Task` execution → `draw` each frame.
+pub fn run<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    mut model: Model,
+    ctx: &UpdateCtx<'_>,
+    theme: &Theme,
+    primer_line: &str,
+) -> Result<()> {
+    loop {
+        let mut frame_area = Rect::default();
+        let status_height = u16::from(model.status_message.is_some());
+
+        // Draw.
+        terminal
+            .draw(|f| {
+                frame_area = f.area();
+                draw(&mut model, f, theme, primer_line);
+            })
+            .into_diagnostic()?;
+
+        // Rebuild mouse hit regions from the frame geometry set during draw.
+        model.hit_regions = compute_hit_regions(&model, status_height, frame_area);
+
+        // Drain pending clipboard yank.
+        // TODO(#1023): move into Task::Cmd so this side effect is explicit.
+        if let Some(text) = model.pending_yank.take() {
+            if let Err(e) = write_clipboard(&text) {
+                model.status_message =
+                    Some(StatusMessage::error(format!("clipboard unavailable: {e}")));
+            }
+        }
+
+        // Poll for the next crossterm event (16 ms ≈ 60 fps cadence).
+        if event::poll(std::time::Duration::from_millis(16)).into_diagnostic()? {
+            match event::read().into_diagnostic()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    // Capture palette input text BEFORE sending Key(Enter) to update(),
+                    // because update() clears palette_input as part of closing the palette.
+                    // If Enter does close the palette (model.palette_open flips false),
+                    // we then dispatch PaletteSubmit with the captured text. If update()
+                    // ever defers closing (e.g., for validation), palette_text is Some but
+                    // the guard `!model.palette_open` will be false, so PaletteSubmit is
+                    // correctly suppressed.
+                    let palette_text = if model.palette_open && key.code == KeyCode::Enter {
+                        Some(model.palette_input.value().to_string())
+                    } else {
+                        None
+                    };
+
+                    let task = update(&mut model, Message::Key(key), ctx);
+                    execute_task(task, &mut model, ctx);
+
+                    // Dispatch the command only if Enter actually closed the palette.
+                    if let Some(text) = palette_text {
+                        if !model.palette_open {
+                            let task =
+                                update(&mut model, Message::PaletteSubmit(text), ctx);
+                            execute_task(task, &mut model, ctx);
+                        }
+                    }
+                }
+                Event::Key(_) => {}
+                Event::Mouse(me) => {
+                    let task = update(&mut model, Message::Mouse(me), ctx);
+                    execute_task(task, &mut model, ctx);
+                }
+                _ => {}
+            }
+        } else {
+            // No event this frame — send a Tick so subscriptions can fire (#1022).
+            let task = update(&mut model, Message::Tick, ctx);
+            execute_task(task, &mut model, ctx);
+        }
+
+        if model.quit {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute a task tree synchronously, feeding results back through `update`.
+///
+/// All current `Task::Cmd` closures are fast (FS writes, clipboard) so synchronous
+/// execution is appropriate. Async `Perform` support is deferred to #1022.
+///
+/// **Recursion depth**: each `Task::Cmd` result is fed back through `update`, which
+/// in turn may return another `Task`. In practice the chain is shallow (draft save →
+/// `Tick` → `Task::None`). If #1022 introduces `Task::Perform` with chained batches
+/// this should be converted to an explicit stack to avoid stack overflow.
+fn execute_task(task: Task<Message>, model: &mut Model, ctx: &UpdateCtx<'_>) {
+    match task {
+        Task::None => {}
+        Task::Cmd(f) => {
+            let msg = f();
+            let next = update(model, msg, ctx);
+            execute_task(next, model, ctx);
+        }
+        Task::Batch(tasks) => {
+            for t in tasks {
+                execute_task(t, model, ctx);
+            }
+        }
+    }
+}
+
+/// Rebuild hit regions after a draw, mirroring the layout computed inside `view::draw`.
+///
+/// SYNC WITH view::draw layout: the constraint array below must stay identical to the
+/// one in `view::draw`. If a chunk is added or reordered there, update this function to
+/// match or click targets will silently drift.
+fn compute_hit_regions(model: &Model, status_height: u16, frame_area: Rect) -> Vec<HitRegion> {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),             // primer header  ← SYNC WITH view::draw
+            Constraint::Min(0),                // active view    ← SYNC WITH view::draw
+            Constraint::Length(status_height), // status message ← SYNC WITH view::draw
+            Constraint::Length(1),             // palette prompt ← SYNC WITH view::draw
+        ])
+        .split(frame_area);
+
+    let view_area = chunks[1];
+    // Tables have a top border (1) + header row (1) before data rows start.
+    let data_y = view_area.y + 2;
+    let data_height = view_area.height.saturating_sub(2);
+
+    let mut regions = Vec::new();
+    match &model.active_view {
+        ActiveView::Query(qv) => {
+            for (i, row) in qv.rows.iter().enumerate() {
+                let y = data_y + i as u16;
+                if i as u16 >= data_height {
+                    break;
+                }
+                regions.push(HitRegion {
+                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    action: HitAction::SelectListRow(i),
+                    text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
+                });
+            }
+        }
+        ActiveView::Resolve(rv) => {
+            for (i, row) in rv.rows.iter().enumerate() {
+                let y = data_y + i as u16;
+                if i as u16 >= data_height {
+                    break;
+                }
+                regions.push(HitRegion {
+                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    action: HitAction::SelectListRow(i),
+                    text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
+                });
+            }
+        }
+        ActiveView::Validate(vv) => {
+            for (i, row) in vv.rows.iter().enumerate() {
+                let y = data_y + i as u16;
+                if i as u16 >= data_height {
+                    break;
+                }
+                regions.push(HitRegion {
+                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    action: HitAction::SelectListRow(i),
+                    text: format!(
+                        "{}\t{}\t{}\t{}",
+                        row.severity, row.rule_id, row.token, row.message
+                    ),
+                });
+            }
+        }
+        ActiveView::Empty | ActiveView::Describe(_) => {}
+    }
+    regions
+}
+
+/// Write `text` to the system clipboard.
+///
+/// - macOS: `pbcopy`
+/// - Linux: `xclip -selection clipboard`
+/// - Windows: not supported.
+fn write_clipboard(text: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    let mut child = Command::new("pbcopy").stdin(Stdio::piped()).spawn()?;
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    let mut child = Command::new("xclip")
+        .args(["-selection", "clipboard"])
+        .stdin(Stdio::piped())
+        .spawn()?;
+
+    #[cfg(target_os = "windows")]
+    return Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "clipboard yank is not supported on Windows",
+    ));
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(text.as_bytes())?;
+        }
+        child.wait()?;
+        Ok(())
+    }
+}

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -17,8 +17,9 @@ use ratatui::{
 };
 
 use crate::app::{
-    ActiveView, App, DescribeView, Modal, QueryView, ResolveView, StatusKind, ValidateView,
+    ActiveView, DescribeView, Modal, QueryView, ResolveView, StatusKind, ValidateView,
 };
+use crate::model::Model;
 use crate::find::{FindScreen, FindWizardState, MAX_PROPERTY_SUGGESTIONS, MAX_SUGGEST_RESULTS};
 use crate::help::HELP_TEXT;
 use crate::naming::{NamingScreen, NamingWizardState};
@@ -48,8 +49,8 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 /// Render a complete frame: primer header, active view, status bar, palette prompt, and any
 /// overlay modal. This is the single entry point for all rendering; call it from
 /// `terminal.draw(|f| draw(app, f, theme, primer_line))`.
-pub fn draw(app: &mut App, frame: &mut Frame, theme: &Theme, primer_line: &str) {
-    let status_height = u16::from(app.status_message.is_some());
+pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &str) {
+    let status_height = u16::from(model.status_message.is_some());
     let area = frame.area();
 
     // Three-region layout (RFC #973 §3.1): primer header / active view / status+palette.
@@ -71,7 +72,7 @@ pub fn draw(app: &mut App, frame: &mut Frame, theme: &Theme, primer_line: &str) 
     frame.render_widget(Paragraph::new(primer_text), chunks[0]);
 
     // Active view.
-    match &mut app.active_view {
+    match &mut model.active_view {
         ActiveView::Empty => {
             let block = Block::default().borders(Borders::ALL).title(" Active View ");
             frame.render_widget(block, chunks[1]);
@@ -83,7 +84,7 @@ pub fn draw(app: &mut App, frame: &mut Frame, theme: &Theme, primer_line: &str) 
     }
 
     // Status message — ok color for info, error color for errors.
-    if let Some(ref msg) = app.status_message {
+    if let Some(ref msg) = model.status_message {
         let color = match msg.kind {
             StatusKind::Info => theme.ok,
             StatusKind::Error => theme.error,
@@ -95,15 +96,15 @@ pub fn draw(app: &mut App, frame: &mut Frame, theme: &Theme, primer_line: &str) 
     }
 
     // Palette prompt (hidden while a modal is open).
-    let palette_text = if app.modal.is_none() && app.palette_open {
-        format!("{}{}", app.palette_prefix(), app.palette_input.value())
+    let palette_text = if model.modal.is_none() && model.palette_open {
+        format!("{}{}", model.palette_prefix(), model.palette_input.value())
     } else {
         String::new()
     };
     frame.render_widget(Paragraph::new(palette_text), chunks[3]);
 
     // Overlay modal (rendered last so it appears on top).
-    match &mut app.modal {
+    match &mut model.modal {
         Some(Modal::Find(ref mut fs)) => {
             let popup_area = centered_rect(82, 85, area);
             frame.render_widget(Clear, popup_area);

--- a/sdk/tui/tests/common/mod.rs
+++ b/sdk/tui/tests/common/mod.rs
@@ -12,8 +12,7 @@ use crossterm::event::{
     KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
 };
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
-use design_data_tui::app::App;
-use design_data_tui::UpdateCtx;
+use design_data_tui::{Model, UpdateCtx};
 use design_data_tui::theme::Theme;
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
@@ -77,20 +76,20 @@ pub fn update_ctx(graph: &TokenGraph) -> UpdateCtx<'_> {
 /// Primer line shown in the header during test renders.
 pub const TEST_PRIMER: &str = "test · 0 tokens";
 
-/// Render `app` via `design_data_tui::draw` into a `TestBackend` and return the `Buffer`.
-pub fn render_to_buffer(app: &mut App, w: u16, h: u16) -> Buffer {
+/// Render `model` via `design_data_tui::draw` into a `TestBackend` and return the `Buffer`.
+pub fn render_to_buffer(model: &mut Model, w: u16, h: u16) -> Buffer {
     let backend = TestBackend::new(w, h);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|f| design_data_tui::draw(app, f, &Theme::terminal(), TEST_PRIMER))
+        .draw(|f| design_data_tui::draw(model, f, &Theme::terminal(), TEST_PRIMER))
         .unwrap();
     terminal.backend().buffer().clone()
 }
 
 #[test]
-fn render_to_buffer_does_not_panic_on_empty_app() {
-    let mut app = App::new();
-    let buf = render_to_buffer(&mut app, 80, 24);
+fn render_to_buffer_does_not_panic_on_empty_model() {
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, 80, 24);
     assert_eq!(buf.area().width, 80);
     assert_eq!(buf.area().height, 24);
 }

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -10,14 +10,14 @@
 
 //! Buffer-cell render tests (GH #1017).
 //!
-//! Pattern: build App state, call render_to_buffer, assert specific cells.
+//! Pattern: build Model state via `update()`, call render_to_buffer, assert specific cells.
 //! No snapshot deps — assertions are direct `buf.cell((x, y)).symbol()` checks.
 
 mod common;
-use common::{key, make_graph_with_tokens, render_to_buffer, TEST_PRIMER};
+use common::{key, make_graph_with_tokens, render_to_buffer, update_ctx, TEST_PRIMER};
 
 use crossterm::event::KeyCode;
-use design_data_tui::app::{App, SubmitContext};
+use design_data_tui::{update, Message, Model};
 use ratatui::buffer::Buffer;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ fn row_str(buf: &Buffer, y: u16, w: u16) -> String {
 
 /// Scan all rows for the first one whose text contains `needle`. Returns that
 /// row's content as a String, or panics with a helpful message if not found.
-fn find_row_containing<'a>(buf: &Buffer, needle: &str, w: u16, h: u16) -> String {
+fn find_row_containing(buf: &Buffer, needle: &str, w: u16, h: u16) -> String {
     for y in 0..h {
         let row = row_str(buf, y, w);
         if row.contains(needle) {
@@ -42,30 +42,24 @@ fn find_row_containing<'a>(buf: &Buffer, needle: &str, w: u16, h: u16) -> String
     panic!("no row contains '{needle}' in {w}×{h} buffer");
 }
 
-/// Open command palette, type `cmd`, submit. Returns the updated app.
-fn submit_query(app: &mut App, graph: &design_data_core::graph::TokenGraph, cmd: &str) {
-    app.handle_key(key(KeyCode::Char(':')));
-    for c in cmd.chars() {
-        app.handle_key(key(KeyCode::Char(c)));
-    }
-    app.submit_palette(&SubmitContext::new(graph));
+/// Open command palette, type `cmd`, submit.
+fn submit_query(model: &mut Model, ctx: &design_data_tui::UpdateCtx<'_>, cmd: &str) {
+    update(model, Message::PaletteSubmit(cmd.into()), ctx);
 }
 
 // ── Empty / initial view ───────────────────────────────────────────────────────
 
 #[test]
 fn empty_app_renders_primer_arrow() {
-    let mut app = App::new();
-    let buf = render_to_buffer(&mut app, W, H);
-    // Row 0 is always the primer header; the arrow marker is the first character.
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
     assert_eq!(buf.cell((0, 0)).unwrap().symbol(), "▶");
 }
 
 #[test]
 fn empty_app_renders_primer_text() {
-    let mut app = App::new();
-    let buf = render_to_buffer(&mut app, W, H);
-    // TEST_PRIMER starts at col 2 (after "▶ ").
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
     let row = row_str(&buf, 0, W);
     assert!(
         row.contains(TEST_PRIMER),
@@ -75,18 +69,16 @@ fn empty_app_renders_primer_text() {
 
 #[test]
 fn empty_app_renders_active_view_border() {
-    let mut app = App::new();
-    let buf = render_to_buffer(&mut app, W, H);
-    // Scan rows 1..H for the top-left border corner "┌" — layout-agnostic.
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
     let border_row = (1..H).find(|&y| buf.cell((0, y)).unwrap().symbol() == "┌");
     assert!(border_row.is_some(), "expected a '┌' border somewhere in rows 1..{H}");
 }
 
 #[test]
 fn empty_app_palette_prompt_row_is_last() {
-    let mut app = App::new();
-    let buf = render_to_buffer(&mut app, W, H);
-    // Last row (H-1) is the palette prompt — empty when palette is closed.
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
     let last_row = row_str(&buf, H - 1, W);
     assert!(
         last_row.trim().is_empty(),
@@ -99,11 +91,11 @@ fn empty_app_palette_prompt_row_is_last() {
 #[test]
 fn query_view_renders_column_headers() {
     let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
-    let mut app = App::new();
-    submit_query(&mut app, &graph, "query property=accent-color");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit_query(&mut model, &ctx, "query property=accent-color");
 
-    let buf = render_to_buffer(&mut app, W, H);
-    // Scan for the row that contains "Name" — the table header row.
+    let buf = render_to_buffer(&mut model, W, H);
     let header_row = find_row_containing(&buf, "Name", W, H);
     assert!(header_row.contains("Value"), "header should also contain 'Value': {header_row}");
 }
@@ -111,11 +103,11 @@ fn query_view_renders_column_headers() {
 #[test]
 fn query_view_renders_token_name_in_data_row() {
     let graph = make_graph_with_tokens(&["accent-color"]);
-    let mut app = App::new();
-    submit_query(&mut app, &graph, "query property=accent-color");
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit_query(&mut model, &ctx, "query property=accent-color");
 
-    let buf = render_to_buffer(&mut app, W, H);
-    // Scan for the row that contains the token name — layout-agnostic.
+    let buf = render_to_buffer(&mut model, W, H);
     find_row_containing(&buf, "accent-color", W, H);
 }
 
@@ -123,10 +115,11 @@ fn query_view_renders_token_name_in_data_row() {
 
 #[test]
 fn help_modal_renders_title() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('?')));
-    let buf = render_to_buffer(&mut app, W, H);
-    // Scan for any row containing "Help" — the modal title bar.
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
     find_row_containing(&buf, "Help", W, H);
 }
 
@@ -134,9 +127,11 @@ fn help_modal_renders_title() {
 
 #[test]
 fn open_palette_renders_colon_on_last_row() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char(':')));
-    let buf = render_to_buffer(&mut app, W, H);
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
     assert_eq!(
         buf.cell((0, H - 1)).unwrap().symbol(),
         ":",
@@ -146,9 +141,11 @@ fn open_palette_renders_colon_on_last_row() {
 
 #[test]
 fn fuzzy_palette_renders_slash_on_last_row() {
-    let mut app = App::new();
-    app.handle_key(key(KeyCode::Char('/')));
-    let buf = render_to_buffer(&mut app, W, H);
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
     assert_eq!(
         buf.cell((0, H - 1)).unwrap().symbol(),
         "/",
@@ -160,9 +157,9 @@ fn fuzzy_palette_renders_slash_on_last_row() {
 
 #[test]
 fn two_consecutive_renders_are_identical() {
-    let mut app = App::new();
-    let buf1 = render_to_buffer(&mut app, W, H);
-    let buf2 = render_to_buffer(&mut app, W, H);
+    let mut model = Model::new();
+    let buf1 = render_to_buffer(&mut model, W, H);
+    let buf2 = render_to_buffer(&mut model, W, H);
     assert!(
         buf1 == buf2,
         "draw must be deterministic — two renders of the same state must be identical"
@@ -173,12 +170,12 @@ fn two_consecutive_renders_are_identical() {
 
 #[test]
 fn draw_does_not_panic_on_1x1_terminal() {
-    let mut app = App::new();
-    render_to_buffer(&mut app, 1, 1);
+    let mut model = Model::new();
+    render_to_buffer(&mut model, 1, 1);
 }
 
 #[test]
 fn draw_does_not_panic_on_narrow_terminal() {
-    let mut app = App::new();
-    render_to_buffer(&mut app, 10, 5);
+    let mut model = Model::new();
+    render_to_buffer(&mut model, 10, 5);
 }

--- a/sdk/tui/tests/runtime.rs
+++ b/sdk/tui/tests/runtime.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Runtime adapter smoke tests (GH #1021).
+//!
+//! These tests drive `update` + `draw` through `render_to_buffer` against a `TestBackend`,
+//! verifying the full update→draw pipeline without requiring a real terminal or event loop.
+
+mod common;
+use common::{empty_graph, key, render_to_buffer, update_ctx};
+
+use crossterm::event::KeyCode;
+use design_data_tui::{update, Message, Model};
+
+#[test]
+fn smoke_colon_opens_palette_and_renders_prompt() {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    assert!(model.palette_open, "':' should open palette");
+
+    // Drive through draw — must not panic and must render ':' on last row.
+    let buf = render_to_buffer(&mut model, 80, 24);
+    assert_eq!(
+        buf.cell((0, 23)).unwrap().symbol(),
+        ":",
+        "palette prompt should be ':' on last row"
+    );
+}
+
+#[test]
+fn smoke_esc_closes_palette_and_clears_prompt() {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+
+    update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+    assert!(!model.palette_open, "Esc should close palette");
+
+    let buf = render_to_buffer(&mut model, 80, 24);
+    let last = (0..80u16)
+        .map(|x| buf.cell((x, 23)).unwrap().symbol().to_string())
+        .collect::<String>();
+    assert!(
+        last.trim().is_empty(),
+        "palette row should be empty after close, got: '{last}'"
+    );
+}
+
+#[test]
+fn smoke_quit_key_sets_quit_flag() {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('q'))), &ctx);
+    assert!(model.quit, "'q' should set model.quit");
+}
+
+#[test]
+fn smoke_render_after_query_shows_data_row() {
+    let graph = common::make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+
+    update(&mut model, Message::PaletteSubmit("query property=accent-color".into()), &ctx);
+
+    let buf = render_to_buffer(&mut model, 80, 24);
+    let found = (0..24u16).any(|y| {
+        let row: String =
+            (0..80u16).map(|x| buf.cell((x, y)).unwrap().symbol().to_string()).collect();
+        row.contains("accent-color")
+    });
+    assert!(found, "query result 'accent-color' should appear somewhere in the rendered buffer");
+}
+
+#[test]
+fn smoke_model_new_with_options_resume_false_has_no_modal() {
+    let model = Model::new_with_options(false);
+    assert!(model.modal.is_none(), "resume_wizard=false should yield no modal");
+}


### PR DESCRIPTION
## Description

The last piece of Phase B. Wires the crossterm event loop to drive `update()` instead of `App` methods.

**New `src/runtime.rs`** — `pub fn run<B: Backend>(terminal, model, ctx, theme, primer)`:
- Polls crossterm → `Message` → `update()` → `execute_task()` → `draw()` each frame
- `execute_task` runs `Task::Cmd` closures synchronously (all current closures are fast FS/clipboard ops)
- Captures palette input text before `Key(Enter)` clears it; dispatches `PaletteSubmit` when Enter closes the palette
- `compute_hit_regions` and `write_clipboard` moved here from `main.rs`
- Pending yank drain with TODO(#1023) comment

**`src/main.rs`** — `run()` is now 5 lines: build `Model`, build `UpdateCtx`, call `lib::run`

**`src/view.rs`** — `draw` switches from `&mut App` to `&mut Model` (fields are identical)

**`src/model.rs`** — adds `Model::new_with_options(resume_wizard)` loading palette history and optional wizard draft from disk

**Tests** — `tests/common::render_to_buffer` takes `&mut Model`; `tests/render.rs` migrated to Model + `update()`; new `tests/runtime.rs` with 5 smoke tests driving update + draw via TestBackend.

## Related Issue

Closes #1021. Part of TUI v2 epic #1014. Completes Phase B. Unblocks #1022 (subscriptions), #1025 (record/replay).

## How Has This Been Tested?

`cargo test` — all 169+ tests pass including 5 new runtime smoke tests.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.