### PR TITLE
feat(tui): make impossible states unrepresentable (#1024)

### DIFF
--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod clipboard;
 pub mod find;
 pub mod help;
 pub mod message;
+pub mod mode;
 pub mod model;
 pub mod naming;
 pub mod runtime;
@@ -25,6 +26,7 @@ pub mod wizard_common;
 pub mod wizard_draft;
 
 pub use message::Message;
+pub use mode::{BrowsingState, Mode, ModalState, MouseMode, PaletteState};
 pub use model::Model;
 pub use runtime::{replay, run};
 pub use task::Task;

--- a/sdk/tui/src/mode.rs
+++ b/sdk/tui/src/mode.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Sum-type application mode, replacing the old `palette_open`, `modal`, and
+//! `selection_mode` booleans/Options (GH #1024).
+//!
+//! Having `Browsing | InModal | InPalette` as a single enum makes impossible
+//! combinations — palette open while a modal is active, selection start without
+//! end — compile-time errors rather than runtime surprises.
+
+use tui_input::Input;
+
+use crate::app::{Modal, PaletteMode};
+
+// ── Top-level mode ────────────────────────────────────────────────────────────
+
+/// The primary interaction mode. Only one can be active at a time.
+pub enum Mode {
+    /// Normal browsing — no palette or modal overlay.
+    Browsing(BrowsingState),
+    /// A modal dialog has keyboard focus.
+    InModal(ModalState),
+    /// The command palette has keyboard focus.
+    InPalette(PaletteState),
+}
+
+// ── Browsing state ────────────────────────────────────────────────────────────
+
+/// State carried while in normal `Browsing` mode.
+#[derive(Debug, Default)]
+pub struct BrowsingState {
+    /// Mouse selection state.
+    pub mouse: MouseMode,
+}
+
+/// Mouse interaction state.
+#[derive(Debug, Default)]
+pub enum MouseMode {
+    /// Normal — no selection mode active.
+    #[default]
+    Normal,
+    /// Selection mode enabled (`v` key was pressed) but no drag has started yet.
+    SelectionEnabled,
+    /// A drag-selection is in progress (mouse Down → Drag).
+    Selecting {
+        start: (u16, u16),
+        end: (u16, u16),
+    },
+}
+
+// ── Modal state ───────────────────────────────────────────────────────────────
+
+/// State carried while a modal overlay is open.
+pub struct ModalState {
+    pub modal: Modal,
+}
+
+// ── Palette state ─────────────────────────────────────────────────────────────
+
+/// State carried while the command palette is open.
+#[derive(Debug)]
+pub struct PaletteState {
+    pub mode: PaletteMode,
+    pub input: Input,
+    /// Index into `Model::palette_history`; `None` = fresh input.
+    pub history_cursor: Option<usize>,
+}
+
+impl PaletteState {
+    /// Open the palette in command (`:`) mode.
+    pub fn command() -> Self {
+        Self { mode: PaletteMode::Command, input: Input::default(), history_cursor: None }
+    }
+
+    /// Open the palette in fuzzy-find (`/`) mode.
+    pub fn fuzzy() -> Self {
+        Self { mode: PaletteMode::FuzzyFind, input: Input::default(), history_cursor: None }
+    }
+
+    /// The prompt prefix character for this palette mode.
+    pub fn prefix(&self) -> &'static str {
+        match self.mode {
+            PaletteMode::Command => ":",
+            PaletteMode::FuzzyFind => "/",
+        }
+    }
+}

--- a/sdk/tui/src/model.rs
+++ b/sdk/tui/src/model.rs
@@ -8,80 +8,222 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! `Model` — the TEA-style application state type (GH #1019).
+//! `Model` — the TEA-style application state type (GH #1019, refined in #1024).
 //!
-//! `Model` mirrors `App` field-for-field and will replace it once the `update`
-//! function (GH #1020) and runtime adapter (GH #1021) land. It is additive for
-//! now — `App` is still the live state type used by `main.rs` and `view.rs`.
+//! The `mode` field replaces the old flat booleans (`palette_open`, `modal`,
+//! `selection_mode`, `sel_start`, `sel_end`) with a sum type so impossible
+//! combinations become compile-time errors.
 
-use tui_input::Input;
-
-use crate::app::{ActiveView, HitRegion, Modal, PaletteMode, StatusMessage};
+use crate::app::{ActiveView, HitRegion, Modal, StatusMessage};
+use crate::mode::{BrowsingState, Mode, ModalState, MouseMode, PaletteState};
 
 /// Top-level application state for the TEA runtime.
-///
-/// Field names and semantics mirror `App` exactly. See `app.rs` for field-level
-/// documentation until `App` is retired.
-// TODO(#1020): remove the cross-reference to app.rs once App is retired.
 pub struct Model {
-    pub palette_open: bool,
-    pub palette_mode: PaletteMode,
-    pub palette_input: Input,
+    /// Primary interaction mode — browsing, modal, or palette.
+    pub mode: Mode,
+    /// Set to `true` when the application should exit.
     pub quit: bool,
+    /// The currently active data view.
     pub active_view: ActiveView,
+    /// One-line status message; `None` when hidden.
     pub status_message: Option<StatusMessage>,
+    /// Text queued for clipboard write via `Task::Cmd`.
     pub pending_yank: Option<String>,
-    pub modal: Option<Modal>,
+    /// Previously submitted palette commands, newest first.
     pub palette_history: Vec<String>,
-    pub palette_history_cursor: Option<usize>,
+    /// Mouse hit regions rebuilt each frame.
     pub hit_regions: Vec<HitRegion>,
-    pub selection_mode: bool,
-    pub sel_start: Option<(u16, u16)>,
-    pub sel_end: Option<(u16, u16)>,
 }
 
 impl Model {
     /// Create the model for a real session, loading palette history from disk and
     /// optionally restoring an in-progress wizard draft.
     pub fn new_with_options(resume_wizard: bool) -> Self {
-        use crate::app::Modal;
         use crate::wizard_draft::{from_draft, load_wizard_draft};
-        let modal = if resume_wizard {
-            load_wizard_draft().map(|d| Modal::Wizard(Box::new(from_draft(d))))
+        let mode = if resume_wizard {
+            load_wizard_draft()
+                .map(|d| Mode::InModal(ModalState { modal: Modal::Wizard(Box::new(from_draft(d))) }))
+                .unwrap_or_else(|| Mode::Browsing(BrowsingState::default()))
         } else {
-            None
+            Mode::Browsing(BrowsingState::default())
         };
         Self {
             palette_history: crate::app::load_palette_history(),
-            modal,
+            mode,
             ..Self::new()
         }
     }
 
     pub fn new() -> Self {
         Self {
-            palette_open: false,
-            palette_mode: PaletteMode::Command,
-            palette_input: Input::default(),
+            mode: Mode::Browsing(BrowsingState::default()),
             quit: false,
             active_view: ActiveView::Empty,
             status_message: None,
             pending_yank: None,
-            modal: None,
             palette_history: Vec::new(),
-            palette_history_cursor: None,
             hit_regions: Vec::new(),
-            selection_mode: false,
-            sel_start: None,
-            sel_end: None,
         }
     }
 
-    /// Return the palette prompt prefix for the current mode.
+    // ── Palette helpers ───────────────────────────────────────────────────────
+
+    pub fn is_palette_open(&self) -> bool {
+        matches!(self.mode, Mode::InPalette(_))
+    }
+
+    pub fn open_command_palette(&mut self) {
+        self.mode = Mode::InPalette(PaletteState::command());
+    }
+
+    pub fn open_fuzzy_palette(&mut self) {
+        self.mode = Mode::InPalette(PaletteState::fuzzy());
+    }
+
+    /// Close the palette and return to Browsing. No-op if not in palette mode.
+    pub fn close_palette(&mut self) {
+        if matches!(self.mode, Mode::InPalette(_)) {
+            self.mode = Mode::Browsing(BrowsingState::default());
+        }
+    }
+
+    /// Return the palette prompt prefix (`:` or `/`), or `""` if closed.
     pub fn palette_prefix(&self) -> &'static str {
-        match self.palette_mode {
-            PaletteMode::Command => ":",
-            PaletteMode::FuzzyFind => "/",
+        if let Mode::InPalette(ref ps) = self.mode { ps.prefix() } else { "" }
+    }
+
+    /// Return the current palette input text, or `""` if palette is closed.
+    pub fn palette_input_value(&self) -> &str {
+        if let Mode::InPalette(ref ps) = self.mode { ps.input.value() } else { "" }
+    }
+
+    // ── Modal helpers ─────────────────────────────────────────────────────────
+
+    pub fn is_modal_open(&self) -> bool {
+        matches!(self.mode, Mode::InModal(_))
+    }
+
+    /// Open a modal, entering `InModal` mode.
+    pub fn open_modal(&mut self, modal: Modal) {
+        self.mode = Mode::InModal(ModalState { modal });
+    }
+
+    /// Close the modal and return to Browsing. No-op if not in modal mode.
+    pub fn close_modal(&mut self) {
+        if matches!(self.mode, Mode::InModal(_)) {
+            self.mode = Mode::Browsing(BrowsingState::default());
+        }
+    }
+
+    /// Immutable reference to the active modal, if any.
+    pub fn modal(&self) -> Option<&Modal> {
+        if let Mode::InModal(ref ms) = self.mode { Some(&ms.modal) } else { None }
+    }
+
+    /// Mutable reference to the active modal, if any.
+    pub fn modal_mut(&mut self) -> Option<&mut Modal> {
+        if let Mode::InModal(ref mut ms) = self.mode { Some(&mut ms.modal) } else { None }
+    }
+
+    // ── Palette accessors ─────────────────────────────────────────────────────
+
+    /// Return the palette history cursor position (`None` = fresh input), or
+    /// `None` if the palette is closed.
+    pub fn palette_history_cursor(&self) -> Option<usize> {
+        if let Mode::InPalette(ref ps) = self.mode { ps.history_cursor } else { None }
+    }
+
+    /// Mutable access to the active `PaletteState`, or `None` if the palette is closed.
+    pub fn palette_state_mut(&mut self) -> Option<&mut PaletteState> {
+        if let Mode::InPalette(ref mut ps) = self.mode { Some(ps) } else { None }
+    }
+
+    /// Return the current `PaletteMode`, or `None` if the palette is closed.
+    ///
+    /// Guard with `is_palette_open()` before calling this to avoid confusing
+    /// "palette closed" with "palette open in Command mode".
+    pub fn palette_mode(&self) -> Option<crate::app::PaletteMode> {
+        if let Mode::InPalette(ref ps) = self.mode { Some(ps.mode) } else { None }
+    }
+
+    // ── Selection helpers ─────────────────────────────────────────────────────
+
+    /// Whether selection mode is enabled (user pressed `v`), with or without
+    /// a drag in progress.
+    pub fn is_selection_mode_enabled(&self) -> bool {
+        matches!(
+            self.mode,
+            Mode::Browsing(BrowsingState {
+                mouse: MouseMode::SelectionEnabled | MouseMode::Selecting { .. }
+            })
+        )
+    }
+
+    /// Whether a drag-selection is actively in progress (mouse is held down).
+    pub fn is_selecting(&self) -> bool {
+        matches!(
+            self.mode,
+            Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { .. } })
+        )
+    }
+
+    /// Begin a drag-selection at `pos`. Transitions `SelectionEnabled → Selecting`.
+    pub fn start_selection(&mut self, pos: (u16, u16)) {
+        if let Mode::Browsing(ref mut bs) = self.mode {
+            bs.mouse = MouseMode::Selecting { start: pos, end: pos };
+        }
+    }
+
+    pub fn update_selection_end(&mut self, pos: (u16, u16)) {
+        if let Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { ref mut end, .. } }) =
+            self.mode
+        {
+            *end = pos;
+        }
+    }
+
+    /// End a drag-selection and return `(start, end)`, resetting to `Normal`.
+    /// Returns `None` if no selection was active.
+    pub fn end_selection(&mut self) -> Option<((u16, u16), (u16, u16))> {
+        if let Mode::Browsing(ref mut bs) = self.mode {
+            if let MouseMode::Selecting { start, end } = bs.mouse {
+                bs.mouse = MouseMode::Normal;
+                return Some((start, end));
+            }
+        }
+        None
+    }
+
+    /// Return the selection start position, if a drag is in progress.
+    pub fn selection_start(&self) -> Option<(u16, u16)> {
+        if let Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { start, .. } }) =
+            self.mode
+        {
+            Some(start)
+        } else {
+            None
+        }
+    }
+
+    /// Return the selection end position, if a drag is in progress.
+    pub fn selection_end(&self) -> Option<(u16, u16)> {
+        if let Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { end, .. } }) =
+            self.mode
+        {
+            Some(end)
+        } else {
+            None
+        }
+    }
+
+    /// Toggle text-selection mode. `Normal ↔ SelectionEnabled`; clears any
+    /// in-progress drag when turning off.
+    pub fn toggle_selection_mode(&mut self) {
+        if let Mode::Browsing(ref mut bs) = self.mode {
+            bs.mouse = match bs.mouse {
+                MouseMode::Normal => MouseMode::SelectionEnabled,
+                MouseMode::SelectionEnabled | MouseMode::Selecting { .. } => MouseMode::Normal,
+            };
         }
     }
 }

--- a/sdk/tui/src/runtime.rs
+++ b/sdk/tui/src/runtime.rs
@@ -70,8 +70,8 @@ pub fn run<B: ratatui::backend::Backend>(
                     // ever defers closing (e.g., for validation), palette_text is Some but
                     // the guard `!model.palette_open` will be false, so PaletteSubmit is
                     // correctly suppressed.
-                    let palette_text = if model.palette_open && key.code == KeyCode::Enter {
-                        Some(model.palette_input.value().to_string())
+                    let palette_text = if model.is_palette_open() && key.code == KeyCode::Enter {
+                        Some(model.palette_input_value().to_string())
                     } else {
                         None
                     };
@@ -80,7 +80,7 @@ pub fn run<B: ratatui::backend::Backend>(
 
                     // Dispatch the command only if Enter actually closed the palette.
                     if let Some(text) = palette_text {
-                        if !model.palette_open {
+                        if !model.is_palette_open() {
                             dispatch_and_record(
                                 &mut model, Message::PaletteSubmit(text), ctx, &mut record,
                             );

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -94,9 +94,7 @@ pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Mess
         Message::Mouse(me) => handle_mouse(model, me),
         Message::PaletteSubmit(raw) => handle_palette_submit(model, raw, ctx),
         Message::PaletteCancel => {
-            model.palette_open = false;
-            model.palette_input = tui_input::Input::default();
-            model.palette_history_cursor = None;
+            model.close_palette();
             Task::none()
         }
         Message::PaletteHistoryNav { older } => {
@@ -110,7 +108,7 @@ pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Mess
                         Some(StatusMessage::info(format!("wrote → {}", path.display())));
                 }
                 Err(e) => {
-                    if let Some(Modal::Wizard(ref mut ws)) = model.modal {
+                    if let Some(Modal::Wizard(ref mut ws)) = model.modal_mut() {
                         ws.error = Some(e);
                     }
                 }
@@ -151,12 +149,12 @@ fn handle_key(
     }
 
     // While the palette is open all keys are consumed here.
-    if model.palette_open {
+    if model.is_palette_open() {
         return handle_palette_key(model, key);
     }
 
     // Modal captures all key input when present.
-    if model.modal.is_some() {
+    if model.is_modal_open() {
         return route_modal_key(model, key, ctx);
     }
 
@@ -169,30 +167,21 @@ fn handle_key(
     // Global fallback keys.
     match key.code {
         KeyCode::Char('?') => {
-            model.modal = Some(Modal::Help(crate::app::HelpModal { scroll: 0 }));
+            model.open_modal(Modal::Help(crate::app::HelpModal { scroll: 0 }));
         }
         KeyCode::Char('v') => {
-            model.selection_mode = !model.selection_mode;
-            if !model.selection_mode {
-                model.sel_start = None;
-                model.sel_end = None;
-            }
-            let label = if model.selection_mode { "on" } else { "off" };
+            let was_selecting = model.is_selecting();
+            model.toggle_selection_mode();
+            let label = if !was_selecting { "on" } else { "off" };
             model.status_message = Some(StatusMessage::info(
                 format!("selection mode {label}  (drag to select, release to copy)"),
             ));
         }
         KeyCode::Char(':') => {
-            model.palette_open = true;
-            model.palette_mode = PaletteMode::Command;
-            model.palette_input = tui_input::Input::default();
-            model.palette_history_cursor = None;
+            model.open_command_palette();
         }
         KeyCode::Char('/') => {
-            model.palette_open = true;
-            model.palette_mode = PaletteMode::FuzzyFind;
-            model.palette_input = tui_input::Input::default();
-            model.palette_history_cursor = None;
+            model.open_fuzzy_palette();
         }
         KeyCode::Char('q') => {
             model.quit = true;
@@ -206,19 +195,19 @@ fn handle_palette_key(
     model: &mut Model,
     key: crossterm::event::KeyEvent,
 ) -> Task<Message> {
+    let palette_cmd_mode = model.palette_mode() == Some(PaletteMode::Command);
+
     match key.code {
         KeyCode::Esc => {
-            model.palette_open = false;
-            model.palette_input = tui_input::Input::default();
-            model.palette_history_cursor = None;
+            model.close_palette();
         }
         KeyCode::Enter => {
             // Close the palette. The runtime sends a separate Message::PaletteSubmit
             // after detecting this transition; submit is NOT dispatched here.
-            model.palette_open = false;
+            model.close_palette();
         }
-        KeyCode::Tab if model.palette_mode == PaletteMode::Command => {
-            let current = model.palette_input.value().to_string();
+        KeyCode::Tab if palette_cmd_mode => {
+            let current = model.palette_input_value().to_string();
             if !current.contains(' ') {
                 let matches: Vec<&str> = KNOWN_COMMANDS
                     .iter()
@@ -228,8 +217,10 @@ fn handle_palette_key(
                 match matches.len() {
                     0 => {}
                     1 => {
-                        model.palette_input =
-                            tui_input::Input::from(format!("{} ", matches[0]));
+                        let new_input = tui_input::Input::from(format!("{} ", matches[0]));
+                        if let Some(ps) = model.palette_state_mut() {
+                            ps.input = new_input;
+                        }
                     }
                     _ => {
                         model.status_message = Some(StatusMessage::info(
@@ -239,50 +230,46 @@ fn handle_palette_key(
                 }
             }
         }
-        KeyCode::Up if model.palette_mode == PaletteMode::Command => {
+        KeyCode::Up if palette_cmd_mode => {
             handle_history_nav(model, true);
         }
-        KeyCode::Down if model.palette_mode == PaletteMode::Command => {
+        KeyCode::Down if palette_cmd_mode => {
             handle_history_nav(model, false);
         }
         _ => {
-            model.palette_history_cursor = None;
-            model
-                .palette_input
-                .handle_event(&crossterm::event::Event::Key(key));
+            if let Some(ps) = model.palette_state_mut() {
+                ps.history_cursor = None;
+                ps.input.handle_event(&crossterm::event::Event::Key(key));
+            }
         }
     }
     Task::none()
 }
 
 fn handle_history_nav(model: &mut Model, older: bool) {
-    if older {
-        let next = match model.palette_history_cursor {
-            None if !model.palette_history.is_empty() => Some(0),
-            Some(i) if i + 1 < model.palette_history.len() => Some(i + 1),
+    // Called only when palette is open (from handle_palette_key).
+    // Two-pass: read first (no borrow conflict), then write.
+    let current_cursor = model.palette_history_cursor();
+    let history_len = model.palette_history.len();
+
+    let next = if older {
+        match current_cursor {
+            None if history_len > 0 => Some(0),
+            Some(i) if i + 1 < history_len => Some(i + 1),
             other => other,
-        };
-        model.palette_history_cursor = next;
-        if let Some(i) = next {
-            if let Some(entry) = model.palette_history.get(i) {
-                model.palette_input = tui_input::Input::from(entry.clone());
-            }
         }
     } else {
-        let next = model.palette_history_cursor.and_then(|i| {
-            if i == 0 { None } else { Some(i - 1) }
-        });
-        model.palette_history_cursor = next;
-        match next {
-            Some(i) => {
-                if let Some(entry) = model.palette_history.get(i) {
-                    model.palette_input = tui_input::Input::from(entry.clone());
-                }
-            }
-            None => {
-                model.palette_input = tui_input::Input::default();
-            }
-        }
+        current_cursor.and_then(|i| if i == 0 { None } else { Some(i - 1) })
+    };
+
+    let entry = next.and_then(|i| model.palette_history.get(i)).cloned();
+
+    if let Some(ps) = model.palette_state_mut() {
+        ps.history_cursor = next;
+        ps.input = match entry {
+            Some(text) => tui_input::Input::from(text),
+            None => tui_input::Input::default(),
+        };
     }
 }
 
@@ -379,10 +366,10 @@ fn route_modal_key(
     ctx: &UpdateCtx<'_>,
 ) -> Task<Message> {
     // Help modal.
-    if let Some(Modal::Help(ref mut hm)) = model.modal {
+    if let Some(Modal::Help(ref mut hm)) = model.modal_mut() {
         match key.code {
             KeyCode::Esc | KeyCode::Char('?') => {
-                model.modal = None;
+                model.close_modal();
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 hm.scroll = hm.scroll.saturating_sub(1);
@@ -402,11 +389,11 @@ fn route_modal_key(
     }
 
     // Find modal.
-    if let Some(Modal::Find(ref mut fs)) = model.modal {
+    if let Some(Modal::Find(ref mut fs)) = model.modal_mut() {
         let event = fs.handle_key(key, ctx.graph);
         match event {
             FindEvent::Cancel => {
-                model.modal = None;
+                model.close_modal();
                 model.status_message = Some(StatusMessage::info("find wizard cancelled"));
             }
             FindEvent::OpenResults(view) => {
@@ -414,7 +401,7 @@ fn route_modal_key(
                 model.active_view = ActiveView::Query(view);
                 model.status_message =
                     Some(StatusMessage::info(format!("{count} token(s) matched")));
-                model.modal = None;
+                model.close_modal();
             }
             FindEvent::Continue => {}
         }
@@ -422,11 +409,11 @@ fn route_modal_key(
     }
 
     // Naming modal.
-    if let Some(Modal::Naming(ref mut ns)) = model.modal {
+    if let Some(Modal::Naming(ref mut ns)) = model.modal_mut() {
         let event = ns.handle_key(key, ctx.graph);
         match event {
             NamingEvent::Cancel => {
-                model.modal = None;
+                model.close_modal();
                 model.status_message = Some(StatusMessage::info("naming wizard cancelled"));
             }
             NamingEvent::Copy(name) => {
@@ -445,20 +432,20 @@ fn route_modal_key(
 
     // Wizard modal.
     let wctx = ctx.as_wizard_ctx();
-    let event = match &mut model.modal {
+    let event = match model.modal_mut() {
         Some(Modal::Wizard(ws)) => ws.handle_key(key, &wctx),
         _ => return Task::none(),
     };
 
     match event {
         WizardEvent::Cancel => {
-            model.modal = None;
+            model.close_modal();
             model.status_message = Some(StatusMessage::info("wizard cancelled"));
             Task::cmd(|| { clear_wizard_draft(); Message::Tick })
         }
         WizardEvent::Submit => {
             if !ctx.allow_write {
-                model.modal = None;
+                model.close_modal();
                 model.status_message = Some(StatusMessage::info(
                     "wizard preview ready — pass --allow-write to enable writes",
                 ));
@@ -466,21 +453,21 @@ fn route_modal_key(
             } else {
                 // TODO(#1023): extract perform_write into Task::Cmd once WizardState
                 // exposes owned submit-data that can be moved into a 'static closure.
-                let write_result = if let Some(Modal::Wizard(ref ws)) = model.modal {
+                let write_result = if let Some(Modal::Wizard(ref ws)) = model.modal() {
                     Some((ws.assembled_name(), ws.perform_write(&wctx)))
                 } else {
                     None
                 };
                 match write_result {
                     Some((name, Ok(written_path))) => {
-                        model.modal = None;
+                        model.close_modal();
                         model.status_message = Some(StatusMessage::info(
                             format!("wrote {name} → {written_path}"),
                         ));
                         Task::cmd(|| { clear_wizard_draft(); Message::Tick })
                     }
                     Some((_, Err(e))) => {
-                        if let Some(Modal::Wizard(ref mut ws)) = model.modal {
+                        if let Some(Modal::Wizard(ref mut ws)) = model.modal_mut() {
                             ws.error = Some(e);
                         }
                         Task::none()
@@ -490,7 +477,7 @@ fn route_modal_key(
             }
         }
         WizardEvent::Continue => {
-            let draft = if let Some(Modal::Wizard(ref ws)) = model.modal {
+            let draft = if let Some(Modal::Wizard(ref ws)) = model.modal() {
                 Some(to_draft(ws))
             } else {
                 None
@@ -514,26 +501,26 @@ fn handle_mouse(model: &mut Model, me: crossterm::event::MouseEvent) -> Task<Mes
             scroll_active(model, 1);
         }
         MouseEventKind::Down(MouseButton::Left) => {
-            if model.selection_mode {
-                model.sel_start = Some((me.row, me.column));
-                model.sel_end = Some((me.row, me.column));
+            if model.is_selection_mode_enabled() {
+                model.start_selection((me.row, me.column));
             } else {
                 click_at(model, me.row, me.column);
             }
         }
-        MouseEventKind::Drag(MouseButton::Left) if model.selection_mode => {
-            model.sel_end = Some((me.row, me.column));
+        MouseEventKind::Drag(MouseButton::Left) if model.is_selecting() => {
+            model.update_selection_end((me.row, me.column));
         }
-        MouseEventKind::Up(MouseButton::Left) if model.selection_mode => {
-            let yank = extract_selection(model);
-            model.sel_start = None;
-            model.sel_end = None;
-            if let Some(text) = yank {
-                if !text.is_empty() {
-                    return Task::cmd(move || {
-                        let err = write_clipboard(&text).err().map(|e| e.to_string());
-                        Message::ClipboardDone(err)
-                    });
+        MouseEventKind::Up(MouseButton::Left) if model.is_selecting() => {
+            if let Some((start, end)) = model.end_selection() {
+                // Extract text from hit regions within the selection bounds.
+                let text = extract_selection_from_regions(&model.hit_regions, start, end);
+                if let Some(t) = text {
+                    if !t.is_empty() {
+                        return Task::cmd(move || {
+                            let err = write_clipboard(&t).err().map(|e| e.to_string());
+                            Message::ClipboardDone(err)
+                        });
+                    }
                 }
             }
         }
@@ -543,7 +530,7 @@ fn handle_mouse(model: &mut Model, me: crossterm::event::MouseEvent) -> Task<Mes
 }
 
 fn scroll_active(model: &mut Model, delta: i32) {
-    if let Some(ref mut modal) = model.modal {
+    if let Some(modal) = model.modal_mut() {
         if modal.wants_scroll() {
             modal.on_scroll(delta);
         }
@@ -589,16 +576,20 @@ fn click_at(model: &mut Model, row: u16, col: u16) {
     }
 }
 
-fn extract_selection(model: &Model) -> Option<String> {
-    let (Some((r1, c1)), Some((r2, c2))) = (model.sel_start, model.sel_end) else {
-        return None;
-    };
+/// Extract text from hit regions within a rectangular selection.
+fn extract_selection_from_regions(
+    regions: &[crate::app::HitRegion],
+    start: (u16, u16),
+    end: (u16, u16),
+) -> Option<String> {
+    let (r1, c1) = start;
+    let (r2, c2) = end;
     let min_row = r1.min(r2);
     let max_row = r1.max(r2);
     let min_col = c1.min(c2);
     let max_col = c1.max(c2);
     let mut lines: Vec<&str> = Vec::new();
-    for region in &model.hit_regions {
+    for region in regions {
         let ry = region.rect.y;
         let rx = region.rect.x;
         let rx_end = rx + region.rect.width;
@@ -617,16 +608,16 @@ fn handle_palette_submit(
     ctx: &UpdateCtx<'_>,
 ) -> Task<Message> {
     // FuzzyFind mode: close without dispatching.
-    if model.palette_mode != PaletteMode::Command {
-        model.palette_open = false;
-        model.palette_input = tui_input::Input::default();
+    // When the model is in Browsing mode (e.g. direct PaletteSubmit from tests or replay),
+    // treat as command mode — the submit should always dispatch.
+    let is_fuzzy = model.palette_mode() == Some(PaletteMode::FuzzyFind);
+    if is_fuzzy {
+        model.close_palette();
         return Task::none();
     }
 
     let raw = raw.trim().to_string();
-    model.palette_open = false;
-    model.palette_input = tui_input::Input::default();
-    model.palette_history_cursor = None;
+    model.close_palette();
 
     // Append to history (dedupe head, cap at HISTORY_CAP).
     let history_task = if !raw.is_empty()
@@ -894,21 +885,21 @@ fn dispatch_command(
         }
         "find" => {
             let fs = FindWizardState::new_with_intent(rest.trim());
-            model.modal = Some(Modal::Find(Box::new(fs)));
+            model.open_modal(Modal::Find(Box::new(fs)));
             model.status_message = None;
             Task::none()
         }
         "name" => {
             let mut ns = NamingWizardState::new_with_intent(rest.trim());
             ns.refresh_suggestions(ctx.graph);
-            model.modal = Some(Modal::Naming(Box::new(ns)));
+            model.open_modal(Modal::Naming(Box::new(ns)));
             model.status_message = None;
             Task::none()
         }
         "new" | "create" => {
             let mut ws = WizardState::new_with_intent(rest.trim());
             ws.refresh_suggestions(ctx.graph);
-            model.modal = Some(Modal::Wizard(Box::new(ws)));
+            model.open_modal(Modal::Wizard(Box::new(ws)));
             model.status_message = None;
             Task::none()
         }

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -95,35 +95,36 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
         );
     }
 
-    // Palette prompt (hidden while a modal is open).
-    let palette_text = if model.modal.is_none() && model.palette_open {
-        format!("{}{}", model.palette_prefix(), model.palette_input.value())
+    // Palette prompt (only visible in InPalette mode).
+    let palette_text = if model.is_palette_open() {
+        format!("{}{}", model.palette_prefix(), model.palette_input_value())
     } else {
         String::new()
     };
     frame.render_widget(Paragraph::new(palette_text), chunks[3]);
 
     // Overlay modal (rendered last so it appears on top).
-    match &mut model.modal {
-        Some(Modal::Find(ref mut fs)) => {
-            let popup_area = centered_rect(82, 85, area);
-            frame.render_widget(Clear, popup_area);
-            render_find(frame, fs, popup_area, theme);
+    if let Some(modal) = model.modal_mut() {
+        match modal {
+            Modal::Find(ref mut fs) => {
+                let popup_area = centered_rect(82, 85, area);
+                frame.render_widget(Clear, popup_area);
+                render_find(frame, fs, popup_area, theme);
+            }
+            Modal::Wizard(ref mut ws) => {
+                let popup_area = centered_rect(82, 85, area);
+                frame.render_widget(Clear, popup_area);
+                render_wizard(frame, ws, popup_area, theme);
+            }
+            Modal::Naming(ref mut ns) => {
+                let popup_area = centered_rect(82, 85, area);
+                frame.render_widget(Clear, popup_area);
+                render_naming(frame, ns, popup_area, theme);
+            }
+            Modal::Help(ref hm) => {
+                render_help_modal(frame, hm.scroll, area);
+            }
         }
-        Some(Modal::Wizard(ref mut ws)) => {
-            let popup_area = centered_rect(82, 85, area);
-            frame.render_widget(Clear, popup_area);
-            render_wizard(frame, ws, popup_area, theme);
-        }
-        Some(Modal::Naming(ref mut ns)) => {
-            let popup_area = centered_rect(82, 85, area);
-            frame.render_widget(Clear, popup_area);
-            render_naming(frame, ns, popup_area, theme);
-        }
-        Some(Modal::Help(ref hm)) => {
-            render_help_modal(frame, hm.scroll, area);
-        }
-        None => {}
     }
 }
 

--- a/sdk/tui/tests/autocomplete.rs
+++ b/sdk/tui/tests/autocomplete.rs
@@ -28,7 +28,7 @@ fn tab_completes_query() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     type_str(&mut model, &ctx, "q");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "query ");
+    assert_eq!(model.palette_input_value(), "query ");
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn tab_completes_resolve() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     type_str(&mut model, &ctx, "re");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "resolve ");
+    assert_eq!(model.palette_input_value(), "resolve ");
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn tab_completes_describe() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     type_str(&mut model, &ctx, "d");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "describe ");
+    assert_eq!(model.palette_input_value(), "describe ");
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn tab_completes_validate() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     type_str(&mut model, &ctx, "v");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "validate ");
+    assert_eq!(model.palette_input_value(), "validate ");
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn ambiguous_prefix_sets_status_and_leaves_buffer_unchanged() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     // Empty prefix matches all commands → ambiguous.
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "");
+    assert_eq!(model.palette_input_value(), "");
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("matches:"), "expected 'matches:' in status: {msg}");
 }
@@ -85,7 +85,7 @@ fn tab_after_space_is_noop() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     type_str(&mut model, &ctx, "query ");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "query ");
+    assert_eq!(model.palette_input_value(), "query ");
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn tab_on_no_match_is_noop() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     type_str(&mut model, &ctx, "zzz");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "zzz");
+    assert_eq!(model.palette_input_value(), "zzz");
 }
 
 #[test]
@@ -107,5 +107,5 @@ fn tab_in_fuzzy_mode_is_noop() {
     update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
     type_str(&mut model, &ctx, "q");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "q");
+    assert_eq!(model.palette_input_value(), "q");
 }

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -329,7 +329,7 @@ fn find_command_opens_find_modal() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
-    assert!(matches!(model.modal, Some(Modal::Find(_))));
+    assert!(matches!(model.modal(), Some(Modal::Find(_))));
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn find_command_with_args_seeds_intent() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find accent background");
-    if let Some(Modal::Find(ref fs)) = model.modal {
+    if let Some(Modal::Find(ref fs)) = model.modal() {
         assert_eq!(fs.intent.value(), "accent background");
     } else {
         panic!("expected Find modal");
@@ -351,7 +351,7 @@ fn find_command_no_args_opens_modal_with_empty_fields() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
-    if let Some(Modal::Find(ref fs)) = model.modal {
+    if let Some(Modal::Find(ref fs)) = model.modal() {
         assert_eq!(fs.intent.value(), "");
         assert_eq!(fs.focused_field, 0);
     } else {
@@ -369,7 +369,7 @@ fn tab_autocompletes_find_command() {
         update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "find ");
+    assert_eq!(model.palette_input_value(), "find ");
 }
 
 #[test]
@@ -378,9 +378,9 @@ fn esc_in_find_modal_closes_it() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
-    assert!(model.modal.is_some());
+    assert!(model.is_modal_open());
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(model.modal.is_none());
+    assert!(!model.is_modal_open());
 }
 
 #[test]
@@ -399,7 +399,7 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
     // Enter → OpenResults.
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
 
-    assert!(model.modal.is_none());
+    assert!(!model.is_modal_open());
     assert!(matches!(model.active_view, ActiveView::Query(_)));
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("matched"), "expected 'matched' in status: {msg}");
@@ -417,9 +417,9 @@ fn e_on_preview_keeps_modal_open_and_returns_to_filters() {
     // Press e → back to Filters.
     update(&mut model, Message::Key(key(KeyCode::Char('e'))), &ctx);
 
-    assert!(model.modal.is_some(), "e should not close the modal");
+    assert!(model.is_modal_open(), "e should not close the modal");
     assert!(matches!(model.active_view, ActiveView::Empty));
-    if let Some(Modal::Find(ref fs)) = model.modal {
+    if let Some(Modal::Find(ref fs)) = model.modal() {
         assert_eq!(fs.screen, FindScreen::Filters);
     }
 }

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -28,7 +28,7 @@ fn question_mark_opens_help_modal() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
-    assert!(matches!(model.modal, Some(Modal::Help(_))), "? should open help modal");
+    assert!(matches!(model.modal(), Some(Modal::Help(_))), "? should open help modal");
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn esc_closes_help_modal() {
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(model.modal.is_none(), "Esc should close help modal");
+    assert!(!model.is_modal_open(), "Esc should close help modal");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn question_mark_closes_help_modal() {
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
-    assert!(model.modal.is_none(), "second ? should close help modal");
+    assert!(!model.is_modal_open(), "second ? should close help modal");
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn pgdn_scrolls_help_body() {
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::PageDown)), &ctx);
-    if let Some(Modal::Help(ref hm)) = model.modal {
+    if let Some(Modal::Help(ref hm)) = model.modal() {
         assert_eq!(hm.scroll, 10, "PageDown should advance help scroll by 10");
     } else {
         panic!("expected Help modal to still be open");
@@ -74,7 +74,7 @@ fn arrow_keys_scroll_help_body() {
     update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
-    if let Some(Modal::Help(ref hm)) = model.modal {
+    if let Some(Modal::Help(ref hm)) = model.modal() {
         assert_eq!(hm.scroll, 1);
     } else {
         panic!("expected Help modal");
@@ -101,13 +101,13 @@ fn up_arrow_in_palette_recalls_last_command() {
 
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx); // open palette
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
-    assert_eq!(model.palette_input.value(), "query foo");
+    assert_eq!(model.palette_input_value(), "query foo");
 
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
-    assert_eq!(model.palette_input.value(), "query bar");
+    assert_eq!(model.palette_input_value(), "query bar");
 
     update(&mut model, Message::Key(key(KeyCode::Down)), &ctx);
-    assert_eq!(model.palette_input.value(), "query foo");
+    assert_eq!(model.palette_input_value(), "query foo");
 }
 
 #[test]
@@ -140,14 +140,14 @@ fn typing_resets_history_cursor() {
 
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
-    assert_eq!(model.palette_history_cursor, Some(0));
+    assert_eq!(model.palette_history_cursor(), Some(0));
 
     update(&mut model, Message::Key(key(KeyCode::Char('x'))), &ctx);
-    assert_eq!(model.palette_history_cursor, None, "typing should reset history cursor");
+    assert_eq!(model.palette_history_cursor(), None, "typing should reset history cursor");
 
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
-    assert_eq!(model.palette_history_cursor, Some(0));
-    assert_eq!(model.palette_input.value(), "query foo");
+    assert_eq!(model.palette_history_cursor(), Some(0));
+    assert_eq!(model.palette_input_value(), "query foo");
 }
 
 // ── Mouse: wheel scroll ───────────────────────────────────────────────────────
@@ -200,7 +200,7 @@ fn v_key_enters_selection_mode() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
-    assert!(model.selection_mode, "v should enable selection mode");
+    assert!(model.is_selection_mode_enabled(), "v should enable selection mode");
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn v_key_toggles_selection_mode_off() {
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
-    assert!(!model.selection_mode, "second v should disable selection mode");
+    assert!(!model.is_selection_mode_enabled(), "second v should disable selection mode");
 }
 
 #[test]
@@ -221,8 +221,8 @@ fn drag_records_selection_endpoints() {
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
     update(&mut model, Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0)), &ctx);
     update(&mut model, Message::Mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 10)), &ctx);
-    assert_eq!(model.sel_start, Some((2, 0)));
-    assert_eq!(model.sel_end, Some((4, 10)));
+    assert_eq!(model.selection_start(), Some((2, 0)));
+    assert_eq!(model.selection_end(), Some((4, 10)));
 }
 
 // ── Theming ───────────────────────────────────────────────────────────────────

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -145,7 +145,7 @@ fn name_command_opens_naming_modal() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "name accent background");
-    assert!(matches!(model.modal, Some(Modal::Naming(_))));
+    assert!(matches!(model.modal(), Some(Modal::Naming(_))));
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn name_command_no_args_opens_naming_modal() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "name");
-    assert!(matches!(model.modal, Some(Modal::Naming(_))));
+    assert!(matches!(model.modal(), Some(Modal::Naming(_))));
 }
 
 #[test]
@@ -163,7 +163,7 @@ fn name_command_seeds_intent_from_args() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "name accent background");
-    if let Some(Modal::Naming(ref ns)) = model.modal {
+    if let Some(Modal::Naming(ref ns)) = model.modal() {
         assert_eq!(ns.intent.value(), "accent background");
     } else {
         panic!("expected Naming modal");
@@ -180,7 +180,7 @@ fn tab_autocompletes_name_command() {
         update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    assert_eq!(model.palette_input.value(), "name ");
+    assert_eq!(model.palette_input_value(), "name ");
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn copy_event_sets_pending_yank_and_status() {
     assert!(model.pending_yank.is_none(), "pending_yank should not be set — clipboard is via Task::Cmd");
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
-    assert!(model.modal.is_some(), "Copy should not close the Naming modal");
+    assert!(model.is_modal_open(), "Copy should not close the Naming modal");
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn esc_in_naming_modal_closes_it() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "name");
-    assert!(model.modal.is_some());
+    assert!(model.is_modal_open());
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(model.modal.is_none());
+    assert!(!model.is_modal_open());
 }

--- a/sdk/tui/tests/palette.rs
+++ b/sdk/tui/tests/palette.rs
@@ -25,8 +25,8 @@ fn colon_opens_palette_in_command_mode() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
-    assert!(model.palette_open);
-    assert_eq!(model.palette_mode, PaletteMode::Command);
+    assert!(model.is_palette_open());
+    assert_eq!(model.palette_mode(), Some(PaletteMode::Command));
 }
 
 #[test]
@@ -35,8 +35,8 @@ fn slash_opens_palette_in_fuzzy_find_mode() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
-    assert!(model.palette_open);
-    assert_eq!(model.palette_mode, PaletteMode::FuzzyFind);
+    assert!(model.is_palette_open());
+    assert_eq!(model.palette_mode(), Some(PaletteMode::FuzzyFind));
 }
 
 #[test]
@@ -45,9 +45,9 @@ fn esc_closes_palette() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
-    assert!(model.palette_open);
+    assert!(model.is_palette_open());
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(!model.palette_open);
+    assert!(!model.is_palette_open());
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn q_does_not_quit_when_palette_open() {
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Char('q'))), &ctx);
     assert!(!model.quit);
-    assert!(model.palette_open);
+    assert!(model.is_palette_open());
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn ctrl_c_always_quits() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
-    assert!(model.palette_open);
+    assert!(model.is_palette_open());
     update(&mut model, Message::Key(ctrl('c')), &ctx);
     assert!(model.quit);
 }
@@ -91,8 +91,8 @@ fn esc_clears_palette_input() {
         update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(!model.palette_open);
-    assert!(model.palette_input.value().is_empty());
+    assert!(!model.is_palette_open());
+    assert!(model.palette_input_value().is_empty());
 }
 
 #[test]
@@ -120,6 +120,6 @@ fn colon_while_palette_open_goes_to_input_buffer() {
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx); // open palette
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx); // forwarded to input
-    assert!(model.palette_open);
-    assert_eq!(model.palette_input.value(), ":");
+    assert!(model.is_palette_open());
+    assert_eq!(model.palette_input_value(), ":");
 }

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -21,7 +21,7 @@ fn submit_valid_query_populates_query_view() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::PaletteSubmit("query property=accent-color".into()), &ctx);
-    assert!(!model.palette_open);
+    assert!(!model.is_palette_open());
     assert!(matches!(model.active_view, ActiveView::Query(_)));
 }
 
@@ -44,7 +44,7 @@ fn submit_invalid_query_sets_status_message() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::PaletteSubmit("query ===bad===".into()), &ctx);
-    assert!(!model.palette_open);
+    assert!(!model.is_palette_open());
     assert!(matches!(model.active_view, ActiveView::Empty));
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(

--- a/sdk/tui/tests/runtime.rs
+++ b/sdk/tui/tests/runtime.rs
@@ -26,7 +26,7 @@ fn smoke_colon_opens_palette_and_renders_prompt() {
     let mut model = Model::new();
 
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
-    assert!(model.palette_open, "':' should open palette");
+    assert!(model.is_palette_open(), "':' should open palette");
 
     // Drive through draw — must not panic and must render ':' on last row.
     let buf = render_to_buffer(&mut model, 80, 24);
@@ -45,7 +45,7 @@ fn smoke_esc_closes_palette_and_clears_prompt() {
 
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(!model.palette_open, "Esc should close palette");
+    assert!(!model.is_palette_open(), "Esc should close palette");
 
     let buf = render_to_buffer(&mut model, 80, 24);
     let last = (0..80u16)
@@ -86,5 +86,5 @@ fn smoke_render_after_query_shows_data_row() {
 #[test]
 fn smoke_model_new_with_options_resume_false_has_no_modal() {
     let model = Model::new_with_options(false);
-    assert!(model.modal.is_none(), "resume_wizard=false should yield no modal");
+    assert!(!model.is_modal_open(), "resume_wizard=false should yield no modal");
 }

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -45,7 +45,7 @@ fn new_command_opens_wizard() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     open_wizard(&mut model, &ctx, "accent background");
-    assert!(model.modal.is_some(), "modal should be open after :new");
+    assert!(model.is_modal_open(), "modal should be open after :new");
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn esc_cancels_wizard() {
     let mut model = Model::new();
     open_wizard(&mut model, &ctx, "accent background");
     let task = update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-    assert!(model.modal.is_none(), "modal should close on Esc");
+    assert!(!model.is_modal_open(), "modal should close on Esc");
     assert!(matches!(task, Task::Cmd(_)), "cancel should return Task::Cmd (draft clear)");
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(msg.contains("cancelled"), "status should say cancelled: {msg}");
@@ -67,7 +67,7 @@ fn intent_populates_suggestions_on_open() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     open_wizard(&mut model, &ctx, "accent background");
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert!(!ws.suggestions.is_empty(), "suggestions should be populated from intent");
     } else {
         panic!("expected wizard modal");
@@ -81,7 +81,7 @@ fn enter_on_screen_1_advances_to_screen_2() {
     let mut model = Model::new();
     open_wizard(&mut model, &ctx, "accent background");
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.screen, WizardScreen::Classification, "should advance to Screen 2");
     } else {
         panic!("expected wizard modal after Enter on Screen 1");
@@ -95,7 +95,7 @@ fn tab_with_suggestion_sets_alias_path_and_jumps_to_confirm() {
     let mut model = Model::new();
     open_wizard(&mut model, &ctx, "accent background");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.screen, WizardScreen::Confirm, "Tab should jump to Confirm");
         assert!(
             matches!(ws.chosen_path, WizardPath::AliasToExisting(_)),
@@ -114,13 +114,13 @@ fn screen_2_layer_cycles_with_arrow_keys() {
     open_wizard(&mut model, &ctx, "background");
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Right)), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.classification.layer, Layer::Platform, "Right should advance layer");
     } else {
         panic!("expected wizard modal");
     }
     update(&mut model, Message::Key(key(KeyCode::Left)), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.classification.layer, Layer::Foundation, "Left should reverse layer");
     }
 }
@@ -133,7 +133,7 @@ fn screen_2_enter_advances_to_screen_3() {
     open_wizard(&mut model, &ctx, "background");
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.screen, WizardScreen::Values, "should advance to Screen 3");
     } else {
         panic!("expected wizard modal");
@@ -148,7 +148,7 @@ fn screen_3_mode_rows_match_cartesian_product() {
     open_wizard(&mut model, &ctx, "background");
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.values.rows.len(), 2, "should have one row per mode combo");
     } else {
         panic!("expected wizard modal");
@@ -164,11 +164,11 @@ fn screen_3_a_l_toggle_value_kind() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.values.rows[0].kind, ValueKind::Literal, "'l' should set Literal");
     }
     update(&mut model, Message::Key(key(KeyCode::Char('a'))), &ctx);
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.values.rows[0].kind, ValueKind::Alias, "'a' should restore Alias");
     }
 }
@@ -190,7 +190,7 @@ fn screen_3_enter_advances_to_screen_4() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.screen, WizardScreen::Confirm, "should advance to Screen 4");
     } else {
         panic!("expected wizard modal");
@@ -215,7 +215,7 @@ fn screen_4_empty_rationale_blocks_submit() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // Submit with empty rationale
-    assert!(model.modal.is_some(), "modal should stay open when rationale is empty");
+    assert!(model.is_modal_open(), "modal should stay open when rationale is empty");
 }
 
 #[test]
@@ -239,7 +239,7 @@ fn screen_4_diff_preview_is_populated_on_enter() {
     }
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
-    if let Some(Modal::Wizard(ref ws)) = model.modal {
+    if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.screen, WizardScreen::Confirm);
         let diff = ws.diff_preview.as_ref().expect("diff_preview should be populated");
         assert!(diff.contains('+'), "diff should contain '+' lines");
@@ -269,7 +269,7 @@ fn screen_4_submit_closes_modal_and_sets_status() {
         update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
     let task = update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
-    assert!(model.modal.is_none(), "modal should close after submit");
+    assert!(!model.is_modal_open(), "modal should close after submit");
     assert!(matches!(task, Task::Cmd(_)), "submit should return Task::Cmd (draft clear)");
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
     assert!(

--- a/sdk/tui/tests/wizard_persistence.rs
+++ b/sdk/tui/tests/wizard_persistence.rs
@@ -107,10 +107,10 @@ fn model_new_with_options_restores_wizard_from_disk() {
 
         let model = Model::new_with_options(true);
         assert!(
-            matches!(model.modal, Some(Modal::Wizard(_))),
+            matches!(model.modal(), Some(Modal::Wizard(_))),
             "Model::new_with_options(true) should restore wizard from disk"
         );
-        if let Some(Modal::Wizard(ref ws)) = model.modal {
+        if let Some(Modal::Wizard(ref ws)) = model.modal() {
             assert_eq!(ws.intent.value(), "restore test");
         }
     });
@@ -124,7 +124,7 @@ fn model_new_with_options_false_ignores_draft() {
 
         let model = Model::new_with_options(false);
         assert!(
-            model.modal.is_none(),
+            !model.is_modal_open(),
             "--no-resume-wizard: modal should be None even if draft exists on disk"
         );
         let path = wizard_draft_path().unwrap();
@@ -136,7 +136,7 @@ fn model_new_with_options_false_ignores_draft() {
 fn model_new_with_no_draft_starts_with_no_modal() {
     let _dir = with_temp_draft(|| {
         let model = Model::new_with_options(true);
-        assert!(model.modal.is_none(), "no draft → no modal");
+        assert!(!model.is_modal_open(), "no draft → no modal");
     });
 }
 
@@ -151,15 +151,15 @@ fn cancelling_wizard_returns_draft_clear_task() {
 
         // Open wizard and persist a draft manually.
         update(&mut model, Message::PaletteSubmit("new test token".into()), &ctx);
-        assert!(model.modal.is_some(), "wizard should be open");
-        if let Some(Modal::Wizard(ref ws)) = model.modal {
+        assert!(model.is_modal_open(), "wizard should be open");
+        if let Some(Modal::Wizard(ref ws)) = model.modal() {
             save_wizard_draft(&to_draft(ws));
         }
         assert!(wizard_draft_path().unwrap().exists(), "draft should be on disk");
 
         // Cancel — should return Task::Cmd that clears the draft.
         let task = update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
-        assert!(model.modal.is_none(), "modal should be closed after Esc");
+        assert!(!model.is_modal_open(), "modal should be closed after Esc");
         assert!(task.is_cmd(), "cancel should return Task::Cmd for draft clear");
 
         // Execute the task to verify it clears the draft file.
@@ -178,7 +178,7 @@ fn wizard_keystroke_returns_persist_task() {
         let mut model = Model::new();
 
         update(&mut model, Message::PaletteSubmit("new".into()), &ctx);
-        assert!(model.modal.is_some());
+        assert!(model.is_modal_open());
 
         // Type into intent field — each key that advances WizardEvent::Continue
         // should return Task::Cmd (save_wizard_draft).

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -103,7 +103,7 @@ fn submit_without_allow_write_does_not_create_file() {
     }
     let task = update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
 
-    assert!(model.modal.is_none(), "modal should close without --allow-write");
+    assert!(!model.is_modal_open(), "modal should close without --allow-write");
     assert!(task.is_cmd(), "submit without allow_write should return Task::Cmd (draft clear)");
 
     let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");


### PR DESCRIPTION
## Description

Replaces 7 flat boolean/Option fields on `Model` with a single `mode: Mode` sum type, making impossible combinations compile-time errors.

**New `src/mode.rs`:**
```rust
pub enum Mode {
    Browsing(BrowsingState),   // mouse: MouseMode (Normal | Selecting{start, end})
    InModal(ModalState),       // absorbs modal: Option<Modal>
    InPalette(PaletteState),   // absorbs palette_open + palette_mode + palette_input + history_cursor
}
```

**Fields removed from `Model`:** `palette_open`, `palette_mode`, `palette_input`, `palette_history_cursor`, `modal`, `selection_mode`, `sel_start`, `sel_end`

**Fields added to `Model`:** `mode: Mode`

**Impossible combinations now prevented at compile time:**
- Palette open while a modal is active
- Selection start recorded without end
- Both palette and modal simultaneously

**`Model` gains ergonomic helpers:** `is_palette_open()`, `open_command_palette()`, `close_palette()`, `is_modal_open()`, `open_modal()`, `close_modal()`, `modal()`, `modal_mut()`, `is_selecting()`, `palette_input_value()`, `palette_mode()`, etc.

All callers (`update.rs`, `view.rs`, `runtime.rs`) and all test files updated.

## Related Issue

Closes #1024. Part of TUI v2 epic #1014. Unblocks #1018 (budget tests) and contributes to #1026 (architecture docs).

## How Has This Been Tested?

`cargo test` — all 185+ tests pass.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.