### PR TITLE
feat(sdk): unify CLI and TUI into a single design-data binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Packages in this monorepo:
 
 ## SDK & TUI
 
-* [design-data-tui](sdk/tui/) interactive terminal UI for authoring and inspecting tokens — command palette, cascade resolver, validator, and four-screen guided authoring wizard.
+* [design-data](sdk/cli/) unified CLI and interactive TUI — validate, resolve, diff, query, and migrate tokens from the command line; run bare (`design-data`) to launch the interactive TUI (command palette, cascade resolver, validator, four-screen authoring wizard). The TUI library lives in [sdk/tui/](sdk/tui/).
 
 ## Setup monorepo locally
 

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "chrono",
  "clap",
  "design-data-core",
+ "design-data-tui",
  "miette",
  "predicates",
  "serde",

--- a/sdk/cli/Cargo.toml
+++ b/sdk/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 design-data-core = { path = "../core", features = ["figma"] }
+design-data-tui = { path = "../tui" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 miette = { version = "7.4", features = ["fancy"] }

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -18,7 +18,8 @@ mod format;
 
 use std::collections::HashSet;
 
-use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
+use design_data_tui::{LaunchOptions, ThemeChoice};
 use design_data_core::cascade::{resolve, ResolutionContext};
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
@@ -40,11 +41,48 @@ use miette::{IntoDiagnostic, WrapErr};
 const SPEC_VERSION: &str = "1.0.0-draft";
 
 /// Spectrum Design Data tooling — validate and migrate design tokens.
+///
+/// Run with no arguments to launch the interactive TUI. Pass a subcommand for
+/// non-interactive use.
 #[derive(Parser)]
-#[command(name = "design-data", version, about)]
+#[command(name = "design-data", version, about,
+          args_conflicts_with_subcommands = true,
+          subcommand_negates_reqs = true)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
+    /// TUI launch options (used when no subcommand is given).
+    #[command(flatten)]
+    tui: TuiArgs,
+}
+
+/// Arguments for launching the interactive TUI (bare invocation or `tui` subcommand).
+#[derive(Args)]
+struct TuiArgs {
+    /// Path to the token dataset directory (default: current directory).
+    #[arg(value_name = "DATASET")]
+    dataset: Option<PathBuf>,
+    /// Path to the components directory (default: spec-bundled).
+    #[arg(long)]
+    components: Option<PathBuf>,
+    /// Path to the mode-sets directory (default: spec-bundled).
+    #[arg(long = "mode-sets")]
+    mode_sets: Option<PathBuf>,
+    /// Enable real disk writes from the wizard (Screen 4 Submit).
+    #[arg(long)]
+    allow_write: bool,
+    /// Color theme (`terminal` or `spectrum`).
+    #[arg(long, value_enum, default_value_t = ThemeChoice::Terminal)]
+    theme: ThemeChoice,
+    /// Do not restore an in-progress wizard draft from the previous session.
+    #[arg(long)]
+    no_resume_wizard: bool,
+    /// Record every dispatched Message to this file as NDJSON for later replay.
+    #[arg(long, conflicts_with = "replay")]
+    record: Option<PathBuf>,
+    /// Replay a previously recorded NDJSON message stream and print the final buffer.
+    #[arg(long)]
+    replay: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -228,6 +266,8 @@ enum Commands {
         #[command(subcommand)]
         cmd: authoring::AuthoringSessionCommand,
     },
+    /// Launch the interactive TUI (same as running with no arguments)
+    Tui(TuiArgs),
 }
 
 #[derive(Subcommand)]
@@ -1317,10 +1357,38 @@ fn run_write_token(
     Ok(ExitCode::SUCCESS)
 }
 
+/// Launch the interactive TUI from a set of parsed TUI arguments.
+fn run_tui(args: TuiArgs) -> ExitCode {
+    let opts = LaunchOptions {
+        dataset: args.dataset.unwrap_or_else(|| PathBuf::from(".")),
+        components: args.components,
+        mode_sets: args.mode_sets,
+        allow_write: args.allow_write,
+        theme: args.theme,
+        no_resume_wizard: args.no_resume_wizard,
+        record: args.record,
+        replay: args.replay,
+    };
+    match design_data_tui::launch(opts) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            ExitCode::from(2)
+        }
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let result = match cli.command {
+    // Bare invocation (no subcommand) or explicit `tui` subcommand → launch the TUI.
+    let command = match cli.command {
+        None => return run_tui(cli.tui),
+        Some(Commands::Tui(args)) => return run_tui(args),
+        Some(other) => other,
+    };
+
+    let result = match command {
         Commands::Validate {
             path,
             format,
@@ -1464,6 +1532,7 @@ fn main() -> ExitCode {
         Commands::AuthoringSession { cmd } => {
             return authoring::run(cmd);
         }
+        Commands::Tui(_) => unreachable!("handled above"),
     };
 
     match result {

--- a/sdk/cli/tests/cli_tui.rs
+++ b/sdk/cli/tests/cli_tui.rs
@@ -1,0 +1,55 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Integration tests for TUI launch wiring in the merged `design-data` binary.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// `design-data --help` must exit 0 and list both CLI subcommands and the `tui` entry.
+#[test]
+fn help_lists_tui_subcommand() {
+    let mut cmd = Command::cargo_bin("design-data").unwrap();
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tui"))
+        .stdout(predicate::str::contains("validate"));
+}
+
+/// `design-data tui --help` must exit 0 and describe TUI-specific flags.
+#[test]
+fn tui_subcommand_help() {
+    let mut cmd = Command::cargo_bin("design-data").unwrap();
+    cmd.args(["tui", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dataset").or(predicate::str::contains("DATASET")))
+        .stdout(predicate::str::contains("theme"));
+}
+
+/// Passing mutually exclusive `--record` and `--replay` flags must be rejected by the parser.
+#[test]
+fn record_replay_conflict_is_rejected() {
+    let mut cmd = Command::cargo_bin("design-data").unwrap();
+    cmd.args(["tui", "--record", "out.ndjson", "--replay", "in.ndjson", "."])
+        .assert()
+        .failure();
+}
+
+/// Passing mutually exclusive `--record` and `--replay` flags at the top level (bare TUI
+/// path) must also be rejected.
+#[test]
+fn bare_record_replay_conflict_is_rejected() {
+    let mut cmd = Command::cargo_bin("design-data").unwrap();
+    cmd.args(["--record", "out.ndjson", "--replay", "in.ndjson"])
+        .assert()
+        .failure();
+}

--- a/sdk/cli/tests/cli_tui.rs
+++ b/sdk/cli/tests/cli_tui.rs
@@ -13,6 +13,12 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+// NOTE: bare `design-data` (no args) is not tested here because it immediately tries
+// to open an interactive TUI session, which requires a TTY and raw-mode terminal that
+// are not available in the test harness. Any user (or CI job) running bare `design-data`
+// in a non-TTY context will get a crossterm raw-mode error — expected and acceptable;
+// `design-data --help` is the correct non-interactive entry point.
+
 /// `design-data --help` must exit 0 and list both CLI subcommands and the `tui` entry.
 #[test]
 fn help_lists_tui_subcommand() {

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -74,7 +74,7 @@ tasks:
     args:
       - run
       - -p
-      - design-data-tui
+      - design-data-cli
       - --release
       - --
       - packages/tokens/dist/json

--- a/sdk/tui/ARCHITECTURE.md
+++ b/sdk/tui/ARCHITECTURE.md
@@ -1,13 +1,13 @@
 # TUI Architecture
 
-The `design-data-tui` binary follows **The Elm Architecture (TEA)** — a functional
+The `design-data` TUI follows **The Elm Architecture (TEA)** — a functional
 state machine where a single `update` function is the only place state can change, and
 all I/O is described as data (`Task`) rather than executed inline.
 
 ## Layered overview
 
 ```
-main.rs        CLI entry point — parse args, build Model + UpdateCtx, call lib::run
+cli/src/main.rs → app_launch::launch  parse args, build Model + UpdateCtx, call lib::run
    │
 runtime.rs     Event loop — poll crossterm → Message → update → execute_task → draw
    │                └── execute_task runs Task::Cmd closures synchronously

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -9,10 +9,6 @@ description = "Interactive TUI for Spectrum design data authoring and inspection
 [lib]
 path = "src/lib.rs"
 
-[[bin]]
-name = "design-data-tui"
-path = "src/main.rs"
-
 [dependencies]
 design-data-core = { path = "../core" }
 ratatui = "0.28"

--- a/sdk/tui/DEMO.md
+++ b/sdk/tui/DEMO.md
@@ -1,4 +1,4 @@
-# design-data-tui Demo Script
+# design-data TUI Demo Script
 
 Two tracks. **Track A** (\~5 min) is for Adobe leadership — outcome-focused, minimal
 jargon. **Track B** (\~15 min) adds technical depth for the Spectrum team and builds on
@@ -15,20 +15,20 @@ Spectrum theme and wizard modal render cleanly.
 cd /path/to/spectrum-design-data
 
 # Clean slate (use this for recordings or first demo run)
-cargo run -p design-data-tui --release -- \
+cargo run -p design-data-cli --release -- \
   packages/tokens/dist/json \
   --theme spectrum \
   --no-resume-wizard
 
 # Draft-restore variant (for the "survives crashes" beat — omit --no-resume-wizard)
-cargo run -p design-data-tui --release -- \
+cargo run -p design-data-cli --release -- \
   packages/tokens/dist/json \
   --theme spectrum
 ```
 
 > **Troubleshooting**: if `cargo run` is slow, build first:
-> `cargo build -p design-data-tui --release`
-> then run the binary directly from `sdk/target/release/design-data-tui`.
+> `cargo build -p design-data-cli --release`
+> then run the binary directly from `sdk/target/release/design-data`.
 
 ***
 
@@ -155,7 +155,7 @@ fields, then press **Ctrl-C** to kill the process abruptly.
 Relaunch **without** `--no-resume-wizard`:
 
 ```bash
-cargo run -p design-data-tui --release -- packages/tokens/dist/json --theme spectrum
+cargo run -p design-data-cli --release -- packages/tokens/dist/json --theme spectrum
 ```
 
 Open the wizard again: `:` → `new` `Enter`. The draft from the previous session is
@@ -198,7 +198,7 @@ This beat uses the `tokens-bad/` fixture so we get visible errors.
 Quit the current session (`q`). Relaunch pointing at the bad fixtures:
 
 ```bash
-cargo run -p design-data-tui --release -- \
+cargo run -p design-data-cli --release -- \
   sdk/tui/tests/fixtures/tokens-bad \
   --theme spectrum \
   --no-resume-wizard
@@ -302,12 +302,12 @@ roughly 9 months of iterative RFC work, all checkpointed."*
 # Leadership cast — 120×36, clean slate
 asciinema rec sdk/tui/docs/demo-leadership.cast \
   --cols 120 --rows 36 \
-  --title "design-data-tui — leadership demo"
+  --title "design-data TUI — leadership demo"
 
 # Spectrum team cast — same dimensions
 asciinema rec sdk/tui/docs/demo-spectrum.cast \
   --cols 120 --rows 36 \
-  --title "design-data-tui — Spectrum team demo"
+  --title "design-data TUI — Spectrum team demo"
 
 # Convert leadership cast to GIF (requires agg)
 # cargo install --git https://github.com/asciinema/agg
@@ -335,11 +335,11 @@ Quick reference:
 
 ```bash
 # Record a session to NDJSON
-cargo run -p design-data-tui --release -- \
+cargo run -p design-data-cli --release -- \
   packages/tokens/dist/json --record /tmp/session.jsonl
 
 # Replay: feeds the stream through update headlessly, prints the final Buffer to stdout
-cargo run -p design-data-tui --release -- \
+cargo run -p design-data-cli --release -- \
   packages/tokens/dist/json --replay /tmp/session.jsonl
 ```
 
@@ -350,7 +350,7 @@ cargo run -p design-data-tui --release -- \
 | Problem                   | Recovery                                                                                        |
 | ------------------------- | ----------------------------------------------------------------------------------------------- |
 | Reuse banner doesn't fire | Type `accent-background` as the intent — high confidence guaranteed                             |
-| Cargo compile time        | Pre-build: `cargo build -p design-data-tui --release` before demo                               |
+| Cargo compile time        | Pre-build: `cargo build -p design-data-cli --release` before demo                               |
 | Terminal leaves raw mode  | Run `reset` in the shell to restore                                                             |
 | Mouse not working         | Ensure terminal supports mouse capture (iTerm2, kitty, wezterm ✓; basic macOS Terminal may not) |
 | Draft not restoring       | Check `~/Library/Application Support/design-data-tui/wizard_draft.json` exists                  |

--- a/sdk/tui/README.md
+++ b/sdk/tui/README.md
@@ -1,4 +1,4 @@
-# design-data-tui
+# design-data — Interactive TUI
 
 An interactive terminal UI for authoring and inspecting Spectrum design tokens, built
 as part of [RFC #973](https://github.com/orgs/adobe/discussions/TODO). It loads a
@@ -13,8 +13,11 @@ tokens before letting you create a new one.
 ## Quick start
 
 ```bash
-# From the repo root
-cargo run -p design-data-tui --release -- packages/tokens/dist/json --theme spectrum
+# From the repo root — bare invocation launches the TUI on the current directory
+cargo run -p design-data-cli --release -- packages/tokens/dist/json --theme spectrum
+
+# Equivalent explicit form
+cargo run -p design-data-cli --release -- tui packages/tokens/dist/json --theme spectrum
 ```
 
 The TUI loads the full Spectrum token corpus (\~2 400 tokens) in under a second and
@@ -26,7 +29,7 @@ drops you into an interactive session. Press `?` for the full keymap.
 
 | Flag                         | Default       | Description                                                                                                                  |
 | ---------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `<dataset>`                  | *(required)*  | Path to a directory of token JSON files                                                                                      |
+| `<dataset>`                  | `.` (cwd)     | Path to a directory of token JSON files                                                                                      |
 | `--theme terminal\|spectrum` | `terminal`    | `terminal` uses terminal-native colors. `spectrum` uses the Adobe Spectrum palette (requires a 24-bit truecolor terminal).   |
 | `--allow-write`              | off           | Enable real disk writes from the wizard Screen 4 Submit. Without this flag the wizard shows a diff preview but never writes. |
 | `--components <dir>`         | auto-detected | Path to component JSON files. Defaults to `packages/design-data-spec/components` relative to the working directory.          |

--- a/sdk/tui/REPLAY.md
+++ b/sdk/tui/REPLAY.md
@@ -5,7 +5,7 @@ The TUI supports recording and replaying sessions for deterministic bug reproduc
 ## Recording a session
 
 ```sh
-design-data-tui --record /tmp/session.jsonl packages/design-data-spec/tokens
+design-data --record /tmp/session.jsonl packages/design-data-spec/tokens
 ```
 
 Every `Message` dispatched during the session is appended to the file as one line of
@@ -15,7 +15,7 @@ a text editor.
 ## Replaying a session
 
 ```sh
-design-data-tui --replay /tmp/session.jsonl packages/design-data-spec/tokens
+design-data --replay /tmp/session.jsonl packages/design-data-spec/tokens
 ```
 
 The replay path feeds each recorded message through `update` with a `TestBackend`,
@@ -29,7 +29,7 @@ then prints the final rendered buffer to stdout. No terminal is required.
 ```sh
 # Keep only the first N lines and replay.
 head -N /tmp/session.jsonl > /tmp/half.jsonl
-design-data-tui --replay /tmp/half.jsonl packages/design-data-spec/tokens
+design-data --replay /tmp/half.jsonl packages/design-data-spec/tokens
 ```
 
 3. Narrow `N` until you find the exact message that triggers the wrong state.

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -580,6 +580,9 @@ pub fn history_path() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("DESIGN_DATA_TUI_HISTORY") {
         return Some(PathBuf::from(p));
     }
+    // "design-data-tui" is the stable app-data name, intentionally kept even
+    // though the binary is now `design-data`, to avoid orphaning history on
+    // existing installs when the binary was renamed.
     dirs::data_dir().map(|d| d.join("design-data-tui").join("history"))
 }
 

--- a/sdk/tui/src/app_launch.rs
+++ b/sdk/tui/src/app_launch.rs
@@ -8,26 +8,17 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! Interactive TUI for Spectrum design data authoring and inspection.
+//! Terminal lifecycle and launch orchestration for the interactive TUI.
 //!
-//! Three-region layout (RFC #973 §3.1):
-//! - Primer header (1 line): token count + dataset path.
-//! - Active view (flex): empty, query, resolve, describe, or validate.
-//! - Status + palette (2 lines at bottom): optional status message, then palette prompt.
-//!
-//! Key bindings (M2):
-//! - `:` opens palette in command mode; `/` opens in fuzzy-find mode.
-//! - In palette, Enter dispatches the command; Esc cancels; Tab completes command name.
-//! - In query/resolve/validate view: Up/k and Down/j navigate; `y` yanks; Esc returns.
-//! - In describe view: Up/k Down/j scroll line-by-line; PgUp/PgDn by 10 lines; Esc returns.
-//! - `q` quits when palette is closed; Ctrl-C always quits.
-//! - `?` opens the help overlay; Esc or `?` closes it.
-//! - `v` toggles text-selection mode; drag to copy.
+//! The public [`launch`] function sets up raw mode, the alternate screen, the
+//! panic hook, drives the event loop via [`crate::runtime::run`] / [`crate::replay`],
+//! and restores the terminal on exit.  All other items in this module are
+//! implementation details moved here from the former standalone binary.
 
 use std::io::{BufRead as _, BufReader, stderr};
 use std::path::PathBuf;
 
-use clap::{Parser, ValueEnum};
+use clap::ValueEnum;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
@@ -38,17 +29,42 @@ use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use design_data_tui::theme::Theme;
-use design_data_tui::{replay as tui_replay, Message, Model, UpdateCtx};
+use crate::theme::Theme;
+use crate::{Message, Model, UpdateCtx};
+use crate::runtime::{run as tui_run, replay as tui_replay};
 
 /// Which visual palette to use.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
-enum ThemeChoice {
+pub enum ThemeChoice {
     /// Terminal-native colors; works in any 256-color terminal.
     #[default]
     Terminal,
     /// Adobe Spectrum palette; requires a 24-bit truecolor terminal.
     Spectrum,
+}
+
+/// Options for [`launch`].
+pub struct LaunchOptions {
+    /// Path to the token dataset directory.
+    pub dataset: PathBuf,
+    /// Path to the components directory (default: spec-bundled).
+    pub components: Option<PathBuf>,
+    /// Path to the mode-sets directory (default: spec-bundled).
+    pub mode_sets: Option<PathBuf>,
+    /// Enable real disk writes from the wizard (Screen 4 Submit). Without this flag the
+    /// wizard shows a diff preview but does not write to the dataset.
+    pub allow_write: bool,
+    /// Color theme.
+    pub theme: ThemeChoice,
+    /// Do not restore an in-progress wizard draft from the previous session. Useful for
+    /// demo recording where you want a clean slate on every launch.
+    pub no_resume_wizard: bool,
+    /// Record every dispatched Message to this file as NDJSON for later replay.
+    /// Mutually exclusive with `replay`.
+    pub record: Option<PathBuf>,
+    /// Replay a previously recorded NDJSON message stream and print the final buffer.
+    /// Mutually exclusive with `record`.
+    pub replay: Option<PathBuf>,
 }
 
 /// Token dataset loaded once at startup and held for the full session.
@@ -166,50 +182,26 @@ fn default_mode_sets_path() -> Option<PathBuf> {
     candidates.into_iter().find(|c| c.is_dir())
 }
 
-#[derive(Parser)]
-#[command(name = "design-data-tui", about = "Interactive Spectrum design data TUI")]
-struct Cli {
-    /// Path to the token dataset directory.
-    dataset: PathBuf,
-    /// Path to the components directory (default: spec-bundled).
-    #[arg(long)]
-    components: Option<PathBuf>,
-    /// Path to the mode-sets directory (default: spec-bundled).
-    #[arg(long = "mode-sets")]
-    mode_sets: Option<PathBuf>,
-    /// Enable real disk writes from the wizard (Screen 4 Submit). Without this
-    /// flag the wizard shows a diff preview but does not write to the dataset.
-    #[arg(long)]
-    allow_write: bool,
-    /// Color theme. `terminal` uses terminal-native colors (default).
-    /// `spectrum` uses the Adobe Spectrum palette (requires truecolor terminal).
-    #[arg(long, value_enum, default_value_t = ThemeChoice::Terminal)]
-    theme: ThemeChoice,
-    /// Do not restore an in-progress wizard draft from the previous session.
-    /// Useful for demo recording where you want a clean slate on every launch.
-    #[arg(long)]
-    no_resume_wizard: bool,
-    /// Record every dispatched Message to this file as NDJSON for later replay.
-    #[arg(long, conflicts_with = "replay")]
-    record: Option<PathBuf>,
-    /// Replay a previously recorded NDJSON message stream and print the final buffer.
-    /// Mutually exclusive with normal interactive mode.
-    #[arg(long)]
-    replay: Option<PathBuf>,
-}
-
-fn main() -> Result<()> {
-    let cli = Cli::parse();
-    let theme = match cli.theme {
+/// Set up the terminal, run the TUI event loop, and restore the terminal on exit.
+///
+/// This is the public entrypoint for launching the interactive TUI from any binary.
+/// It owns the full terminal lifecycle: raw mode, alternate screen, mouse capture,
+/// panic hook installation, and cleanup.
+pub fn launch(opts: LaunchOptions) -> miette::Result<()> {
+    let theme = match opts.theme {
         ThemeChoice::Terminal => Theme::terminal(),
         ThemeChoice::Spectrum => Theme::spectrum(),
     };
-    // Extract record/replay paths before the partial move into DatasetHandle::load.
-    let record_path = cli.record;
-    let replay_path = cli.replay;
-    let handle =
-        DatasetHandle::load(cli.dataset, cli.components, cli.mode_sets, cli.allow_write, theme)?;
-    let resume_wizard = !cli.no_resume_wizard;
+    let record_path = opts.record;
+    let replay_path = opts.replay;
+    let handle = DatasetHandle::load(
+        opts.dataset,
+        opts.components,
+        opts.mode_sets,
+        opts.allow_write,
+        theme,
+    )?;
+    let resume_wizard = !opts.no_resume_wizard;
 
     // Restore terminal on panic so the shell is not left in a broken state.
     let original_hook = std::panic::take_hook();
@@ -226,7 +218,7 @@ fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).into_diagnostic()?;
 
-    let result = run(&mut terminal, &handle, resume_wizard, record_path, replay_path);
+    let result = drive_terminal(&mut terminal, &handle, resume_wizard, record_path, replay_path);
 
     // Best-effort cleanup — continue even if individual steps fail.
     let _ = disable_raw_mode();
@@ -236,7 +228,10 @@ fn main() -> Result<()> {
     result
 }
 
-fn run<B: ratatui::backend::Backend>(
+/// Drive the terminal event loop (replay or interactive) with an already-constructed
+/// `Terminal`.  Extracted from the former standalone binary's `run()` function and
+/// renamed to avoid shadowing the re-exported [`crate::runtime::run`].
+fn drive_terminal<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     handle: &DatasetHandle,
     resume_wizard: bool,
@@ -290,7 +285,7 @@ fn run<B: ratatui::backend::Backend>(
         .transpose()
         .into_diagnostic()
         .wrap_err("failed to create record file")?;
-    design_data_tui::run(
+    tui_run(
         terminal, model, &ctx, &handle.theme, &handle.primer_line(),
         record_file.as_mut().map(|f| f as &mut dyn std::io::Write),
     )

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -9,6 +9,7 @@
 // governing permissions and limitations under the License.
 
 pub mod app;
+pub mod app_launch;
 pub mod app_views;
 pub(crate) mod app_palette;
 pub(crate) mod clipboard;
@@ -29,10 +30,12 @@ pub mod wizard;
 pub mod wizard_common;
 pub mod wizard_draft;
 
+pub use app_launch::{launch, LaunchOptions, ThemeChoice};
 pub use message::Message;
 pub use mode::{BrowsingState, Mode, ModalState, MouseMode, PaletteState};
 pub use model::Model;
 pub use runtime::{replay, run};
 pub use task::Task;
+pub use theme::Theme;
 pub use update::{update, UpdateCtx};
 pub use view::draw;

--- a/sdk/tui/src/runtime.rs
+++ b/sdk/tui/src/runtime.rs
@@ -150,24 +150,24 @@ fn dispatch_and_record(
 
 /// Execute a task tree synchronously, feeding results back through `update`.
 ///
-/// All current `Task::Cmd` closures are fast (FS writes, clipboard) so synchronous
-/// execution is appropriate. Async `Perform` support is deferred to #1022.
+/// Execute a task tree iteratively, feeding `Cmd` results back through `update`.
 ///
-/// **Recursion depth**: each `Task::Cmd` result is fed back through `update`, which
-/// in turn may return another `Task`. In practice the chain is shallow (draft save →
-/// `Tick` → `Task::None`). If #1022 introduces `Task::Perform` with chained batches
-/// this should be converted to an explicit stack to avoid stack overflow.
-fn execute_task(task: Task<Message>, model: &mut Model, ctx: &UpdateCtx<'_>) {
-    match task {
-        Task::None => {}
-        Task::Cmd(f) => {
-            let msg = f();
-            let next = update(model, msg, ctx);
-            execute_task(next, model, ctx);
-        }
-        Task::Batch(tasks) => {
-            for t in tasks {
-                execute_task(t, model, ctx);
+/// Uses an explicit work queue (no recursion) so arbitrarily deep `Task::Batch`
+/// trees — as may arise when #1022 Subscriptions land — are handled without
+/// stack-overflow risk. All current `Cmd` closures are synchronous (FS writes,
+/// clipboard); async `Task::Perform` support is deferred.
+fn execute_task(initial: Task<Message>, model: &mut Model, ctx: &UpdateCtx<'_>) {
+    let mut work: Vec<Task<Message>> = vec![initial];
+    while let Some(task) = work.pop() {
+        match task {
+            Task::None => {}
+            Task::Cmd(f) => {
+                let msg = f();
+                work.push(update(model, msg, ctx));
+            }
+            Task::Batch(tasks) => {
+                // Reverse so the first element in the batch executes first (LIFO pop).
+                work.extend(tasks.into_iter().rev());
             }
         }
     }
@@ -241,5 +241,26 @@ fn compute_hit_regions(model: &Model, status_height: u16, frame_area: Rect) -> V
         ActiveView::Empty | ActiveView::Describe(_) => {}
     }
     regions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use design_data_core::graph::TokenGraph;
+    use crate::update::UpdateCtx;
+
+    #[test]
+    fn execute_task_handles_deeply_nested_batch_without_stack_overflow() {
+        // 10 000 levels of Batch nesting would overflow the call stack with a
+        // recursive execute_task. The iterative implementation handles it in O(1) stack.
+        let graph = TokenGraph::default();
+        let ctx = UpdateCtx::minimal(&graph);
+        let mut model = Model::new();
+
+        let deep = (0..10_000).fold(Task::none(), |inner, _| Task::batch(vec![inner]));
+
+        // Passes if it completes without stack overflow or panic.
+        execute_task(deep, &mut model, &ctx);
+    }
 }
 

--- a/sdk/tui/src/wizard_draft.rs
+++ b/sdk/tui/src/wizard_draft.rs
@@ -131,6 +131,9 @@ pub fn wizard_draft_path() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("DESIGN_DATA_TUI_WIZARD_DRAFT") {
         return Some(PathBuf::from(p));
     }
+    // "design-data-tui" is the stable app-data name, intentionally kept even
+    // though the binary is now `design-data`, to avoid orphaning saved drafts
+    // on existing installs when the binary was renamed.
     dirs::data_dir().map(|d| d.join("design-data-tui").join("wizard-draft.json"))
 }
 


### PR DESCRIPTION
## Description

Merges the standalone `design-data-tui` binary into the `design-data` CLI, Obsidian-style:

- **Bare `design-data`** → launches the interactive TUI on the current directory
- **`design-data tui [DATASET]`** → explicit TUI subcommand (discoverable in `--help`)
- **`design-data <subcommand>`** → all existing CLI subcommands work unchanged

The standalone `design-data-tui` binary is removed. The TUI library crate is kept (tests depend on it); only its `[[bin]]` entry is gone.

## Related Issue

Closes #1043 (if one exists; otherwise tracks the /btw session design discussion)

## Motivation and Context

Two separate binaries sharing the same core library made the tooling surface unnecessarily fragmented. Users had to know which binary to reach for. The unified model (`design-data` does everything) is more discoverable and eliminates the `design-data-tui` install step.

## How Has This Been Tested?

- `cargo check --workspace` — clean
- `cargo test --workspace` — all tests pass (0 failures across all crates)
- `cargo clippy --workspace -- -D warnings` — clean
- Manual: `./sdk/target/debug/design-data --help` lists all subcommands including `tui`; `design-data validate` still works; `moon run sdk:tui` updated to use `-p design-data-cli`
- New integration tests in `sdk/cli/tests/cli_tui.rs`: help output, `tui --help`, and `--record`/`--replay` conflict rejection

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.