### PR TITLE
feat(sdk/core): central DataSource resolver — replace hardcoded default_*_path() helpers

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "uuid",
  "walkdir",
 ]
@@ -2044,6 +2045,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2411,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3095,6 +3146,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -986,11 +986,11 @@ fn run_primer(
         vec![]
     };
 
-    let components = scan_json_name_field(
-        &resolved
-            .components
-            .unwrap_or_else(|| PathBuf::from("packages/design-data-spec/components")),
-    );
+    let components = resolved
+        .components
+        .as_deref()
+        .map(scan_json_name_field)
+        .unwrap_or_default();
 
     let taxonomy_fields: Vec<serde_json::Value> = resolved
         .fields

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -21,6 +21,7 @@ use std::collections::HashSet;
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use design_data_tui::{LaunchOptions, ThemeChoice};
 use design_data_core::cascade::{resolve, ResolutionContext};
+use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
@@ -377,63 +378,13 @@ enum DiffFormat {
 
 fn load_exceptions(path: Option<&Path>) -> miette::Result<HashSet<String>> {
     let Some(p) = path else {
-        return Ok(default_exceptions_path()
-            .and_then(|p| NamingExceptionsFile::load(&p).ok())
-            .map(|f| f.token_set())
-            .unwrap_or_default());
+        // No path provided and not resolved — no exceptions file found.
+        return Ok(HashSet::new());
     };
     let file = NamingExceptionsFile::load(p)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load exceptions from {}", p.display()))?;
     Ok(file.token_set())
-}
-
-fn default_exceptions_path() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("packages/tokens/naming-exceptions.json"),
-        PathBuf::from("../packages/tokens/naming-exceptions.json"),
-    ];
-    candidates.into_iter().find(|c| c.is_file())
-}
-
-fn default_schema_path() -> PathBuf {
-    if let Ok(p) = std::env::var("DESIGN_DATA_SCHEMA_ROOT") {
-        return PathBuf::from(p);
-    }
-    let candidates = [
-        PathBuf::from("packages/tokens/schemas"),
-        PathBuf::from("../packages/tokens/schemas"),
-    ];
-    for c in &candidates {
-        if c.join("token-types").is_dir() {
-            return c.clone();
-        }
-    }
-    PathBuf::from("packages/tokens/schemas")
-}
-
-fn default_mode_sets_path() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("packages/design-data-spec/mode-sets"),
-        PathBuf::from("../packages/design-data-spec/mode-sets"),
-    ];
-    candidates.into_iter().find(|c| c.is_dir())
-}
-
-fn default_components_path() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("packages/design-data-spec/components"),
-        PathBuf::from("../packages/design-data-spec/components"),
-    ];
-    candidates.into_iter().find(|c| c.is_dir())
-}
-
-fn default_fields_path() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("packages/design-data-spec/fields"),
-        PathBuf::from("../packages/design-data-spec/fields"),
-    ];
-    candidates.into_iter().find(|c| c.is_dir())
 }
 
 fn run_resolve(
@@ -465,7 +416,12 @@ fn run_resolve(
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
     // Load mode sets from spec catalog.
-    let ms_dir = mode_sets_path.or_else(default_mode_sets_path);
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+        mode_sets: mode_sets_path,
+        ..Default::default()
+    }).into_diagnostic()?;
+    let ms_dir = resolved.mode_sets;
     if let Some(dir) = ms_dir {
         if dir.is_dir() {
             let mode_sets = TokenGraph::load_spec_mode_sets(&dir)
@@ -558,14 +514,23 @@ fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
     if !validate::engine_ready() {
         miette::bail!("validation engine not ready");
     }
-    let schema_root = opts.schema_path.unwrap_or_else(default_schema_path);
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+        schema_root: opts.schema_path,
+        exceptions: opts.exceptions_path,
+        mode_sets: opts.mode_sets_path,
+        components: opts.components_path,
+        ..Default::default()
+    }).into_diagnostic()?;
+
+    let schema_root = resolved.schemas_root;
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load schemas from {}", schema_root.display()))?;
-    let exceptions = load_exceptions(opts.exceptions_path.as_deref())?;
+    let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
 
-    let dims_dir = opts.mode_sets_path.or_else(default_mode_sets_path);
-    let comps_dir = opts.components_path.or_else(default_components_path);
+    let dims_dir = resolved.mode_sets;
+    let comps_dir = resolved.components;
 
     let report = validate::validate_all_with_options_and_names(
         path,
@@ -599,9 +564,14 @@ fn run_migrate_verify(
     schema_path: Option<PathBuf>,
     exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
-    let schema_root = schema_path.unwrap_or_else(default_schema_path);
-    let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root).into_diagnostic()?;
-    let exceptions = load_exceptions(exceptions_path.as_deref())?;
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+        schema_root: schema_path,
+        exceptions: exceptions_path,
+        ..Default::default()
+    }).into_diagnostic()?;
+    let registry = SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
+    let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
     let report =
         validate::validate_all_with_exceptions(path, &registry, &exceptions).into_diagnostic()?;
     let expected = load_snapshot(snapshot).into_diagnostic()?;
@@ -694,9 +664,14 @@ fn run_migrate_snapshot(
     schema_path: Option<PathBuf>,
     exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
-    let schema_root = schema_path.unwrap_or_else(default_schema_path);
-    let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root).into_diagnostic()?;
-    let exceptions = load_exceptions(exceptions_path.as_deref())?;
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+        schema_root: schema_path,
+        exceptions: exceptions_path,
+        ..Default::default()
+    }).into_diagnostic()?;
+    let registry = SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
+    let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
     let report =
         validate::validate_all_with_exceptions(path, &registry, &exceptions).into_diagnostic()?;
     let snap = ValidationSnapshot::from(&report);
@@ -987,7 +962,14 @@ fn run_primer(
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
     let token_count = graph.tokens.len();
 
-    let ms_dir = mode_sets_dir.or_else(default_mode_sets_path);
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+        mode_sets: mode_sets_dir,
+        components: components_dir,
+        fields: fields_dir,
+        ..Default::default()
+    }).into_diagnostic()?;
+    let ms_dir = resolved.mode_sets;
     let mode_sets: Vec<serde_json::Value> = if let Some(dir) = ms_dir {
         TokenGraph::load_spec_mode_sets(&dir)
             .unwrap_or_default()
@@ -1005,13 +987,13 @@ fn run_primer(
     };
 
     let components = scan_json_name_field(
-        &components_dir
-            .or_else(default_components_path)
+        &resolved
+            .components
             .unwrap_or_else(|| PathBuf::from("packages/design-data-spec/components")),
     );
 
-    let taxonomy_fields: Vec<serde_json::Value> = fields_dir
-        .or_else(default_fields_path)
+    let taxonomy_fields: Vec<serde_json::Value> = resolved
+        .fields
         .map(|dir| {
             let Ok(entries) = std::fs::read_dir(&dir) else {
                 return vec![];
@@ -1132,8 +1114,13 @@ fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<Ex
         return Ok(ExitCode::from(1));
     }
 
-    let dir = components_dir
-        .or_else(default_components_path)
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+        components: components_dir,
+        ..Default::default()
+    }).into_diagnostic()?;
+    let dir = resolved
+        .components
         .ok_or_else(|| miette::miette!("could not locate components directory"))?;
 
     let file = dir.join(format!("{id}.json"));

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -20,6 +20,7 @@ tempfile = "3.14"
 thiserror = "2.0"
 uuid = { version = "1.11", features = ["v4"] }
 semver = "1"
+toml = "0.8"
 walkdir = "2.5"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -1,0 +1,616 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Data source resolution for the design-data CLI.
+//!
+//! Determines where token data, schemas, and spec catalog files live at runtime.
+//! Resolution precedence (first match wins per path field):
+//!
+//! 1. **Explicit CLI flags / positional args** — passed via [`CliPathOverrides`].
+//!    `Some` values are used directly; `None` falls through to the next tier.
+//! 2. **`.design-data.toml` config file** — discovered by walking up from `cwd`.
+//!    Only the `path` source type is active in this release; `npm`/`github`/`git`
+//!    return [`DataSourceError::NotYetImplemented`] until `#1050` lands.
+//! 3. **CWD-relative probing** — tries `packages/tokens/…` and
+//!    `packages/design-data-spec/…` relative to `cwd`.  Preserves the original
+//!    in-monorepo behaviour as the last resort, so existing workflows are unaffected.
+//! 4. **Embedded snapshot** — baked into the binary at build time.
+//!    Filled in by `#1049`; absent until then (tier silently skipped).
+//!
+//! [`resolve`] returns a [`ResolvedData`] with concrete [`PathBuf`]s for every
+//! location the CLI needs.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Config file structs — `.design-data.toml`
+// ---------------------------------------------------------------------------
+
+/// Top-level structure of an optional `.design-data.toml` project config.
+///
+/// Absent file → fall through to CWD-relative probing (tier 3).
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DesignDataConfig {
+    /// Where to obtain design data.
+    pub source: Option<SourceConfig>,
+    /// Cache location overrides.
+    pub cache: Option<CacheConfig>,
+}
+
+/// Describes where to obtain or locate the design data.
+///
+/// Serialised as `type = "npm"` / `"github"` / `"git"` / `"path"` in the TOML.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum SourceConfig {
+    /// A local filesystem path; the root of a repo that follows the standard
+    /// monorepo layout (`packages/tokens/`, `packages/design-data-spec/`, …).
+    ///
+    /// This is the only source type active in this release.  The `root` is
+    /// resolved relative to the directory containing `.design-data.toml`.
+    Path {
+        /// Path to the local design-data repo root (absolute, or relative to
+        /// the directory containing `.design-data.toml`).
+        root: PathBuf,
+    },
+    /// `@adobe/spectrum-tokens` (and matching `design-data-spec`) from the npm
+    /// registry.  **Not yet implemented — planned for `#1050`.**
+    Npm {
+        /// Package name (default: `@adobe/spectrum-tokens`).
+        package: Option<String>,
+        /// Exact version to resolve.
+        version: String,
+    },
+    /// A GitHub release tarball.  **Not yet implemented — planned for `#1050`.**
+    Github {
+        /// `owner/repo` slug, e.g. `adobe/spectrum-design-data`.
+        repo: String,
+        /// Release tag to download.
+        tag: String,
+    },
+    /// A git repository (clone / fetch at a ref).
+    /// **Not yet implemented — planned for `#1050`.**
+    Git {
+        /// Repository URL.
+        url: String,
+        /// Branch, tag, or commit SHA.
+        #[serde(rename = "ref")]
+        git_ref: String,
+    },
+}
+
+/// Cache configuration.  Defaults to `dirs::cache_dir()/design-data`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheConfig {
+    /// Override the cache directory path.
+    pub dir: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Resolver input / output types
+// ---------------------------------------------------------------------------
+
+/// Path overrides coming from explicit CLI flags or positional args (tier 1).
+///
+/// A `None` field means "not specified by the caller; fall through to tiers 2–N".
+#[derive(Debug, Default)]
+pub struct CliPathOverrides {
+    /// Token dataset root (the primary positional argument, default `.`).
+    pub tokens_root: Option<PathBuf>,
+    /// `--schema-path` / `DESIGN_DATA_SCHEMA_ROOT` env var.
+    pub schema_root: Option<PathBuf>,
+    /// `--mode-sets-path`.
+    pub mode_sets: Option<PathBuf>,
+    /// `--components-path`.
+    pub components: Option<PathBuf>,
+    /// `--fields-path`.
+    pub fields: Option<PathBuf>,
+    /// Naming-exceptions file (`--exceptions-path`).
+    pub exceptions: Option<PathBuf>,
+}
+
+/// Records how the paths were determined so callers and diagnostics can report it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Provenance {
+    /// CWD-relative probing — original in-monorepo behaviour.
+    InRepo,
+    /// Resolved from a `.design-data.toml` `[source]` block.
+    Config {
+        /// Absolute path to the config file that was found.
+        config_path: PathBuf,
+    },
+    /// Fetched from a remote source and cached on disk (`#1050`).
+    Cache {
+        /// Directory where the cached data lives.
+        cache_dir: PathBuf,
+    },
+    /// Materialized from the binary's embedded snapshot (`#1049`).
+    Embedded {
+        /// Semver string of the baked-in `@adobe/spectrum-tokens` release.
+        version: &'static str,
+    },
+}
+
+/// All resolved paths that the CLI needs to operate on a dataset.
+///
+/// Returned by [`resolve`].  Every field that is `Some` is guaranteed to point
+/// to an existing file or directory at the time `resolve` returned.
+/// `schemas_root` is always present (with a sensible default) so callers may
+/// attempt to load schemas and gracefully handle failure.
+#[derive(Debug)]
+pub struct ResolvedData {
+    /// Root directory of the token JSON files (the "dataset").
+    pub tokens_root: PathBuf,
+    /// Directory containing JSON schema files (`token-types/`, `token-file.json`, …).
+    pub schemas_root: PathBuf,
+    /// Directory containing mode-set declaration JSONs.
+    pub mode_sets: Option<PathBuf>,
+    /// Directory containing component declaration JSONs.
+    pub components: Option<PathBuf>,
+    /// Directory containing taxonomy field JSONs.
+    pub fields: Option<PathBuf>,
+    /// `naming-exceptions.json` path.
+    pub exceptions: Option<PathBuf>,
+    /// Build `manifest.json` path (the token-source file list, not the platform manifest).
+    pub manifest: Option<PathBuf>,
+    /// How these paths were determined.
+    pub provenance: Provenance,
+}
+
+/// Errors that can occur during data-source resolution.
+#[derive(Debug, Error)]
+pub enum DataSourceError {
+    /// A `[source]` type that requires network/fetch is not yet wired up.
+    #[error("data source type '{source_type}' is not yet supported (planned for issue #1050)")]
+    NotYetImplemented {
+        /// The source type string from the config, e.g. `"npm"`.
+        source_type: String,
+    },
+    /// The `.design-data.toml` file was found but could not be read.
+    #[error("`.design-data.toml` found at {path} but could not be read: {source}")]
+    ConfigRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The `.design-data.toml` file contains invalid TOML or unexpected fields.
+    #[error("`.design-data.toml` at {path} is invalid: {source}")]
+    ConfigParse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    /// `source.type = "path"` but the `root` directory does not exist.
+    #[error(
+        "source.root '{root}' in `.design-data.toml` does not exist or is not a directory"
+    )]
+    PathNotFound {
+        /// The resolved (possibly absolute) path that was probed.
+        root: PathBuf,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Public resolver
+// ---------------------------------------------------------------------------
+
+/// Resolve all data paths for a CLI invocation.
+///
+/// `cwd` is the working directory from which ancestor-walk and CWD-relative
+/// probing are performed.  Pass `std::env::current_dir()?` at call sites.
+///
+/// `overrides` carries any explicit CLI flags.  A `None` field means the CLI
+/// did not specify it; the resolver will fill it in from the config file or
+/// CWD probing.
+///
+/// # Errors
+///
+/// Returns [`DataSourceError`] when:
+/// - A `.design-data.toml` exists but cannot be read or parsed.
+/// - `source.type = "path"` and `root` does not exist.
+/// - `source.type` is `npm`, `github`, or `git` (not yet implemented).
+pub fn resolve(
+    cwd: &Path,
+    overrides: &CliPathOverrides,
+) -> Result<ResolvedData, DataSourceError> {
+    // Tier 1 is handled per-field inside each helper (overrides win always).
+
+    // Tier 2: look for `.design-data.toml` walking up from cwd.
+    if let Some((config_path, config)) = find_config(cwd)? {
+        if let Some(source) = &config.source {
+            return match source {
+                SourceConfig::Path { root } => {
+                    // Resolve root relative to the config file's directory.
+                    let config_dir = config_path.parent().unwrap_or(cwd);
+                    let abs_root = if root.is_absolute() {
+                        root.clone()
+                    } else {
+                        config_dir.join(root)
+                    };
+                    if !abs_root.is_dir() {
+                        return Err(DataSourceError::PathNotFound { root: abs_root });
+                    }
+                    // Canonicalize to resolve `..` components before passing to from_root.
+                    let canonical = abs_root.canonicalize().unwrap_or(abs_root);
+                    Ok(from_root(&canonical, overrides, Provenance::Config { config_path }))
+                }
+                SourceConfig::Npm { .. } => Err(DataSourceError::NotYetImplemented {
+                    source_type: "npm".into(),
+                }),
+                SourceConfig::Github { .. } => Err(DataSourceError::NotYetImplemented {
+                    source_type: "github".into(),
+                }),
+                SourceConfig::Git { .. } => Err(DataSourceError::NotYetImplemented {
+                    source_type: "git".into(),
+                }),
+            };
+        }
+        // Config file present but no [source] block → fall through to probing.
+    }
+
+    // Tier 3: CWD-relative probing — original in-monorepo behaviour.
+    // Tier 4 (cache) and tier 5 (embedded) are stubs filled in by #1050 / #1049.
+    Ok(probe_cwd(cwd, overrides))
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Walk ancestors of `start` looking for `.design-data.toml`.
+///
+/// Returns `Ok(None)` when no file is found — that is not an error.
+fn find_config(start: &Path) -> Result<Option<(PathBuf, DesignDataConfig)>, DataSourceError> {
+    for dir in start.ancestors() {
+        let candidate = dir.join(".design-data.toml");
+        if candidate.is_file() {
+            let text = std::fs::read_to_string(&candidate).map_err(|e| DataSourceError::ConfigRead {
+                path: candidate.clone(),
+                source: e,
+            })?;
+            let config: DesignDataConfig =
+                toml::from_str(&text).map_err(|e| DataSourceError::ConfigParse {
+                    path: candidate.clone(),
+                    source: e,
+                })?;
+            return Ok(Some((candidate, config)));
+        }
+    }
+    Ok(None)
+}
+
+/// Build [`ResolvedData`] from a known monorepo `root` directory (tier 2 path source).
+///
+/// Tier 1 overrides still win for any individually-set CLI flags.
+fn from_root(root: &Path, overrides: &CliPathOverrides, provenance: Provenance) -> ResolvedData {
+    let tokens_root = overrides
+        .tokens_root
+        .clone()
+        .unwrap_or_else(|| root.to_path_buf());
+
+    let schemas_root = resolve_schema_root(overrides, || root.join("packages/tokens/schemas"));
+
+    let mode_sets = overrides.mode_sets.clone().or_else(|| {
+        let c = root.join("packages/design-data-spec/mode-sets");
+        c.is_dir().then_some(c)
+    });
+
+    let components = overrides.components.clone().or_else(|| {
+        let c = root.join("packages/design-data-spec/components");
+        c.is_dir().then_some(c)
+    });
+
+    let fields = overrides.fields.clone().or_else(|| {
+        let c = root.join("packages/design-data-spec/fields");
+        c.is_dir().then_some(c)
+    });
+
+    let exceptions = overrides.exceptions.clone().or_else(|| {
+        let c = root.join("packages/tokens/naming-exceptions.json");
+        c.is_file().then_some(c)
+    });
+
+    let manifest = {
+        let c = root.join("packages/tokens/manifest.json");
+        c.is_file().then_some(c)
+    };
+
+    ResolvedData {
+        tokens_root,
+        schemas_root,
+        mode_sets,
+        components,
+        fields,
+        exceptions,
+        manifest,
+        provenance,
+    }
+}
+
+/// Tier 3: replicate the original `default_*_path()` probing logic.
+///
+/// Tries both `packages/…` (run from repo root) and `../packages/…` (run from
+/// inside `sdk/`), exactly matching the previous per-function behaviour.
+fn probe_cwd(cwd: &Path, overrides: &CliPathOverrides) -> ResolvedData {
+    // tokens_root — original default was PathBuf::from(".") i.e. CWD.
+    let tokens_root = overrides
+        .tokens_root
+        .clone()
+        .unwrap_or_else(|| cwd.to_path_buf());
+
+    // schemas_root
+    let schemas_root = resolve_schema_root(overrides, || {
+        let candidates = [
+            cwd.join("packages/tokens/schemas"),
+            cwd.join("../packages/tokens/schemas"),
+        ];
+        candidates
+            .into_iter()
+            .find(|c| c.join("token-types").is_dir())
+            .unwrap_or_else(|| cwd.join("packages/tokens/schemas"))
+    });
+
+    // mode_sets
+    let mode_sets = overrides.mode_sets.clone().or_else(|| {
+        let candidates = [
+            cwd.join("packages/design-data-spec/mode-sets"),
+            cwd.join("../packages/design-data-spec/mode-sets"),
+        ];
+        candidates.into_iter().find(|c| c.is_dir())
+    });
+
+    // components
+    let components = overrides.components.clone().or_else(|| {
+        let candidates = [
+            cwd.join("packages/design-data-spec/components"),
+            cwd.join("../packages/design-data-spec/components"),
+        ];
+        candidates.into_iter().find(|c| c.is_dir())
+    });
+
+    // fields
+    let fields = overrides.fields.clone().or_else(|| {
+        let candidates = [
+            cwd.join("packages/design-data-spec/fields"),
+            cwd.join("../packages/design-data-spec/fields"),
+        ];
+        candidates.into_iter().find(|c| c.is_dir())
+    });
+
+    // exceptions
+    let exceptions = overrides.exceptions.clone().or_else(|| {
+        let candidates = [
+            cwd.join("packages/tokens/naming-exceptions.json"),
+            cwd.join("../packages/tokens/naming-exceptions.json"),
+        ];
+        candidates.into_iter().find(|c| c.is_file())
+    });
+
+    // manifest (the build manifest.json file listing token sources)
+    let manifest = {
+        let candidates = [
+            cwd.join("packages/tokens/manifest.json"),
+            cwd.join("../packages/tokens/manifest.json"),
+        ];
+        candidates.into_iter().find(|c| c.is_file())
+    };
+
+    ResolvedData {
+        tokens_root,
+        schemas_root,
+        mode_sets,
+        components,
+        fields,
+        exceptions,
+        manifest,
+        provenance: Provenance::InRepo,
+    }
+}
+
+/// Resolve the schema root: CLI override → `DESIGN_DATA_SCHEMA_ROOT` env → `fallback()`.
+///
+/// The env var is honoured at this level so it works regardless of which tier
+/// resolved the other paths.
+fn resolve_schema_root(overrides: &CliPathOverrides, fallback: impl FnOnce() -> PathBuf) -> PathBuf {
+    overrides
+        .schema_root
+        .clone()
+        .or_else(|| std::env::var("DESIGN_DATA_SCHEMA_ROOT").ok().map(PathBuf::from))
+        .unwrap_or_else(fallback)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_monorepo(dir: &Path) {
+        fs::create_dir_all(dir.join("packages/tokens/schemas/token-types")).unwrap();
+        fs::write(dir.join("packages/tokens/schemas/token-file.json"), b"{}").unwrap();
+        fs::create_dir_all(dir.join("packages/design-data-spec/mode-sets")).unwrap();
+        fs::create_dir_all(dir.join("packages/design-data-spec/components")).unwrap();
+        fs::create_dir_all(dir.join("packages/design-data-spec/fields")).unwrap();
+        fs::write(dir.join("packages/tokens/naming-exceptions.json"), b"{}").unwrap();
+        fs::write(dir.join("packages/tokens/manifest.json"), b"[]").unwrap();
+    }
+
+    // --- Tier 3: CWD probing (no config) ---
+
+    #[test]
+    fn probe_finds_schemas_in_repo_root() {
+        let tmp = TempDir::new().unwrap();
+        make_monorepo(tmp.path());
+
+        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        assert_eq!(resolved.provenance, Provenance::InRepo);
+        assert!(resolved.schemas_root.ends_with("packages/tokens/schemas"));
+        assert!(resolved.mode_sets.is_some());
+        assert!(resolved.components.is_some());
+        assert!(resolved.fields.is_some());
+        assert!(resolved.exceptions.is_some());
+        assert!(resolved.manifest.is_some());
+    }
+
+    #[test]
+    fn probe_tokens_root_defaults_to_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        assert_eq!(resolved.tokens_root, tmp.path());
+    }
+
+    #[test]
+    fn probe_returns_none_for_absent_spec_dirs() {
+        let tmp = TempDir::new().unwrap();
+        // No spec dirs present.
+        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        assert!(resolved.mode_sets.is_none());
+        assert!(resolved.components.is_none());
+        assert!(resolved.fields.is_none());
+        assert!(resolved.exceptions.is_none());
+    }
+
+    // --- Tier 1: CLI overrides ---
+
+    #[test]
+    fn cli_override_wins_over_probe() {
+        let tmp = TempDir::new().unwrap();
+        make_monorepo(tmp.path());
+
+        let custom_schema = tmp.path().join("custom-schemas");
+        fs::create_dir_all(&custom_schema).unwrap();
+
+        let overrides = CliPathOverrides {
+            schema_root: Some(custom_schema.clone()),
+            ..Default::default()
+        };
+        let resolved = resolve(tmp.path(), &overrides).unwrap();
+        assert_eq!(resolved.schemas_root, custom_schema);
+    }
+
+    #[test]
+    fn cli_tokens_root_override() {
+        let tmp = TempDir::new().unwrap();
+        let dataset = tmp.path().join("my-tokens");
+        fs::create_dir_all(&dataset).unwrap();
+
+        let overrides = CliPathOverrides {
+            tokens_root: Some(dataset.clone()),
+            ..Default::default()
+        };
+        let resolved = resolve(tmp.path(), &overrides).unwrap();
+        assert_eq!(resolved.tokens_root, dataset);
+    }
+
+    // --- Tier 2: Config file ---
+
+    #[test]
+    fn config_path_source_resolves_from_root() {
+        let tmp = TempDir::new().unwrap();
+
+        // Create a separate "external repo" with the monorepo layout.
+        let ext_repo = tmp.path().join("spectrum-repo");
+        make_monorepo(&ext_repo);
+
+        // Create a project dir with a `.design-data.toml` pointing at the external repo.
+        let project = tmp.path().join("my-project");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(
+            project.join(".design-data.toml"),
+            format!("[source]\ntype = \"path\"\nroot = \"../spectrum-repo\"\n"),
+        )
+        .unwrap();
+
+        let resolved = resolve(&project, &CliPathOverrides::default()).unwrap();
+        assert!(matches!(resolved.provenance, Provenance::Config { .. }));
+        // Canonicalize both sides: on macOS /tmp → /private/tmp via symlink.
+        let canon_root = ext_repo.canonicalize().unwrap_or(ext_repo.clone());
+        assert_eq!(resolved.tokens_root, canon_root);
+        assert!(resolved.schemas_root.starts_with(&canon_root));
+        assert!(resolved.components.is_some());
+    }
+
+    #[test]
+    fn config_path_source_nonexistent_root_errors() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".design-data.toml"),
+            "[source]\ntype = \"path\"\nroot = \"/does/not/exist\"\n",
+        )
+        .unwrap();
+
+        let err = resolve(tmp.path(), &CliPathOverrides::default()).unwrap_err();
+        assert!(matches!(err, DataSourceError::PathNotFound { .. }));
+    }
+
+    #[test]
+    fn config_npm_source_returns_not_yet_implemented() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".design-data.toml"),
+            "[source]\ntype = \"npm\"\npackage = \"@adobe/spectrum-tokens\"\nversion = \"14.0.0\"\n",
+        )
+        .unwrap();
+
+        let err = resolve(tmp.path(), &CliPathOverrides::default()).unwrap_err();
+        assert!(matches!(err, DataSourceError::NotYetImplemented { .. }));
+    }
+
+    #[test]
+    fn config_ancestor_walk_finds_toml_in_parent() {
+        let tmp = TempDir::new().unwrap();
+        let ext_repo = tmp.path().join("external");
+        make_monorepo(&ext_repo);
+
+        // Config lives in the parent; we resolve from a nested child dir.
+        let parent = tmp.path().join("parent");
+        fs::create_dir_all(&parent).unwrap();
+        fs::write(
+            parent.join(".design-data.toml"),
+            format!("[source]\ntype = \"path\"\nroot = \"{}\"\n", ext_repo.display()),
+        )
+        .unwrap();
+
+        let child = parent.join("sub").join("nested");
+        fs::create_dir_all(&child).unwrap();
+
+        let resolved = resolve(&child, &CliPathOverrides::default()).unwrap();
+        assert!(matches!(resolved.provenance, Provenance::Config { .. }));
+    }
+
+    #[test]
+    fn config_without_source_block_falls_through_to_probe() {
+        let tmp = TempDir::new().unwrap();
+        make_monorepo(tmp.path());
+        fs::write(tmp.path().join(".design-data.toml"), "# no source block\n").unwrap();
+
+        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        // Falls through to CWD probing.
+        assert_eq!(resolved.provenance, Provenance::InRepo);
+    }
+
+    #[test]
+    fn config_invalid_toml_errors() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".design-data.toml"), "not valid toml [[[").unwrap();
+
+        let err = resolve(tmp.path(), &CliPathOverrides::default()).unwrap_err();
+        assert!(matches!(err, DataSourceError::ConfigParse { .. }));
+    }
+}

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -164,6 +164,8 @@ pub struct ResolvedData {
     /// `naming-exceptions.json` path.
     pub exceptions: Option<PathBuf>,
     /// Build `manifest.json` path (the token-source file list, not the platform manifest).
+    /// Populated here but consumed by #1049 (embedded snapshot provenance tracking).
+    #[allow(dead_code)]
     pub manifest: Option<PathBuf>,
     /// How these paths were determined.
     pub provenance: Provenance,
@@ -612,5 +614,22 @@ mod tests {
 
         let err = resolve(tmp.path(), &CliPathOverrides::default()).unwrap_err();
         assert!(matches!(err, DataSourceError::ConfigParse { .. }));
+    }
+
+    #[test]
+    fn env_var_schema_root_wins_over_probe() {
+        let tmp = TempDir::new().unwrap();
+        make_monorepo(tmp.path());
+
+        let custom = tmp.path().join("my-schemas");
+        fs::create_dir_all(&custom).unwrap();
+
+        // Set the env var; resolve must return its value even though CWD probing
+        // would find packages/tokens/schemas instead.
+        std::env::set_var("DESIGN_DATA_SCHEMA_ROOT", custom.to_str().unwrap());
+        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        std::env::remove_var("DESIGN_DATA_SCHEMA_ROOT");
+
+        assert_eq!(resolved.schemas_root, custom);
     }
 }

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod authoring;
 pub mod cascade;
+pub mod data_source;
 pub mod compat;
 pub mod diff;
 pub mod discovery;

--- a/sdk/tui/src/app_launch.rs
+++ b/sdk/tui/src/app_launch.rs
@@ -24,6 +24,7 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
+use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::graph::TokenGraph;
 use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
@@ -93,8 +94,17 @@ impl DatasetHandle {
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
-        // Resolve components directory: explicit arg → spec-bundled fallback.
-        let components_dir = components_arg.or_else(default_components_path);
+        // Resolve spec paths via the central data_source resolver.
+        // The dataset path is already explicit; we only need spec catalog dirs + schema.
+        let cwd = std::env::current_dir().into_diagnostic()?;
+        let resolved = data_source::resolve(&cwd, &CliPathOverrides {
+            components: components_arg,
+            mode_sets: mode_sets_arg,
+            ..Default::default()
+        })
+        .into_diagnostic()?;
+
+        let components_dir = resolved.components;
         if let Some(ref dir) = components_dir {
             if dir.is_dir() {
                 let comps = TokenGraph::load_spec_components(dir)
@@ -106,8 +116,7 @@ impl DatasetHandle {
             }
         }
 
-        // Resolve mode-sets directory: explicit arg → spec-bundled fallback.
-        let mode_sets_dir = mode_sets_arg.or_else(default_mode_sets_path);
+        let mode_sets_dir = resolved.mode_sets;
         if let Some(ref dir) = mode_sets_dir {
             if dir.is_dir() {
                 let mode_sets = TokenGraph::load_spec_mode_sets(dir)
@@ -119,9 +128,10 @@ impl DatasetHandle {
             }
         }
 
-        // Load schema registry for `:validate`. Silently skip if schema dir is absent.
-        let schema_registry = default_schema_path()
-            .and_then(|p| SchemaRegistry::load_legacy_token_schemas(&p).ok());
+        // Load schema registry for `:validate`. Silently skip if schema dir is absent
+        // (schema_root has a fallback default; the load itself may fail when not in-repo).
+        let schema_registry =
+            SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).ok();
 
         Ok(Self {
             token_count: graph.tokens.len(),
@@ -153,33 +163,6 @@ impl DatasetHandle {
             allow_write: self.allow_write,
         }
     }
-}
-
-fn default_schema_path() -> Option<PathBuf> {
-    if let Ok(p) = std::env::var("DESIGN_DATA_SCHEMA_ROOT") {
-        return Some(PathBuf::from(p));
-    }
-    let candidates = [
-        PathBuf::from("packages/tokens/schemas"),
-        PathBuf::from("../packages/tokens/schemas"),
-    ];
-    candidates.into_iter().find(|c| c.join("token-types").is_dir())
-}
-
-fn default_components_path() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("packages/design-data-spec/components"),
-        PathBuf::from("../packages/design-data-spec/components"),
-    ];
-    candidates.into_iter().find(|c| c.is_dir())
-}
-
-fn default_mode_sets_path() -> Option<PathBuf> {
-    let candidates = [
-        PathBuf::from("packages/design-data-spec/mode-sets"),
-        PathBuf::from("../packages/design-data-spec/mode-sets"),
-    ];
-    candidates.into_iter().find(|c| c.is_dir())
 }
 
 /// Set up the terminal, run the TUI event loop, and restore the terminal on exit.


### PR DESCRIPTION
## Description

Introduces `sdk/core/src/data_source/mod.rs` — a central data-source resolver that replaces the five scattered `default_*_path()` helpers in `sdk/cli/src/main.rs` and three duplicate helpers in `sdk/tui/src/app_launch.rs`.

The resolver implements a 5-tier precedence (first match per path field wins):

1. **Explicit CLI flag / positional arg** — unchanged behaviour
2. **`.design-data.toml` config file** — discovered by walking up from CWD; supports `path`, `npm`, `github`, `git` source types (`npm`/`github`/`git` return a clear `NotYetImplemented` error until #1050)
3. **CWD-relative probing** — the original `packages/tokens/…` / `packages/design-data-spec/…` logic, moved verbatim; preserves full backward compatibility for in-monorepo usage
4. **Cached fetched data** — stub; filled by #1050
5. **Embedded snapshot** — stub; filled by #1049

Key types added to `design_data_core::data_source`:
- `ResolvedData` — concrete `PathBuf`s for tokens root, schemas, mode-sets, components, fields, exceptions, manifest
- `CliPathOverrides` — per-field `Option<PathBuf>` for CLI flags
- `DesignDataConfig` / `SourceConfig` / `CacheConfig` — `.design-data.toml` serde structs
- `Provenance` — records how paths were determined (`InRepo`, `Config`, `Cache`, `Embedded`)
- `DataSourceError` — typed errors for config parse failures and not-yet-implemented sources

## Related Issue

Resolves #1048 · Part of epic #1047

## Motivation and Context

Today `design-data` only works when run from inside this monorepo — all path defaults are hardcoded relative to CWD. This is the foundational resolver that unblocks:
- **#1049** (embedded snapshot — zero-config offline use for designers)
- **#1050** (fetch/cache engine — npm/github/git sources)
- **#1051** (npm distribution)
- **#1052 / #1053** (Claude Code Skill + MCP server)

## How Has This Been Tested?

- `cargo test --workspace` — all 399 tests pass (11 new unit tests in `data_source::tests` covering tier precedence, ancestor-walk discovery, path source, error cases)
- `cargo clippy --workspace -- -D warnings` — clean
- Smoke: `design-data primer packages/tokens/src --format json` from repo root → 2460 tokens, 81 components, 3 mode-sets (unchanged)
- Smoke: from a temp dir with `.design-data.toml` using `source.type = "path"` → same result

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.