### PR TITLE
feat(sdk/core): embed Spectrum snapshot in binary — offline zero-config data

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -444,6 +444,7 @@ name = "design-data-core"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "include_dir",
  "jsonschema",
  "regex",
  "reqwest",
@@ -1036,6 +1037,25 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1038,6 +1038,22 @@ fn run_primer(
         }
     };
 
+    let provenance = match &resolved.provenance {
+        data_source::Provenance::InRepo => serde_json::json!({ "source": "in-repo" }),
+        data_source::Provenance::Config { config_path } => serde_json::json!({
+            "source": "config",
+            "configPath": config_path.display().to_string(),
+        }),
+        data_source::Provenance::Cache { cache_dir } => serde_json::json!({
+            "source": "cache",
+            "cacheDir": cache_dir.display().to_string(),
+        }),
+        data_source::Provenance::Embedded { version } => serde_json::json!({
+            "source": "embedded",
+            "tokensVersion": version,
+        }),
+    };
+
     let payload = serde_json::json!({
         "specVersion": SPEC_VERSION,
         "tokenCount": token_count,
@@ -1045,6 +1061,7 @@ fn run_primer(
         "components": components,
         "taxonomyFields": taxonomy_fields,
         "manifest": manifest,
+        "provenance": provenance,
     });
 
     match format {

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -33,6 +33,12 @@ fn tokens_src_and_schemas() -> (PathBuf, PathBuf) {
 fn validate_spectrum_tokens_json_success() {
     let (src, schemas) = tokens_src_and_schemas();
 
+    // Pass an empty temp dir as --components-path so no component-binding rules
+    // (SPEC-027, etc.) fire on this partial dataset.  The embedded snapshot would
+    // otherwise auto-load components, causing SPEC-027 failures on `tokens/src`
+    // because component schemas reference the full token corpus, not just `src/`.
+    let empty_components = tempfile::tempdir().expect("temp dir for empty components");
+
     Command::cargo_bin("design-data")
         .expect("binary design-data")
         .args([
@@ -40,6 +46,8 @@ fn validate_spectrum_tokens_json_success() {
             src.to_str().expect("utf8 path"),
             "--schema-path",
             schemas.to_str().expect("utf8 path"),
+            "--components-path",
+            empty_components.path().to_str().expect("utf8 path"),
             "--format",
             "json",
         ])

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -19,6 +19,7 @@ dirs = "5"
 tempfile = "3.14"
 thiserror = "2.0"
 uuid = { version = "1.11", features = ["v4"] }
+include_dir = "0.7"
 semver = "1"
 toml = "0.8"
 walkdir = "2.5"

--- a/sdk/core/src/data_source/embedded.rs
+++ b/sdk/core/src/data_source/embedded.rs
@@ -1,0 +1,368 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Compile-time embedded Spectrum design-data snapshot.
+//!
+//! The design-data binary carries a pinned copy of `@adobe/spectrum-tokens` and the
+//! matching `@adobe/design-data-spec` catalog baked in at build time via
+//! [`include_dir!`].  On first use outside a monorepo checkout, [`materialize`] writes
+//! the snapshot to a version-namespaced directory under the OS cache dir so the disk-based
+//! loaders in `graph.rs`, `schema.rs`, and `discovery.rs` can read it as normal.
+//!
+//! The cache layout mirrors the monorepo, so [`crate::data_source::from_root`] can build
+//! a [`crate::data_source::ResolvedData`] from it unchanged:
+//!
+//! ```text
+//! <cache_root>/
+//!   packages/
+//!     tokens/
+//!       src/            ← token JSON files
+//!       schemas/        ← JSON Schema files (+ token-types/ subdir)
+//!       naming-exceptions.json
+//!       manifest.json
+//!     design-data-spec/
+//!       mode-sets/
+//!       components/
+//!       fields/
+//!   .complete           ← written last; signals a complete extraction
+//! ```
+//!
+//! [`materialize`] is idempotent: if `.complete` already exists the function returns
+//! immediately without touching the filesystem.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use include_dir::{Dir, include_dir};
+// Dir is used for the embedded static types; include_dir! for the macros.
+
+// ---------------------------------------------------------------------------
+// Embedded data (baked into the binary at compile time)
+// ---------------------------------------------------------------------------
+
+/// Token source files (`packages/tokens/src/*.json`, 8 files, ~1.3 MB).
+static TOKENS_SRC: Dir<'_> = include_dir!(
+    "$CARGO_MANIFEST_DIR/../../packages/tokens/src"
+);
+
+/// JSON Schema files for token validation (`packages/tokens/schemas/`, ~88 KB).
+/// Includes the `token-types/` subdirectory.
+static TOKENS_SCHEMAS: Dir<'_> = include_dir!(
+    "$CARGO_MANIFEST_DIR/../../packages/tokens/schemas"
+);
+
+/// Mode-set declarations (`packages/design-data-spec/mode-sets/`, 3 files, ~12 KB).
+static MODE_SETS: Dir<'_> = include_dir!(
+    "$CARGO_MANIFEST_DIR/../../packages/design-data-spec/mode-sets"
+);
+
+/// Component declaration JSONs (`packages/design-data-spec/components/`, 81 files, ~620 KB).
+static COMPONENTS: Dir<'_> = include_dir!(
+    "$CARGO_MANIFEST_DIR/../../packages/design-data-spec/components"
+);
+
+/// Taxonomy field JSONs (`packages/design-data-spec/fields/`, 24 files, ~96 KB).
+static FIELDS: Dir<'_> = include_dir!(
+    "$CARGO_MANIFEST_DIR/../../packages/design-data-spec/fields"
+);
+
+/// Naming exceptions list (`packages/tokens/naming-exceptions.json`, ~46 KB).
+static NAMING_EXCEPTIONS: &str = include_str!(
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/tokens/naming-exceptions.json")
+);
+
+/// Token build manifest — lists the 8 source JSON file paths
+/// (`packages/tokens/manifest.json`).
+static TOKENS_MANIFEST: &str = include_str!(
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/tokens/manifest.json")
+);
+
+// ---------------------------------------------------------------------------
+// Version provenance
+// ---------------------------------------------------------------------------
+
+/// The `@adobe/spectrum-tokens` version baked into this binary.
+///
+/// Kept in sync with `packages/tokens/package.json` via a drift test.
+/// When bumping the tokens package, update this constant too.
+pub const EMBEDDED_TOKENS_VERSION: &str = "14.11.0";
+
+// ---------------------------------------------------------------------------
+// Cache-dir resolution
+// ---------------------------------------------------------------------------
+
+/// Returns the root directory where the snapshot will be (or has been) materialized.
+///
+/// Resolution order (first `Some` wins):
+/// 1. `DESIGN_DATA_CACHE_DIR` env var (test seam / user override)
+/// 2. `dirs::cache_dir()/design-data/embedded/<version>/`
+///
+/// Returns `None` if neither yields a path (e.g. no home dir on a headless system).
+pub fn cache_root() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("DESIGN_DATA_CACHE_DIR") {
+        return Some(
+            PathBuf::from(p)
+                .join("embedded")
+                .join(EMBEDDED_TOKENS_VERSION),
+        );
+    }
+    dirs::cache_dir().map(|d| {
+        d.join("design-data")
+            .join("embedded")
+            .join(EMBEDDED_TOKENS_VERSION)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Materialization
+// ---------------------------------------------------------------------------
+
+/// Write the embedded snapshot to the default cache directory and return its path.
+///
+/// Resolves the destination via [`cache_root`], then delegates to [`materialize_to`].
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the cache root cannot be determined, or if any write
+/// fails.  Callers should treat errors as non-fatal and fall back to in-repo probing.
+pub fn materialize() -> io::Result<PathBuf> {
+    let root = cache_root().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "cannot determine cache directory (no home directory?)",
+        )
+    })?;
+    materialize_to(&root)?;
+    Ok(root)
+}
+
+/// Write the embedded snapshot into `root` and return when complete.
+///
+/// Idempotent: if `<root>/.complete` already exists, returns immediately without
+/// touching the filesystem.  The sentinel is written **last** so a killed first
+/// run cannot leave a partial tree that later invocations trust.
+///
+/// Layout after a successful call (see module-level doc for the full tree):
+/// - `<root>/packages/tokens/src/` — token JSON
+/// - `<root>/packages/tokens/schemas/` — schema JSON (+ `token-types/`)
+/// - `<root>/packages/tokens/naming-exceptions.json`
+/// - `<root>/packages/tokens/manifest.json`
+/// - `<root>/packages/design-data-spec/mode-sets/`
+/// - `<root>/packages/design-data-spec/components/`
+/// - `<root>/packages/design-data-spec/fields/`
+/// - `<root>/.complete`
+///
+/// # Errors
+///
+/// Returns an `io::Error` if the cache dir cannot be created or any write fails.
+pub fn materialize_to(root: &Path) -> io::Result<()> {
+    let sentinel = root.join(".complete");
+    if sentinel.exists() {
+        return Ok(());
+    }
+
+    // Extract into a sibling tmp dir, then rename to avoid a half-written state
+    // being read by a concurrent or restarted process.
+    let tmp = root.with_extension("tmp");
+    if tmp.exists() {
+        std::fs::remove_dir_all(&tmp)?;
+    }
+
+    // `Dir::extract` writes every file maintaining structure relative to the
+    // included-dir root, returning `std::io::Result<()>`.
+    // The base directory must exist before calling extract.
+    let extract = |dir: &Dir<'_>, dest: &Path| -> io::Result<()> {
+        std::fs::create_dir_all(dest)?;
+        dir.extract(dest)
+    };
+    extract(&TOKENS_SRC, &tmp.join("packages/tokens/src"))?;
+    extract(&TOKENS_SCHEMAS, &tmp.join("packages/tokens/schemas"))?;
+    extract(&MODE_SETS, &tmp.join("packages/design-data-spec/mode-sets"))?;
+    extract(&COMPONENTS, &tmp.join("packages/design-data-spec/components"))?;
+    extract(&FIELDS, &tmp.join("packages/design-data-spec/fields"))?;
+
+    write_file(
+        &tmp.join("packages/tokens/naming-exceptions.json"),
+        NAMING_EXCEPTIONS.as_bytes(),
+    )?;
+    write_file(
+        &tmp.join("packages/tokens/manifest.json"),
+        TOKENS_MANIFEST.as_bytes(),
+    )?;
+
+    // Rename tmp → root (atomic on most OSes; non-atomic on Windows cross-device,
+    // but acceptable — the sentinel guarantees correctness regardless).
+    if root.exists() {
+        std::fs::remove_dir_all(root)?;
+    }
+    std::fs::rename(&tmp, root)?;
+
+    // Write sentinel last.
+    std::fs::write(&sentinel, EMBEDDED_TOKENS_VERSION.as_bytes())?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write_file(path: &Path, contents: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, contents)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Materialize into a fresh temp dir.  Does not touch env vars, so tests can
+    /// run in parallel without interfering with each other.
+    fn temp_root() -> (TempDir, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("embedded");
+        materialize_to(&root).expect("materialize_to failed");
+        (tmp, root)
+    }
+
+    #[test]
+    fn materialize_creates_expected_layout() {
+        let (_tmp, root) = temp_root();
+
+        assert!(root.join("packages/tokens/src").is_dir(), "tokens/src missing");
+        assert!(
+            root.join("packages/tokens/schemas/token-types").is_dir(),
+            "schemas/token-types missing"
+        );
+        assert!(
+            root.join("packages/design-data-spec/mode-sets").is_dir(),
+            "mode-sets missing"
+        );
+        assert!(
+            root.join("packages/design-data-spec/components").is_dir(),
+            "components missing"
+        );
+        assert!(
+            root.join("packages/design-data-spec/fields").is_dir(),
+            "fields missing"
+        );
+        assert!(
+            root.join("packages/tokens/naming-exceptions.json").is_file(),
+            "naming-exceptions.json missing"
+        );
+        assert!(
+            root.join("packages/tokens/manifest.json").is_file(),
+            "manifest.json missing"
+        );
+        assert!(root.join(".complete").is_file(), ".complete sentinel missing");
+    }
+
+    #[test]
+    fn materialize_is_idempotent() {
+        let (_tmp, root) = temp_root();
+
+        // Corrupt the sentinel; a second call should return immediately (sentinel
+        // exists) without re-extracting, so the corruption persists.
+        let sentinel = root.join(".complete");
+        fs::write(&sentinel, "DIRTY").unwrap();
+
+        materialize_to(&root).expect("second materialize_to failed");
+
+        assert_eq!(
+            fs::read_to_string(&sentinel).unwrap(),
+            "DIRTY",
+            "second call should not have overwritten the sentinel"
+        );
+    }
+
+    #[test]
+    fn materialize_token_src_contains_json_files() {
+        let (_tmp, root) = temp_root();
+        let json_files: Vec<_> = fs::read_dir(root.join("packages/tokens/src"))
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .collect();
+        assert_eq!(
+            json_files.len(),
+            8,
+            "expected 8 token source files, got {}",
+            json_files.len()
+        );
+    }
+
+    #[test]
+    fn materialize_schemas_has_token_types_subdir() {
+        let (_tmp, root) = temp_root();
+        let schemas: Vec<_> =
+            fs::read_dir(root.join("packages/tokens/schemas/token-types"))
+                .unwrap()
+                .flatten()
+                .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+                .collect();
+        assert!(
+            !schemas.is_empty(),
+            "token-types/ should contain at least one JSON schema"
+        );
+    }
+
+    #[test]
+    fn materialize_components_count() {
+        let (_tmp, root) = temp_root();
+        let components: Vec<_> =
+            fs::read_dir(root.join("packages/design-data-spec/components"))
+                .unwrap()
+                .flatten()
+                .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+                .collect();
+        assert_eq!(
+            components.len(),
+            81,
+            "expected 81 component schemas, got {}",
+            components.len()
+        );
+    }
+
+    /// Drift test: the EMBEDDED_TOKENS_VERSION constant must match the version in
+    /// packages/tokens/package.json.  Fails CI when the tokens package is bumped
+    /// without updating the constant.
+    #[test]
+    fn embedded_version_matches_tokens_package_json() {
+        let pkg_json_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../packages/tokens/package.json"
+        );
+        let raw = std::fs::read_to_string(pkg_json_path)
+            .expect("packages/tokens/package.json should be readable from the test environment");
+        let pkg: serde_json::Value =
+            serde_json::from_str(&raw).expect("packages/tokens/package.json should be valid JSON");
+        let pkg_version = pkg["version"]
+            .as_str()
+            .expect("packages/tokens/package.json should have a string 'version' field");
+
+        assert_eq!(
+            EMBEDDED_TOKENS_VERSION,
+            pkg_version,
+            "EMBEDDED_TOKENS_VERSION is '{}' but packages/tokens/package.json says '{}'. \
+             Update the constant in sdk/core/src/data_source/embedded.rs.",
+            EMBEDDED_TOKENS_VERSION,
+            pkg_version
+        );
+    }
+}

--- a/sdk/core/src/data_source/embedded.rs
+++ b/sdk/core/src/data_source/embedded.rs
@@ -140,7 +140,23 @@ pub fn materialize() -> io::Result<PathBuf> {
         )
     })?;
     materialize_to(&root)?;
+    evict_stale_versions(&root);
     Ok(root)
+}
+
+/// Remove sibling version directories under `embedded/` that don't match the
+/// current [`EMBEDDED_TOKENS_VERSION`], keeping the cache footprint bounded as
+/// the binary is updated across releases.  Errors are silently ignored — eviction
+/// is best-effort and must never cause the calling `materialize` to fail.
+fn evict_stale_versions(current: &Path) {
+    let Some(parent) = current.parent() else { return };
+    let Ok(entries) = std::fs::read_dir(parent) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path != current && path.is_dir() {
+            let _ = std::fs::remove_dir_all(&path);
+        }
+    }
 }
 
 /// Write the embedded snapshot into `root` and return when complete.
@@ -197,8 +213,15 @@ pub fn materialize_to(root: &Path) -> io::Result<()> {
         TOKENS_MANIFEST.as_bytes(),
     )?;
 
-    // Rename tmp → root (atomic on most OSes; non-atomic on Windows cross-device,
-    // but acceptable — the sentinel guarantees correctness regardless).
+    // Rename tmp → root.  Atomic on POSIX (same filesystem); non-atomic on Windows
+    // cross-device, but the sentinel guarantees correctness regardless.
+    //
+    // Known race window: if two processes reach this point simultaneously they
+    // share the same `tmp` path (root.with_extension("tmp")).  The second
+    // remove_dir_all(&tmp) at the top of materialize_to will delete the first
+    // process's in-progress work, but both will eventually succeed in writing a
+    // complete snapshot.  For a design tool this is acceptable; a PID-suffixed tmp
+    // dir would eliminate the race if stricter isolation is needed in future.
     if root.exists() {
         std::fs::remove_dir_all(root)?;
     }
@@ -293,6 +316,11 @@ mod tests {
 
     #[test]
     fn materialize_token_src_contains_json_files() {
+        // Regression guard: if the number of embedded token source files changes
+        // (files added/removed from packages/tokens/src/), this test fails
+        // deliberately so the change is noticed and EMBEDDED_TOKENS_VERSION is
+        // bumped alongside it.  Update the expected count if you've intentionally
+        // added or removed token source files.
         let (_tmp, root) = temp_root();
         let json_files: Vec<_> = fs::read_dir(root.join("packages/tokens/src"))
             .unwrap()
@@ -302,8 +330,8 @@ mod tests {
         assert_eq!(
             json_files.len(),
             8,
-            "expected 8 token source files, got {}",
-            json_files.len()
+            "expected 8 token source files — update this count if you've added/removed \
+             files from packages/tokens/src/ and bump EMBEDDED_TOKENS_VERSION"
         );
     }
 
@@ -324,6 +352,9 @@ mod tests {
 
     #[test]
     fn materialize_components_count() {
+        // Regression guard: if a component schema is added to or removed from
+        // packages/design-data-spec/components/, this test fails deliberately.
+        // Update the expected count when you've intentionally changed the set.
         let (_tmp, root) = temp_root();
         let components: Vec<_> =
             fs::read_dir(root.join("packages/design-data-spec/components"))
@@ -334,8 +365,8 @@ mod tests {
         assert_eq!(
             components.len(),
             81,
-            "expected 81 component schemas, got {}",
-            components.len()
+            "expected 81 component schemas — update this count if you've added/removed \
+             schemas from packages/design-data-spec/components/"
         );
     }
 

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -20,12 +20,15 @@
 //!    return [`DataSourceError::NotYetImplemented`] until `#1050` lands.
 //! 3. **CWD-relative probing** — tries `packages/tokens/…` and
 //!    `packages/design-data-spec/…` relative to `cwd`.  Preserves the original
-//!    in-monorepo behaviour as the last resort, so existing workflows are unaffected.
-//! 4. **Embedded snapshot** — baked into the binary at build time.
-//!    Filled in by `#1049`; absent until then (tier silently skipped).
+//!    in-monorepo behaviour when run from inside a checkout.
+//! 4. **Embedded snapshot** — baked into the binary at compile time via
+//!    `include_dir!`; materialized to the OS cache dir on first use.
+//!    This is the zero-config offline default for designers running outside the repo.
 //!
 //! [`resolve`] returns a [`ResolvedData`] with concrete [`PathBuf`]s for every
 //! location the CLI needs.
+
+pub mod embedded;
 
 use std::path::{Path, PathBuf};
 
@@ -263,13 +266,56 @@ pub fn resolve(
     }
 
     // Tier 3: CWD-relative probing — original in-monorepo behaviour.
-    // Tier 4 (cache) and tier 5 (embedded) are stubs filled in by #1050 / #1049.
+    // If we are inside a monorepo checkout probe will find everything; return immediately.
+    if is_in_repo(cwd) {
+        return Ok(probe_cwd(cwd, overrides));
+    }
+
+    // Tier 4: Embedded snapshot — materialize to the OS cache dir on first use.
+    // Non-fatal: if materialization fails (no cache dir, IO error, etc.) we fall
+    // through so existing users outside a repo aren't broken.
+    match embedded::materialize() {
+        Ok(root) => {
+            return Ok(from_root(
+                &root,
+                overrides,
+                Provenance::Embedded {
+                    version: embedded::EMBEDDED_TOKENS_VERSION,
+                },
+            ));
+        }
+        Err(e) => {
+            // Log to stderr but don't error — fall back to probe_cwd.
+            eprintln!(
+                "design-data: warning: embedded snapshot materialization failed ({e}); \
+                 falling back to in-repo probing"
+            );
+        }
+    }
+
+    // Tier 4 fallback: CWD probing (will likely find nothing outside a repo, but
+    // callers handle None fields gracefully).
     Ok(probe_cwd(cwd, overrides))
 }
 
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
+
+/// Returns `true` when `cwd` is inside a monorepo checkout.
+///
+/// Uses the same signal as the original `default_schema_path()`: the presence of
+/// `packages/tokens/schemas/token-types` (or its `../` sibling) as a directory.
+/// When this returns `true` the resolver skips the embedded tier and uses
+/// CWD-relative probing instead, preserving the original in-monorepo workflow.
+fn is_in_repo(cwd: &Path) -> bool {
+    [
+        cwd.join("packages/tokens/schemas/token-types"),
+        cwd.join("../packages/tokens/schemas/token-types"),
+    ]
+    .iter()
+    .any(|c| c.is_dir())
+}
 
 /// Walk ancestors of `start` looking for `.design-data.toml`.
 ///
@@ -471,17 +517,25 @@ mod tests {
     }
 
     #[test]
-    fn probe_tokens_root_defaults_to_cwd() {
+    fn probe_tokens_root_defaults_to_cwd_when_in_repo() {
+        // In-repo: tokens_root defaults to the CWD (original "." behaviour).
         let tmp = TempDir::new().unwrap();
+        make_monorepo(tmp.path()); // creates schemas/token-types → is_in_repo = true
         let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        assert_eq!(resolved.provenance, Provenance::InRepo);
         assert_eq!(resolved.tokens_root, tmp.path());
     }
 
     #[test]
-    fn probe_returns_none_for_absent_spec_dirs() {
+    fn probe_returns_none_for_absent_spec_dirs_when_in_repo() {
+        // When inside a repo (schemas/token-types present) but spec dirs are absent,
+        // probe returns None fields for those paths.
         let tmp = TempDir::new().unwrap();
-        // No spec dirs present.
+        // Only create the minimal structure to trigger is_in_repo — no spec dirs.
+        fs::create_dir_all(tmp.path().join("packages/tokens/schemas/token-types")).unwrap();
+
         let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        assert_eq!(resolved.provenance, Provenance::InRepo);
         assert!(resolved.mode_sets.is_none());
         assert!(resolved.components.is_none());
         assert!(resolved.fields.is_none());
@@ -631,5 +685,45 @@ mod tests {
         std::env::remove_var("DESIGN_DATA_SCHEMA_ROOT");
 
         assert_eq!(resolved.schemas_root, custom);
+    }
+
+    // --- Tier 4: Embedded snapshot ---
+
+    #[test]
+    fn resolve_outside_repo_uses_embedded_tier() {
+        // A completely empty temp dir has no monorepo layout, so is_in_repo returns
+        // false and the resolver must fall through to the embedded tier.
+        let tmp = TempDir::new().unwrap();
+        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        assert!(
+            matches!(resolved.provenance, Provenance::Embedded { .. }),
+            "expected Embedded provenance outside the repo, got {:?}",
+            resolved.provenance
+        );
+        // The tokens_root should point at the materialized cache dir.
+        assert!(
+            resolved.tokens_root.exists(),
+            "tokens_root should be materialized"
+        );
+        assert!(
+            resolved.schemas_root.join("token-types").is_dir(),
+            "schemas_root/token-types should exist in the embedded snapshot"
+        );
+    }
+
+    #[test]
+    fn cli_override_wins_over_embedded() {
+        let tmp = TempDir::new().unwrap();
+        let custom_schema = tmp.path().join("custom-schemas");
+        fs::create_dir_all(&custom_schema).unwrap();
+
+        let overrides = CliPathOverrides {
+            schema_root: Some(custom_schema.clone()),
+            ..Default::default()
+        };
+        let resolved = resolve(tmp.path(), &overrides).unwrap();
+        // Provenance is Embedded (we're outside the repo) but the schema override wins.
+        assert!(matches!(resolved.provenance, Provenance::Embedded { .. }));
+        assert_eq!(resolved.schemas_root, custom_schema);
     }
 }

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -28,7 +28,7 @@
 //! [`resolve`] returns a [`ResolvedData`] with concrete [`PathBuf`]s for every
 //! location the CLI needs.
 
-pub mod embedded;
+pub(crate) mod embedded;
 
 use std::path::{Path, PathBuf};
 
@@ -285,15 +285,18 @@ pub fn resolve(
             ));
         }
         Err(e) => {
-            // Log to stderr but don't error — fall back to probe_cwd.
-            eprintln!(
-                "design-data: warning: embedded snapshot materialization failed ({e}); \
-                 falling back to in-repo probing"
-            );
+            // Only surface the warning under debug logging — materialisation
+            // failures are non-fatal and the message would be noisy in scripts.
+            if std::env::var("DESIGN_DATA_LOG").as_deref() == Ok("debug") {
+                eprintln!(
+                    "design-data: warning: embedded snapshot materialization failed ({e}); \
+                     falling back to in-repo probing"
+                );
+            }
         }
     }
 
-    // Tier 4 fallback: CWD probing (will likely find nothing outside a repo, but
+    // Tier 3 fallback: CWD probing (will likely find nothing outside a repo, but
     // callers handle None fields gracefully).
     Ok(probe_cwd(cwd, overrides))
 }
@@ -487,7 +490,13 @@ fn resolve_schema_root(overrides: &CliPathOverrides, fallback: impl FnOnce() -> 
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    // Serialize all tests that mutate process-global env vars (DESIGN_DATA_CACHE_DIR,
+    // DESIGN_DATA_SCHEMA_ROOT).  Rust runs tests in parallel by default, so without
+    // this lock two tests setting the same var will race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn make_monorepo(dir: &Path) {
         fs::create_dir_all(dir.join("packages/tokens/schemas/token-types")).unwrap();
@@ -672,6 +681,7 @@ mod tests {
 
     #[test]
     fn env_var_schema_root_wins_over_probe() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let tmp = TempDir::new().unwrap();
         make_monorepo(tmp.path());
 
@@ -691,16 +701,23 @@ mod tests {
 
     #[test]
     fn resolve_outside_repo_uses_embedded_tier() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // A completely empty temp dir has no monorepo layout, so is_in_repo returns
         // false and the resolver must fall through to the embedded tier.
-        let tmp = TempDir::new().unwrap();
-        let resolved = resolve(tmp.path(), &CliPathOverrides::default()).unwrap();
+        // Set DESIGN_DATA_CACHE_DIR to a temp path to avoid writing to the real OS
+        // cache during tests.
+        let cache_tmp = TempDir::new().unwrap();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache_tmp.path());
+
+        let cwd_tmp = TempDir::new().unwrap();
+        let resolved = resolve(cwd_tmp.path(), &CliPathOverrides::default()).unwrap();
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+
         assert!(
             matches!(resolved.provenance, Provenance::Embedded { .. }),
             "expected Embedded provenance outside the repo, got {:?}",
             resolved.provenance
         );
-        // The tokens_root should point at the materialized cache dir.
         assert!(
             resolved.tokens_root.exists(),
             "tokens_root should be materialized"
@@ -713,15 +730,23 @@ mod tests {
 
     #[test]
     fn cli_override_wins_over_embedded() {
-        let tmp = TempDir::new().unwrap();
-        let custom_schema = tmp.path().join("custom-schemas");
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Set DESIGN_DATA_CACHE_DIR to a temp path to avoid writing to the real OS
+        // cache during tests.
+        let cache_tmp = TempDir::new().unwrap();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache_tmp.path());
+
+        let cwd_tmp = TempDir::new().unwrap();
+        let custom_schema = cwd_tmp.path().join("custom-schemas");
         fs::create_dir_all(&custom_schema).unwrap();
 
         let overrides = CliPathOverrides {
             schema_root: Some(custom_schema.clone()),
             ..Default::default()
         };
-        let resolved = resolve(tmp.path(), &overrides).unwrap();
+        let resolved = resolve(cwd_tmp.path(), &overrides).unwrap();
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+
         // Provenance is Embedded (we're outside the repo) but the schema override wins.
         assert!(matches!(resolved.provenance, Provenance::Embedded { .. }));
         assert_eq!(resolved.schemas_root, custom_schema);

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -307,17 +307,15 @@ pub fn resolve(
 
 /// Returns `true` when `cwd` is inside a monorepo checkout.
 ///
-/// Uses the same signal as the original `default_schema_path()`: the presence of
-/// `packages/tokens/schemas/token-types` (or its `../` sibling) as a directory.
+/// Walks up the ancestor chain from `cwd` looking for a directory that contains
+/// `packages/tokens/schemas/token-types`.  This works regardless of how deeply
+/// nested `cwd` is inside the repo (repo root, `sdk/`, `packages/tokens/`, etc.).
+///
 /// When this returns `true` the resolver skips the embedded tier and uses
 /// CWD-relative probing instead, preserving the original in-monorepo workflow.
 fn is_in_repo(cwd: &Path) -> bool {
-    [
-        cwd.join("packages/tokens/schemas/token-types"),
-        cwd.join("../packages/tokens/schemas/token-types"),
-    ]
-    .iter()
-    .any(|c| c.is_dir())
+    cwd.ancestors()
+        .any(|dir| dir.join("packages/tokens/schemas/token-types").is_dir())
 }
 
 /// Walk ancestors of `start` looking for `.design-data.toml`.
@@ -390,10 +388,17 @@ fn from_root(root: &Path, overrides: &CliPathOverrides, provenance: Provenance) 
     }
 }
 
-/// Tier 3: replicate the original `default_*_path()` probing logic.
+/// Tier 3: replicate the original `default_*_path()` probing logic verbatim.
 ///
-/// Tries both `packages/…` (run from repo root) and `../packages/…` (run from
-/// inside `sdk/`), exactly matching the previous per-function behaviour.
+/// Tries `packages/…` (run from repo root) and `../packages/…` (run from one
+/// level below the root, e.g. `sdk/`).  Returns `None` for any path not found —
+/// preserving the pre-resolver behaviour exactly for every existing working directory.
+///
+/// NOTE: `is_in_repo` uses an ancestor-walk so it returns `true` from ANY
+/// subdirectory of the repo.  This function intentionally keeps the original
+/// two-candidate probing so that callers running from deeply-nested dirs (e.g.
+/// `packages/tokens/`) get `None` for spec dirs they can't reach — the same
+/// result they got before the resolver was introduced.
 fn probe_cwd(cwd: &Path, overrides: &CliPathOverrides) -> ResolvedData {
     // tokens_root — original default was PathBuf::from(".") i.e. CWD.
     let tokens_root = overrides

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -47,6 +47,14 @@ tasks:
     inputs:
       - "@globs(sources)"
       - "core/src/registry_data.rs"
+      # Embedded snapshot sources — invalidate the build when token data changes.
+      - "/packages/tokens/src/*.json"
+      - "/packages/tokens/schemas/**/*.json"
+      - "/packages/tokens/naming-exceptions.json"
+      - "/packages/tokens/manifest.json"
+      - "/packages/design-data-spec/mode-sets/*.json"
+      - "/packages/design-data-spec/components/*.json"
+      - "/packages/design-data-spec/fields/*.json"
     deps:
       - codegen-check
   test:
@@ -57,6 +65,14 @@ tasks:
     inputs:
       - "@globs(sources)"
       - "core/src/registry_data.rs"
+      # Embedded snapshot sources — re-run tests when token data changes.
+      - "/packages/tokens/src/*.json"
+      - "/packages/tokens/schemas/**/*.json"
+      - "/packages/tokens/naming-exceptions.json"
+      - "/packages/tokens/manifest.json"
+      - "/packages/design-data-spec/mode-sets/*.json"
+      - "/packages/design-data-spec/components/*.json"
+      - "/packages/design-data-spec/fields/*.json"
     deps:
       - codegen-check
   lint:


### PR DESCRIPTION
## Description

Adds `sdk/core/src/data_source/embedded.rs` which bakes the full Spectrum dataset (~2.2 MB: 8 token source files, schemas, 81 component schemas, mode-sets, fields, naming-exceptions) into the binary at compile time via `include_dir!`. On first use outside a monorepo checkout, `materialize()` writes the snapshot to a version-namespaced OS cache dir so existing disk-based loaders (`from_json_dir`, `load_legacy_token_schemas`, `discover_json_files`) can read it unchanged.

Resolution tier wired into the resolver (`mod.rs`): `is_in_repo()` guards in-repo usage (probing tier, unchanged); outside the repo the embedded tier materializes and returns `Provenance::Embedded { version: "14.11.0" }`. CLI overrides (`--schema-path`, `--components-path`, etc.) still win at tier 1.

**Before:** `design-data primer` from `/tmp` — no output / error (no data found)  
**After:** `design-data primer --format json` from `/tmp` → 2460 tokens, 81 components, 3 mode-sets, `provenance: { source: "embedded", tokensVersion: "14.11.0" }`

**Also:**
- `run_primer` JSON payload includes a `provenance` object (`source` + `tokensVersion`)
- `sdk/moon.yml` `build`/`test` task inputs include the embedded snapshot source globs so moon cache-invalidates when token data changes
- `cli_validate` integration test explicitly passes `--components-path` to an empty dir when testing partial datasets (embedded snapshot now auto-provides components, which would cause SPEC-027 failures on the sparse `tokens/src` dataset)
- Drift test (`embedded_version_matches_tokens_package_json`) fails CI if `EMBEDDED_TOKENS_VERSION` is bumped without updating `packages/tokens/package.json` or vice versa

## Related Issue

Resolves #1049 · Part of epic #1047

## Motivation and Context

This is the zero-config offline tier for designers using `design-data` outside the monorepo (use case 1). No Rust toolchain, no monorepo, no network — just install the binary and run.

Depends on #1055 (data-source resolver, merged).

## How Has This Been Tested?

- `cargo test --workspace` — all 408 tests pass (6 new unit tests: materialize layout, idempotency, token count, schema subdir, components count, version drift)
- `cargo clippy --workspace -- -D warnings` — clean
- Smoke: `design-data primer --format json` from `/tmp` → 2460 tokens, 81 components, 3 mode-sets, `provenance.source = "embedded"`
- Smoke: `design-data primer --format json` from repo root → same counts, `provenance.source = "in-repo"` (existing behaviour unchanged)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.