### PR TITLE
fix(ci): use --ignore-scripts on Windows build-binaries pnpm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,11 @@ jobs:
 
       - run: npm install -g pnpm@10.17.1
 
-      - run: pnpm install --frozen-lockfile
+      # --ignore-scripts skips prepare hooks (e.g. docs/s2-tokens-viewer uses
+      # `mkdir -p` which is not available on the Windows runner).
+      # The codegen-check step only needs Node + the script itself, not workspace
+      # lifecycle hooks.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       # Moon codegen generates sdk/core/src/registry_data.rs, which is a
       # required build input for cargo (declared in sdk/moon.yml inputs).


### PR DESCRIPTION
## Problem

The `build-binaries` job for `win32-x64` fails because `docs/s2-tokens-viewer`'s prepare script runs `mkdir -p` — not available on the Windows runner:

```
docs/s2-tokens-viewer prepare: Error occurred while processing: -p.
docs/s2-tokens-viewer prepare: A subdirectory or file tokens already exists.
```

## Fix

Add `--ignore-scripts` to the `pnpm install` in `build-binaries`. The codegen-check step only needs Node.js to run the script — it doesn't depend on any workspace lifecycle hooks.

The `release` job (which does need prepare scripts for the tokens build) is unaffected.