### PR TITLE
fix(ci): run sdk:codegen instead of codegen-check in build-binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,15 +67,19 @@ jobs:
       # lifecycle hooks.
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
-      # Moon codegen generates sdk/core/src/registry_data.rs, which is a
-      # required build input for cargo (declared in sdk/moon.yml inputs).
+      # Regenerate sdk/core/src/registry_data.rs before cargo build.
+      # We run sdk:codegen (not codegen-check) because codegen-check compares
+      # file content as strings and fails on Windows when git checks out the
+      # committed LF file with CRLF endings, producing a spurious mismatch.
+      # Regenerating is always safe — it produces the same content as the
+      # committed file and sidesteps the line-ending issue entirely.
       - name: Set up moonrepo
         uses: moonrepo/setup-toolchain@v0
         with:
           auto-install: true
 
-      - name: Run codegen
-        run: moon run sdk:codegen-check
+      - name: Regenerate registry data
+        run: moon run sdk:codegen
         working-directory: .
 
       - name: Build binary


### PR DESCRIPTION
## Problem

`build-binaries` fails on `win32-x64` with `registry_data.rs is out of date` even when the file is current. The `codegen-check` script does a string comparison — on Windows, git may check out the committed LF file with CRLF endings, while the Node script generates LF, so the strings never match.

## Fix

Replace `moon run sdk:codegen-check` with `moon run sdk:codegen` (regenerate). Running codegen is always safe — it produces the same file content as what's committed and doesn't have the line-ending comparison problem.

The `codegen-check` validation still runs on Linux via the regular `moon ci` job, so drift is still caught.