### PR TITLE
feat(tools): claude code skill for design-data — auto-bootstrap via npx

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "design-data",
-      "description": "Spectrum design tokens, component schemas, and design-system insights via the design-data CLI. Query tokens, get component options, suggest tokens from natural language, and resolve token values.",
+      "description": "Spectrum design tokens and component schemas via the design-data CLI.",
       "source": "./tools/design-data-skill"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,6 +10,11 @@
       "name": "s2-docs",
       "description": "Spectrum 2 component documentation on-demand. Fetches S2 design guidelines, component options, and usage patterns without loading a persistent MCP server.",
       "source": "./tools/s2-docs-mcp"
+    },
+    {
+      "name": "design-data",
+      "description": "Spectrum design tokens, component schemas, and design-system insights via the design-data CLI. Query tokens, get component options, suggest tokens from natural language, and resolve token values.",
+      "source": "./tools/design-data-skill"
     }
   ]
 }

--- a/tools/design-data-skill/.claude-plugin/plugin.json
+++ b/tools/design-data-skill/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "design-data",
+  "description": "Spectrum design tokens, component schemas, and design-system insights for Claude Code.",
+  "version": "1.0.0",
+  "author": { "name": "Adobe" },
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill",
+  "repository": "https://github.com/adobe/spectrum-design-data",
+  "license": "Apache-2.0"
+}

--- a/tools/design-data-skill/README.md
+++ b/tools/design-data-skill/README.md
@@ -1,0 +1,38 @@
+# design-data Claude Code Skill
+
+A Claude Code plugin that gives agents access to Spectrum design tokens,
+component schemas, and design-system data via the `@adobe/design-data` CLI.
+
+## Structure
+
+```
+tools/design-data-skill/
+  .claude-plugin/plugin.json    Plugin manifest (name, description, version)
+  skills/design-data/SKILL.md   Skill definition (frontmatter + workflow docs)
+  README.md                     This file
+```
+
+**No `package.json`** — this is a pure-skills plugin with no build step or
+Node.js dependencies. It wraps an external CLI (`@adobe/design-data`) that
+users install separately via npm. This is intentional and consistent with
+the plugin format: the `.claude-plugin/plugin.json` manifest is the only
+metadata file needed. Compare with `tools/s2-docs-mcp/` which bundles its
+own Node.js server and therefore needs a full package.
+
+## Installation
+
+In Claude Code, install from the marketplace:
+
+```
+claude plugin install spectrum-design-data
+```
+
+Or point directly at this repository.
+
+## Usage
+
+See [`skills/design-data/SKILL.md`](skills/design-data/SKILL.md) for the
+full command reference and workflow.
+
+For Cursor users (native agent, not Claude Code), use the
+[`@adobe/design-data-mcp`](../design-data-mcp/) MCP server instead.

--- a/tools/design-data-skill/skills/design-data/SKILL.md
+++ b/tools/design-data-skill/skills/design-data/SKILL.md
@@ -27,7 +27,13 @@ On first use, ensure the CLI is installed:
 npx @adobe/design-data --version
 ```
 
-npm will install the binary automatically on first run — no manual setup needed.
+`npx` installs the binary automatically on first run. For frequent use or
+air-gapped environments, install globally to avoid the per-invocation
+network check:
+
+```
+npm install -g @adobe/design-data
+```
 
 ## Commands
 
@@ -56,6 +62,9 @@ Expression syntax examples:
 * `"property=color-*"` — all color property tokens
 * `"colorScheme=dark"` — dark-scheme tokens
 
+Returns an empty array when no tokens match (not an error). Exit code 1 only
+when the expression itself is malformed.
+
 ***
 
 **Suggest tokens** — natural-language intent → ranked token matches:
@@ -69,7 +78,7 @@ Example: `"primary CTA button background color"`
 
 ***
 
-**Component schema** — full component declaration (always JSON, no `--format` flag):
+**Component schema** — full component declaration:
 
 ```
 npx @adobe/design-data component <id>
@@ -78,6 +87,7 @@ npx @adobe/design-data component <id>
 Example: `npx @adobe/design-data component button`
 
 Returns: displayName, description, options (variants, sizes, states, etc.).
+This command always outputs JSON; it does not accept a `--format` flag.
 
 ***
 
@@ -101,7 +111,8 @@ Example: `npx @adobe/design-data resolve background-color-default --format json 
 ## When working in Cursor
 
 Cursor's native agent does not support Claude Code Skills. For Cursor users,
-recommend the `@adobe/design-data-mcp` MCP server instead:
+recommend the `@adobe/design-data-mcp` MCP server instead — add to
+`.cursor/mcp-servers.json` in the project root:
 
 ```json
 {
@@ -113,8 +124,6 @@ recommend the `@adobe/design-data-mcp` MCP server instead:
   }
 }
 ```
-
-Add this to `.cursor/mcp-servers.json` in the project root.
 
 ## Using a custom dataset
 

--- a/tools/design-data-skill/skills/design-data/SKILL.md
+++ b/tools/design-data-skill/skills/design-data/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: design-data
+description: >
+  Look up Spectrum design tokens, component schemas, and design-system decisions
+  when building with or extending Adobe Spectrum. Use when the user asks about
+  token values, component options, naming conventions, or wants to
+  validate/explore design-token data. Also triggers when a .design-data.toml
+  config is involved or the user mentions the design-data CLI.
+when_to_use: >
+  Trigger on: token names (color, spacing, typography, dimension), "which token",
+  "Spectrum component options", validate tokens, design-data primer, query tokens,
+  suggest token, resolve token value, component schema, design system config,
+  @adobe/design-data, design-data CLI.
+allowed-tools: Bash(npx @adobe/design-data *)
+---
+
+# Spectrum Design Data
+
+Access Spectrum design tokens, component schemas, and design-system structure
+via the `@adobe/design-data` CLI.
+
+## Bootstrap
+
+On first use, ensure the CLI is installed:
+
+```
+npx @adobe/design-data --version
+```
+
+npm will install the binary automatically on first run — no manual setup needed.
+
+## Commands
+
+**Session overview** — call at the start of a design-token session to understand
+the available data:
+
+```
+npx @adobe/design-data primer --format json
+```
+
+Returns: token count, mode-sets, component list, fields, and data provenance
+(embedded snapshot or fetched version).
+
+***
+
+**Query tokens** — filter by name, property, component, state, or any combination:
+
+```
+npx @adobe/design-data query --filter "<expr>" --format json
+```
+
+Expression syntax examples:
+
+* `"component=button"` — all button tokens
+* `"component=button,state=hover"` — button hover tokens
+* `"property=color-*"` — all color property tokens
+* `"colorScheme=dark"` — dark-scheme tokens
+
+***
+
+**Suggest tokens** — natural-language intent → ranked token matches:
+
+```
+npx @adobe/design-data suggest "<intent>" --format json
+npx @adobe/design-data suggest "<intent>" --format json --limit 10
+```
+
+Example: `"primary CTA button background color"`
+
+***
+
+**Component schema** — full component declaration (always JSON, no `--format` flag):
+
+```
+npx @adobe/design-data component <id>
+```
+
+Example: `npx @adobe/design-data component button`
+
+Returns: displayName, description, options (variants, sizes, states, etc.).
+
+***
+
+**Resolve token value** — resolve a token for a given mode-set context:
+
+```
+npx @adobe/design-data resolve <property> --format json
+npx @adobe/design-data resolve <property> --format json --color-scheme light --scale medium
+```
+
+Example: `npx @adobe/design-data resolve background-color-default --format json --color-scheme dark`
+
+## Workflow
+
+1. **Start with `primer`** to understand what data is available.
+2. **Use `query`** when you know the component/property/state.
+3. **Use `suggest`** when the user describes an intent in natural language.
+4. **Use `component`** to check all available options for a specific component.
+5. **Use `resolve`** to get the concrete value for a token in a given context.
+
+## When working in Cursor
+
+Cursor's native agent does not support Claude Code Skills. For Cursor users,
+recommend the `@adobe/design-data-mcp` MCP server instead:
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    }
+  }
+}
+```
+
+Add this to `.cursor/mcp-servers.json` in the project root.
+
+## Using a custom dataset
+
+To point at a specific Spectrum version or a custom design-data fork, add
+a `.design-data.toml` to your project root:
+
+```toml
+[source]
+type = "github"
+repo = "adobe/spectrum-design-data"
+tag = "@adobe/spectrum-tokens@14.11.0"
+```
+
+Without a config file, the embedded Spectrum snapshot is used automatically.


### PR DESCRIPTION
## Description

Adds a Claude Code plugin at `tools/design-data-skill/` with a skill that wraps `@adobe/design-data`. Designers using Claude Code get Spectrum token and component lookup with zero manual setup — the agent bootstraps via `npx` on first trigger.

**Five commands:**
| Command | What it does |
|---|---|
| `npx @adobe/design-data primer --format json` | Session-start overview: token count, mode-sets, components |
| `npx @adobe/design-data query --filter "<expr>" --format json` | Filter tokens by query expression |
| `npx @adobe/design-data suggest "<intent>" --format json` | Natural-language token suggestions |
| `npx @adobe/design-data component <id>` | Full component schema (always JSON) |
| `npx @adobe/design-data resolve <property> --format json` | Resolve token value for a mode context |

Also registers the new plugin in `.claude-plugin/marketplace.json` alongside `s2-docs`.

## Related Issue

Resolves spectrum-design-data-c1z · Part of epic #1047