### PR TITLE
feat(tools): mcp server for design-data — Cursor native agent surface

### DIFF
--- a/.changeset/design-data-mcp-initial.md
+++ b/.changeset/design-data-mcp-initial.md
@@ -1,0 +1,8 @@
+---
+"@adobe/design-data-mcp": minor
+---
+
+Initial release of `@adobe/design-data-mcp` — an MCP server that wraps the
+`@adobe/design-data` CLI as five tools for Cursor, Claude Desktop, and other
+MCP-compatible agents: `design-data-primer`, `design-data-query`,
+`design-data-suggest`, `design-data-component`, `design-data-resolve`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 #     Gated on hasChangesets==false AND the local package version being ahead of
 #     npm. Builds the Rust binary for all four platforms in a matrix.
 #
-#   Phase 3 — `release`  (after all binaries built)
-#     Downloads the artifacts, stages them into sdk/npm/*/bin/, then runs
-#     `pnpm release` (changeset publish) via OIDC.
+#   Phase 3 — `release`  (every version-PR merge)
+#     Runs whenever a version PR merges (hasChangesets==false), independent of
+#     whether anything was compiled. When binaries were built it downloads the
+#     artifacts and stages them into sdk/npm/*/bin/; when build-binaries was
+#     skipped (nothing to compile, e.g. an MCP-only release) those steps are
+#     skipped and it publishes the bumped Node packages. Then runs
+#     `pnpm release` (changeset publish) via OIDC. Only an actual binary build
+#     failure blocks the publish.
 #
 # Net effect: `cargo build --release` runs exactly ONCE per release cycle —
 # never on unrelated pushes or the changeset-PR-creation commit.
@@ -180,8 +185,14 @@ jobs:
   # ── Phase 3: publish ────────────────────────────────────────────────────────
   release:
     name: Publish to npm
-    needs: build-binaries
-    if: needs.build-binaries.result == 'success'
+    needs: [changesets, version, build-binaries]
+    # Runs on any version-PR merge. Only blocks on an actual binary build
+    # failure: 'skipped' (nothing to compile, e.g. MCP-only release) and
+    # 'success' both proceed, while 'failure' aborts the publish.
+    if: |
+      !cancelled() &&
+      needs.changesets.outputs.hasChangesets == 'false' &&
+      needs.build-binaries.result != 'failure'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -203,14 +214,17 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # Download pre-built binaries and stage them into the platform packages
-      # so they are present when `npm publish` runs.
+      # so they are present when `npm publish` runs. Skipped when cli-version is
+      # empty (nothing was compiled, e.g. an MCP-only release).
       - name: Download binary artifacts
+        if: needs.version.outputs.cli-version
         uses: actions/download-artifact@v4
         with:
           pattern: design-data-*
           merge-multiple: false
 
       - name: Stage binaries into platform packages
+        if: needs.version.outputs.cli-version
         shell: bash
         run: |
           for platform in darwin-arm64 darwin-x64 linux-x64; do

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,6 +569,10 @@ importers:
       "@modelcontextprotocol/sdk":
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)
+    devDependencies:
+      ava:
+        specifier: ^6.0.1
+        version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
   tools/diff-generator:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,12 @@ importers:
         specifier: ^6.0.1
         version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
+  tools/design-data-mcp:
+    dependencies:
+      "@modelcontextprotocol/sdk":
+        specifier: ^1.27.1
+        version: 1.27.1(zod@3.25.76)
+
   tools/diff-generator:
     dependencies:
       "@adobe/optimized-diff":

--- a/tools/design-data-mcp/LICENSE
+++ b/tools/design-data-mcp/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tools/design-data-mcp/README.md
+++ b/tools/design-data-mcp/README.md
@@ -1,0 +1,62 @@
+# [**@adobe/design-data-mcp**](https://github.com/adobe/design-data-mcp)
+
+MCP server for [Adobe Spectrum](https://spectrum.adobe.com) design tokens and component schemas, powered by the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI.
+
+## Setup
+
+### Cursor
+
+Add to `.cursor/mcp-servers.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool                    | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `design-data-primer`    | Session-start overview: token count, mode-sets, components, provenance     |
+| `design-data-query`     | Filter tokens by query expression (`component=button`, `property=color-*`) |
+| `design-data-suggest`   | Natural-language token suggestions with confidence scores                  |
+| `design-data-component` | Full component schema (variants, sizes, states, props)                     |
+| `design-data-resolve`   | Resolve a token's concrete value for a mode context                        |
+
+## Custom dataset
+
+Add a `.design-data.toml` to your project root to use a specific Spectrum version or a custom fork:
+
+```toml
+[source]
+type = "github"
+repo = "adobe/spectrum-design-data"
+tag = "@adobe/spectrum-tokens@14.11.0"
+```
+
+Without a config file the embedded Spectrum snapshot is used automatically (offline, zero-setup).
+
+## License
+
+Apache-2.0 — see the [project repository](https://github.com/adobe/spectrum-design-data) for details.

--- a/tools/design-data-mcp/ava.config.js
+++ b/tools/design-data-mcp/ava.config.js
@@ -1,0 +1,17 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+export default {
+  files: ["test/**/*.test.js"],
+  verbose: true,
+  environmentVariables: {
+    NODE_ENV: "test",
+  },
+};

--- a/tools/design-data-mcp/moon.yml
+++ b/tools/design-data-mcp/moon.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+$schema: "https://moonrepo.dev/schemas/project.json"
+layer: tool
+tasks:
+  start:
+    command:
+      - node
+      - src/cli.js
+    platform: node
+    local: true

--- a/tools/design-data-mcp/moon.yml
+++ b/tools/design-data-mcp/moon.yml
@@ -16,3 +16,8 @@ tasks:
       - src/cli.js
     platform: node
     local: true
+  test:
+    command:
+      - pnpm
+      - ava
+    platform: node

--- a/tools/design-data-mcp/package.json
+++ b/tools/design-data-mcp/package.json
@@ -13,7 +13,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "start": "node src/cli.js"
+    "start": "node src/cli.js",
+    "test": "ava"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "ava": "^6.0.1"
   },
   "engines": {
     "node": ">=20.12.0"

--- a/tools/design-data-mcp/package.json
+++ b/tools/design-data-mcp/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@adobe/design-data-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for Spectrum design tokens and component schemas via the design-data CLI",
+  "type": "module",
+  "main": "./src/index.js",
+  "bin": {
+    "design-data-mcp": "./src/cli.js"
+  },
+  "files": [
+    "src/",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "node src/cli.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-design-data.git",
+    "directory": "tools/design-data-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
+  },
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-mcp#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "keywords": [
+    "mcp",
+    "spectrum",
+    "design-system",
+    "design-tokens",
+    "cli"
+  ],
+  "author": "Adobe",
+  "license": "Apache-2.0"
+}

--- a/tools/design-data-mcp/src/cli.js
+++ b/tools/design-data-mcp/src/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMCPServer } from "./index.js";
+
+const server = createMCPServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/tools/design-data-mcp/src/index.js
+++ b/tools/design-data-mcp/src/index.js
@@ -24,7 +24,6 @@ import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,

--- a/tools/design-data-mcp/src/index.js
+++ b/tools/design-data-mcp/src/index.js
@@ -1,0 +1,84 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * @adobe/design-data-mcp — MCP server for Spectrum design tokens and components.
+ *
+ * Wraps the @adobe/design-data CLI as five MCP tools, making Spectrum design
+ * data available to any MCP-compatible agent (Cursor, Claude Desktop, etc.)
+ * without requiring a Rust toolchain or monorepo checkout.
+ *
+ * The CLI resolves data automatically: it uses the embedded Spectrum snapshot
+ * for zero-config offline use, or a `.design-data.toml` config for custom sources.
+ */
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { createDesignDataTools } from "./tools/design-data.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../package.json"), "utf8"),
+);
+
+export function createMCPServer() {
+  const server = new Server(
+    { name: "design-data", version: packageJson.version },
+    { capabilities: { tools: {} } },
+  );
+
+  const tools = createDesignDataTools();
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: tools.map(({ name, description, inputSchema }) => ({
+      name,
+      description,
+      inputSchema,
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const tool = tools.find((t) => t.name === request.params.name);
+    if (!tool) {
+      throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+
+    try {
+      const result = await tool.handler(request.params.arguments ?? {});
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              typeof result === "string"
+                ? result
+                : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: String(err.message) }],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -20,15 +20,25 @@
 import { spawnSync } from "child_process";
 
 /**
- * Run `npx @adobe/design-data` with the given args and return parsed JSON stdout.
- * Throws with stderr content on non-zero exit.
+ * Run `npx -y @adobe/design-data` with the given args and return parsed JSON stdout.
+ *
+ * Uses spawnSync (blocking) intentionally: this MCP server serves a single
+ * stdio client and processes requests sequentially, so blocking the event
+ * loop is safe. The -y flag suppresses the interactive "install?" prompt on
+ * first run so the server doesn't hang waiting for user input.
+ *
+ * Throws if the process can't start (result.error) or exits non-zero.
  */
 function runDesignData(args) {
-  const result = spawnSync("npx", ["@adobe/design-data", ...args], {
+  const result = spawnSync("npx", ["-y", "@adobe/design-data", ...args], {
     encoding: "utf8",
-    // Allow up to 30s for first-run install + execution.
+    // Allow up to 30s for first-run install + binary execution.
     timeout: 30_000,
   });
+
+  // result.error is set when the process can't start at all (binary not found,
+  // timeout exceeded, etc.) — check before result.status.
+  if (result.error) throw result.error;
 
   if (result.status !== 0) {
     const msg = (result.stderr || result.stdout || "").trim();
@@ -57,6 +67,7 @@ export function createDesignDataTools() {
       inputSchema: {
         type: "object",
         properties: {},
+        additionalProperties: false,
       },
       handler() {
         return runDesignData(["primer", "--format", "json"]);
@@ -81,6 +92,7 @@ export function createDesignDataTools() {
           },
         },
         required: ["filter"],
+        additionalProperties: false,
       },
       handler({ filter }) {
         return runDesignData(["query", "--filter", filter, "--format", "json"]);
@@ -109,6 +121,7 @@ export function createDesignDataTools() {
           },
         },
         required: ["intent"],
+        additionalProperties: false,
       },
       handler({ intent, limit = 5 }) {
         return runDesignData([
@@ -140,6 +153,7 @@ export function createDesignDataTools() {
           },
         },
         required: ["id"],
+        additionalProperties: false,
       },
       handler({ id }) {
         // component always outputs JSON — no --format flag.
@@ -176,6 +190,7 @@ export function createDesignDataTools() {
           },
         },
         required: ["property"],
+        additionalProperties: false,
       },
       handler({ property, colorScheme, scale, contrast }) {
         const args = ["resolve", property, "--format", "json"];

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -1,0 +1,189 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * MCP tool definitions that wrap the @adobe/design-data CLI.
+ *
+ * Each tool shells out to `npx @adobe/design-data <subcommand>` and returns
+ * the parsed JSON output. The CLI handles data resolution automatically —
+ * it uses the embedded Spectrum snapshot when no `.design-data.toml` is present,
+ * or the configured source/version if one exists in the project.
+ */
+
+import { spawnSync } from "child_process";
+
+/**
+ * Run `npx @adobe/design-data` with the given args and return parsed JSON stdout.
+ * Throws with stderr content on non-zero exit.
+ */
+function runDesignData(args) {
+  const result = spawnSync("npx", ["@adobe/design-data", ...args], {
+    encoding: "utf8",
+    // Allow up to 30s for first-run install + execution.
+    timeout: 30_000,
+  });
+
+  if (result.status !== 0) {
+    const msg = (result.stderr || result.stdout || "").trim();
+    throw new Error(`design-data exited ${result.status}: ${msg}`);
+  }
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    // Some commands (e.g. component) output valid JSON but without --format json.
+    // If JSON.parse fails, return the raw string so the caller can decide.
+    return result.stdout.trim();
+  }
+}
+
+export function createDesignDataTools() {
+  return [
+    // ── primer ────────────────────────────────────────────────────────────────
+    {
+      name: "design-data-primer",
+      description:
+        "Get a structural overview of the Spectrum design dataset: token count, " +
+        "available mode-sets (color-scheme, scale, contrast), component list, " +
+        "taxonomy fields, and data provenance. Call this at the start of a " +
+        "design-token session to understand what data is available.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+      handler() {
+        return runDesignData(["primer", "--format", "json"]);
+      },
+    },
+
+    // ── query ─────────────────────────────────────────────────────────────────
+    {
+      name: "design-data-query",
+      description:
+        "Filter Spectrum tokens by a query expression. " +
+        "Expression syntax: `component=button`, `component=button,state=hover`, " +
+        "`property=color-*`, `colorScheme=dark`. " +
+        "Returns an array of matching token objects.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          filter: {
+            type: "string",
+            description:
+              'Query expression, e.g. "component=button" or "property=color-*,component=action-button"',
+          },
+        },
+        required: ["filter"],
+      },
+      handler({ filter }) {
+        return runDesignData(["query", "--filter", filter, "--format", "json"]);
+      },
+    },
+
+    // ── suggest ───────────────────────────────────────────────────────────────
+    {
+      name: "design-data-suggest",
+      description:
+        "Suggest Spectrum tokens matching a natural-language intent. " +
+        "Returns ranked matches with confidence scores, token names, and values. " +
+        "Use when the user describes what they need rather than knowing the token name.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          intent: {
+            type: "string",
+            description:
+              'Natural-language description of the design need, e.g. "primary CTA button background color"',
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of suggestions to return (default: 5)",
+            default: 5,
+          },
+        },
+        required: ["intent"],
+      },
+      handler({ intent, limit = 5 }) {
+        return runDesignData([
+          "suggest",
+          intent,
+          "--format",
+          "json",
+          "--limit",
+          String(limit),
+        ]);
+      },
+    },
+
+    // ── component ─────────────────────────────────────────────────────────────
+    {
+      name: "design-data-component",
+      description:
+        "Get the full component declaration for a Spectrum component by ID. " +
+        "Returns the component's displayName, description, and all available options " +
+        "(variants, sizes, states, boolean props, etc.). " +
+        "Component IDs are kebab-case, e.g. button, action-button, text-field, picker.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description:
+              "Component ID in kebab-case, e.g. button, action-button, picker, text-field",
+          },
+        },
+        required: ["id"],
+      },
+      handler({ id }) {
+        // component always outputs JSON — no --format flag.
+        return runDesignData(["component", id]);
+      },
+    },
+
+    // ── resolve ───────────────────────────────────────────────────────────────
+    {
+      name: "design-data-resolve",
+      description:
+        "Resolve the concrete value of a Spectrum token property for a given " +
+        "mode-set context (color-scheme, scale, contrast). " +
+        "Returns the winning token with its resolved value.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          property: {
+            type: "string",
+            description:
+              "Token property name, e.g. background-color-default, accent-color",
+          },
+          colorScheme: {
+            type: "string",
+            description: 'Color scheme mode, e.g. "light" or "dark"',
+          },
+          scale: {
+            type: "string",
+            description: 'Scale mode, e.g. "medium" or "large"',
+          },
+          contrast: {
+            type: "string",
+            description: 'Contrast mode, e.g. "standard" or "high"',
+          },
+        },
+        required: ["property"],
+      },
+      handler({ property, colorScheme, scale, contrast }) {
+        const args = ["resolve", property, "--format", "json"];
+        if (colorScheme) args.push("--color-scheme", colorScheme);
+        if (scale) args.push("--scale", scale);
+        if (contrast) args.push("--contrast", contrast);
+        return runDesignData(args);
+      },
+    },
+  ];
+}

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -19,6 +19,9 @@
 
 import { spawnSync } from "child_process";
 
+/** npx executable name — .cmd suffix required on Windows without shell: true. */
+const NPX = process.platform === "win32" ? "npx.cmd" : "npx";
+
 /**
  * Run `npx -y @adobe/design-data` with the given args and return parsed JSON stdout.
  *
@@ -30,7 +33,7 @@ import { spawnSync } from "child_process";
  * Throws if the process can't start (result.error) or exits non-zero.
  */
 function runDesignData(args) {
-  const result = spawnSync("npx", ["-y", "@adobe/design-data", ...args], {
+  const result = spawnSync(NPX, ["-y", "@adobe/design-data", ...args], {
     encoding: "utf8",
     // Allow up to 30s for first-run install + binary execution.
     timeout: 30_000,
@@ -126,6 +129,7 @@ export function createDesignDataTools() {
       handler({ intent, limit = 5 }) {
         return runDesignData([
           "suggest",
+          "--",
           intent,
           "--format",
           "json",
@@ -157,7 +161,7 @@ export function createDesignDataTools() {
       },
       handler({ id }) {
         // component always outputs JSON — no --format flag.
-        return runDesignData(["component", id]);
+        return runDesignData(["component", "--", id]);
       },
     },
 
@@ -193,7 +197,7 @@ export function createDesignDataTools() {
         additionalProperties: false,
       },
       handler({ property, colorScheme, scale, contrast }) {
-        const args = ["resolve", property, "--format", "json"];
+        const args = ["resolve", "--", property, "--format", "json"];
         if (colorScheme) args.push("--color-scheme", colorScheme);
         if (scale) args.push("--scale", scale);
         if (contrast) args.push("--contrast", contrast);

--- a/tools/design-data-mcp/test/design-data.test.js
+++ b/tools/design-data-mcp/test/design-data.test.js
@@ -1,0 +1,48 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { createDesignDataTools } from "../src/tools/design-data.js";
+
+const EXPECTED_TOOLS = [
+  "design-data-primer",
+  "design-data-query",
+  "design-data-suggest",
+  "design-data-component",
+  "design-data-resolve",
+];
+
+test("createDesignDataTools exposes five CLI wrapper tools", (t) => {
+  const tools = createDesignDataTools();
+  t.is(tools.length, 5);
+  t.deepEqual(
+    tools.map(({ name }) => name),
+    EXPECTED_TOOLS,
+  );
+});
+
+test("each tool schema rejects unknown properties", (t) => {
+  for (const tool of createDesignDataTools()) {
+    t.is(
+      tool.inputSchema.additionalProperties,
+      false,
+      `${tool.name} should set additionalProperties: false`,
+    );
+  }
+});
+
+test("query and resolve require their primary argument", (t) => {
+  const tools = Object.fromEntries(
+    createDesignDataTools().map((tool) => [tool.name, tool]),
+  );
+
+  t.deepEqual(tools["design-data-query"].inputSchema.required, ["filter"]);
+  t.deepEqual(tools["design-data-resolve"].inputSchema.required, ["property"]);
+});

--- a/tools/design-data-mcp/test/index.test.js
+++ b/tools/design-data-mcp/test/index.test.js
@@ -1,0 +1,17 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { createMCPServer } from "../src/index.js";
+
+test("MCP server initializes", (t) => {
+  const server = createMCPServer();
+  t.truthy(server);
+});


### PR DESCRIPTION
## Description

Adds `@adobe/design-data-mcp` — an MCP server that wraps `@adobe/design-data` as five tools for Cursor, Claude Desktop, and any other MCP-compatible agent.

**Five tools:**
| Tool | CLI command |
|---|---|
| `design-data-primer` | `npx @adobe/design-data primer --format json` |
| `design-data-query` | `npx @adobe/design-data query --filter <expr> --format json` |
| `design-data-suggest` | `npx @adobe/design-data suggest <intent> --format json` |
| `design-data-component` | `npx @adobe/design-data component <id>` |
| `design-data-resolve` | `npx @adobe/design-data resolve <property> --format json` |

**Cursor setup** (`.cursor/mcp-servers.json`):
```json
{"mcpServers": {"design-data": {"command": "npx", "args": ["-y", "@adobe/design-data-mcp"]}}}
```

Each tool shells out to the published binary. Data resolves from the embedded snapshot or `.design-data.toml`.

## Related Issue

Resolves spectrum-design-data-3ne · Part of epic #1047