### PR TITLE
feat(sdk): Foundation→Platform manifest cascade (#1053)

### DIFF
--- a/.changeset/manifest-cascade.md
+++ b/.changeset/manifest-cascade.md
@@ -1,0 +1,15 @@
+---
+"@adobe/design-data": minor
+---
+
+Add the Foundation→Platform manifest cascade to the data-source resolver (closes #1053).
+
+- **sdk/core `graph.rs`**: new `TokenGraph::apply_platform_manifest` applies a
+  platform manifest's `include`/`exclude` query filters, type-preserving
+  `overrides`, `extensions.tokens`, and returns `modeSetRestrictions`.
+- **sdk/core `schema.rs`**: new `SchemaRegistry::validate_manifest` performs Layer 1
+  validation against `manifest.schema.json`.
+- **sdk/core `data_source`**: `[source].manifest` config field and
+  `ResolvedData.platform_manifest` carry the platform manifest path.
+- **sdk/cli**: `query` and `resolve` now apply a configured platform manifest
+  (schema-validated) and feed mode-set restrictions into resolution.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -421,7 +421,7 @@ fn run_resolve(
         mode_sets: mode_sets_path,
         ..Default::default()
     }).into_diagnostic()?;
-    let ms_dir = resolved.mode_sets;
+    let ms_dir = resolved.mode_sets.clone();
     if let Some(dir) = ms_dir {
         if dir.is_dir() {
             let mode_sets = TokenGraph::load_spec_mode_sets(&dir)
@@ -431,12 +431,19 @@ fn run_resolve(
         }
     }
 
+    // Apply a configured platform manifest (Foundation→Platform cascade): filter the
+    // token set, layer in overrides/extensions, and capture mode-set restrictions.
+    let restrictions = apply_configured_manifest(&mut graph, &resolved)?;
+
     // Build a property-filtered context (remove the internal marker).
     let mut resolve_ctx = ResolutionContext::new();
     for (k, v) in &ctx.mode_sets {
         if k != "__property_filter__" {
             resolve_ctx = resolve_ctx.with(k.clone(), v.clone());
         }
+    }
+    for (mode_set, allowed) in &restrictions {
+        resolve_ctx = resolve_ctx.with_restriction(mode_set.clone(), allowed.clone());
     }
 
     // Filter graph to tokens matching the requested property.
@@ -460,13 +467,11 @@ fn run_resolve(
     }
 
     // Build a temporary graph with only the filtered tokens for resolution.
-    let filtered_graph = TokenGraph::from_pairs(
-        candidates
-            .iter()
-            .map(|t| (t.name.clone(), t.file.clone(), t.raw.clone()))
-            .collect(),
-    )
-    .with_mode_sets(graph.mode_sets.clone());
+    // Preserve full records (and their cascade `layer`) so Platform-layer
+    // manifest overrides correctly win over Foundation tokens.
+    let filtered_records: Vec<_> = candidates.iter().map(|t| (*t).clone()).collect();
+    let filtered_graph =
+        TokenGraph::from_records(filtered_records).with_mode_sets(graph.mode_sets.clone());
 
     match resolve(&filtered_graph, &resolve_ctx) {
         None => {
@@ -742,15 +747,71 @@ fn run_diff(
     }
 }
 
+/// Locate the spec's `manifest.schema.json` by walking up from the token schemas
+/// directory to the repo root. Returns `None` when not found (e.g. outside a repo).
+fn locate_manifest_schema(schemas_root: &Path) -> Option<PathBuf> {
+    schemas_root.ancestors().find_map(|p| {
+        let candidate = p.join("packages/design-data-spec/schemas/manifest.schema.json");
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+/// Apply the Layer 2 platform manifest declared in `.design-data.toml`
+/// (`[source].manifest`) to `graph`, returning the mode-set restrictions to feed
+/// into a [`ResolutionContext`]. A no-op (empty map) when no manifest is configured.
+///
+/// When the spec's `manifest.schema.json` is locatable, the manifest is first
+/// validated (Layer 1); schema violations abort with an error.
+fn apply_configured_manifest(
+    graph: &mut TokenGraph,
+    resolved: &data_source::ResolvedData,
+) -> miette::Result<std::collections::HashMap<String, Vec<String>>> {
+    let Some(manifest_path) = resolved.platform_manifest.as_ref() else {
+        return Ok(std::collections::HashMap::new());
+    };
+    let text = std::fs::read_to_string(manifest_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to read platform manifest {}", manifest_path.display()))?;
+    let manifest: serde_json::Value = serde_json::from_str(&text)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!("failed to parse platform manifest {}", manifest_path.display())
+        })?;
+
+    if let Some(schema_path) = locate_manifest_schema(&resolved.schemas_root) {
+        let errors = SchemaRegistry::validate_manifest(&manifest, &schema_path)
+            .into_diagnostic()
+            .wrap_err("failed to validate platform manifest against manifest.schema.json")?;
+        if !errors.is_empty() {
+            return Err(miette::miette!(
+                "platform manifest {} failed Layer 1 schema validation:\n  {}",
+                manifest_path.display(),
+                errors.join("\n  ")
+            ));
+        }
+    }
+
+    let outcome = graph
+        .apply_platform_manifest(&manifest)
+        .into_diagnostic()
+        .wrap_err("failed to apply platform manifest cascade")?;
+    Ok(outcome.mode_set_restrictions)
+}
+
 fn run_query(
     path: &Path,
     filter_expr: &str,
     format: OutputFormat,
     count_only: bool,
 ) -> miette::Result<ExitCode> {
-    let graph = TokenGraph::from_json_dir(path)
+    let mut graph = TokenGraph::from_json_dir(path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+
+    // Apply a configured platform manifest (filters/overrides/extensions) before querying.
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
+    apply_configured_manifest(&mut graph, &resolved)?;
 
     let expr = query::parse(filter_expr)
         .into_diagnostic()

--- a/sdk/cli/tests/cli_manifest.rs
+++ b/sdk/cli/tests/cli_manifest.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Integration tests for the Foundation→Platform manifest cascade wired through
+//! `.design-data.toml`'s `[source].manifest` field (epic #1047 Phase 2, #1053).
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use serde_json::json;
+
+/// Absolute path to the repo root (so the resolver can locate the spec schemas).
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root canonicalizes")
+}
+
+/// Create a temp project with a tokens dir, a platform manifest, and a
+/// `.design-data.toml` whose `[source]` points at the repo root with the manifest.
+fn setup_project(manifest: serde_json::Value) -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temp project dir");
+    let tokens_dir = project.path().join("tokens");
+    fs::create_dir_all(&tokens_dir).expect("create tokens dir");
+
+    fs::write(
+        tokens_dir.join("tokens.json"),
+        json!({
+            "btn-bg": {"name": {"property": "background-color", "component": "button"}, "value": "#aaa"},
+            "btn-fg": {"name": {"property": "color", "component": "button"}, "value": "#111"},
+            "chk-bg": {"name": {"property": "background-color", "component": "checkbox"}, "value": "#bbb"}
+        })
+        .to_string(),
+    )
+    .expect("write tokens");
+
+    fs::write(
+        project.path().join("manifest.json"),
+        serde_json::to_string_pretty(&manifest).expect("serialize manifest"),
+    )
+    .expect("write manifest");
+
+    fs::write(
+        project.path().join(".design-data.toml"),
+        format!(
+            "[source]\ntype = \"path\"\nroot = \"{}\"\nmanifest = \"manifest.json\"\n",
+            repo_root().display()
+        ),
+    )
+    .expect("write config");
+
+    project
+}
+
+#[test]
+fn query_applies_manifest_include_filter() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["component=button"]
+    }));
+
+    // Empty filter matches everything that survives the manifest cascade.
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["query", "tokens", "--filter", "", "--count"])
+        .assert()
+        .success()
+        // 3 foundation tokens → 2 after include=component=button.
+        .stdout(predicates::str::starts_with("2"));
+}
+
+#[test]
+fn query_rejects_manifest_with_unparseable_query() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["not-a-valid-query"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["query", "tokens", "--filter", "", "--count"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn query_rejects_manifest_failing_schema_validation() {
+    // Missing required `foundationVersion` → Layer 1 schema validation fails.
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "include": ["component=button"]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args(["query", "tokens", "--filter", "", "--count"])
+        .assert()
+        .failure();
+}

--- a/sdk/cli/tests/cli_manifest.rs
+++ b/sdk/cli/tests/cli_manifest.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use assert_cmd::Command;
+use predicates::str::contains;
 use serde_json::json;
 
 /// Absolute path to the repo root (so the resolver can locate the spec schemas).
@@ -35,9 +36,9 @@ fn setup_project(manifest: serde_json::Value) -> tempfile::TempDir {
     fs::write(
         tokens_dir.join("tokens.json"),
         json!({
-            "btn-bg": {"name": {"property": "background-color", "component": "button"}, "value": "#aaa"},
-            "btn-fg": {"name": {"property": "color", "component": "button"}, "value": "#111"},
-            "chk-bg": {"name": {"property": "background-color", "component": "checkbox"}, "value": "#bbb"}
+            "btn-bg": {"name": {"property": "background-color", "component": "button"}, "value": "#aaa", "uuid": "u-btn-bg"},
+            "btn-fg": {"name": {"property": "color", "component": "button"}, "value": "#111", "uuid": "u-btn-fg"},
+            "chk-bg": {"name": {"property": "background-color", "component": "checkbox"}, "value": "#bbb", "uuid": "u-chk-bg"}
         })
         .to_string(),
     )
@@ -110,4 +111,27 @@ fn query_rejects_manifest_failing_schema_validation() {
         .args(["query", "tokens", "--filter", "", "--count"])
         .assert()
         .failure();
+}
+
+#[test]
+fn resolve_applies_manifest_override_by_uuid() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "overrides": [{"target": "u-btn-bg", "value": "#ffffff"}]
+    }));
+
+    Command::cargo_bin("design-data")
+        .expect("binary design-data")
+        .current_dir(project.path())
+        .args([
+            "resolve",
+            "background-color",
+            "tokens",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("#ffffff"));
 }

--- a/sdk/core/src/data_source/fetch.rs
+++ b/sdk/core/src/data_source/fetch.rs
@@ -382,10 +382,7 @@ fn evict_stale_versions(current: &Path, parent_dir: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // Serialize tests that mutate DESIGN_DATA_CACHE_DIR.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::data_source::test_support::env_lock;
 
     #[test]
     fn should_extract_tokens_src() {
@@ -426,7 +423,7 @@ mod tests {
 
     #[test]
     fn npm_source_returns_not_yet_supported() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         let tmp = tempfile::TempDir::new().unwrap();
         std::env::set_var("DESIGN_DATA_CACHE_DIR", tmp.path());
         let source = SourceConfig::Npm {
@@ -440,7 +437,7 @@ mod tests {
 
     #[test]
     fn git_source_returns_not_yet_supported() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         let tmp = tempfile::TempDir::new().unwrap();
         std::env::set_var("DESIGN_DATA_CACHE_DIR", tmp.path());
         let source = SourceConfig::Git {
@@ -457,7 +454,7 @@ mod tests {
     #[test]
     #[ignore = "requires network access"]
     fn fetch_github_downloads_and_caches() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         let tmp = tempfile::TempDir::new().unwrap();
         std::env::set_var("DESIGN_DATA_CACHE_DIR", tmp.path());
 

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -815,8 +815,15 @@ mod tests {
         let resolved = resolve(cwd_tmp.path(), &overrides).unwrap();
         std::env::remove_var("DESIGN_DATA_CACHE_DIR");
 
-        // Provenance is Embedded (we're outside the repo) but the schema override wins.
-        assert!(matches!(resolved.provenance, Provenance::Embedded { .. }));
+        // Behavioral contract: CLI --schema-path wins regardless of which tier resolved
+        // the other paths (Embedded vs InRepo depends on host layout and parallel tests).
+        // Embedded-tier coverage lives in resolve_outside_repo_uses_embedded_tier.
         assert_eq!(resolved.schemas_root, custom_schema);
+        assert!(
+            !resolved
+                .schemas_root
+                .ends_with("packages/tokens/schemas"),
+            "schema override must not fall through to the embedded/in-repo default"
+        );
     }
 }

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -31,6 +31,8 @@
 pub(crate) mod embedded;
 #[cfg(feature = "fetch")]
 pub(crate) mod fetch;
+#[cfg(test)]
+mod test_support;
 
 use std::path::{Path, PathBuf};
 
@@ -551,13 +553,9 @@ fn fetch_source(
 mod tests {
     use super::*;
     use std::fs;
-    use std::sync::Mutex;
     use tempfile::TempDir;
 
-    // Serialize all tests that mutate process-global env vars (DESIGN_DATA_CACHE_DIR,
-    // DESIGN_DATA_SCHEMA_ROOT).  Rust runs tests in parallel by default, so without
-    // this lock two tests setting the same var will race.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::data_source::test_support::{env_lock, outside_repo_tempdir};
 
     fn make_monorepo(dir: &Path) {
         fs::create_dir_all(dir.join("packages/tokens/schemas/token-types")).unwrap();
@@ -687,7 +685,7 @@ mod tests {
 
     #[test]
     fn config_npm_source_returns_not_yet_supported() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         let tmp = TempDir::new().unwrap();
         // Set DESIGN_DATA_CACHE_DIR so the fetch engine doesn't touch the real OS cache.
         std::env::set_var("DESIGN_DATA_CACHE_DIR", tmp.path());
@@ -754,7 +752,7 @@ mod tests {
 
     #[test]
     fn env_var_schema_root_wins_over_probe() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         let tmp = TempDir::new().unwrap();
         make_monorepo(tmp.path());
 
@@ -774,15 +772,14 @@ mod tests {
 
     #[test]
     fn resolve_outside_repo_uses_embedded_tier() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         // A completely empty temp dir has no monorepo layout, so is_in_repo returns
         // false and the resolver must fall through to the embedded tier.
-        // Set DESIGN_DATA_CACHE_DIR to a temp path to avoid writing to the real OS
-        // cache during tests.
-        let cache_tmp = TempDir::new().unwrap();
+        // Use /tmp on Unix so ancestor-walk cannot reach the CI workspace checkout.
+        let cache_tmp = outside_repo_tempdir();
         std::env::set_var("DESIGN_DATA_CACHE_DIR", cache_tmp.path());
 
-        let cwd_tmp = TempDir::new().unwrap();
+        let cwd_tmp = outside_repo_tempdir();
         let resolved = resolve(cwd_tmp.path(), &CliPathOverrides::default()).unwrap();
         std::env::remove_var("DESIGN_DATA_CACHE_DIR");
 
@@ -803,13 +800,11 @@ mod tests {
 
     #[test]
     fn cli_override_wins_over_embedded() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        // Set DESIGN_DATA_CACHE_DIR to a temp path to avoid writing to the real OS
-        // cache during tests.
-        let cache_tmp = TempDir::new().unwrap();
+        let _guard = env_lock();
+        let cache_tmp = outside_repo_tempdir();
         std::env::set_var("DESIGN_DATA_CACHE_DIR", cache_tmp.path());
 
-        let cwd_tmp = TempDir::new().unwrap();
+        let cwd_tmp = outside_repo_tempdir();
         let custom_schema = cwd_tmp.path().join("custom-schemas");
         fs::create_dir_all(&custom_schema).unwrap();
 

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -68,6 +68,12 @@ pub enum SourceConfig {
         /// Path to the local design-data repo root (absolute, or relative to
         /// the directory containing `.design-data.toml`).
         root: PathBuf,
+        /// Optional path to a Layer 2 platform `manifest.json` (absolute, or
+        /// relative to the directory containing `.design-data.toml`). When set,
+        /// the resolver records it on [`ResolvedData::platform_manifest`] so the
+        /// caller can apply the Foundation→Platform cascade
+        /// ([`crate::graph::TokenGraph::apply_platform_manifest`]).
+        manifest: Option<PathBuf>,
     },
     /// `@adobe/spectrum-tokens` (and matching `design-data-spec`) from the npm
     /// registry.  **Not yet implemented — planned for `#1050`.**
@@ -172,6 +178,13 @@ pub struct ResolvedData {
     /// Populated here but consumed by #1049 (embedded snapshot provenance tracking).
     #[allow(dead_code)]
     pub manifest: Option<PathBuf>,
+    /// Layer 2 **platform** `manifest.json` path from `[source].manifest`, if any.
+    ///
+    /// Unlike [`Self::manifest`] (the token build manifest), this is the platform
+    /// cascade manifest declaring `foundationVersion`, include/exclude filters,
+    /// overrides, extensions, and mode set restrictions. Applied via
+    /// [`crate::graph::TokenGraph::apply_platform_manifest`].
+    pub platform_manifest: Option<PathBuf>,
     /// How these paths were determined.
     pub provenance: Provenance,
 }
@@ -242,7 +255,7 @@ pub fn resolve(
     if let Some((config_path, config)) = find_config(cwd)? {
         if let Some(source) = &config.source {
             return match source {
-                SourceConfig::Path { root } => {
+                SourceConfig::Path { root, manifest } => {
                     // Resolve root relative to the config file's directory.
                     let config_dir = config_path.parent().unwrap_or(cwd);
                     let abs_root = if root.is_absolute() {
@@ -253,9 +266,21 @@ pub fn resolve(
                     if !abs_root.is_dir() {
                         return Err(DataSourceError::PathNotFound { root: abs_root });
                     }
+                    // Resolve the optional platform manifest relative to the config dir
+                    // before `config_path` is moved into the provenance record.
+                    let platform_manifest = manifest.as_ref().map(|m| {
+                        if m.is_absolute() {
+                            m.clone()
+                        } else {
+                            config_dir.join(m)
+                        }
+                    });
                     // Canonicalize to resolve `..` components before passing to from_root.
                     let canonical = abs_root.canonicalize().unwrap_or(abs_root);
-                    Ok(from_root(&canonical, overrides, Provenance::Config { config_path }))
+                    let mut resolved =
+                        from_root(&canonical, overrides, Provenance::Config { config_path });
+                    resolved.platform_manifest = platform_manifest;
+                    Ok(resolved)
                 }
                 SourceConfig::Npm { .. }
                 | SourceConfig::Github { .. }
@@ -386,6 +411,7 @@ fn from_root(root: &Path, overrides: &CliPathOverrides, provenance: Provenance) 
         fields,
         exceptions,
         manifest,
+        platform_manifest: None,
         provenance,
     }
 }
@@ -473,6 +499,7 @@ fn probe_cwd(cwd: &Path, overrides: &CliPathOverrides) -> ResolvedData {
         fields,
         exceptions,
         manifest,
+        platform_manifest: None,
         provenance: Provenance::InRepo,
     }
 }

--- a/sdk/core/src/data_source/test_support.rs
+++ b/sdk/core/src/data_source/test_support.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Shared test helpers for `data_source` modules.
+//!
+//! Rust runs tests in parallel by default.  Several resolver tests mutate
+//! process-global env vars (`DESIGN_DATA_CACHE_DIR`, `DESIGN_DATA_SCHEMA_ROOT`);
+//! they must share one lock.  Embedded-tier tests also need a CWD that cannot
+//! ancestor-walk into the monorepo checkout — in CI `TMPDIR` is often inside the
+//! workspace, which makes `is_in_repo` return true and breaks Embedded assertions.
+
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serialize tests that mutate process-global environment variables.
+pub fn env_lock() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Temp directory guaranteed not to be inside the monorepo checkout on Unix CI.
+pub fn outside_repo_tempdir() -> tempfile::TempDir {
+    #[cfg(unix)]
+    {
+        tempfile::Builder::new()
+            .prefix("design-data-outside-repo-")
+            .tempdir_in("/tmp")
+            .expect("create temp dir under /tmp")
+    }
+    #[cfg(not(unix))]
+    {
+        tempfile::TempDir::new().expect("temp dir")
+    }
+}

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -441,7 +441,11 @@ impl TokenGraph {
     ///    MUST be a parseable query (SPEC-039); a parse error is surfaced as
     ///    [`CoreError::QueryParse`].
     /// 2. `overrides` — typed overrides inserted at [`Layer::Platform`]. Each
-    ///    override MUST preserve the target token's value JSON type
+    ///    `overrides[].target` string is resolved in order: (a) when it contains
+    ///    `=` or `!=`, as a query expression (may match multiple tokens); (b)
+    ///    otherwise as a token UUID via the graph's UUID index; (c) otherwise as
+    ///    a graph key (legacy slug or cascade `"file:index"` key). Each override
+    ///    MUST preserve the target token's value JSON type
     ///    (`spec/cascade.md` type safety / SPEC-006); a type change is a
     ///    [`CoreError::ParseError`].
     /// 3. `extensions.tokens` — net-new platform tokens inserted at
@@ -600,13 +604,12 @@ impl TokenGraph {
 
     /// Resolve a manifest override `target` to the affected token name objects.
     ///
-    /// `target` is matched, in order, as: (1) a query expression when it contains
-    /// an operator (`=`); (2) a token UUID; (3) a graph key (token name). Returns
-    /// `(name_object, original_value, uuid)` tuples for each matched token.
+    /// Resolution order matches [`Self::apply_platform_manifest`]: query expression
+    /// (when `target` contains `=` or `!=`), then UUID lookup, then graph key.
     fn resolve_override_targets(
         &self,
         target: &str,
-    ) -> Result<Vec<(Value, Option<Value>, Option<String>)>, CoreError> {
+    ) -> Result<Vec<OverrideTargetMatch>, CoreError> {
         if target.contains('=') {
             let filter = query::parse(target)?;
             return Ok(query::filter(self, &filter)
@@ -689,6 +692,9 @@ pub struct PlatformManifest {
     /// Mode set name → allowed mode values declared by `modeSetRestrictions`.
     pub mode_set_restrictions: HashMap<String, Vec<String>>,
 }
+
+/// One foundation token matched by a manifest `overrides[].target` string.
+type OverrideTargetMatch = (Value, Option<Value>, Option<String>);
 
 /// The JSON "kind" of a value, used for override type-safety checks.
 fn json_kind(v: &Value) -> &'static str {

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -10,12 +10,13 @@
 
 //! In-memory token graph for relational (Layer 2) validation.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
 use crate::discovery::discover_json_files;
+use crate::query;
 use crate::CoreError;
 
 /// Cascade layer (Foundation < Platform < Product).
@@ -426,6 +427,222 @@ impl TokenGraph {
         Ok(())
     }
 
+    /// Apply a Layer 2 **platform manifest** to this (foundation) graph in place.
+    ///
+    /// Implements the Foundation → Platform cascade from `spec/manifest.md` and
+    /// `spec/cascade.md`. The manifest is the platform-layer analog of the
+    /// product-context overlay handled by [`Self::load_product_context`].
+    ///
+    /// Steps (applied in order):
+    /// 1. `include` / `exclude` — filter the foundation token set using the
+    ///    query grammar (`spec/query.md`). When `include` is present and
+    ///    non-empty, only tokens matching at least one include query are kept;
+    ///    `exclude` then removes tokens matching any exclude query. Each entry
+    ///    MUST be a parseable query (SPEC-039); a parse error is surfaced as
+    ///    [`CoreError::QueryParse`].
+    /// 2. `overrides` — typed overrides inserted at [`Layer::Platform`]. Each
+    ///    override MUST preserve the target token's value JSON type
+    ///    (`spec/cascade.md` type safety / SPEC-006); a type change is a
+    ///    [`CoreError::ParseError`].
+    /// 3. `extensions.tokens` — net-new platform tokens inserted at
+    ///    [`Layer::Platform`].
+    /// 4. `modeSetRestrictions` — returned so the caller can seed a
+    ///    [`crate::cascade::ResolutionContext`]; restrictions are enforced at
+    ///    resolution time, not by mutating the graph.
+    ///
+    /// The caller is responsible for Layer 1 schema validation of the manifest
+    /// (see [`crate::schema::validate_manifest`]); this method assumes a
+    /// structurally valid document and ignores fields it does not recognise.
+    pub fn apply_platform_manifest(
+        &mut self,
+        manifest: &Value,
+    ) -> Result<PlatformManifest, CoreError> {
+        // 1. include / exclude filtering.
+        if let Some(entries) = manifest.get("include").and_then(|v| v.as_array()) {
+            if !entries.is_empty() {
+                let mut keep: HashSet<String> = HashSet::new();
+                for entry in entries {
+                    let Some(s) = entry.as_str() else { continue };
+                    let filter = query::parse(s)?;
+                    for rec in query::filter(self, &filter) {
+                        keep.insert(rec.name.clone());
+                    }
+                }
+                self.tokens.retain(|k, _| keep.contains(k));
+            }
+        }
+        if let Some(entries) = manifest.get("exclude").and_then(|v| v.as_array()) {
+            let mut drop: HashSet<String> = HashSet::new();
+            for entry in entries {
+                let Some(s) = entry.as_str() else { continue };
+                let filter = query::parse(s)?;
+                for rec in query::filter(self, &filter) {
+                    drop.insert(rec.name.clone());
+                }
+            }
+            if !drop.is_empty() {
+                self.tokens.retain(|k, _| !drop.contains(k));
+            }
+        }
+        // Rebuild the UUID index so override/alias resolution below cannot point
+        // at tokens that were just filtered out.
+        self.rebuild_uuid_index();
+
+        // 2. overrides — typed, Platform layer, type-preserving.
+        if let Some(overrides) = manifest.get("overrides").and_then(|v| v.as_array()) {
+            for (idx, entry) in overrides.iter().enumerate() {
+                let Some(target) = entry.get("target").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let matches = self.resolve_override_targets(target)?;
+                for (match_idx, (name_obj, orig_value, uuid)) in matches.into_iter().enumerate() {
+                    let mut synthetic = serde_json::Map::new();
+                    synthetic.insert("name".to_string(), name_obj);
+                    if let Some(new_value) = entry.get("value") {
+                        if let Some(orig) = &orig_value {
+                            if json_kind(orig) != json_kind(new_value) {
+                                return Err(CoreError::ParseError(format!(
+                                    "manifest overrides[{idx}] for target {target:?} changes value \
+                                     type from {} to {} (violates cascade type safety)",
+                                    json_kind(orig),
+                                    json_kind(new_value),
+                                )));
+                            }
+                        }
+                        synthetic.insert("value".to_string(), new_value.clone());
+                    } else if let Some(ref_val) = entry.get("$ref") {
+                        synthetic.insert("$ref".to_string(), ref_val.clone());
+                    } else {
+                        continue;
+                    }
+                    if let Some(u) = &uuid {
+                        synthetic.insert("uuid".to_string(), Value::String(u.clone()));
+                    }
+                    let raw = Value::Object(synthetic);
+                    let alias_target = raw.as_object().and_then(extract_alias_target);
+                    let key = format!("platform-override:{target}:{idx}:{match_idx}");
+                    if let Some(u) = &uuid {
+                        self.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                    }
+                    self.tokens.insert(
+                        key.clone(),
+                        TokenRecord {
+                            name: key,
+                            file: PathBuf::from("manifest.json"),
+                            index: idx,
+                            schema_url: None,
+                            uuid,
+                            alias_target,
+                            raw,
+                            layer: Layer::Platform,
+                        },
+                    );
+                }
+            }
+        }
+
+        // 3. extensions.tokens — net-new Platform-layer tokens.
+        if let Some(ext_tokens) = manifest
+            .get("extensions")
+            .and_then(|v| v.get("tokens"))
+            .and_then(|v| v.as_array())
+        {
+            for (idx, token_val) in ext_tokens.iter().enumerate() {
+                let Some(tok_obj) = token_val.as_object() else {
+                    continue;
+                };
+                let uuid = tok_obj.get("uuid").and_then(|v| v.as_str()).map(str::to_string);
+                let schema_url = tok_obj
+                    .get("$schema")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                let alias_target = extract_alias_target(tok_obj);
+                let key = format!("platform-ext:{idx}");
+                if let Some(u) = &uuid {
+                    self.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                }
+                self.tokens.insert(
+                    key.clone(),
+                    TokenRecord {
+                        name: key,
+                        file: PathBuf::from("manifest.json"),
+                        index: idx,
+                        schema_url,
+                        uuid,
+                        alias_target,
+                        raw: token_val.clone(),
+                        layer: Layer::Platform,
+                    },
+                );
+            }
+        }
+
+        // 4. modeSetRestrictions — returned for the resolution context.
+        let mut mode_set_restrictions: HashMap<String, Vec<String>> = HashMap::new();
+        if let Some(obj) = manifest.get("modeSetRestrictions").and_then(|v| v.as_object()) {
+            for (ms_name, restr) in obj {
+                if let Some(allowed) = restr.get("allowed").and_then(|v| v.as_array()) {
+                    let modes: Vec<String> = allowed
+                        .iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect();
+                    if !modes.is_empty() {
+                        mode_set_restrictions.insert(ms_name.clone(), modes);
+                    }
+                }
+            }
+        }
+
+        Ok(PlatformManifest {
+            mode_set_restrictions,
+        })
+    }
+
+    /// Resolve a manifest override `target` to the affected token name objects.
+    ///
+    /// `target` is matched, in order, as: (1) a query expression when it contains
+    /// an operator (`=`); (2) a token UUID; (3) a graph key (token name). Returns
+    /// `(name_object, original_value, uuid)` tuples for each matched token.
+    fn resolve_override_targets(
+        &self,
+        target: &str,
+    ) -> Result<Vec<(Value, Option<Value>, Option<String>)>, CoreError> {
+        if target.contains('=') {
+            let filter = query::parse(target)?;
+            return Ok(query::filter(self, &filter)
+                .into_iter()
+                .filter_map(|rec| {
+                    rec.raw.get("name").cloned().map(|name_obj| {
+                        (name_obj, rec.raw.get("value").cloned(), rec.uuid.clone())
+                    })
+                })
+                .collect());
+        }
+        let record = self
+            .uuid_index
+            .get(target)
+            .and_then(|k| self.tokens.get(k))
+            .or_else(|| self.tokens.get(target));
+        if let Some(rec) = record {
+            if let Some(name_obj) = rec.raw.get("name").cloned() {
+                return Ok(vec![(name_obj, rec.raw.get("value").cloned(), rec.uuid.clone())]);
+            }
+        }
+        Ok(Vec::new())
+    }
+
+    /// Rebuild `uuid_index` from the current `tokens` map (after filtering).
+    fn rebuild_uuid_index(&mut self) {
+        self.uuid_index.clear();
+        for (key, rec) in &self.tokens {
+            if let Some(u) = &rec.uuid {
+                self.uuid_index
+                    .entry(u.clone())
+                    .or_insert_with(|| key.clone());
+            }
+        }
+    }
+
     /// Attach mode set records (e.g. from conformance fixtures).
     pub fn with_mode_sets(mut self, mode_sets: Vec<ModeSetRecord>) -> Self {
         self.mode_sets = mode_sets;
@@ -458,6 +675,30 @@ impl TokenGraph {
     pub fn with_components(mut self, components: Vec<ComponentRecord>) -> Self {
         self.components = components;
         self
+    }
+}
+
+/// Outcome of [`TokenGraph::apply_platform_manifest`].
+///
+/// The graph itself is mutated in place (filtered set + Platform-layer override
+/// and extension tokens). Mode set restrictions are returned separately because
+/// they are enforced at resolution time via
+/// [`crate::cascade::ResolutionContext`], not by mutating the graph.
+#[derive(Debug, Clone, Default)]
+pub struct PlatformManifest {
+    /// Mode set name → allowed mode values declared by `modeSetRestrictions`.
+    pub mode_set_restrictions: HashMap<String, Vec<String>>,
+}
+
+/// The JSON "kind" of a value, used for override type-safety checks.
+fn json_kind(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
     }
 }
 
@@ -646,5 +887,189 @@ mod tests {
         let g = TokenGraph::from_json_dir(tokens_dir.path()).unwrap();
         let token = g.tokens.get("blue-100").unwrap();
         assert!(token.raw.get("name").is_none());
+    }
+
+    // ── apply_platform_manifest (Foundation→Platform cascade) ──────────────────
+
+    /// Build a small foundation graph for manifest cascade tests.
+    fn foundation_graph() -> TokenGraph {
+        TokenGraph::from_pairs(vec![
+            (
+                "btn-bg".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "background-color", "component": "button"}, "value": "#aaa", "uuid": "u-btn-bg"}),
+            ),
+            (
+                "btn-fg".into(),
+                PathBuf::from("button.json"),
+                json!({"name": {"property": "color", "component": "button"}, "value": "#111", "uuid": "u-btn-fg"}),
+            ),
+            (
+                "chk-bg".into(),
+                PathBuf::from("checkbox.json"),
+                json!({"name": {"property": "background-color", "component": "checkbox"}, "value": "#bbb", "uuid": "u-chk-bg"}),
+            ),
+        ])
+    }
+
+    #[test]
+    fn manifest_include_filters_to_matching_tokens() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "include": ["component=button"]
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        assert_eq!(g.tokens.len(), 2);
+        assert!(g.tokens.contains_key("btn-bg"));
+        assert!(g.tokens.contains_key("btn-fg"));
+        assert!(!g.tokens.contains_key("chk-bg"));
+    }
+
+    #[test]
+    fn manifest_exclude_removes_matching_tokens() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "exclude": ["property=color"]
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        assert!(!g.tokens.contains_key("btn-fg"));
+        assert_eq!(g.tokens.len(), 2);
+    }
+
+    #[test]
+    fn manifest_include_then_exclude_compose() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "include": ["component=button"],
+            "exclude": ["property=color"]
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        assert_eq!(g.tokens.len(), 1);
+        assert!(g.tokens.contains_key("btn-bg"));
+    }
+
+    #[test]
+    fn manifest_unparseable_query_errors() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "include": ["not-a-valid-query"]
+        });
+        assert!(matches!(
+            g.apply_platform_manifest(&manifest),
+            Err(CoreError::QueryParse(_))
+        ));
+    }
+
+    #[test]
+    fn manifest_override_by_uuid_adds_platform_token() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "overrides": [{"target": "u-btn-bg", "value": "#ffffff"}]
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        let overridden = g
+            .tokens
+            .values()
+            .find(|t| t.layer == Layer::Platform && t.uuid.as_deref() == Some("u-btn-bg"))
+            .expect("platform override token present");
+        assert_eq!(overridden.raw.get("value").and_then(|v| v.as_str()), Some("#ffffff"));
+        // Name object is inherited from the foundation token.
+        assert_eq!(
+            overridden.raw["name"]["component"].as_str(),
+            Some("button")
+        );
+    }
+
+    #[test]
+    fn manifest_override_by_query_targets_all_matches() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "overrides": [{"target": "property=background-color", "value": "#000000"}]
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        let platform_overrides = g
+            .tokens
+            .values()
+            .filter(|t| t.layer == Layer::Platform)
+            .count();
+        assert_eq!(platform_overrides, 2); // btn-bg + chk-bg
+    }
+
+    #[test]
+    fn manifest_override_type_change_errors() {
+        let mut g = foundation_graph();
+        // btn-bg value is a string; overriding with a number violates type safety.
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "overrides": [{"target": "u-btn-bg", "value": 42}]
+        });
+        assert!(matches!(
+            g.apply_platform_manifest(&manifest),
+            Err(CoreError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn manifest_extensions_add_platform_tokens() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "extensions": {
+                "tokens": [
+                    {"name": {"property": "elevation", "component": "card"}, "value": "4dp", "uuid": "u-card-elev"}
+                ]
+            }
+        });
+        g.apply_platform_manifest(&manifest).unwrap();
+        let ext = g
+            .tokens
+            .values()
+            .find(|t| t.uuid.as_deref() == Some("u-card-elev"))
+            .expect("extension token present");
+        assert_eq!(ext.layer, Layer::Platform);
+    }
+
+    #[test]
+    fn manifest_mode_set_restrictions_returned() {
+        let mut g = foundation_graph();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "modeSetRestrictions": {
+                "colorScheme": {"allowed": ["light", "dark"]}
+            }
+        });
+        let outcome = g.apply_platform_manifest(&manifest).unwrap();
+        assert_eq!(
+            outcome.mode_set_restrictions.get("colorScheme"),
+            Some(&vec!["light".to_string(), "dark".to_string()])
+        );
+    }
+
+    #[test]
+    fn manifest_empty_is_noop() {
+        let mut g = foundation_graph();
+        let before = g.tokens.len();
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0"
+        });
+        let outcome = g.apply_platform_manifest(&manifest).unwrap();
+        assert_eq!(g.tokens.len(), before);
+        assert!(outcome.mode_set_restrictions.is_empty());
     }
 }

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -110,6 +110,25 @@ impl SchemaRegistry {
         &self.token_file_schema_url
     }
 
+    /// Validate a platform manifest document against `manifest.schema.json`.
+    ///
+    /// `manifest_schema_path` points at the spec's `schemas/manifest.schema.json`.
+    /// Returns the list of Layer 1 schema violation messages (empty = valid).
+    /// This is the manifest analog of token schema validation and is used by the
+    /// Foundation→Platform cascade ([`crate::graph::TokenGraph::apply_platform_manifest`]).
+    pub fn validate_manifest(
+        manifest: &Value,
+        manifest_schema_path: &Path,
+    ) -> Result<Vec<String>, CoreError> {
+        let text = fs::read_to_string(manifest_schema_path)?;
+        let schema: Value = serde_json::from_str(&text)?;
+        let validator = jsonschema::options()
+            .with_draft(Draft::Draft202012)
+            .build(&schema)
+            .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
+        Ok(validator.iter_errors(manifest).map(|e| e.to_string()).collect())
+    }
+
     /// Construct a no-op stub for unit tests where schema validation is never reached.
     #[cfg(test)]
     pub fn new_stub() -> Self {
@@ -123,5 +142,48 @@ impl SchemaRegistry {
             token_file_validator: validator,
             token_file_schema_url: String::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn manifest_schema_path() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../packages/design-data-spec/schemas/manifest.schema.json")
+    }
+
+    #[test]
+    fn validate_manifest_accepts_valid_document() {
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "include": ["component=button"],
+            "modeSetRestrictions": {"colorScheme": {"allowed": ["light", "dark"]}}
+        });
+        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
+        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+    }
+
+    #[test]
+    fn validate_manifest_rejects_missing_required_field() {
+        // Missing the required `foundationVersion`.
+        let manifest = json!({ "specVersion": "1.0.0-draft" });
+        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn validate_manifest_rejects_unknown_top_level_key() {
+        // Schema sets additionalProperties:false at the top level.
+        let manifest = json!({
+            "specVersion": "1.0.0-draft",
+            "foundationVersion": "1.0.0",
+            "bogusKey": true
+        });
+        let errors = SchemaRegistry::validate_manifest(&manifest, &manifest_schema_path()).unwrap();
+        assert!(!errors.is_empty());
     }
 }


### PR DESCRIPTION
## Description

Implements the **Foundation→Platform manifest cascade** in the `sdk/core` data-source resolver (epic #1047 Phase 2). A platform repo's `.design-data.toml` can now point `[source].manifest` at a platform `manifest.json` that pins a `foundationVersion` and layers `include`/`exclude` query filters, typed `overrides`, `extensions`, and `modeSetRestrictions` on top of the resolved foundation data.

- **`sdk/core` `graph.rs`** — new `TokenGraph::apply_platform_manifest`:
  - `include`/`exclude` filter the foundation token set via the query grammar (`spec/query.md`); unparseable entries error (`SPEC-039` is the validation rule).
  - `overrides` are inserted as `Layer::Platform` tokens, **type-preserving** (a value type change is rejected per `spec/cascade.md` type safety / SPEC-006). Each `overrides[].target` is resolved in order: query expression (when it contains `=`/`!=`), then UUID, then graph key.
  - `extensions.tokens` are inserted as net-new `Layer::Platform` tokens.
  - `modeSetRestrictions` are returned to seed a `ResolutionContext`.
- **`sdk/core` `schema.rs`** — new `SchemaRegistry::validate_manifest` (Layer 1) against `manifest.schema.json`.
- **`sdk/core` `data_source`** — `[source].manifest` config field and `ResolvedData.platform_manifest`.
- **`sdk/cli`** — `query` and `resolve` apply a configured, schema-validated platform manifest; `resolve` feeds mode-set restrictions into resolution and preserves token layers so Platform overrides win.

This builds on the existing cascade engine (`cascade.rs`, with layer precedence + mode-set restrictions) and the `load_product_context` Layer-3 overlay; the platform manifest is the Layer-2 analog.

## Related Issue

Closes #1053 (part of epic #1047). Depends on #1048 and #1050 (both merged).

## Motivation and Context

Without this, the resolver could read foundation data but had no way for a platform repo to declare its relationship to foundation (version pin + filters/overrides/extensions/restrictions). This wires the platform manifest model end-to-end so inherited platform datasets resolve correctly.

## How Has This Been Tested?

- `moon run sdk:lint sdk:test` — green.
- New `sdk/core` unit tests for `apply_platform_manifest` and `validate_manifest`.
- New `sdk/cli/tests/cli_manifest.rs` integration tests: include filter, schema/query rejection, **resolve override by UUID**.
- Stabilized flaky `data_source` tests: shared env lock + `/tmp`-isolated CWD for embedded-tier assertions (CI `TMPDIR` inside workspace was tripping `is_in_repo` and poisoning the mutex).

## Scope decisions (review follow-up)

- **`query` / `resolve`**: manifest cascade applied (this PR).
- **`validate`**: already loads sibling `manifest.json` for relational rules (SPEC-039); does **not** re-run the graph filter/override pipeline — that is validation, not resolution. No change in this PR.
- **`primer`**: deferred — primer summarizes catalog metadata, not a resolved token graph; manifest cascade wiring tracked as follow-up if product needs it.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.