### PR TITLE
feat(sdk): embedded-database cache layer and shared CLI/TUI manifest resolution

### DIFF
--- a/.changeset/embedded-db-cache-layer.md
+++ b/.changeset/embedded-db-cache-layer.md
@@ -1,0 +1,19 @@
+---
+"@adobe/design-data": minor
+---
+
+Add a derived embedded-database cache (redb) over the canonical token JSON so the
+CLI/TUI skip re-parsing JSON each run and gain indexed queries (spectrum-design-data-15a).
+
+- **sdk/core `cache`**: new module behind a default-on `cache` feature; a
+  content-addressed redb DB (MessagePack values) with `tokens`/`uuid_index`/per-field
+  `idx_*` multimap tables, written atomically and namespaced by tokens version.
+- **sdk/core `graph.rs`**: `TokenGraph::open_cached` is a drop-in for `from_json_dir` —
+  hits a fresh cache, rebuilds on miss, falls back to JSON on any error (never load-bearing).
+- **sdk/core `query.rs`**: `TokenIndex` + `filter_with_index` add an index-backed fast path
+  for single-field equality (lands #783); the in-memory scan stays the fallback.
+- **sdk/core `cache::mem_backend`**: in-memory redb backend plus
+  `build_bytes`/`load_from_bytes`/`load_index_from_bytes` for read-only WASM web tools.
+- **sdk/cli**: `query`/`resolve`/`diff`/`primer`/`suggest` load via the cache; new
+  `cache-build` subcommand emits a portable `index.redb` asset.
+- **deps**: add `redb` (pinned 2.6.x for MSRV 1.85) and `rmp-serde`.

--- a/.changeset/tui-cli-shared-manifest.md
+++ b/.changeset/tui-cli-shared-manifest.md
@@ -1,0 +1,13 @@
+---
+"@adobe/design-data": minor
+---
+
+Share platform manifest application and property resolution between CLI and TUI.
+
+- **sdk/core `manifest.rs`**: new `apply_configured` reads/validates `[source].manifest`
+  and applies the platform cascade.
+- **sdk/core `cascade.rs`**: new `resolve_property` + `ResolvedCandidate` unify
+  property-scoped resolution.
+- **sdk/cli**: `query`/`resolve` call shared core helpers; duplicate manifest helpers removed.
+- **sdk/tui**: manifest at session load, `mode_set_restrictions` on `UpdateCtx`, `:resolve`
+  uses `resolve_property`.

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,12 @@ dist
 # Rust (design-data SDK workspace)
 sdk/target/
 
+# design-data derived embedded-database cache (rebuildable from canonical JSON,
+# never authoritative). Includes the OS cache dir contents and any locally built
+# cache assets emitted by `design-data cache-build`.
+*.redb
+*.redb.tmp
+
 # design-data platform binary slots — tracked placeholder shell scripts are
 # committed in sdk/npm/{platform}/bin/; real compiled binaries are written
 # there by CI immediately before `npm publish` and are NEVER committed.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -456,8 +456,10 @@ dependencies = [
  "flate2",
  "include_dir",
  "jsonschema",
+ "redb",
  "regex",
  "reqwest",
+ "rmp-serde",
  "semver",
  "serde",
  "serde_json",
@@ -1772,6 +1774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1923,25 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -130,7 +130,7 @@ Cache files live at `<cache_root>/cache/<tokens-version>/<dataset-key>.redb` and
 
 **Invalidation** uses per-file size + mtime (not a full content hash) for speed. A stale miss only forces a rebuild. **Known limitation (schema v1):** inline mode-set JSON files co-located in the token tree are not persisted in the cache; the canonical Spectrum layout (mode sets under `design-data-spec/mode-sets`) is unaffected.
 
-**CLI vs TUI with a platform manifest:** `design-data query` applies a configured `[source].manifest` before filtering and rebuilds the query index; the TUI loads the raw token set for the session and does not apply manifests — so query results can differ when a manifest is present.
+**Platform manifest (CLI/TUI):** Both surfaces apply a configured `[source].manifest` at session start via the shared `design-data-core::manifest::apply_configured` helper. Query/find use the platform-scoped token set and index; `:resolve` layers manifest mode-set restrictions through `cascade::resolve_property`. The TUI header shows `N platform` (vs `N tokens`) when a manifest is active. CLI `primer` still reports raw on-disk counts.
 
 Opt out of the cache layer when depending on `design-data-core` as a library:
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -14,6 +14,7 @@ sdk/
 │       ├── validate/   # two-layer validation (structural + relational)
 │       ├── diff/       # token dataset diffing
 │       ├── query/      # filter expressions
+│       ├── cache/      # derived redb cache over canonical JSON (default-on)
 │       ├── migrate/    # snapshot, convert, legacy helpers
 │       ├── figma/      # Figma Variables bridge (feature-gated)
 │       ├── schema/     # JSON Schema registry
@@ -105,6 +106,34 @@ design-data migrate convert input/ --output output/
 design-data migrate legacy-output input/ --output output/
 design-data migrate add-uuids input/ --output output/
 design-data migrate roundtrip-verify packages/tokens/src
+```
+
+### cache-build
+
+Build a portable `.redb` cache asset from a token dataset (for WASM web tools or offline distribution).
+
+```bash
+design-data cache-build packages/tokens/src -o index.redb
+```
+
+### Derived cache (CLI/TUI)
+
+The SDK builds a **derived, content-addressed redb cache** over the canonical JSON on disk. JSON remains the source of truth; the cache is rebuildable and never load-bearing (any cache error falls back to JSON parsing).
+
+| Variable / flag           | Purpose                                                               |
+| ------------------------- | --------------------------------------------------------------------- |
+| `DESIGN_DATA_CACHE_DIR`   | Override the OS cache root (default: `dirs::cache_dir()/design-data`) |
+| `DESIGN_DATA_LOG=debug`   | Log cache miss/rebuild/fallback events to stderr                      |
+| `design-data cache-build` | Emit a portable `index.redb` blob for WASM or CI artifacts            |
+
+Cache files live at `<cache_root>/cache/<tokens-version>/<dataset-key>.redb` and are gitignored (`*.redb`).
+
+**Invalidation** uses per-file size + mtime (not a full content hash) for speed. A stale miss only forces a rebuild. **Known limitation (schema v1):** inline mode-set JSON files co-located in the token tree are not persisted in the cache; the canonical Spectrum layout (mode sets under `design-data-spec/mode-sets`) is unaffected.
+
+Opt out of the cache layer when depending on `design-data-core` as a library:
+
+```toml
+design-data-core = { path = "../core", default-features = false }
 ```
 
 ### figma

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -130,6 +130,8 @@ Cache files live at `<cache_root>/cache/<tokens-version>/<dataset-key>.redb` and
 
 **Invalidation** uses per-file size + mtime (not a full content hash) for speed. A stale miss only forces a rebuild. **Known limitation (schema v1):** inline mode-set JSON files co-located in the token tree are not persisted in the cache; the canonical Spectrum layout (mode sets under `design-data-spec/mode-sets`) is unaffected.
 
+**CLI vs TUI with a platform manifest:** `design-data query` applies a configured `[source].manifest` before filtering and rebuilds the query index; the TUI loads the raw token set for the session and does not apply manifests — so query results can differ when a manifest is present.
+
 Opt out of the cache layer when depending on `design-data-core` as a library:
 
 ```toml

--- a/sdk/cli/src/authoring.rs
+++ b/sdk/cli/src/authoring.rs
@@ -18,8 +18,8 @@ use std::process::ExitCode;
 
 use clap::Subcommand;
 use design_data_core::authoring::session::{
-    CommitInput, ValueRowInput, cancel_session, commit_session, get_session, list_sessions,
-    start_session, step_classification, step_intent, step_values,
+    cancel_session, commit_session, get_session, list_sessions, start_session, step_classification,
+    step_intent, step_values, CommitInput, ValueRowInput,
 };
 use design_data_core::graph::Layer;
 use design_data_core::schema::SchemaRegistry;
@@ -143,7 +143,9 @@ fn run_inner(cmd: AuthoringSessionCommand) -> Result<(), String> {
     match cmd {
         AuthoringSessionCommand::Start { dataset_path } => {
             let session = start_session(
-                dataset_path.to_str().ok_or("dataset_path is not valid UTF-8")?,
+                dataset_path
+                    .to_str()
+                    .ok_or("dataset_path is not valid UTF-8")?,
             )?;
             print_json(&session)?;
         }
@@ -153,9 +155,15 @@ fn run_inner(cmd: AuthoringSessionCommand) -> Result<(), String> {
                 let result = step_intent(&session_id, &intent)?;
                 print_json(&result)?;
             }
-            StepCommand::Classification { session_id, layer, property, name_fields } => {
+            StepCommand::Classification {
+                session_id,
+                layer,
+                property,
+                name_fields,
+            } => {
                 let parsed_fields = parse_name_fields(&name_fields)?;
-                let session = step_classification(&session_id, layer.into(), &property, parsed_fields)?;
+                let session =
+                    step_classification(&session_id, layer.into(), &property, parsed_fields)?;
                 print_json(&session)?;
             }
             StepCommand::Values { session_id, rows } => {

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -853,22 +853,24 @@ fn run_query(
     format: OutputFormat,
     count_only: bool,
 ) -> miette::Result<ExitCode> {
-    let mut graph = TokenGraph::open_cached(path)
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
+
+    let (mut graph, mut index) = TokenGraph::open_cached_with_index(path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
     // Apply a configured platform manifest (filters/overrides/extensions) before querying.
-    let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
     apply_configured_manifest(&mut graph, &resolved)?;
+    // Manifest overlays change the token set — rebuild the index when one is configured.
+    if resolved.platform_manifest.is_some() {
+        index = query::TokenIndex::build(&graph);
+    }
 
     let expr = query::parse(filter_expr)
         .into_diagnostic()
         .wrap_err("failed to parse filter expression")?;
 
-    // Build a secondary index so single-field equality queries use an indexed
-    // lookup instead of an O(n) scan; complex expressions fall back internally.
-    let index = query::TokenIndex::build(&graph);
     let results = query::filter_with_index(&graph, &index, &expr);
 
     if count_only {

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -421,18 +421,16 @@ fn run_resolve(
     format: OutputFormat,
 ) -> miette::Result<ExitCode> {
     // Build resolution context from flags.
-    let mut ctx = ResolutionContext::new();
+    let mut resolve_ctx = ResolutionContext::new();
     if let Some(m) = color_scheme {
-        ctx = ctx.with("colorScheme", m);
+        resolve_ctx = resolve_ctx.with("colorScheme", m);
     }
     if let Some(m) = scale {
-        ctx = ctx.with("scale", m);
+        resolve_ctx = resolve_ctx.with("scale", m);
     }
     if let Some(m) = contrast {
-        ctx = ctx.with("contrast", m);
+        resolve_ctx = resolve_ctx.with("contrast", m);
     }
-    // A property filter: only consider tokens whose name.property matches.
-    ctx = ctx.with("__property_filter__", property.to_string());
 
     // Load token graph (via the embedded-database cache when fresh).
     let mut graph = TokenGraph::open_cached(path)
@@ -465,13 +463,6 @@ fn run_resolve(
         .into_diagnostic()
         .wrap_err("failed to apply platform manifest cascade")?;
 
-    // Build a property-filtered context (remove the internal marker).
-    let mut resolve_ctx = ResolutionContext::new();
-    for (k, v) in &ctx.mode_sets {
-        if k != "__property_filter__" {
-            resolve_ctx = resolve_ctx.with(k.clone(), v.clone());
-        }
-    }
     for (mode_set, allowed) in &restrictions {
         resolve_ctx = resolve_ctx.with_restriction(mode_set.clone(), allowed.clone());
     }

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use design_data_core::cache;
-use design_data_core::cascade::{resolve, ResolutionContext};
+use design_data_core::cascade::{resolve_property, ResolutionContext};
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
@@ -30,6 +30,7 @@ use design_data_core::diff::display_name;
 use design_data_core::figma;
 use design_data_core::graph::TokenGraph;
 use design_data_core::legacy;
+use design_data_core::manifest;
 use design_data_core::migrate;
 use design_data_core::naming::NamingExceptionsFile;
 use design_data_core::query;
@@ -460,7 +461,9 @@ fn run_resolve(
 
     // Apply a configured platform manifest (Foundation→Platform cascade): filter the
     // token set, layer in overrides/extensions, and capture mode-set restrictions.
-    let restrictions = apply_configured_manifest(&mut graph, &resolved)?;
+    let restrictions = manifest::apply_configured(&mut graph, &resolved)
+        .into_diagnostic()
+        .wrap_err("failed to apply platform manifest cascade")?;
 
     // Build a property-filtered context (remove the internal marker).
     let mut resolve_ctx = ResolutionContext::new();
@@ -473,39 +476,20 @@ fn run_resolve(
         resolve_ctx = resolve_ctx.with_restriction(mode_set.clone(), allowed.clone());
     }
 
-    // Filter graph to tokens matching the requested property.
-    let property_filter = property.to_string();
-    let candidates: Vec<_> = graph
-        .tokens
-        .values()
-        .filter(|t| {
-            t.raw
-                .get("name")
-                .and_then(|v| v.as_object())
-                .and_then(|n| n.get("property"))
-                .and_then(|v| v.as_str())
-                == Some(property_filter.as_str())
-        })
-        .collect();
+    let candidates = resolve_property(&graph, property, &resolve_ctx);
 
     if candidates.is_empty() {
         eprintln!("No tokens found with property: {property}");
         return Ok(ExitCode::from(1));
     }
 
-    // Build a temporary graph with only the filtered tokens for resolution.
-    // Preserve full records (and their cascade `layer`) so Platform-layer
-    // manifest overrides correctly win over Foundation tokens.
-    let filtered_records: Vec<_> = candidates.iter().map(|t| (*t).clone()).collect();
-    let filtered_graph =
-        TokenGraph::from_records(filtered_records).with_mode_sets(graph.mode_sets.clone());
-
-    match resolve(&filtered_graph, &resolve_ctx) {
+    match candidates.iter().find(|c| c.is_winner) {
         None => {
             eprintln!("No matching token for property '{property}' in given context");
             Ok(ExitCode::from(1))
         }
         Some(winner) => {
+            let winner = &winner.record;
             match format {
                 OutputFormat::Json => {
                     println!(
@@ -788,65 +772,6 @@ fn run_diff(
     }
 }
 
-/// Locate the spec's `manifest.schema.json` by walking up from the token schemas
-/// directory to the repo root. Returns `None` when not found (e.g. outside a repo).
-fn locate_manifest_schema(schemas_root: &Path) -> Option<PathBuf> {
-    schemas_root.ancestors().find_map(|p| {
-        let candidate = p.join("packages/design-data-spec/schemas/manifest.schema.json");
-        candidate.is_file().then_some(candidate)
-    })
-}
-
-/// Apply the Layer 2 platform manifest declared in `.design-data.toml`
-/// (`[source].manifest`) to `graph`, returning the mode-set restrictions to feed
-/// into a [`ResolutionContext`]. A no-op (empty map) when no manifest is configured.
-///
-/// When the spec's `manifest.schema.json` is locatable, the manifest is first
-/// validated (Layer 1); schema violations abort with an error.
-fn apply_configured_manifest(
-    graph: &mut TokenGraph,
-    resolved: &data_source::ResolvedData,
-) -> miette::Result<std::collections::HashMap<String, Vec<String>>> {
-    let Some(manifest_path) = resolved.platform_manifest.as_ref() else {
-        return Ok(std::collections::HashMap::new());
-    };
-    let text = std::fs::read_to_string(manifest_path)
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!(
-                "failed to read platform manifest {}",
-                manifest_path.display()
-            )
-        })?;
-    let manifest: serde_json::Value = serde_json::from_str(&text)
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!(
-                "failed to parse platform manifest {}",
-                manifest_path.display()
-            )
-        })?;
-
-    if let Some(schema_path) = locate_manifest_schema(&resolved.schemas_root) {
-        let errors = SchemaRegistry::validate_manifest(&manifest, &schema_path)
-            .into_diagnostic()
-            .wrap_err("failed to validate platform manifest against manifest.schema.json")?;
-        if !errors.is_empty() {
-            return Err(miette::miette!(
-                "platform manifest {} failed Layer 1 schema validation:\n  {}",
-                manifest_path.display(),
-                errors.join("\n  ")
-            ));
-        }
-    }
-
-    let outcome = graph
-        .apply_platform_manifest(&manifest)
-        .into_diagnostic()
-        .wrap_err("failed to apply platform manifest cascade")?;
-    Ok(outcome.mode_set_restrictions)
-}
-
 fn run_query(
     path: &Path,
     filter_expr: &str,
@@ -861,7 +786,9 @@ fn run_query(
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
     // Apply a configured platform manifest (filters/overrides/extensions) before querying.
-    apply_configured_manifest(&mut graph, &resolved)?;
+    manifest::apply_configured(&mut graph, &resolved)
+        .into_diagnostic()
+        .wrap_err("failed to apply platform manifest cascade")?;
     // Manifest overlays change the token set — rebuild the index when one is configured.
     if resolved.platform_manifest.is_some() {
         index = query::TokenIndex::build(&graph);

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -19,12 +19,12 @@ mod format;
 use std::collections::HashSet;
 
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
-use design_data_tui::{LaunchOptions, ThemeChoice};
+use design_data_core::cache;
 use design_data_core::cascade::{resolve, ResolutionContext};
-use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::compat::{
     load_snapshot, snapshot_matches, write_snapshot, ValidationSnapshot,
 };
+use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::diff;
 use design_data_core::diff::display_name;
 use design_data_core::figma;
@@ -36,7 +36,8 @@ use design_data_core::query;
 use design_data_core::schema::SchemaRegistry;
 use design_data_core::suggest;
 use design_data_core::validate;
-use design_data_core::write::{WriteTokenInput, write_token};
+use design_data_core::write::{write_token, WriteTokenInput};
+use design_data_tui::{LaunchOptions, ThemeChoice};
 use miette::{IntoDiagnostic, WrapErr};
 
 const SPEC_VERSION: &str = "1.0.0-draft";
@@ -46,9 +47,13 @@ const SPEC_VERSION: &str = "1.0.0-draft";
 /// Run with no arguments to launch the interactive TUI. Pass a subcommand for
 /// non-interactive use.
 #[derive(Parser)]
-#[command(name = "design-data", version, about,
-          args_conflicts_with_subcommands = true,
-          subcommand_negates_reqs = true)]
+#[command(
+    name = "design-data",
+    version,
+    about,
+    args_conflicts_with_subcommands = true,
+    subcommand_negates_reqs = true
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -227,7 +232,12 @@ enum Commands {
     /// Create or update a product-context.json document for a product-layer working copy
     Write {
         /// Path to the product context JSON file to create or update
-        #[arg(short, long, value_name = "FILE", default_value = "product-context.json")]
+        #[arg(
+            short,
+            long,
+            value_name = "FILE",
+            default_value = "product-context.json"
+        )]
         output: PathBuf,
         /// Why this product-layer working copy exists (recorded in the document's rationale field)
         #[arg(short, long, value_name = "TEXT")]
@@ -260,6 +270,19 @@ enum Commands {
         /// Path to schemas directory (default: packages/tokens/schemas relative to target)
         #[arg(long, value_name = "DIR")]
         schema_path: Option<PathBuf>,
+    },
+    /// Build the derived embedded-database cache as a portable .redb asset
+    ///
+    /// Emits a single-file cache from the canonical JSON. Useful for shipping a
+    /// prebuilt index to WASM web tools, which open it read-only in memory.
+    #[command(name = "cache-build")]
+    CacheBuild {
+        /// Token dataset directory (default: resolved canonical dataset)
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Output .redb file path
+        #[arg(short, long, value_name = "FILE", default_value = "index.redb")]
+        output: PathBuf,
     },
     /// Manage token authoring sessions (MCP parity, RFC #973 Q4)
     #[command(name = "authoring-session")]
@@ -410,17 +433,21 @@ fn run_resolve(
     // A property filter: only consider tokens whose name.property matches.
     ctx = ctx.with("__property_filter__", property.to_string());
 
-    // Load token graph.
-    let mut graph = TokenGraph::from_json_dir(path)
+    // Load token graph (via the embedded-database cache when fresh).
+    let mut graph = TokenGraph::open_cached(path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
     // Load mode sets from spec catalog.
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-        mode_sets: mode_sets_path,
-        ..Default::default()
-    }).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            mode_sets: mode_sets_path,
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
     let ms_dir = resolved.mode_sets.clone();
     if let Some(dir) = ms_dir {
         if dir.is_dir() {
@@ -520,13 +547,17 @@ fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
         miette::bail!("validation engine not ready");
     }
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-        schema_root: opts.schema_path,
-        exceptions: opts.exceptions_path,
-        mode_sets: opts.mode_sets_path,
-        components: opts.components_path,
-        ..Default::default()
-    }).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            schema_root: opts.schema_path,
+            exceptions: opts.exceptions_path,
+            mode_sets: opts.mode_sets_path,
+            components: opts.components_path,
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
 
     let schema_root = resolved.schemas_root;
     let registry = SchemaRegistry::load_legacy_token_schemas(&schema_root)
@@ -570,12 +601,17 @@ fn run_migrate_verify(
     exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-        schema_root: schema_path,
-        exceptions: exceptions_path,
-        ..Default::default()
-    }).into_diagnostic()?;
-    let registry = SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            schema_root: schema_path,
+            exceptions: exceptions_path,
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
+    let registry =
+        SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
     let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
     let report =
         validate::validate_all_with_exceptions(path, &registry, &exceptions).into_diagnostic()?;
@@ -670,12 +706,17 @@ fn run_migrate_snapshot(
     exceptions_path: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-        schema_root: schema_path,
-        exceptions: exceptions_path,
-        ..Default::default()
-    }).into_diagnostic()?;
-    let registry = SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            schema_root: schema_path,
+            exceptions: exceptions_path,
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
+    let registry =
+        SchemaRegistry::load_legacy_token_schemas(&resolved.schemas_root).into_diagnostic()?;
     let exceptions = load_exceptions(resolved.exceptions.as_deref())?;
     let report =
         validate::validate_all_with_exceptions(path, &registry, &exceptions).into_diagnostic()?;
@@ -691,10 +732,10 @@ fn run_diff(
     format: DiffFormat,
     filter_expr: Option<&str>,
 ) -> miette::Result<ExitCode> {
-    let old_graph = TokenGraph::from_json_dir(old_path)
+    let old_graph = TokenGraph::open_cached(old_path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load old tokens from {}", old_path.display()))?;
-    let new_graph = TokenGraph::from_json_dir(new_path)
+    let new_graph = TokenGraph::open_cached(new_path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load new tokens from {}", new_path.display()))?;
 
@@ -771,11 +812,19 @@ fn apply_configured_manifest(
     };
     let text = std::fs::read_to_string(manifest_path)
         .into_diagnostic()
-        .wrap_err_with(|| format!("failed to read platform manifest {}", manifest_path.display()))?;
+        .wrap_err_with(|| {
+            format!(
+                "failed to read platform manifest {}",
+                manifest_path.display()
+            )
+        })?;
     let manifest: serde_json::Value = serde_json::from_str(&text)
         .into_diagnostic()
         .wrap_err_with(|| {
-            format!("failed to parse platform manifest {}", manifest_path.display())
+            format!(
+                "failed to parse platform manifest {}",
+                manifest_path.display()
+            )
         })?;
 
     if let Some(schema_path) = locate_manifest_schema(&resolved.schemas_root) {
@@ -804,7 +853,7 @@ fn run_query(
     format: OutputFormat,
     count_only: bool,
 ) -> miette::Result<ExitCode> {
-    let mut graph = TokenGraph::from_json_dir(path)
+    let mut graph = TokenGraph::open_cached(path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
@@ -817,7 +866,10 @@ fn run_query(
         .into_diagnostic()
         .wrap_err("failed to parse filter expression")?;
 
-    let results = query::filter(&graph, &expr);
+    // Build a secondary index so single-field equality queries use an indexed
+    // lookup instead of an O(n) scan; complex expressions fall back internally.
+    let index = query::TokenIndex::build(&graph);
+    let results = query::filter_with_index(&graph, &index, &expr);
 
     if count_only {
         println!("{}", results.len());
@@ -1019,18 +1071,22 @@ fn run_primer(
     mode_sets_dir: Option<PathBuf>,
 ) -> miette::Result<ExitCode> {
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-        tokens_root: explicit_path.map(|p| p.to_path_buf()),
-        mode_sets: mode_sets_dir,
-        components: components_dir,
-        fields: fields_dir,
-        ..Default::default()
-    }).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            tokens_root: explicit_path.map(|p| p.to_path_buf()),
+            mode_sets: mode_sets_dir,
+            components: components_dir,
+            fields: fields_dir,
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
 
     // Dataset path: explicit arg wins; otherwise use the resolved tokens root (which
     // comes from the config source, embedded snapshot, or in-repo CWD probing).
     let path = resolved.tokens_root.clone();
-    let graph = TokenGraph::from_json_dir(&path)
+    let graph = TokenGraph::open_cached(&path)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
     let token_count = graph.tokens.len();
@@ -1178,7 +1234,11 @@ fn run_primer(
             println!("Fields:        {}", taxonomy_fields.len());
             println!(
                 "Manifest:      {}",
-                if manifest.is_null() { "none" } else { "present" }
+                if manifest.is_null() {
+                    "none"
+                } else {
+                    "present"
+                }
             );
         }
     }
@@ -1188,7 +1248,9 @@ fn run_primer(
 
 fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<ExitCode> {
     // Reject IDs that could escape the components directory via path traversal.
-    if !id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
         || id.is_empty()
         || !id.chars().next().is_some_and(|c| c.is_ascii_lowercase())
     {
@@ -1197,10 +1259,14 @@ fn run_component(id: &str, components_dir: Option<PathBuf>) -> miette::Result<Ex
     }
 
     let cwd = std::env::current_dir().into_diagnostic()?;
-    let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-        components: components_dir,
-        ..Default::default()
-    }).into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            components: components_dir,
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
     let dir = resolved
         .components
         .ok_or_else(|| miette::miette!("could not locate components directory"))?;
@@ -1237,7 +1303,7 @@ fn run_suggest(
     let target = path
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
-    let graph = TokenGraph::from_json_dir(&target)
+    let graph = TokenGraph::open_cached(&target)
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", target.display()))?;
 
@@ -1258,7 +1324,10 @@ fn run_suggest(
                 })
             })
             .collect();
-        println!("{}", serde_json::to_string_pretty(&json_vals).into_diagnostic()?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_vals).into_diagnostic()?
+        );
     } else if results.is_empty() {
         println!("No matching tokens found for: {intent:?}");
     } else {
@@ -1276,6 +1345,36 @@ fn run_suggest(
         }
     }
 
+    Ok(ExitCode::SUCCESS)
+}
+
+fn run_cache_build(explicit_path: Option<&Path>, output: &Path) -> miette::Result<ExitCode> {
+    // Resolve the dataset: explicit arg wins, else the canonical resolved root.
+    let tokens_root = match explicit_path {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let cwd = std::env::current_dir().into_diagnostic()?;
+            let resolved =
+                data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
+            resolved.tokens_root
+        }
+    };
+
+    cache::build_file(&tokens_root, output)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "failed to build cache from {} into {}",
+                tokens_root.display(),
+                output.display()
+            )
+        })?;
+
+    println!(
+        "Built cache from {} → {}",
+        tokens_root.display(),
+        output.display()
+    );
     Ok(ExitCode::SUCCESS)
 }
 
@@ -1311,9 +1410,7 @@ fn run_write(output: &Path, rationale: Option<&str>) -> miette::Result<ExitCode>
         );
         map.insert(
             "createdAt".to_string(),
-            serde_json::Value::String(
-                Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
-            ),
+            serde_json::Value::String(Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()),
         );
         serde_json::Value::Object(map)
     };
@@ -1354,12 +1451,15 @@ struct WriteTokenOpts<'a> {
     schema_path: Option<&'a Path>,
 }
 
-fn run_write_token(
-    key: &str,
-    target: &Path,
-    opts: WriteTokenOpts<'_>,
-) -> miette::Result<ExitCode> {
-    let WriteTokenOpts { token_json, token_file, product_context, rationale, is_override, schema_path } = opts;
+fn run_write_token(key: &str, target: &Path, opts: WriteTokenOpts<'_>) -> miette::Result<ExitCode> {
+    let WriteTokenOpts {
+        token_json,
+        token_file,
+        product_context,
+        rationale,
+        is_override,
+        schema_path,
+    } = opts;
     let token: serde_json::Value = match (token_json, token_file) {
         (Some(raw), _) => serde_json::from_str(raw)
             .into_diagnostic()
@@ -1390,9 +1490,7 @@ fn run_write_token(
             })
         })
         .ok_or_else(|| {
-            miette::miette!(
-                "cannot locate schemas directory; pass --schema-path explicitly"
-            )
+            miette::miette!("cannot locate schemas directory; pass --schema-path explicitly")
         })?;
 
     let registry = SchemaRegistry::load_legacy_token_schemas(&schemas_dir)
@@ -1556,9 +1654,13 @@ fn main() -> ExitCode {
             components_dir,
             fields_dir,
             mode_sets_dir,
-        } => {
-            run_primer(path.as_deref(), format, components_dir, fields_dir, mode_sets_dir)
-        }
+        } => run_primer(
+            path.as_deref(),
+            format,
+            components_dir,
+            fields_dir,
+            mode_sets_dir,
+        ),
         Commands::Component { id, components_dir } => run_component(&id, components_dir),
         Commands::Suggest {
             intent,
@@ -1566,16 +1668,8 @@ fn main() -> ExitCode {
             property,
             limit,
             format,
-        } => run_suggest(
-            &intent,
-            path.as_deref(),
-            property.as_deref(),
-            limit,
-            format,
-        ),
-        Commands::Write { output, rationale } => {
-            run_write(&output, rationale.as_deref())
-        }
+        } => run_suggest(&intent, path.as_deref(), property.as_deref(), limit, format),
+        Commands::Write { output, rationale } => run_write(&output, rationale.as_deref()),
         Commands::WriteToken {
             key,
             token_json,
@@ -1597,6 +1691,7 @@ fn main() -> ExitCode {
                 schema_path: schema_path.as_deref(),
             },
         ),
+        Commands::CacheBuild { path, output } => run_cache_build(path.as_deref(), &output),
         Commands::AuthoringSession { cmd } => {
             return authoring::run(cmd);
         }

--- a/sdk/cli/tests/cli_manifest.rs
+++ b/sdk/cli/tests/cli_manifest.rs
@@ -124,13 +124,7 @@ fn resolve_applies_manifest_override_by_uuid() {
     Command::cargo_bin("design-data")
         .expect("binary design-data")
         .current_dir(project.path())
-        .args([
-            "resolve",
-            "background-color",
-            "tokens",
-            "--format",
-            "json",
-        ])
+        .args(["resolve", "background-color", "tokens", "--format", "json"])
         .assert()
         .success()
         .stdout(contains("#ffffff"));

--- a/sdk/cli/tests/cli_tui.rs
+++ b/sdk/cli/tests/cli_tui.rs
@@ -45,9 +45,16 @@ fn tui_subcommand_help() {
 #[test]
 fn record_replay_conflict_is_rejected() {
     let mut cmd = Command::cargo_bin("design-data").unwrap();
-    cmd.args(["tui", "--record", "out.ndjson", "--replay", "in.ndjson", "."])
-        .assert()
-        .failure();
+    cmd.args([
+        "tui",
+        "--record",
+        "out.ndjson",
+        "--replay",
+        "in.ndjson",
+        ".",
+    ])
+    .assert()
+    .failure();
 }
 
 /// Passing mutually exclusive `--record` and `--replay` flags at the top level (bare TUI

--- a/sdk/cli/tests/cli_validate.rs
+++ b/sdk/cli/tests/cli_validate.rs
@@ -180,7 +180,10 @@ fn write_updates_existing_rationale() {
     let second: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&path).expect("read")).expect("json");
     assert_eq!(second["rationale"], "updated");
-    assert_eq!(second["createdAt"], created_at, "createdAt must not change on update");
+    assert_eq!(
+        second["createdAt"], created_at,
+        "createdAt must not change on update"
+    );
 }
 
 #[test]
@@ -194,7 +197,10 @@ fn write_creates_parent_dirs() {
         .assert()
         .success();
 
-    assert!(output.exists(), "output file should exist after creating parent dirs");
+    assert!(
+        output.exists(),
+        "output file should exist after creating parent dirs"
+    );
     let content = std::fs::read_to_string(&output).expect("read output");
     let doc: serde_json::Value = serde_json::from_str(&content).expect("valid json");
     assert_eq!(doc["specVersion"], "1.0.0-draft");
@@ -217,11 +223,7 @@ fn primer_paths() -> (PathBuf, PathBuf, PathBuf, PathBuf) {
         "expected mode sets at {}",
         mode_sets.display()
     );
-    assert!(
-        fields.is_dir(),
-        "expected fields at {}",
-        fields.display()
-    );
+    assert!(fields.is_dir(), "expected fields at {}", fields.display());
     (src, components, mode_sets, fields)
 }
 
@@ -262,11 +264,15 @@ fn primer_emits_json_with_required_fields() {
         "modeSets must be non-empty"
     );
     assert!(
-        doc["components"].as_array().map_or(false, |a| !a.is_empty()),
+        doc["components"]
+            .as_array()
+            .map_or(false, |a| !a.is_empty()),
         "components must be non-empty"
     );
     assert!(
-        doc["taxonomyFields"].as_array().map_or(false, |a| !a.is_empty()),
+        doc["taxonomyFields"]
+            .as_array()
+            .map_or(false, |a| !a.is_empty()),
         "taxonomyFields must be non-empty"
     );
 }
@@ -373,7 +379,10 @@ fn component_button_returns_json() {
         serde_json::from_slice(&output).expect("component output must be valid JSON");
 
     assert_eq!(doc["name"], "button");
-    assert!(doc["tokenBindings"].is_array(), "tokenBindings must be present");
+    assert!(
+        doc["tokenBindings"].is_array(),
+        "tokenBindings must be present"
+    );
     assert!(doc["anatomy"].is_array(), "anatomy must be present");
 }
 
@@ -397,7 +406,13 @@ fn component_nonexistent_fails() {
 fn component_path_traversal_rejected() {
     let dir = component_dir();
 
-    for bad_id in &["../button", "/etc/passwd", "button.json", "Button", "button/x"] {
+    for bad_id in &[
+        "../button",
+        "/etc/passwd",
+        "button.json",
+        "Button",
+        "button/x",
+    ] {
         Command::cargo_bin("design-data")
             .expect("binary design-data")
             .args([

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -27,9 +27,24 @@ flate2 = { version = "1", optional = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], optional = true }
 tar = { version = "0.4", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
+# Embedded-database cache layer. Pinned to 2.6.x to keep the workspace MSRV at
+# Rust 1.85 (redb 4.x requires Rust 1.89). Pure-Rust + WASM-capable via the
+# in-memory storage backend in `cache::mem_backend`.
+redb = { version = "2.6", optional = true }
+# MessagePack codec for the values stored in the cache. Must be self-describing
+# (supports `deserialize_any`) so it can round-trip `serde_json::Value`; this
+# rules out postcard/bincode. Pure-Rust, compact, and WASM-friendly.
+rmp-serde = { version = "1.3", optional = true }
 
 [features]
-default = []
+default = ["cache"]
+# Derived embedded-database cache over the canonical JSON files. On by default so
+# the CLI/TUI skip re-parsing JSON on every invocation; library consumers may opt
+# out with `--no-default-features`.
+cache = ["dep:redb", "dep:rmp-serde"]
+# Forward-looking flag for `wasm32` web tools: the cache's in-memory open-from-bytes
+# path (`cache::load_from_bytes`) needs no filesystem and works under this feature.
+wasm = ["cache"]
 fetch = ["dep:reqwest", "dep:tokio", "dep:flate2", "dep:tar"]
 figma = ["dep:reqwest", "dep:tokio"]
 

--- a/sdk/core/src/authoring/draft.rs
+++ b/sdk/core/src/authoring/draft.rs
@@ -102,7 +102,10 @@ impl WizardDraft {
                 name_fields: Vec::new(),
                 focused_field: 0,
             },
-            values: ValuesDraftDto { rows: Vec::new(), selected: 0 },
+            values: ValuesDraftDto {
+                rows: Vec::new(),
+                selected: 0,
+            },
             rationale: String::new(),
             schema_url: None,
             schema_url_input: String::new(),

--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -21,14 +21,14 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::graph::{Layer, TokenGraph};
-use crate::schema::SchemaRegistry;
-use crate::suggest;
-use crate::write::{WriteTokenInput, write_token};
 use super::draft::{
     ClassificationDraftDto, NameFieldDto, ValueKind, ValueRowDto, ValuesDraftDto, WizardDraft,
     WizardScreen,
 };
+use crate::graph::{Layer, TokenGraph};
+use crate::schema::SchemaRegistry;
+use crate::suggest;
+use crate::write::{write_token, WriteTokenInput};
 
 // ── On-disk session format ────────────────────────────────────────────────────
 
@@ -119,8 +119,7 @@ fn save_session(draft: &SessionDraft) -> Result<(), String> {
     let tmp = path.with_extension("tmp");
     std::fs::write(&tmp, &json)
         .map_err(|e| format!("failed to write session file to {tmp:?}: {e}"))?;
-    std::fs::rename(&tmp, &path)
-        .map_err(|e| format!("failed to commit session file: {e}"))
+    std::fs::rename(&tmp, &path).map_err(|e| format!("failed to commit session file: {e}"))
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -170,8 +169,12 @@ pub fn get_session(session_id: &str) -> Option<SessionDraft> {
 
 /// List all sessions in the sessions directory, sorted by session_id.
 pub fn list_sessions() -> Vec<SessionDraft> {
-    let Some(dir) = sessions_dir() else { return Vec::new() };
-    let Ok(entries) = std::fs::read_dir(&dir) else { return Vec::new() };
+    let Some(dir) = sessions_dir() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
     let mut sessions: Vec<SessionDraft> = entries
         .filter_map(|e| e.ok())
         .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
@@ -186,7 +189,9 @@ pub fn list_sessions() -> Vec<SessionDraft> {
 
 /// Delete the session file.  Ignores `NotFound`.
 pub fn cancel_session(session_id: &str) {
-    let Some(path) = session_path(session_id) else { return };
+    let Some(path) = session_path(session_id) else {
+        return;
+    };
     let _ = std::fs::remove_file(&path);
 }
 
@@ -206,7 +211,10 @@ pub fn step_intent(session_id: &str, intent: &str) -> Result<IntentStepResult, S
         .map_err(|e| format!("failed to load dataset at {:?}: {e}", session.dataset_path))?;
 
     let raw = suggest::suggest(&graph, intent, None, 10);
-    let can_alias = raw.first().map(|s| s.confidence >= alias_threshold()).unwrap_or(false);
+    let can_alias = raw
+        .first()
+        .map(|s| s.confidence >= alias_threshold())
+        .unwrap_or(false);
 
     let suggestions: Vec<SuggestionSnapshot> = raw
         .iter()
@@ -219,7 +227,11 @@ pub fn step_intent(session_id: &str, intent: &str) -> Result<IntentStepResult, S
         .collect();
 
     save_session(&session)?;
-    Ok(IntentStepResult { session, suggestions, can_alias })
+    Ok(IntentStepResult {
+        session,
+        suggestions,
+        can_alias,
+    })
 }
 
 /// Update classification fields (layer, property, name-object fields).
@@ -248,10 +260,7 @@ pub fn step_classification(
 }
 
 /// Replace the values rows for Screen 3.
-pub fn step_values(
-    session_id: &str,
-    rows: Vec<ValueRowInput>,
-) -> Result<SessionDraft, String> {
+pub fn step_values(session_id: &str, rows: Vec<ValueRowInput>) -> Result<SessionDraft, String> {
     let mut session =
         get_session(session_id).ok_or_else(|| format!("session not found: {session_id}"))?;
 
@@ -285,8 +294,11 @@ pub fn commit_session(
     let key = derive_token_key(wizard);
     let token = build_token_value(wizard, &input.schema_url, &input.rationale);
 
-    let rationale_opt =
-        if input.rationale.is_empty() { None } else { Some(input.rationale.clone()) };
+    let rationale_opt = if input.rationale.is_empty() {
+        None
+    } else {
+        Some(input.rationale.clone())
+    };
 
     let write_input = WriteTokenInput {
         key,
@@ -327,7 +339,11 @@ fn derive_token_key(wizard: &WizardDraft) -> String {
             parts.push(&field.value);
         }
     }
-    if parts.is_empty() { "unnamed-token".to_string() } else { parts.join("-") }
+    if parts.is_empty() {
+        "unnamed-token".to_string()
+    } else {
+        parts.join("-")
+    }
 }
 
 /// Construct the token JSON value from wizard state.
@@ -335,14 +351,13 @@ fn derive_token_key(wizard: &WizardDraft) -> String {
 /// A single row with an empty `mode_combo` produces a flat `value`/`$ref` field.
 /// Multiple rows, or rows with mode conditions, produce a nested `sets` structure
 /// keyed by each row's first-dimension mode value (recursively for deeper combos).
-fn build_token_value(
-    wizard: &WizardDraft,
-    schema_url: &str,
-    rationale: &str,
-) -> serde_json::Value {
+fn build_token_value(wizard: &WizardDraft, schema_url: &str, rationale: &str) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
 
-    obj.insert("$schema".into(), serde_json::Value::String(schema_url.to_string()));
+    obj.insert(
+        "$schema".into(),
+        serde_json::Value::String(schema_url.to_string()),
+    );
 
     let mut name_obj = serde_json::Map::new();
     name_obj.insert(
@@ -350,38 +365,45 @@ fn build_token_value(
         serde_json::Value::String(wizard.classification.property.clone()),
     );
     for field in &wizard.classification.name_fields {
-        name_obj.insert(field.key.clone(), serde_json::Value::String(field.value.clone()));
+        name_obj.insert(
+            field.key.clone(),
+            serde_json::Value::String(field.value.clone()),
+        );
     }
     obj.insert("name".into(), serde_json::Value::Object(name_obj));
 
     match wizard.values.rows.as_slice() {
         [] => {}
-        [single] if single.mode_combo.is_empty() => {
-            match single.kind {
-                ValueKind::Alias => {
-                    obj.insert(
-                        "$ref".into(),
-                        serde_json::Value::String(single.alias_target.clone()),
-                    );
-                }
-                ValueKind::Literal => {
-                    obj.insert(
-                        "value".into(),
-                        serde_json::Value::String(single.literal.clone()),
-                    );
-                }
+        [single] if single.mode_combo.is_empty() => match single.kind {
+            ValueKind::Alias => {
+                obj.insert(
+                    "$ref".into(),
+                    serde_json::Value::String(single.alias_target.clone()),
+                );
             }
-        }
+            ValueKind::Literal => {
+                obj.insert(
+                    "value".into(),
+                    serde_json::Value::String(single.literal.clone()),
+                );
+            }
+        },
         rows => {
             obj.insert("sets".into(), build_sets_from_rows(rows));
         }
     }
 
     if !rationale.is_empty() {
-        obj.insert("rationale".into(), serde_json::Value::String(rationale.to_string()));
+        obj.insert(
+            "rationale".into(),
+            serde_json::Value::String(rationale.to_string()),
+        );
     }
 
-    obj.insert("uuid".into(), serde_json::Value::String(Uuid::new_v4().to_string()));
+    obj.insert(
+        "uuid".into(),
+        serde_json::Value::String(Uuid::new_v4().to_string()),
+    );
 
     serde_json::Value::Object(obj)
 }
@@ -531,8 +553,7 @@ mod tests {
             let s1 = start_session("/a").unwrap();
             let s2 = start_session("/b").unwrap();
             let sessions = list_sessions();
-            let ids: Vec<&str> =
-                sessions.iter().map(|s| s.session_id.as_str()).collect();
+            let ids: Vec<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
             assert!(ids.contains(&s1.session_id.as_str()));
             assert!(ids.contains(&s2.session_id.as_str()));
         });

--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -207,7 +207,7 @@ pub fn step_intent(session_id: &str, intent: &str) -> Result<IntentStepResult, S
     session.wizard.screen = WizardScreen::Intent;
 
     let dataset_path = std::path::Path::new(&session.dataset_path);
-    let graph = TokenGraph::from_json_dir(dataset_path)
+    let graph = TokenGraph::open_cached(dataset_path)
         .map_err(|e| format!("failed to load dataset at {:?}: {e}", session.dataset_path))?;
 
     let raw = suggest::suggest(&graph, intent, None, 10);

--- a/sdk/core/src/cache/mem_backend.rs
+++ b/sdk/core/src/cache/mem_backend.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! An in-memory [`redb::StorageBackend`] backed by a `Vec<u8>`.
+//!
+//! This is the WASM-friendly half of the cache: a redb database can be built
+//! into a byte buffer (no filesystem) and later opened read-only from those same
+//! bytes. Web tools compiled to `wasm32` fetch the cache blob over HTTP and open
+//! it through this backend — no OPFS, Web Worker, or cross-origin-isolation
+//! headers required, because a derived cache needs no in-browser persistence.
+//!
+//! redb's `StorageBackend` is a synchronous interface; an in-memory `Vec<u8>`
+//! satisfies it on every target (native and `wasm32-unknown-unknown`).
+
+use std::io;
+use std::sync::{Arc, RwLock};
+
+/// In-memory storage for a redb [`Database`](redb::Database).
+///
+/// Clones share the same underlying buffer (via [`Arc`]), so a clone retained
+/// before constructing the database can read the serialized bytes back out with
+/// [`MemBackend::snapshot`] after the database is committed and dropped.
+#[derive(Clone)]
+pub struct MemBackend {
+    data: Arc<RwLock<Vec<u8>>>,
+}
+
+impl std::fmt::Debug for MemBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.data.read().map(|d| d.len()).unwrap_or(0);
+        f.debug_struct("MemBackend").field("len", &len).finish()
+    }
+}
+
+impl Default for MemBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemBackend {
+    /// Create an empty backend (used when building a fresh cache in memory).
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Create a backend seeded with existing bytes (used to open a cache blob).
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self {
+            data: Arc::new(RwLock::new(bytes)),
+        }
+    }
+
+    /// Copy the current backing bytes out — the serialized redb database.
+    pub fn snapshot(&self) -> Vec<u8> {
+        self.data.read().map(|d| d.clone()).unwrap_or_default()
+    }
+}
+
+fn lock_poisoned() -> io::Error {
+    io::Error::new(io::ErrorKind::Other, "MemBackend lock poisoned")
+}
+
+impl redb::StorageBackend for MemBackend {
+    fn len(&self) -> Result<u64, io::Error> {
+        let data = self.data.read().map_err(|_| lock_poisoned())?;
+        Ok(data.len() as u64)
+    }
+
+    fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, io::Error> {
+        let data = self.data.read().map_err(|_| lock_poisoned())?;
+        let start = offset as usize;
+        let end = start
+            .checked_add(len)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "read length overflow"))?;
+        if end > data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "read past end of in-memory database",
+            ));
+        }
+        Ok(data[start..end].to_vec())
+    }
+
+    fn set_len(&self, len: u64) -> Result<(), io::Error> {
+        let mut data = self.data.write().map_err(|_| lock_poisoned())?;
+        data.resize(len as usize, 0);
+        Ok(())
+    }
+
+    fn sync_data(&self, _eventual: bool) -> Result<(), io::Error> {
+        // No durable medium to flush — the bytes already live in memory.
+        Ok(())
+    }
+
+    fn write(&self, offset: u64, src: &[u8]) -> Result<(), io::Error> {
+        let mut data = self.data.write().map_err(|_| lock_poisoned())?;
+        let start = offset as usize;
+        let end = start
+            .checked_add(src.len())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "write length overflow"))?;
+        if end > data.len() {
+            data.resize(end, 0);
+        }
+        data[start..end].copy_from_slice(src);
+        Ok(())
+    }
+}

--- a/sdk/core/src/cache/mod.rs
+++ b/sdk/core/src/cache/mod.rs
@@ -52,6 +52,22 @@
 //! [`build_bytes`] serializes a cache to an in-memory byte buffer and
 //! [`load_from_bytes`] / [`load_index_from_bytes`] open it again with no
 //! filesystem, via [`mem_backend::MemBackend`].
+//!
+//! ## Invalidation
+//!
+//! Cache freshness uses per-file **size + mtime** (not a full content hash) for
+//! speed. A stale miss only forces a rebuild (safe). A false hit requires a
+//! same-size edit with an unchanged mtime — unlikely in normal editor/git
+//! workflows, but possible in CI that preserves mtimes aggressively.
+//!
+//! ## Known limitations (schema v1)
+//!
+//! - **Inline mode sets** discovered by [`TokenGraph::from_json_dir`] inside the
+//!   tokens tree are not persisted; hydration uses [`TokenGraph::from_records`],
+//!   which clears `mode_sets`. The canonical Spectrum layout (mode sets under
+//!   `design-data-spec/mode-sets`) is unaffected.
+//! - **`components` / `mode_sets` catalog tables** from the plan are deferred;
+//!   only tokens and query indexes are cached today.
 
 mod mem_backend;
 
@@ -70,6 +86,13 @@ use crate::discovery::discover_json_files;
 use crate::graph::{TokenGraph, TokenRecord};
 use crate::query::{self, TokenIndex, ALLOWED_KEYS};
 use crate::CoreError;
+
+/// A token graph plus its query index, loaded together from cache or JSON.
+#[derive(Debug)]
+pub struct CachedDataset {
+    pub graph: TokenGraph,
+    pub index: TokenIndex,
+}
 
 /// Bump when the on-disk schema or value encoding changes, to invalidate caches
 /// written by older binaries (in addition to the tokens-version namespace).
@@ -163,25 +186,33 @@ fn debug_log(args: std::fmt::Arguments<'_>) {
 
 /// Load a [`TokenGraph`] for `tokens_root`, using the on-disk cache when fresh.
 ///
-/// Drop-in replacement for [`TokenGraph::from_json_dir`]:
-/// 1. On a cache hit (schema + tokens-version + content-hash all match) the
-///    graph is hydrated from redb — no JSON parsing.
-/// 2. On a miss or any cache error, the graph is built from JSON (the source of
-///    truth) and the cache is rewritten best-effort.
+/// Drop-in replacement for [`TokenGraph::from_json_dir`]. Prefer
+/// [`open_cached_with_index`] when you also need the persisted query index.
 ///
 /// Never fails because of the cache; only a JSON load error propagates.
 pub fn open_cached(tokens_root: &Path) -> Result<TokenGraph, CoreError> {
+    open_cached_with_index(tokens_root).map(|loaded| loaded.graph)
+}
+
+/// Load a graph **and** its query index for `tokens_root`.
+///
+/// On a cache hit both are hydrated from the redb file — including the `idx_*`
+/// multimap tables — without rebuilding the index in memory. On a miss or any
+/// cache error the graph is built from JSON (source of truth), the index is
+/// built from that graph, and the cache is rewritten best-effort.
+pub fn open_cached_with_index(tokens_root: &Path) -> Result<CachedDataset, CoreError> {
     match load_from_disk(tokens_root) {
-        Ok(Some(graph)) => return Ok(graph),
+        Ok(Some(loaded)) => return Ok(loaded),
         Ok(None) => {}
         Err(e) => debug_log(format_args!("read failed ({e}); rebuilding from json")),
     }
 
     let graph = TokenGraph::from_json_dir(tokens_root)?;
+    let index = TokenIndex::build(&graph);
     if let Err(e) = write_to_disk(tokens_root, &graph) {
         debug_log(format_args!("write failed ({e}); cache not updated"));
     }
-    Ok(graph)
+    Ok(CachedDataset { graph, index })
 }
 
 /// Serialize a freshly built cache for `tokens_root` into an in-memory byte
@@ -279,9 +310,9 @@ fn content_hash(tokens_root: &Path) -> std::io::Result<u64> {
 // Read path
 // ---------------------------------------------------------------------------
 
-/// Returns `Ok(Some(graph))` on a fresh cache hit, `Ok(None)` on a miss
+/// Returns `Ok(Some(loaded))` on a fresh cache hit, `Ok(None)` on a miss
 /// (absent/stale), or `Err` on a real cache error.
-fn load_from_disk(tokens_root: &Path) -> Result<Option<TokenGraph>, CacheError> {
+fn load_from_disk(tokens_root: &Path) -> Result<Option<CachedDataset>, CacheError> {
     let Some(path) = cache_db_path(tokens_root) else {
         return Ok(None);
     };
@@ -302,7 +333,10 @@ fn load_from_disk(tokens_root: &Path) -> Result<Option<TokenGraph>, CacheError> 
         return Ok(None);
     }
 
-    Ok(Some(hydrate(&rtx)?))
+    Ok(Some(CachedDataset {
+        graph: hydrate(&rtx)?,
+        index: read_index(&rtx)?,
+    }))
 }
 
 fn read_meta(rtx: &redb::ReadTransaction) -> Result<Option<CacheMeta>, CacheError> {
@@ -550,10 +584,15 @@ mod tests {
         // load_from_disk must report a genuine hit (Some) — proving the redb
         // read + MessagePack hydration path works, not the JSON fallback.
         let hit = load_from_disk(&root).unwrap();
-        let graph = hit.expect("expected a cache hit after priming");
-        assert_eq!(graph.tokens.len(), 2);
-        assert!(graph.tokens.contains_key("blue-100"));
-        assert!(graph.tokens.contains_key("blue-200"));
+        let loaded = hit.expect("expected a cache hit after priming");
+        assert_eq!(loaded.graph.tokens.len(), 2);
+        assert!(loaded.graph.tokens.contains_key("blue-100"));
+        assert!(loaded.graph.tokens.contains_key("blue-200"));
+
+        // Index must come from the persisted multimap tables, not a rebuild.
+        let expr = query::parse("component=button").unwrap();
+        let via_index = query::filter_with_index(&loaded.graph, &loaded.index, &expr);
+        assert_eq!(via_index.len(), 2);
 
         std::env::remove_var("DESIGN_DATA_CACHE_DIR");
     }

--- a/sdk/core/src/cache/mod.rs
+++ b/sdk/core/src/cache/mod.rs
@@ -1,0 +1,646 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Derived embedded-database cache over the canonical token JSON.
+//!
+//! The JSON files on disk remain the single source of truth. This module builds
+//! a compact, indexed [redb](https://www.redb.org) database from them and caches
+//! it so the CLI/TUI can skip re-parsing ~2 MB of JSON on every invocation. The
+//! cache is **never authoritative**: it is content-addressed, rebuilt whenever
+//! the JSON changes, and any cache error falls back to loading from JSON.
+//!
+//! ## Why this layer exists
+//!
+//! Every CLI subcommand previously called [`TokenGraph::from_json_dir`], walking
+//! the dataset and `serde_json`-parsing every file on each run. [`open_cached`]
+//! is a drop-in replacement that hydrates the same [`TokenGraph`] from the redb
+//! cache on a hit, and rebuilds + caches on a miss.
+//!
+//! ## Cache layout
+//!
+//! ```text
+//! <cache_base>/cache/<tokens_version>/<dataset_key>.redb
+//! ```
+//!
+//! - `cache_base`: `DESIGN_DATA_CACHE_DIR` env override, else `dirs::cache_dir()/design-data`.
+//! - `tokens_version`: [`EMBEDDED_TOKENS_VERSION`] — upgrades self-invalidate.
+//! - `dataset_key`: hash of the dataset's absolute path, so distinct datasets do
+//!   not thrash a single shared cache file.
+//!
+//! ## redb schema
+//!
+//! | table          | kind        | key            | value                          |
+//! |----------------|-------------|----------------|--------------------------------|
+//! | `meta`         | table       | `"meta"`       | MessagePack [`CacheMeta`]      |
+//! | `tokens`       | table       | graph key      | MessagePack [`TokenRecord`]    |
+//! | `uuid_index`   | table       | uuid           | graph key                      |
+//! | `idx_<field>`  | multimap    | field value    | graph keys (one per query key) |
+//!
+//! `tokens` drives hydration; the `uuid_index` / `idx_*` tables exist so a
+//! read-only consumer (e.g. a WASM web tool via [`load_index_from_bytes`]) can
+//! answer indexed equality queries without materializing the whole graph.
+//!
+//! ## WASM
+//!
+//! [`build_bytes`] serializes a cache to an in-memory byte buffer and
+//! [`load_from_bytes`] / [`load_index_from_bytes`] open it again with no
+//! filesystem, via [`mem_backend::MemBackend`].
+
+mod mem_backend;
+
+pub use mem_backend::MemBackend;
+
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use redb::{
+    Database, MultimapTableDefinition, ReadableMultimapTable, ReadableTable, TableDefinition,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::data_source::embedded::EMBEDDED_TOKENS_VERSION;
+use crate::discovery::discover_json_files;
+use crate::graph::{TokenGraph, TokenRecord};
+use crate::query::{self, TokenIndex, ALLOWED_KEYS};
+use crate::CoreError;
+
+/// Bump when the on-disk schema or value encoding changes, to invalidate caches
+/// written by older binaries (in addition to the tokens-version namespace).
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+const META: TableDefinition<&str, &[u8]> = TableDefinition::new("meta");
+const TOKENS: TableDefinition<&str, &[u8]> = TableDefinition::new("tokens");
+const UUID_INDEX: TableDefinition<&str, &str> = TableDefinition::new("uuid_index");
+
+// One multimap index table per query field (see `query::ALLOWED_KEYS`).
+const IDX_PROPERTY: MultimapTableDefinition<&str, &str> =
+    MultimapTableDefinition::new("idx_property");
+const IDX_COMPONENT: MultimapTableDefinition<&str, &str> =
+    MultimapTableDefinition::new("idx_component");
+const IDX_VARIANT: MultimapTableDefinition<&str, &str> =
+    MultimapTableDefinition::new("idx_variant");
+const IDX_STATE: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("idx_state");
+const IDX_COLOR_SCHEME: MultimapTableDefinition<&str, &str> =
+    MultimapTableDefinition::new("idx_colorScheme");
+const IDX_SCALE: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("idx_scale");
+const IDX_CONTRAST: MultimapTableDefinition<&str, &str> =
+    MultimapTableDefinition::new("idx_contrast");
+const IDX_UUID: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("idx_uuid");
+const IDX_SCHEMA: MultimapTableDefinition<&str, &str> = MultimapTableDefinition::new("idx_schema");
+
+/// Map a query field name to its multimap index table definition.
+fn index_table(
+    field: &str,
+) -> Option<MultimapTableDefinition<'static, &'static str, &'static str>> {
+    Some(match field {
+        "property" => IDX_PROPERTY,
+        "component" => IDX_COMPONENT,
+        "variant" => IDX_VARIANT,
+        "state" => IDX_STATE,
+        "colorScheme" => IDX_COLOR_SCHEME,
+        "scale" => IDX_SCALE,
+        "contrast" => IDX_CONTRAST,
+        "uuid" => IDX_UUID,
+        "$schema" => IDX_SCHEMA,
+        _ => return None,
+    })
+}
+
+/// Provenance + invalidation metadata stored in the `meta` table.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct CacheMeta {
+    schema_version: u32,
+    tokens_version: String,
+    /// Hash of the canonical JSON inputs (path + size + mtime).
+    content_hash: u64,
+}
+
+/// Internal cache errors. These are intentionally **not** surfaced to callers of
+/// [`open_cached`]: a cache problem simply triggers a rebuild / JSON fallback.
+#[derive(Debug, thiserror::Error)]
+enum CacheError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("redb open: {0}")]
+    Db(#[from] redb::DatabaseError),
+    #[error("redb txn: {0}")]
+    Txn(#[from] redb::TransactionError),
+    #[error("redb table: {0}")]
+    Table(#[from] redb::TableError),
+    #[error("redb storage: {0}")]
+    Storage(#[from] redb::StorageError),
+    #[error("redb commit: {0}")]
+    Commit(#[from] redb::CommitError),
+    #[error("messagepack encode: {0}")]
+    Encode(#[from] rmp_serde::encode::Error),
+    #[error("messagepack decode: {0}")]
+    Decode(#[from] rmp_serde::decode::Error),
+    #[error("build from json: {0}")]
+    Build(#[from] CoreError),
+    #[error("no cache directory available")]
+    NoCacheDir,
+}
+
+/// Emit a one-line warning only under `DESIGN_DATA_LOG=debug` (mirrors the
+/// embedded-snapshot module). Cache failures are non-fatal and would otherwise
+/// be noisy in scripts.
+fn debug_log(args: std::fmt::Arguments<'_>) {
+    if std::env::var("DESIGN_DATA_LOG").as_deref() == Ok("debug") {
+        eprintln!("design-data: cache: {args}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Load a [`TokenGraph`] for `tokens_root`, using the on-disk cache when fresh.
+///
+/// Drop-in replacement for [`TokenGraph::from_json_dir`]:
+/// 1. On a cache hit (schema + tokens-version + content-hash all match) the
+///    graph is hydrated from redb — no JSON parsing.
+/// 2. On a miss or any cache error, the graph is built from JSON (the source of
+///    truth) and the cache is rewritten best-effort.
+///
+/// Never fails because of the cache; only a JSON load error propagates.
+pub fn open_cached(tokens_root: &Path) -> Result<TokenGraph, CoreError> {
+    match load_from_disk(tokens_root) {
+        Ok(Some(graph)) => return Ok(graph),
+        Ok(None) => {}
+        Err(e) => debug_log(format_args!("read failed ({e}); rebuilding from json")),
+    }
+
+    let graph = TokenGraph::from_json_dir(tokens_root)?;
+    if let Err(e) = write_to_disk(tokens_root, &graph) {
+        debug_log(format_args!("write failed ({e}); cache not updated"));
+    }
+    Ok(graph)
+}
+
+/// Serialize a freshly built cache for `tokens_root` into an in-memory byte
+/// buffer (no filesystem). Use this as a build step to emit a `index.redb`
+/// static asset for WASM web tools.
+pub fn build_bytes(tokens_root: &Path) -> Result<Vec<u8>, CoreError> {
+    let graph = TokenGraph::from_json_dir(tokens_root)?;
+    let hash = content_hash(tokens_root).map_err(CoreError::Io)?;
+    build_bytes_from_graph(&graph, hash).map_err(into_core)
+}
+
+/// Build a cache for `tokens_root` and write it to an explicit `.redb` file.
+///
+/// Build-step primitive for emitting a shippable cache asset. Unlike
+/// [`open_cached`], the destination is caller-controlled rather than the OS
+/// cache directory.
+pub fn build_file(tokens_root: &Path, out_path: &Path) -> Result<(), CoreError> {
+    let graph = TokenGraph::from_json_dir(tokens_root)?;
+    let hash = content_hash(tokens_root).map_err(CoreError::Io)?;
+    write_db_file(out_path, &graph, hash).map_err(into_core)
+}
+
+/// Hydrate a [`TokenGraph`] from cache bytes (read-only, no filesystem).
+///
+/// The WASM read path: open a cache blob produced by [`build_bytes`].
+pub fn load_from_bytes(bytes: &[u8]) -> Result<TokenGraph, CoreError> {
+    let backend = MemBackend::from_bytes(bytes.to_vec());
+    let db = Database::builder()
+        .create_with_backend(backend)
+        .map_err(into_core_db)?;
+    let rtx = db.begin_read().map_err(|e| into_core(CacheError::Txn(e)))?;
+    hydrate(&rtx).map_err(into_core)
+}
+
+/// Reconstruct a [`TokenIndex`] from the multimap index tables in a cache blob.
+///
+/// Lets a read-only consumer answer indexed equality queries straight from the
+/// cached tables, without first hydrating the whole graph.
+pub fn load_index_from_bytes(bytes: &[u8]) -> Result<TokenIndex, CoreError> {
+    let backend = MemBackend::from_bytes(bytes.to_vec());
+    let db = Database::builder()
+        .create_with_backend(backend)
+        .map_err(into_core_db)?;
+    let rtx = db.begin_read().map_err(|e| into_core(CacheError::Txn(e)))?;
+    read_index(&rtx).map_err(into_core)
+}
+
+// ---------------------------------------------------------------------------
+// Disk path resolution + invalidation
+// ---------------------------------------------------------------------------
+
+fn cache_db_path(tokens_root: &Path) -> Option<PathBuf> {
+    let base = if let Ok(p) = std::env::var("DESIGN_DATA_CACHE_DIR") {
+        PathBuf::from(p)
+    } else {
+        dirs::cache_dir()?.join("design-data")
+    };
+    // Namespace by absolute dataset path so distinct datasets get distinct files.
+    let abs = tokens_root
+        .canonicalize()
+        .unwrap_or_else(|_| tokens_root.to_path_buf());
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    abs.to_string_lossy().hash(&mut hasher);
+    let dataset_key = format!("{:016x}", hasher.finish());
+    Some(
+        base.join("cache")
+            .join(EMBEDDED_TOKENS_VERSION)
+            .join(format!("{dataset_key}.redb")),
+    )
+}
+
+/// Content hash of the canonical inputs: per-file `(path, len, mtime)`, sorted.
+/// `mtime + len` is used (rather than full content) for speed; a false-positive
+/// match is impossible in practice and a false miss only forces a rebuild.
+fn content_hash(tokens_root: &Path) -> std::io::Result<u64> {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    CACHE_SCHEMA_VERSION.hash(&mut hasher);
+    EMBEDDED_TOKENS_VERSION.hash(&mut hasher);
+    let mut paths = discover_json_files(tokens_root)?;
+    paths.sort();
+    for p in &paths {
+        p.to_string_lossy().hash(&mut hasher);
+        let meta = std::fs::metadata(p)?;
+        meta.len().hash(&mut hasher);
+        if let Ok(modified) = meta.modified() {
+            if let Ok(dur) = modified.duration_since(std::time::UNIX_EPOCH) {
+                dur.as_nanos().hash(&mut hasher);
+            }
+        }
+    }
+    Ok(hasher.finish())
+}
+
+// ---------------------------------------------------------------------------
+// Read path
+// ---------------------------------------------------------------------------
+
+/// Returns `Ok(Some(graph))` on a fresh cache hit, `Ok(None)` on a miss
+/// (absent/stale), or `Err` on a real cache error.
+fn load_from_disk(tokens_root: &Path) -> Result<Option<TokenGraph>, CacheError> {
+    let Some(path) = cache_db_path(tokens_root) else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let expected = content_hash(tokens_root)?;
+    let db = Database::open(&path)?;
+    let rtx = db.begin_read()?;
+
+    let meta = read_meta(&rtx)?;
+    let fresh = meta.is_some_and(|m| {
+        m.schema_version == CACHE_SCHEMA_VERSION
+            && m.tokens_version == EMBEDDED_TOKENS_VERSION
+            && m.content_hash == expected
+    });
+    if !fresh {
+        return Ok(None);
+    }
+
+    Ok(Some(hydrate(&rtx)?))
+}
+
+fn read_meta(rtx: &redb::ReadTransaction) -> Result<Option<CacheMeta>, CacheError> {
+    let table = rtx.open_table(META)?;
+    let Some(bytes) = table.get("meta")? else {
+        return Ok(None);
+    };
+    Ok(Some(rmp_serde::from_slice(bytes.value())?))
+}
+
+/// Rebuild the in-memory [`TokenGraph`] from the `tokens` table. `from_records`
+/// rebuilds the UUID index, so the cached `uuid_index` table is not needed here.
+fn hydrate(rtx: &redb::ReadTransaction) -> Result<TokenGraph, CacheError> {
+    let table = rtx.open_table(TOKENS)?;
+    let mut records: Vec<TokenRecord> = Vec::new();
+    for item in table.iter()? {
+        let (_key, value) = item?;
+        let record: TokenRecord = rmp_serde::from_slice(value.value())?;
+        records.push(record);
+    }
+    Ok(TokenGraph::from_records(records))
+}
+
+fn read_index(rtx: &redb::ReadTransaction) -> Result<TokenIndex, CacheError> {
+    let mut index = TokenIndex::default();
+    for field in ALLOWED_KEYS {
+        let Some(def) = index_table(field) else {
+            continue;
+        };
+        let table = match rtx.open_multimap_table(def) {
+            Ok(t) => t,
+            // A missing index table just means no entries for that field.
+            Err(redb::TableError::TableDoesNotExist(_)) => continue,
+            Err(e) => return Err(e.into()),
+        };
+        for entry in table.iter()? {
+            let (value_guard, keys) = entry?;
+            let value = value_guard.value().to_string();
+            for key in keys {
+                let key = key?;
+                index.insert(field, &value, key.value());
+            }
+        }
+    }
+    Ok(index)
+}
+
+// ---------------------------------------------------------------------------
+// Write path
+// ---------------------------------------------------------------------------
+
+fn write_to_disk(tokens_root: &Path, graph: &TokenGraph) -> Result<(), CacheError> {
+    let path = cache_db_path(tokens_root).ok_or(CacheError::NoCacheDir)?;
+    let hash = content_hash(tokens_root)?;
+    write_db_file(&path, graph, hash)?;
+    evict_stale_versions(&path);
+    Ok(())
+}
+
+/// Write a cache database to `path` atomically: build into a sibling `.tmp`
+/// file, then rename over the destination (mirrors `embedded::materialize_to`).
+fn write_db_file(path: &Path, graph: &TokenGraph, hash: u64) -> Result<(), CacheError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("redb.tmp");
+    let _ = std::fs::remove_file(&tmp);
+
+    {
+        let db = Database::create(&tmp)?;
+        write_tables(&db, graph, hash)?;
+        // `db` drops here, flushing and releasing the file lock before rename.
+    }
+
+    if path.exists() {
+        let _ = std::fs::remove_file(path);
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Serialize a cache entirely in memory and return the bytes.
+fn build_bytes_from_graph(graph: &TokenGraph, hash: u64) -> Result<Vec<u8>, CacheError> {
+    let backend = MemBackend::new();
+    let handle = backend.clone();
+    {
+        let db = Database::builder().create_with_backend(backend)?;
+        write_tables(&db, graph, hash)?;
+    }
+    Ok(handle.snapshot())
+}
+
+fn write_tables(db: &Database, graph: &TokenGraph, hash: u64) -> Result<(), CacheError> {
+    let wtx = db.begin_write()?;
+    {
+        let meta = CacheMeta {
+            schema_version: CACHE_SCHEMA_VERSION,
+            tokens_version: EMBEDDED_TOKENS_VERSION.to_string(),
+            content_hash: hash,
+        };
+        let mut meta_t = wtx.open_table(META)?;
+        let bytes = rmp_serde::to_vec(&meta)?;
+        meta_t.insert("meta", bytes.as_slice())?;
+    }
+    {
+        let mut tokens_t = wtx.open_table(TOKENS)?;
+        let mut uuid_t = wtx.open_table(UUID_INDEX)?;
+        for (key, record) in &graph.tokens {
+            let bytes = rmp_serde::to_vec(record)?;
+            tokens_t.insert(key.as_str(), bytes.as_slice())?;
+            if let Some(uuid) = &record.uuid {
+                // First-seen wins, matching TokenGraph's uuid_index semantics.
+                if uuid_t.get(uuid.as_str())?.is_none() {
+                    uuid_t.insert(uuid.as_str(), key.as_str())?;
+                }
+            }
+        }
+    }
+    for field in ALLOWED_KEYS {
+        let Some(def) = index_table(field) else {
+            continue;
+        };
+        let mut table = wtx.open_multimap_table(def)?;
+        for (key, record) in &graph.tokens {
+            if let Some(value) = query::resolve_key(&record.raw, field) {
+                table.insert(value.as_str(), key.as_str())?;
+            }
+        }
+    }
+    wtx.commit()?;
+    Ok(())
+}
+
+/// Best-effort removal of cache files for other tokens-versions, keeping the
+/// footprint bounded as the binary is upgraded. Errors are ignored.
+fn evict_stale_versions(current: &Path) {
+    // `current` = <base>/cache/<version>/<key>.redb — its grandparent is `cache/`.
+    let Some(version_dir) = current.parent() else {
+        return;
+    };
+    let Some(cache_dir) = version_dir.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(cache_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p != version_dir && p.is_dir() {
+            let _ = std::fs::remove_dir_all(&p);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping (internal CacheError → public CoreError) for the byte APIs
+// ---------------------------------------------------------------------------
+
+fn into_core(e: CacheError) -> CoreError {
+    match e {
+        CacheError::Io(io) => CoreError::Io(io),
+        CacheError::Decode(d) => CoreError::ParseError(format!("cache decode: {d}")),
+        CacheError::Build(c) => c,
+        other => CoreError::ParseError(format!("cache: {other}")),
+    }
+}
+
+fn into_core_db(e: redb::DatabaseError) -> CoreError {
+    CoreError::ParseError(format!("cache: redb open: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_tokens(dir: &Path, file: &str, value: serde_json::Value) {
+        let path = dir.join(file);
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(f, "{value}").unwrap();
+    }
+
+    /// A dataset dir plus an isolated cache dir wired via `DESIGN_DATA_CACHE_DIR`.
+    fn fixture() -> (TempDir, TempDir, PathBuf) {
+        let data = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+        write_tokens(
+            data.path(),
+            "color.json",
+            json!({
+                "blue-100": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#00f",
+                    "uuid": "11111111-1111-4111-8111-111111111111",
+                    "name": {"property": "background-color", "component": "button"}
+                },
+                "blue-200": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#00e",
+                    "uuid": "22222222-2222-4222-8222-222222222222",
+                    "name": {"property": "color", "component": "button"}
+                }
+            }),
+        );
+        let root = data.path().to_path_buf();
+        (data, cache, root)
+    }
+
+    #[test]
+    fn miss_then_hit_roundtrip() {
+        let _env = crate::data_source::test_support::env_lock();
+        let (_data, cache, root) = fixture();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        // First load builds + writes the cache (miss).
+        let g1 = open_cached(&root).unwrap();
+        let path = cache_db_path(&root).unwrap();
+        assert!(path.exists(), "cache file should be written on first load");
+
+        // Second load is a hit; graph must match the JSON-built one.
+        let g2 = open_cached(&root).unwrap();
+        let g_json = TokenGraph::from_json_dir(&root).unwrap();
+        assert_eq!(g1.tokens.len(), g_json.tokens.len());
+        assert_eq!(g2.tokens.len(), g_json.tokens.len());
+        assert!(g2.tokens.contains_key("blue-100"));
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn disk_hit_serves_from_cache_not_fallback() {
+        let _env = crate::data_source::test_support::env_lock();
+        let (_data, cache, root) = fixture();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        // Prime the cache.
+        let _ = open_cached(&root).unwrap();
+
+        // load_from_disk must report a genuine hit (Some) — proving the redb
+        // read + MessagePack hydration path works, not the JSON fallback.
+        let hit = load_from_disk(&root).unwrap();
+        let graph = hit.expect("expected a cache hit after priming");
+        assert_eq!(graph.tokens.len(), 2);
+        assert!(graph.tokens.contains_key("blue-100"));
+        assert!(graph.tokens.contains_key("blue-200"));
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn edit_invalidates_cache() {
+        let _env = crate::data_source::test_support::env_lock();
+        let (data, cache, root) = fixture();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        let g1 = open_cached(&root).unwrap();
+        assert_eq!(g1.tokens.len(), 2);
+
+        // Mutate the dataset; the content hash must change → rebuild.
+        // Sleep briefly so mtime advances on coarse-grained filesystems.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_tokens(
+            data.path(),
+            "extra.json",
+            json!({
+                "green-100": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#0f0",
+                    "uuid": "33333333-3333-4333-8333-333333333333",
+                    "name": {"property": "border-color"}
+                }
+            }),
+        );
+
+        let g2 = open_cached(&root).unwrap();
+        assert_eq!(
+            g2.tokens.len(),
+            3,
+            "edited dataset must reload, not serve stale cache"
+        );
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn corrupt_cache_falls_back_to_json() {
+        let _env = crate::data_source::test_support::env_lock();
+        let (_data, cache, root) = fixture();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        // Prime the cache, then corrupt the file.
+        let _ = open_cached(&root).unwrap();
+        let path = cache_db_path(&root).unwrap();
+        std::fs::write(&path, b"not a redb database").unwrap();
+
+        // Must not error — falls back to JSON and rewrites the cache.
+        let g = open_cached(&root).unwrap();
+        assert_eq!(g.tokens.len(), 2);
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn in_memory_bytes_roundtrip() {
+        let (_data, _cache, root) = fixture();
+        let bytes = build_bytes(&root).unwrap();
+        assert!(!bytes.is_empty());
+
+        let graph = load_from_bytes(&bytes).unwrap();
+        assert_eq!(graph.tokens.len(), 2);
+        assert!(graph.tokens.contains_key("blue-200"));
+    }
+
+    #[test]
+    fn in_memory_index_uses_multimap_tables() {
+        let (_data, _cache, root) = fixture();
+        let bytes = build_bytes(&root).unwrap();
+
+        // The index is reconstructed purely from the cached multimap tables.
+        let index = load_index_from_bytes(&bytes).unwrap();
+        let graph = load_from_bytes(&bytes).unwrap();
+
+        let expr = query::parse("component=button").unwrap();
+        let via_index = query::filter_with_index(&graph, &index, &expr);
+        assert_eq!(via_index.len(), 2);
+
+        let expr = query::parse("property=color").unwrap();
+        let via_index = query::filter_with_index(&graph, &index, &expr);
+        assert_eq!(via_index.len(), 1);
+        assert_eq!(
+            via_index[0].uuid.as_deref(),
+            Some("22222222-2222-4222-8222-222222222222")
+        );
+    }
+}

--- a/sdk/core/src/cascade.rs
+++ b/sdk/core/src/cascade.rs
@@ -193,6 +193,84 @@ pub fn resolve<'a>(graph: &'a TokenGraph, context: &ResolutionContext) -> Option
     candidates.into_iter().next()
 }
 
+// ── Property-scoped resolution ────────────────────────────────────────────────
+
+/// One candidate returned by [`resolve_property`]: a token matching the
+/// requested property, its cascade specificity, and whether it won resolution.
+#[derive(Debug, Clone)]
+pub struct ResolvedCandidate {
+    pub record: TokenRecord,
+    pub specificity: u32,
+    pub is_winner: bool,
+}
+
+/// Resolve all tokens whose `name.property` equals `property`, ranked by cascade
+/// precedence, with the winning token flagged.
+///
+/// Builds a property-filtered subgraph (preserving full records and their cascade
+/// `layer` so Platform-layer manifest overrides correctly win over Foundation
+/// tokens), sorts candidates by layer/specificity/document order, and runs
+/// [`resolve`] on the subgraph to determine the winner.
+pub fn resolve_property(
+    graph: &TokenGraph,
+    property: &str,
+    ctx: &ResolutionContext,
+) -> Vec<ResolvedCandidate> {
+    let candidates: Vec<TokenRecord> = graph
+        .tokens
+        .values()
+        .filter(|t| {
+            t.raw
+                .get("name")
+                .and_then(|v| v.as_object())
+                .and_then(|n| n.get("property"))
+                .and_then(|v| v.as_str())
+                == Some(property)
+        })
+        .cloned()
+        .collect();
+
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let filtered_graph =
+        TokenGraph::from_records(candidates).with_mode_sets(graph.mode_sets.clone());
+
+    let mut with_spec: Vec<(&TokenRecord, u32)> = filtered_graph
+        .tokens
+        .values()
+        .map(|t| {
+            let s = t
+                .raw
+                .get("name")
+                .and_then(|v| v.as_object())
+                .map(|n| specificity(n, &filtered_graph.mode_sets))
+                .unwrap_or(0);
+            (t, s)
+        })
+        .collect();
+
+    with_spec.sort_by(|(a, sa), (b, sb)| {
+        b.layer
+            .cmp(&a.layer)
+            .then_with(|| sb.cmp(sa))
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.index.cmp(&b.index))
+    });
+
+    let winner = resolve(&filtered_graph, ctx);
+
+    with_spec
+        .into_iter()
+        .map(|(t, spec)| ResolvedCandidate {
+            record: t.clone(),
+            specificity: spec,
+            is_winner: winner.map(|w| w.name == t.name).unwrap_or(false),
+        })
+        .collect()
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -477,6 +555,57 @@ mod tests {
         assert_eq!(
             winner.raw.get("value").and_then(|v| v.as_str()),
             Some("#product")
+        );
+    }
+
+    // ── resolve_property ─────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_property_flags_winner_and_filters_by_property() {
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "btn-bg".into(),
+                PathBuf::from("a.json"),
+                json!({"name": {"property": "background-color", "component": "button"}, "value": "#aaa"}),
+            ),
+            (
+                "btn-fg".into(),
+                PathBuf::from("a.json"),
+                json!({"name": {"property": "color", "component": "button"}, "value": "#111"}),
+            ),
+        ]);
+        let ctx = ResolutionContext::new();
+        let results = resolve_property(&g, "background-color", &ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_winner);
+        assert_eq!(results[0].record.name, "btn-bg");
+    }
+
+    #[test]
+    fn resolve_property_respects_restrictions() {
+        let g = TokenGraph::from_pairs(vec![
+            (
+                "t-light".into(),
+                PathBuf::from("a.json"),
+                json!({"name": {"property": "bg", "colorScheme": "light"}, "value": "#fff"}),
+            ),
+            (
+                "t-dark".into(),
+                PathBuf::from("a.json"),
+                json!({"name": {"property": "bg", "colorScheme": "dark"}, "value": "#000"}),
+            ),
+        ])
+        .with_mode_sets(vec![color_scheme_mode_set()]);
+
+        let ctx = ResolutionContext::new()
+            .with("colorScheme", "light")
+            .with_restriction("colorScheme", vec!["light"]);
+        let results = resolve_property(&g, "bg", &ctx);
+        assert_eq!(results.len(), 2);
+        let winner = results.iter().find(|c| c.is_winner).expect("winner");
+        assert_eq!(
+            winner.record.raw["name"]["colorScheme"].as_str(),
+            Some("light")
         );
     }
 }

--- a/sdk/core/src/cascade.rs
+++ b/sdk/core/src/cascade.rs
@@ -59,8 +59,10 @@ impl ResolutionContext {
         mode_set: impl Into<String>,
         allowed: Vec<impl Into<String>>,
     ) -> Self {
-        self.mode_set_restrictions
-            .insert(mode_set.into(), allowed.into_iter().map(Into::into).collect());
+        self.mode_set_restrictions.insert(
+            mode_set.into(),
+            allowed.into_iter().map(Into::into).collect(),
+        );
         self
     }
 }

--- a/sdk/core/src/data_source/embedded.rs
+++ b/sdk/core/src/data_source/embedded.rs
@@ -40,7 +40,7 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use include_dir::{Dir, include_dir};
+use include_dir::{include_dir, Dir};
 // Dir is used for the embedded static types; include_dir! for the macros.
 
 // ---------------------------------------------------------------------------
@@ -48,41 +48,35 @@ use include_dir::{Dir, include_dir};
 // ---------------------------------------------------------------------------
 
 /// Token source files (`packages/tokens/src/*.json`, 8 files, ~1.3 MB).
-static TOKENS_SRC: Dir<'_> = include_dir!(
-    "$CARGO_MANIFEST_DIR/../../packages/tokens/src"
-);
+static TOKENS_SRC: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../packages/tokens/src");
 
 /// JSON Schema files for token validation (`packages/tokens/schemas/`, ~88 KB).
 /// Includes the `token-types/` subdirectory.
-static TOKENS_SCHEMAS: Dir<'_> = include_dir!(
-    "$CARGO_MANIFEST_DIR/../../packages/tokens/schemas"
-);
+static TOKENS_SCHEMAS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../packages/tokens/schemas");
 
 /// Mode-set declarations (`packages/design-data-spec/mode-sets/`, 3 files, ~12 KB).
-static MODE_SETS: Dir<'_> = include_dir!(
-    "$CARGO_MANIFEST_DIR/../../packages/design-data-spec/mode-sets"
-);
+static MODE_SETS: Dir<'_> =
+    include_dir!("$CARGO_MANIFEST_DIR/../../packages/design-data-spec/mode-sets");
 
 /// Component declaration JSONs (`packages/design-data-spec/components/`, 81 files, ~620 KB).
-static COMPONENTS: Dir<'_> = include_dir!(
-    "$CARGO_MANIFEST_DIR/../../packages/design-data-spec/components"
-);
+static COMPONENTS: Dir<'_> =
+    include_dir!("$CARGO_MANIFEST_DIR/../../packages/design-data-spec/components");
 
 /// Taxonomy field JSONs (`packages/design-data-spec/fields/`, 24 files, ~96 KB).
-static FIELDS: Dir<'_> = include_dir!(
-    "$CARGO_MANIFEST_DIR/../../packages/design-data-spec/fields"
-);
+static FIELDS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../packages/design-data-spec/fields");
 
 /// Naming exceptions list (`packages/tokens/naming-exceptions.json`, ~46 KB).
-static NAMING_EXCEPTIONS: &str = include_str!(
-    concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/tokens/naming-exceptions.json")
-);
+static NAMING_EXCEPTIONS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../packages/tokens/naming-exceptions.json"
+));
 
 /// Token build manifest — lists the 8 source JSON file paths
 /// (`packages/tokens/manifest.json`).
-static TOKENS_MANIFEST: &str = include_str!(
-    concat!(env!("CARGO_MANIFEST_DIR"), "/../../packages/tokens/manifest.json")
-);
+static TOKENS_MANIFEST: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../packages/tokens/manifest.json"
+));
 
 // ---------------------------------------------------------------------------
 // Version provenance
@@ -149,8 +143,12 @@ pub fn materialize() -> io::Result<PathBuf> {
 /// the binary is updated across releases.  Errors are silently ignored — eviction
 /// is best-effort and must never cause the calling `materialize` to fail.
 fn evict_stale_versions(current: &Path) {
-    let Some(parent) = current.parent() else { return };
-    let Ok(entries) = std::fs::read_dir(parent) else { return };
+    let Some(parent) = current.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
     for entry in entries.flatten() {
         let path = entry.path();
         if path != current && path.is_dir() {
@@ -201,7 +199,10 @@ pub fn materialize_to(root: &Path) -> io::Result<()> {
     extract(&TOKENS_SRC, &tmp.join("packages/tokens/src"))?;
     extract(&TOKENS_SCHEMAS, &tmp.join("packages/tokens/schemas"))?;
     extract(&MODE_SETS, &tmp.join("packages/design-data-spec/mode-sets"))?;
-    extract(&COMPONENTS, &tmp.join("packages/design-data-spec/components"))?;
+    extract(
+        &COMPONENTS,
+        &tmp.join("packages/design-data-spec/components"),
+    )?;
     extract(&FIELDS, &tmp.join("packages/design-data-spec/fields"))?;
 
     write_file(
@@ -268,7 +269,10 @@ mod tests {
     fn materialize_creates_expected_layout() {
         let (_tmp, root) = temp_root();
 
-        assert!(root.join("packages/tokens/src").is_dir(), "tokens/src missing");
+        assert!(
+            root.join("packages/tokens/src").is_dir(),
+            "tokens/src missing"
+        );
         assert!(
             root.join("packages/tokens/schemas/token-types").is_dir(),
             "schemas/token-types missing"
@@ -286,14 +290,18 @@ mod tests {
             "fields missing"
         );
         assert!(
-            root.join("packages/tokens/naming-exceptions.json").is_file(),
+            root.join("packages/tokens/naming-exceptions.json")
+                .is_file(),
             "naming-exceptions.json missing"
         );
         assert!(
             root.join("packages/tokens/manifest.json").is_file(),
             "manifest.json missing"
         );
-        assert!(root.join(".complete").is_file(), ".complete sentinel missing");
+        assert!(
+            root.join(".complete").is_file(),
+            ".complete sentinel missing"
+        );
     }
 
     #[test]
@@ -338,12 +346,11 @@ mod tests {
     #[test]
     fn materialize_schemas_has_token_types_subdir() {
         let (_tmp, root) = temp_root();
-        let schemas: Vec<_> =
-            fs::read_dir(root.join("packages/tokens/schemas/token-types"))
-                .unwrap()
-                .flatten()
-                .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
-                .collect();
+        let schemas: Vec<_> = fs::read_dir(root.join("packages/tokens/schemas/token-types"))
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .collect();
         assert!(
             !schemas.is_empty(),
             "token-types/ should contain at least one JSON schema"
@@ -356,12 +363,11 @@ mod tests {
         // packages/design-data-spec/components/, this test fails deliberately.
         // Update the expected count when you've intentionally changed the set.
         let (_tmp, root) = temp_root();
-        let components: Vec<_> =
-            fs::read_dir(root.join("packages/design-data-spec/components"))
-                .unwrap()
-                .flatten()
-                .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
-                .collect();
+        let components: Vec<_> = fs::read_dir(root.join("packages/design-data-spec/components"))
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+            .collect();
         assert_eq!(
             components.len(),
             81,
@@ -388,12 +394,10 @@ mod tests {
             .expect("packages/tokens/package.json should have a string 'version' field");
 
         assert_eq!(
-            EMBEDDED_TOKENS_VERSION,
-            pkg_version,
+            EMBEDDED_TOKENS_VERSION, pkg_version,
             "EMBEDDED_TOKENS_VERSION is '{}' but packages/tokens/package.json says '{}'. \
              Update the constant in sdk/core/src/data_source/embedded.rs.",
-            EMBEDDED_TOKENS_VERSION,
-            pkg_version
+            EMBEDDED_TOKENS_VERSION, pkg_version
         );
     }
 }

--- a/sdk/core/src/data_source/fetch.rs
+++ b/sdk/core/src/data_source/fetch.rs
@@ -65,9 +65,7 @@ use super::SourceConfig;
 #[derive(Debug, Error)]
 pub enum FetchError {
     /// The source type is recognised but not yet implemented.
-    #[error(
-        "source type '{source_type}' is not yet fully implemented: {reason}"
-    )]
+    #[error("source type '{source_type}' is not yet fully implemented: {reason}")]
     NotYetSupported {
         source_type: &'static str,
         reason: &'static str,
@@ -191,12 +189,18 @@ fn download_bytes(url: &str) -> Result<Vec<u8>, FetchError> {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(60))
             .build()
-            .map_err(|e| FetchError::Network { url: url.to_string(), source: e })?;
+            .map_err(|e| FetchError::Network {
+                url: url.to_string(),
+                source: e,
+            })?;
         let resp = client
             .get(url)
             .send()
             .await
-            .map_err(|e| FetchError::Network { url: url.to_string(), source: e })?;
+            .map_err(|e| FetchError::Network {
+                url: url.to_string(),
+                source: e,
+            })?;
         let status = resp.status();
         if !status.is_success() {
             return Err(FetchError::Network {
@@ -206,10 +210,10 @@ fn download_bytes(url: &str) -> Result<Vec<u8>, FetchError> {
                     .expect_err("non-success status confirmed"),
             });
         }
-        let bytes = resp
-            .bytes()
-            .await
-            .map_err(|e| FetchError::Network { url: url.to_string(), source: e })?;
+        let bytes = resp.bytes().await.map_err(|e| FetchError::Network {
+            url: url.to_string(),
+            source: e,
+        })?;
         Ok(bytes.to_vec())
     })
 }
@@ -258,16 +262,22 @@ fn extract_tarball_inner(bytes: &[u8], url: &str, dest: &Path) -> Result<(), Fet
     // We'll strip it from every path before writing.
     let mut prefix: Option<String> = None;
 
-    let entries = archive
-        .entries()
-        .map_err(|e| FetchError::Extract { url: url.to_string(), source: e })?;
+    let entries = archive.entries().map_err(|e| FetchError::Extract {
+        url: url.to_string(),
+        source: e,
+    })?;
 
     for entry_result in entries {
-        let mut entry = entry_result
-            .map_err(|e| FetchError::Extract { url: url.to_string(), source: e })?;
+        let mut entry = entry_result.map_err(|e| FetchError::Extract {
+            url: url.to_string(),
+            source: e,
+        })?;
         let raw_path = entry
             .path()
-            .map_err(|e| FetchError::Extract { url: url.to_string(), source: e })?
+            .map_err(|e| FetchError::Extract {
+                url: url.to_string(),
+                source: e,
+            })?
             .to_path_buf();
 
         // Establish the top-level prefix from the first *regular* entry.
@@ -309,16 +319,21 @@ fn extract_tarball_inner(bytes: &[u8], url: &str, dest: &Path) -> Result<(), Fet
         let target = dest.join(&rel);
 
         if entry.header().entry_type().is_dir() {
-            std::fs::create_dir_all(&target)
-                .map_err(|e| FetchError::Extract { url: url.to_string(), source: e })?;
+            std::fs::create_dir_all(&target).map_err(|e| FetchError::Extract {
+                url: url.to_string(),
+                source: e,
+            })?;
         } else {
             if let Some(parent) = target.parent() {
-                std::fs::create_dir_all(parent)
-                    .map_err(|e| FetchError::Extract { url: url.to_string(), source: e })?;
+                std::fs::create_dir_all(parent).map_err(|e| FetchError::Extract {
+                    url: url.to_string(),
+                    source: e,
+                })?;
             }
-            entry
-                .unpack(&target)
-                .map_err(|e| FetchError::Extract { url: url.to_string(), source: e })?;
+            entry.unpack(&target).map_err(|e| FetchError::Extract {
+                url: url.to_string(),
+                source: e,
+            })?;
         }
     }
 
@@ -366,7 +381,9 @@ fn evict_stale_versions(current: &Path, parent_dir: &Path) {
         Some(n) => n,
         None => return,
     };
-    let Ok(entries) = std::fs::read_dir(parent_dir) else { return };
+    let Ok(entries) = std::fs::read_dir(parent_dir) else {
+        return;
+    };
     for entry in entries.flatten() {
         let path = entry.path();
         if path.file_name() != Some(current_name) && path.is_dir() {
@@ -387,11 +404,15 @@ mod tests {
     #[test]
     fn should_extract_tokens_src() {
         assert!(should_extract(Path::new("packages/tokens/src/color.json")));
-        assert!(should_extract(Path::new("packages/tokens/schemas/token-file.json")));
+        assert!(should_extract(Path::new(
+            "packages/tokens/schemas/token-file.json"
+        )));
         assert!(should_extract(Path::new(
             "packages/tokens/schemas/token-types/color.json"
         )));
-        assert!(should_extract(Path::new("packages/tokens/naming-exceptions.json")));
+        assert!(should_extract(Path::new(
+            "packages/tokens/naming-exceptions.json"
+        )));
         assert!(should_extract(Path::new("packages/tokens/manifest.json")));
     }
 
@@ -416,7 +437,9 @@ mod tests {
         assert!(!should_extract(Path::new(
             "packages/design-data-spec/rules/rules.yaml"
         )));
-        assert!(!should_extract(Path::new("packages/component-schemas/index.js")));
+        assert!(!should_extract(Path::new(
+            "packages/component-schemas/index.js"
+        )));
         assert!(!should_extract(Path::new("sdk/cli/src/main.rs")));
         assert!(!should_extract(Path::new("README.md")));
     }
@@ -432,7 +455,13 @@ mod tests {
         };
         let err = ensure_cached(&source, None).unwrap_err();
         std::env::remove_var("DESIGN_DATA_CACHE_DIR");
-        assert!(matches!(err, FetchError::NotYetSupported { source_type: "npm", .. }));
+        assert!(matches!(
+            err,
+            FetchError::NotYetSupported {
+                source_type: "npm",
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -446,7 +475,13 @@ mod tests {
         };
         let err = ensure_cached(&source, None).unwrap_err();
         std::env::remove_var("DESIGN_DATA_CACHE_DIR");
-        assert!(matches!(err, FetchError::NotYetSupported { source_type: "git", .. }));
+        assert!(matches!(
+            err,
+            FetchError::NotYetSupported {
+                source_type: "git",
+                ..
+            }
+        ));
     }
 
     // Integration test — requires network; skipped in offline/CI environments.
@@ -465,7 +500,10 @@ mod tests {
 
         // First call — downloads.
         let root = ensure_cached(&source, None).expect("first fetch failed");
-        assert!(root.join("packages/tokens/src").is_dir(), "tokens/src missing");
+        assert!(
+            root.join("packages/tokens/src").is_dir(),
+            "tokens/src missing"
+        );
         assert!(
             root.join("packages/tokens/schemas/token-types").is_dir(),
             "schemas/token-types missing"

--- a/sdk/core/src/data_source/mod.rs
+++ b/sdk/core/src/data_source/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod embedded;
 #[cfg(feature = "fetch")]
 pub(crate) mod fetch;
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 
 use std::path::{Path, PathBuf};
 
@@ -215,9 +215,7 @@ pub enum DataSourceError {
         source: toml::de::Error,
     },
     /// `source.type = "path"` but the `root` directory does not exist.
-    #[error(
-        "source.root '{root}' in `.design-data.toml` does not exist or is not a directory"
-    )]
+    #[error("source.root '{root}' in `.design-data.toml` does not exist or is not a directory")]
     PathNotFound {
         /// The resolved (possibly absolute) path that was probed.
         root: PathBuf,
@@ -247,10 +245,7 @@ pub enum DataSourceError {
 /// - A `.design-data.toml` exists but cannot be read or parsed.
 /// - `source.type = "path"` and `root` does not exist.
 /// - `source.type` is `npm`, `github`, or `git` (not yet implemented).
-pub fn resolve(
-    cwd: &Path,
-    overrides: &CliPathOverrides,
-) -> Result<ResolvedData, DataSourceError> {
+pub fn resolve(cwd: &Path, overrides: &CliPathOverrides) -> Result<ResolvedData, DataSourceError> {
     // Tier 1 is handled per-field inside each helper (overrides win always).
 
     // Tier 2: look for `.design-data.toml` walking up from cwd.
@@ -286,9 +281,11 @@ pub fn resolve(
                 }
                 SourceConfig::Npm { .. }
                 | SourceConfig::Github { .. }
-                | SourceConfig::Git { .. } => {
-                    fetch_source(source, config.cache.as_ref().and_then(|c| c.dir.as_deref()), overrides)
-                }
+                | SourceConfig::Git { .. } => fetch_source(
+                    source,
+                    config.cache.as_ref().and_then(|c| c.dir.as_deref()),
+                    overrides,
+                ),
             };
         }
         // Config file present but no [source] block → fall through to probing.
@@ -354,10 +351,11 @@ fn find_config(start: &Path) -> Result<Option<(PathBuf, DesignDataConfig)>, Data
     for dir in start.ancestors() {
         let candidate = dir.join(".design-data.toml");
         if candidate.is_file() {
-            let text = std::fs::read_to_string(&candidate).map_err(|e| DataSourceError::ConfigRead {
-                path: candidate.clone(),
-                source: e,
-            })?;
+            let text =
+                std::fs::read_to_string(&candidate).map_err(|e| DataSourceError::ConfigRead {
+                    path: candidate.clone(),
+                    source: e,
+                })?;
             let config: DesignDataConfig =
                 toml::from_str(&text).map_err(|e| DataSourceError::ConfigParse {
                     path: candidate.clone(),
@@ -510,11 +508,18 @@ fn probe_cwd(cwd: &Path, overrides: &CliPathOverrides) -> ResolvedData {
 ///
 /// The env var is honoured at this level so it works regardless of which tier
 /// resolved the other paths.
-fn resolve_schema_root(overrides: &CliPathOverrides, fallback: impl FnOnce() -> PathBuf) -> PathBuf {
+fn resolve_schema_root(
+    overrides: &CliPathOverrides,
+    fallback: impl FnOnce() -> PathBuf,
+) -> PathBuf {
     overrides
         .schema_root
         .clone()
-        .or_else(|| std::env::var("DESIGN_DATA_SCHEMA_ROOT").ok().map(PathBuf::from))
+        .or_else(|| {
+            std::env::var("DESIGN_DATA_SCHEMA_ROOT")
+                .ok()
+                .map(PathBuf::from)
+        })
         .unwrap_or_else(fallback)
 }
 
@@ -533,7 +538,9 @@ fn fetch_source(
         Ok(from_root(
             &cache_root,
             overrides,
-            Provenance::Cache { cache_dir: cache_root.clone() },
+            Provenance::Cache {
+                cache_dir: cache_root.clone(),
+            },
         ))
     }
     #[cfg(not(feature = "fetch"))]
@@ -719,7 +726,10 @@ mod tests {
         fs::create_dir_all(&parent).unwrap();
         fs::write(
             parent.join(".design-data.toml"),
-            format!("[source]\ntype = \"path\"\nroot = \"{}\"\n", ext_repo.display()),
+            format!(
+                "[source]\ntype = \"path\"\nroot = \"{}\"\n",
+                ext_repo.display()
+            ),
         )
         .unwrap();
 
@@ -820,9 +830,7 @@ mod tests {
         // Embedded-tier coverage lives in resolve_outside_repo_uses_embedded_tier.
         assert_eq!(resolved.schemas_root, custom_schema);
         assert!(
-            !resolved
-                .schemas_root
-                .ends_with("packages/tokens/schemas"),
+            !resolved.schemas_root.ends_with("packages/tokens/schemas"),
             "schema override must not fall through to the embedded/in-repo default"
         );
     }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -138,10 +138,8 @@ impl TokenGraph {
     /// Load a graph for `root`, using the derived embedded-database cache when
     /// the `cache` feature is enabled.
     ///
-    /// Drop-in replacement for [`Self::from_json_dir`]: a fresh cache is
-    /// hydrated without re-parsing JSON; a stale/absent/corrupt cache rebuilds
-    /// from JSON (the source of truth) and rewrites the cache best-effort. When
-    /// the `cache` feature is disabled this is exactly [`Self::from_json_dir`].
+    /// Drop-in replacement for [`Self::from_json_dir`]. See also
+    /// [`Self::open_cached_with_index`] when the persisted query index is needed.
     pub fn open_cached(root: &Path) -> Result<Self, CoreError> {
         #[cfg(feature = "cache")]
         {
@@ -150,6 +148,25 @@ impl TokenGraph {
         #[cfg(not(feature = "cache"))]
         {
             Self::from_json_dir(root)
+        }
+    }
+
+    /// Load a graph and its query index together from cache or JSON.
+    ///
+    /// On a cache hit the `idx_*` multimap tables are hydrated without an
+    /// in-memory rebuild. When the `cache` feature is disabled this builds the
+    /// index from the JSON-loaded graph.
+    pub fn open_cached_with_index(root: &Path) -> Result<(Self, query::TokenIndex), CoreError> {
+        #[cfg(feature = "cache")]
+        {
+            let loaded = crate::cache::open_cached_with_index(root)?;
+            Ok((loaded.graph, loaded.index))
+        }
+        #[cfg(not(feature = "cache"))]
+        {
+            let graph = Self::from_json_dir(root)?;
+            let index = query::TokenIndex::build(&graph);
+            Ok((graph, index))
         }
     }
 

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -24,8 +24,17 @@ use crate::CoreError;
 /// Layer ordering is encoded in the discriminant so `Ord` gives correct
 /// precedence: `Foundation < Platform < Product`.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default,
-    serde::Serialize, serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum Layer {
@@ -49,7 +58,7 @@ impl std::str::FromStr for Layer {
 }
 
 /// One component declaration (spec-format JSON), loaded for relational rules.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ComponentRecord {
     pub name: String,
     pub file: PathBuf,
@@ -57,7 +66,7 @@ pub struct ComponentRecord {
 }
 
 /// One mode set declaration (new spec shape), when present in a JSON file.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModeSetRecord {
     pub file: PathBuf,
     pub name: String,
@@ -66,7 +75,7 @@ pub struct ModeSetRecord {
 }
 
 /// One token entry (legacy file key, cascade array element, or test fixture id).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TokenRecord {
     pub name: String,
     pub file: PathBuf,
@@ -100,9 +109,7 @@ impl TokenGraph {
     ///
     /// Each file is `{ "<token-slug>": { <name-object> }, … }`.  All files are
     /// merged into a single map.  Duplicate slugs across files return an error.
-    fn load_sidecar_names(
-        dir: &Path,
-    ) -> Result<HashMap<String, Value>, CoreError> {
+    fn load_sidecar_names(dir: &Path) -> Result<HashMap<String, Value>, CoreError> {
         let mut map: HashMap<String, Value> = HashMap::new();
         for path in discover_json_files(dir)? {
             let text = std::fs::read_to_string(&path)?;
@@ -126,6 +133,24 @@ impl TokenGraph {
     /// Convenience wrapper: equivalent to `from_json_dir_with_names(root, None)`.
     pub fn from_json_dir(root: &Path) -> Result<Self, CoreError> {
         Self::from_json_dir_with_names(root, None)
+    }
+
+    /// Load a graph for `root`, using the derived embedded-database cache when
+    /// the `cache` feature is enabled.
+    ///
+    /// Drop-in replacement for [`Self::from_json_dir`]: a fresh cache is
+    /// hydrated without re-parsing JSON; a stale/absent/corrupt cache rebuilds
+    /// from JSON (the source of truth) and rewrites the cache best-effort. When
+    /// the `cache` feature is disabled this is exactly [`Self::from_json_dir`].
+    pub fn open_cached(root: &Path) -> Result<Self, CoreError> {
+        #[cfg(feature = "cache")]
+        {
+            crate::cache::open_cached(root)
+        }
+        #[cfg(not(feature = "cache"))]
+        {
+            Self::from_json_dir(root)
+        }
     }
 
     /// Build a graph from legacy Spectrum token sources (`*.json` token maps).
@@ -320,7 +345,9 @@ impl TokenGraph {
         let mut uuid_index = HashMap::new();
         for record in records {
             if let Some(u) = &record.uuid {
-                uuid_index.entry(u.clone()).or_insert_with(|| record.name.clone());
+                uuid_index
+                    .entry(u.clone())
+                    .or_insert_with(|| record.name.clone());
             }
             tokens.insert(record.name.clone(), record);
         }
@@ -402,11 +429,16 @@ impl TokenGraph {
                 let Some(tok_obj) = token_val.as_object() else {
                     continue;
                 };
-                let uuid = tok_obj.get("uuid").and_then(|v| v.as_str()).map(str::to_string);
+                let uuid = tok_obj
+                    .get("uuid")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
                 let alias_target = extract_alias_target(tok_obj);
                 let key = format!("product-context-ext:{}:{}", path.display(), idx);
                 if let Some(u) = &uuid {
-                    self.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                    self.uuid_index
+                        .entry(u.clone())
+                        .or_insert_with(|| key.clone());
                 }
                 self.tokens.insert(
                     key.clone(),
@@ -526,7 +558,9 @@ impl TokenGraph {
                     let alias_target = raw.as_object().and_then(extract_alias_target);
                     let key = format!("platform-override:{target}:{idx}:{match_idx}");
                     if let Some(u) = &uuid {
-                        self.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                        self.uuid_index
+                            .entry(u.clone())
+                            .or_insert_with(|| key.clone());
                     }
                     self.tokens.insert(
                         key.clone(),
@@ -555,7 +589,10 @@ impl TokenGraph {
                 let Some(tok_obj) = token_val.as_object() else {
                     continue;
                 };
-                let uuid = tok_obj.get("uuid").and_then(|v| v.as_str()).map(str::to_string);
+                let uuid = tok_obj
+                    .get("uuid")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
                 let schema_url = tok_obj
                     .get("$schema")
                     .and_then(|v| v.as_str())
@@ -563,7 +600,9 @@ impl TokenGraph {
                 let alias_target = extract_alias_target(tok_obj);
                 let key = format!("platform-ext:{idx}");
                 if let Some(u) = &uuid {
-                    self.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                    self.uuid_index
+                        .entry(u.clone())
+                        .or_insert_with(|| key.clone());
                 }
                 self.tokens.insert(
                     key.clone(),
@@ -583,7 +622,10 @@ impl TokenGraph {
 
         // 4. modeSetRestrictions — returned for the resolution context.
         let mut mode_set_restrictions: HashMap<String, Vec<String>> = HashMap::new();
-        if let Some(obj) = manifest.get("modeSetRestrictions").and_then(|v| v.as_object()) {
+        if let Some(obj) = manifest
+            .get("modeSetRestrictions")
+            .and_then(|v| v.as_object())
+        {
             for (ms_name, restr) in obj {
                 if let Some(allowed) = restr.get("allowed").and_then(|v| v.as_array()) {
                     let modes: Vec<String> = allowed
@@ -615,9 +657,10 @@ impl TokenGraph {
             return Ok(query::filter(self, &filter)
                 .into_iter()
                 .filter_map(|rec| {
-                    rec.raw.get("name").cloned().map(|name_obj| {
-                        (name_obj, rec.raw.get("value").cloned(), rec.uuid.clone())
-                    })
+                    rec.raw
+                        .get("name")
+                        .cloned()
+                        .map(|name_obj| (name_obj, rec.raw.get("value").cloned(), rec.uuid.clone()))
                 })
                 .collect());
         }
@@ -628,7 +671,11 @@ impl TokenGraph {
             .or_else(|| self.tokens.get(target));
         if let Some(rec) = record {
             if let Some(name_obj) = rec.raw.get("name").cloned() {
-                return Ok(vec![(name_obj, rec.raw.get("value").cloned(), rec.uuid.clone())]);
+                return Ok(vec![(
+                    name_obj,
+                    rec.raw.get("value").cloned(),
+                    rec.uuid.clone(),
+                )]);
             }
         }
         Ok(Vec::new())
@@ -796,9 +843,9 @@ impl TokenRecord {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
     use std::io::Write;
     use tempfile::tempdir;
-    use serde_json::json;
 
     use super::*;
 
@@ -813,12 +860,20 @@ mod tests {
         let tokens_dir = tempdir().unwrap();
         let names_dir = tempdir().unwrap();
 
-        write_json(&tokens_dir, "t.json", json!({
-            "blue-100": { "$schema": "https://example.com/color-set.json", "value": "#0000ff" }
-        }));
-        write_json(&names_dir, "t.json", json!({
-            "blue-100": { "property": "color", "colorFamily": "blue", "scaleIndex": 100 }
-        }));
+        write_json(
+            &tokens_dir,
+            "t.json",
+            json!({
+                "blue-100": { "$schema": "https://example.com/color-set.json", "value": "#0000ff" }
+            }),
+        );
+        write_json(
+            &names_dir,
+            "t.json",
+            json!({
+                "blue-100": { "property": "color", "colorFamily": "blue", "scaleIndex": 100 }
+            }),
+        );
 
         let g = TokenGraph::from_json_dir_with_names(tokens_dir.path(), Some(names_dir.path()))
             .unwrap();
@@ -833,22 +888,33 @@ mod tests {
         let tokens_dir = tempdir().unwrap();
         let names_dir = tempdir().unwrap();
 
-        write_json(&tokens_dir, "t.json", json!({
-            "blue-100": {
-                "$schema": "https://example.com/color-set.json",
-                "value": "#0000ff",
-                "name": { "property": "color", "colorFamily": "inline-value" }
-            }
-        }));
-        write_json(&names_dir, "t.json", json!({
-            "blue-100": { "property": "color", "colorFamily": "sidecar-value" }
-        }));
+        write_json(
+            &tokens_dir,
+            "t.json",
+            json!({
+                "blue-100": {
+                    "$schema": "https://example.com/color-set.json",
+                    "value": "#0000ff",
+                    "name": { "property": "color", "colorFamily": "inline-value" }
+                }
+            }),
+        );
+        write_json(
+            &names_dir,
+            "t.json",
+            json!({
+                "blue-100": { "property": "color", "colorFamily": "sidecar-value" }
+            }),
+        );
 
         let g = TokenGraph::from_json_dir_with_names(tokens_dir.path(), Some(names_dir.path()))
             .unwrap();
         let token = g.tokens.get("blue-100").unwrap();
         let name = token.raw.get("name").unwrap();
-        assert_eq!(name["colorFamily"], "inline-value", "inline name must win over sidecar");
+        assert_eq!(
+            name["colorFamily"], "inline-value",
+            "inline name must win over sidecar"
+        );
     }
 
     #[test]
@@ -856,12 +922,20 @@ mod tests {
         let tokens_dir = tempdir().unwrap();
         let names_dir = tempdir().unwrap();
 
-        write_json(&tokens_dir, "t.json", json!({
-            "real-token": { "$schema": "https://example.com/color.json", "value": "#fff" }
-        }));
-        write_json(&names_dir, "t.json", json!({
-            "nonexistent-token": { "property": "color", "colorFamily": "blue" }
-        }));
+        write_json(
+            &tokens_dir,
+            "t.json",
+            json!({
+                "real-token": { "$schema": "https://example.com/color.json", "value": "#fff" }
+            }),
+        );
+        write_json(
+            &names_dir,
+            "t.json",
+            json!({
+                "nonexistent-token": { "property": "color", "colorFamily": "blue" }
+            }),
+        );
 
         let g = TokenGraph::from_json_dir_with_names(tokens_dir.path(), Some(names_dir.path()))
             .unwrap();
@@ -872,12 +946,20 @@ mod tests {
     #[test]
     fn duplicate_sidecar_slug_returns_error() {
         let names_dir = tempdir().unwrap();
-        write_json(&names_dir, "a.json", json!({
-            "blue-100": { "property": "color", "colorFamily": "blue" }
-        }));
-        write_json(&names_dir, "b.json", json!({
-            "blue-100": { "property": "color", "colorFamily": "blue" }
-        }));
+        write_json(
+            &names_dir,
+            "a.json",
+            json!({
+                "blue-100": { "property": "color", "colorFamily": "blue" }
+            }),
+        );
+        write_json(
+            &names_dir,
+            "b.json",
+            json!({
+                "blue-100": { "property": "color", "colorFamily": "blue" }
+            }),
+        );
 
         let result = TokenGraph::load_sidecar_names(names_dir.path());
         assert!(result.is_err());
@@ -886,9 +968,13 @@ mod tests {
     #[test]
     fn from_json_dir_without_names_unchanged() {
         let tokens_dir = tempdir().unwrap();
-        write_json(&tokens_dir, "t.json", json!({
-            "blue-100": { "$schema": "https://example.com/color-set.json", "value": "#0000ff" }
-        }));
+        write_json(
+            &tokens_dir,
+            "t.json",
+            json!({
+                "blue-100": { "$schema": "https://example.com/color-set.json", "value": "#0000ff" }
+            }),
+        );
 
         let g = TokenGraph::from_json_dir(tokens_dir.path()).unwrap();
         let token = g.tokens.get("blue-100").unwrap();
@@ -988,12 +1074,12 @@ mod tests {
             .values()
             .find(|t| t.layer == Layer::Platform && t.uuid.as_deref() == Some("u-btn-bg"))
             .expect("platform override token present");
-        assert_eq!(overridden.raw.get("value").and_then(|v| v.as_str()), Some("#ffffff"));
-        // Name object is inherited from the foundation token.
         assert_eq!(
-            overridden.raw["name"]["component"].as_str(),
-            Some("button")
+            overridden.raw.get("value").and_then(|v| v.as_str()),
+            Some("#ffffff")
         );
+        // Name object is inherited from the foundation token.
+        assert_eq!(overridden.raw["name"]["component"].as_str(), Some("button"));
     }
 
     #[test]

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -578,9 +578,8 @@ fn build_set_entry(
     // schema types that share a mode set key (e.g. typography-scale vs scale-set).
     // Falls back to the legacy default (color-set or scale-set) for older cascade
     // files that were produced before set_schema was stored.
-    let stored_set_schema = consistent_str_field(tokens, |t| {
-        t.get("set_schema").and_then(|v| v.as_str())
-    });
+    let stored_set_schema =
+        consistent_str_field(tokens, |t| t.get("set_schema").and_then(|v| v.as_str()));
     let set_schema = stored_set_schema.unwrap_or(if dim_key == "colorScheme" {
         COLOR_SET_SCHEMA
     } else {

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod discovery;
 pub mod figma;
 pub mod graph;
 pub mod legacy;
+pub mod manifest;
 pub mod migrate;
 pub mod naming;
 pub mod query;

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -11,9 +11,11 @@
 //! Design Data core library — validation, resolution, and tooling.
 
 pub mod authoring;
+#[cfg(feature = "cache")]
+pub mod cache;
 pub mod cascade;
-pub mod data_source;
 pub mod compat;
+pub mod data_source;
 pub mod diff;
 pub mod discovery;
 #[cfg(feature = "figma")]
@@ -647,9 +649,8 @@ mod validation_conformance {
                     .get("message_pattern")
                     .and_then(|v| v.as_str())
                     .unwrap_or(".*");
-                let re = Regex::new(pattern).unwrap_or_else(|e| {
-                    panic!("{case}: invalid message_pattern {pattern:?}: {e}")
-                });
+                let re = Regex::new(pattern)
+                    .unwrap_or_else(|e| panic!("{case}: invalid message_pattern {pattern:?}: {e}"));
 
                 let matched = diagnostics.iter().any(|d| {
                     d.rule_id.as_deref() == Some(rule_id)
@@ -833,8 +834,7 @@ mod resolution_conformance {
             .cloned()
             .collect();
 
-        let filtered = TokenGraph::from_records(candidates)
-            .with_mode_sets(graph.mode_sets.clone());
+        let filtered = TokenGraph::from_records(candidates).with_mode_sets(graph.mode_sets.clone());
 
         let should_resolve = expected["resolved"].as_bool().unwrap_or(true);
         let winner = resolve(&filtered, &ctx);

--- a/sdk/core/src/manifest.rs
+++ b/sdk/core/src/manifest.rs
@@ -1,0 +1,195 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Platform manifest application for the Foundation→Platform cascade.
+//!
+//! Reads a Layer 2 platform `manifest.json` declared in `.design-data.toml`
+//! (`[source].manifest`), optionally validates it against `manifest.schema.json`,
+//! and applies it to a [`TokenGraph`] via
+//! [`TokenGraph::apply_platform_manifest`](crate::graph::TokenGraph::apply_platform_manifest).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::data_source::ResolvedData;
+use crate::graph::TokenGraph;
+use crate::schema::SchemaRegistry;
+use crate::CoreError;
+
+/// Locate `packages/design-data-spec/schemas/manifest.schema.json` by walking up
+/// from `schemas_root`.
+pub fn locate_manifest_schema(schemas_root: &Path) -> Option<PathBuf> {
+    schemas_root.ancestors().find_map(|p| {
+        let candidate = p.join("packages/design-data-spec/schemas/manifest.schema.json");
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+/// Apply the Layer 2 platform manifest declared in `.design-data.toml`
+/// (`[source].manifest`) to `graph`, returning mode-set restrictions to feed
+/// into a [`ResolutionContext`](crate::cascade::ResolutionContext).
+///
+/// A no-op (empty map) when no manifest is configured. When the spec's
+/// `manifest.schema.json` is locatable, the manifest is first validated (Layer 1);
+/// schema violations return an error.
+pub fn apply_configured(
+    graph: &mut TokenGraph,
+    resolved: &ResolvedData,
+) -> Result<HashMap<String, Vec<String>>, CoreError> {
+    let Some(manifest_path) = resolved.platform_manifest.as_ref() else {
+        return Ok(HashMap::new());
+    };
+    let text = std::fs::read_to_string(manifest_path).map_err(|e| {
+        CoreError::ParseError(format!(
+            "failed to read platform manifest {}: {e}",
+            manifest_path.display()
+        ))
+    })?;
+    let manifest: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        CoreError::ParseError(format!(
+            "failed to parse platform manifest {}: {e}",
+            manifest_path.display()
+        ))
+    })?;
+
+    if let Some(schema_path) = locate_manifest_schema(&resolved.schemas_root) {
+        let errors = SchemaRegistry::validate_manifest(&manifest, &schema_path)?;
+        if !errors.is_empty() {
+            return Err(CoreError::ParseError(format!(
+                "platform manifest {} failed Layer 1 schema validation:\n  {}",
+                manifest_path.display(),
+                errors.join("\n  ")
+            )));
+        }
+    }
+
+    let outcome = graph.apply_platform_manifest(&manifest)?;
+    Ok(outcome.mode_set_restrictions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_source::{Provenance, ResolvedData};
+    use crate::graph::TokenGraph;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn resolved_with_manifest(manifest_path: PathBuf, schemas_root: PathBuf) -> ResolvedData {
+        ResolvedData {
+            tokens_root: PathBuf::from("tokens"),
+            schemas_root,
+            mode_sets: None,
+            components: None,
+            fields: None,
+            exceptions: None,
+            manifest: None,
+            platform_manifest: Some(manifest_path),
+            provenance: Provenance::InRepo,
+        }
+    }
+
+    fn make_graph() -> TokenGraph {
+        TokenGraph::from_pairs(vec![
+            (
+                "btn-bg".into(),
+                PathBuf::from("tokens.json"),
+                json!({
+                    "name": {"property": "background-color", "component": "button"},
+                    "value": "#aaa",
+                    "uuid": "u-btn-bg"
+                }),
+            ),
+            (
+                "btn-fg".into(),
+                PathBuf::from("tokens.json"),
+                json!({
+                    "name": {"property": "color", "component": "button"},
+                    "value": "#111",
+                    "uuid": "u-btn-fg"
+                }),
+            ),
+            (
+                "chk-bg".into(),
+                PathBuf::from("tokens.json"),
+                json!({
+                    "name": {"property": "background-color", "component": "checkbox"},
+                    "value": "#bbb",
+                    "uuid": "u-chk-bg"
+                }),
+            ),
+        ])
+    }
+
+    #[test]
+    fn no_manifest_is_noop() {
+        let mut graph = make_graph();
+        let resolved = ResolvedData {
+            tokens_root: PathBuf::from("tokens"),
+            schemas_root: PathBuf::from("schemas"),
+            mode_sets: None,
+            components: None,
+            fields: None,
+            exceptions: None,
+            manifest: None,
+            platform_manifest: None,
+            provenance: Provenance::InRepo,
+        };
+        let restrictions = apply_configured(&mut graph, &resolved).unwrap();
+        assert!(restrictions.is_empty());
+        assert_eq!(graph.tokens.len(), 3);
+    }
+
+    #[test]
+    fn include_filter_reduces_token_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "include": ["component=button"]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, dir.path().to_path_buf());
+        let restrictions = apply_configured(&mut graph, &resolved).unwrap();
+        assert!(restrictions.is_empty());
+        assert_eq!(graph.tokens.len(), 2);
+        assert!(graph.tokens.contains_key("btn-bg"));
+        assert!(graph.tokens.contains_key("btn-fg"));
+        assert!(!graph.tokens.contains_key("chk-bg"));
+    }
+
+    #[test]
+    fn invalid_manifest_query_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join("manifest.json");
+        std::fs::write(
+            &manifest_path,
+            json!({
+                "specVersion": "1.0.0-draft",
+                "foundationVersion": "1.0.0",
+                "include": ["not-a-valid-query"]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut graph = make_graph();
+        let resolved = resolved_with_manifest(manifest_path, dir.path().to_path_buf());
+        let err = apply_configured(&mut graph, &resolved).unwrap_err();
+        assert!(err.to_string().contains("query parse error"));
+    }
+}

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -629,6 +629,71 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    // ── filter_with_index equivalence (#783) ─────────────────────────────
+
+    /// Assert `filter` and `filter_with_index` return the same names for `expr`.
+    fn assert_filter_equivalent(graph: &TokenGraph, expr_str: &str) {
+        let expr = parse(expr_str).unwrap();
+        let index = TokenIndex::build(graph);
+        let scan: Vec<_> = filter(graph, &expr)
+            .into_iter()
+            .map(|t| t.name.clone())
+            .collect();
+        let indexed: Vec<_> = filter_with_index(graph, &index, &expr)
+            .into_iter()
+            .map(|t| t.name.clone())
+            .collect();
+        assert_eq!(scan, indexed, "expr={expr_str:?}");
+    }
+
+    #[test]
+    fn filter_with_index_matches_filter_single_equality() {
+        let g = make_graph(vec![
+            (
+                "btn",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+            ),
+            (
+                "chk",
+                json!({"name": {"property": "bg", "component": "checkbox"}, "value": "2"}),
+            ),
+        ]);
+        assert_filter_equivalent(&g, "component=button");
+        assert_filter_equivalent(&g, "property=bg");
+    }
+
+    #[test]
+    fn filter_with_index_matches_filter_complex_expressions() {
+        let g = make_graph(vec![
+            (
+                "btn",
+                json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"}),
+            ),
+            (
+                "chk",
+                json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "2"}),
+            ),
+            (
+                "slider",
+                json!({"name": {"property": "bg", "component": "slider", "state": "default"}, "value": "3"}),
+            ),
+            (
+                "light",
+                json!({"name": {"property": "fg", "colorScheme": "light"}, "value": "4"}),
+            ),
+            (
+                "dark",
+                json!({"name": {"property": "fg", "colorScheme": "dark"}, "value": "5"}),
+            ),
+        ]);
+        assert_filter_equivalent(&g, "");
+        assert_filter_equivalent(&g, "component=button,state=hover");
+        assert_filter_equivalent(&g, "component=button|component=checkbox");
+        assert_filter_equivalent(&g, "colorScheme!=light");
+        assert_filter_equivalent(&g, "property=*-bg");
+        assert_filter_equivalent(&g, "component=missing");
+    }
+
     // ── Index builder ───────────────────────────────────────────────────
 
     #[test]

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -21,7 +21,7 @@ use crate::CoreError;
 // ── Allowed keys (per spec) ─────────────────────────────────────────────────
 
 /// Keys that may appear in filter expressions.
-const ALLOWED_KEYS: &[&str] = &[
+pub(crate) const ALLOWED_KEYS: &[&str] = &[
     "property",
     "component",
     "variant",
@@ -50,6 +50,27 @@ const NAME_OBJECT_KEYS: &[&str] = &[
 #[derive(Debug, Clone)]
 pub struct TokenFilter {
     expr: FilterExpr,
+}
+
+impl TokenFilter {
+    /// If this filter is exactly one `key=value` equality condition (no `,`,
+    /// `|`, `!=`, or `*`), return `(key, value)`. Used to choose the index-backed
+    /// fast path in [`filter_with_index`].
+    fn single_equality(&self) -> Option<(&str, &str)> {
+        let FilterExpr::Or(alternatives) = &self.expr else {
+            return None;
+        };
+        let [group] = alternatives.as_slice() else {
+            return None;
+        };
+        let [cond] = group.as_slice() else {
+            return None;
+        };
+        if cond.op != Operator::Eq || cond.value.contains('*') {
+            return None;
+        }
+        Some((&cond.key, &cond.value))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -193,7 +214,7 @@ fn matches_condition(raw: &serde_json::Value, cond: &Condition) -> bool {
 }
 
 /// Resolve a query key to the field value in a token's raw JSON.
-fn resolve_key(raw: &serde_json::Value, key: &str) -> Option<String> {
+pub(crate) fn resolve_key(raw: &serde_json::Value, key: &str) -> Option<String> {
     if NAME_OBJECT_KEYS.contains(&key) {
         raw.get("name")
             .and_then(|n| n.get(key))
@@ -247,11 +268,56 @@ fn glob_match(pattern: &str, text: &str) -> bool {
     true
 }
 
-// ── Index builder (optional optimization, #783) ─────────────────────────────
+// ── Secondary index (#783) ──────────────────────────────────────────────────
 
-/// Build a secondary index mapping field values to token graph keys.
+/// A prebuilt secondary index: `field -> value -> graph keys`.
 ///
-/// Useful for accelerating single-field equality queries on large token sets.
+/// Accelerates single-field equality queries from an O(n) scan over every token
+/// to an O(matches) lookup. Built once from a [`TokenGraph`] (or hydrated from
+/// the cache's multimap tables) and reused across queries.
+#[derive(Debug, Clone, Default)]
+pub struct TokenIndex {
+    by_field: HashMap<String, HashMap<String, Vec<String>>>,
+}
+
+impl TokenIndex {
+    /// Build an index over every queryable field of every token in `graph`.
+    pub fn build(graph: &TokenGraph) -> Self {
+        let mut index = TokenIndex::default();
+        for (graph_key, token) in &graph.tokens {
+            for key in ALLOWED_KEYS {
+                if let Some(value) = resolve_key(&token.raw, key) {
+                    index.insert(key, &value, graph_key);
+                }
+            }
+        }
+        index
+    }
+
+    /// Insert one `field=value -> graph key` mapping (used when loading the
+    /// index from the cache's multimap tables).
+    pub(crate) fn insert(&mut self, field: &str, value: &str, graph_key: &str) {
+        self.by_field
+            .entry(field.to_string())
+            .or_default()
+            .entry(value.to_string())
+            .or_default()
+            .push(graph_key.to_string());
+    }
+
+    /// Graph keys matching `field == value`, if that field is indexed.
+    fn lookup(&self, field: &str, value: &str) -> Option<&[String]> {
+        self.by_field
+            .get(field)
+            .and_then(|m| m.get(value))
+            .map(Vec::as_slice)
+    }
+}
+
+/// Build a secondary index mapping a single field's values to token graph keys.
+///
+/// Retained for callers that only need one field; prefer [`TokenIndex`] when
+/// querying repeatedly across fields.
 pub fn build_index(graph: &TokenGraph, key: &str) -> HashMap<String, Vec<String>> {
     let mut index: HashMap<String, Vec<String>> = HashMap::new();
     for (graph_key, token) in &graph.tokens {
@@ -260,6 +326,33 @@ pub fn build_index(graph: &TokenGraph, key: &str) -> HashMap<String, Vec<String>
         }
     }
     index
+}
+
+/// Filter tokens using a prebuilt [`TokenIndex`] for the common single-field
+/// equality case, falling back to the full [`filter`] scan for everything else
+/// (wildcards, negation, `AND`/`OR` compositions).
+///
+/// Results are identical to [`filter`]; only the evaluation strategy differs.
+pub fn filter_with_index<'a>(
+    graph: &'a TokenGraph,
+    index: &TokenIndex,
+    expr: &TokenFilter,
+) -> Vec<&'a TokenRecord> {
+    if let Some((key, value)) = expr.single_equality() {
+        if let Some(graph_keys) = index.lookup(key, value) {
+            let mut results: Vec<&TokenRecord> = graph_keys
+                .iter()
+                .filter_map(|k| graph.tokens.get(k))
+                .collect();
+            results.sort_by(|a, b| a.name.cmp(&b.name));
+            return results;
+        }
+        // Indexed field, but no entries for this value → empty (not a fallback).
+        if index.by_field.contains_key(key) {
+            return Vec::new();
+        }
+    }
+    filter(graph, expr)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/sdk/core/src/registry.rs
+++ b/sdk/core/src/registry.rs
@@ -144,7 +144,7 @@ mod tests {
         assert!(fields.contains(&"variant"));
         assert!(fields.contains(&"size"));
         assert!(fields.contains(&"property")); // advisory registry added in #941
-        // mode-set fields must not appear
+                                               // mode-set fields must not appear
         assert!(!fields.contains(&"colorScheme"));
         assert!(!fields.contains(&"scale"));
         assert!(!fields.contains(&"contrast"));

--- a/sdk/core/src/schema.rs
+++ b/sdk/core/src/schema.rs
@@ -126,7 +126,10 @@ impl SchemaRegistry {
             .with_draft(Draft::Draft202012)
             .build(&schema)
             .map_err(|e| CoreError::SchemaBuild(e.to_string()))?;
-        Ok(validator.iter_errors(manifest).map(|e| e.to_string()).collect())
+        Ok(validator
+            .iter_errors(manifest)
+            .map(|e| e.to_string())
+            .collect())
     }
 
     /// Construct a no-op stub for unit tests where schema validation is never reached.

--- a/sdk/core/src/suggest.rs
+++ b/sdk/core/src/suggest.rs
@@ -83,13 +83,16 @@ pub fn suggest<'a>(
         .into_iter()
         .take(limit)
         .map(|(confidence, tok)| {
-            let name_object = tok.raw.get("name").and_then(|v| {
-                if v.is_object() {
-                    Some(v.clone())
-                } else {
-                    None
-                }
-            });
+            let name_object =
+                tok.raw.get("name").and_then(
+                    |v| {
+                        if v.is_object() {
+                            Some(v.clone())
+                        } else {
+                            None
+                        }
+                    },
+                );
             let value = tok.raw.get("value").cloned();
             SuggestionResult {
                 token_uuid: tok.uuid.clone(),
@@ -109,7 +112,11 @@ pub fn suggest<'a>(
 /// Returns 0.0 when:
 /// - `property_hint` is set and the token's `name.property` does not match it.
 /// - There is no word overlap at all.
-fn score_token(tok: &TokenRecord, intent_words: &HashSet<String>, property_hint: Option<&str>) -> f32 {
+fn score_token(
+    tok: &TokenRecord,
+    intent_words: &HashSet<String>,
+    property_hint: Option<&str>,
+) -> f32 {
     // Property hint filter: hard-exclude tokens whose name.property doesn't match.
     if let Some(hint) = property_hint {
         let token_property = tok
@@ -252,7 +259,10 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, k)| {
-                (k.as_str(), json!({ "name": { "property": "color", "scaleIndex": i + 1 } }))
+                (
+                    k.as_str(),
+                    json!({ "name": { "property": "color", "scaleIndex": i + 1 } }),
+                )
             })
             .collect();
         let g = make_graph(tokens);
@@ -277,7 +287,10 @@ mod tests {
             results[0].token_uuid.as_deref(),
             Some("aaaaaaaa-0001-4001-8001-000000000001")
         );
-        assert_eq!(results[0].value.as_ref().and_then(|v| v.as_str()), Some("rgb(0, 0, 0)"));
+        assert_eq!(
+            results[0].value.as_ref().and_then(|v| v.as_str()),
+            Some("rgb(0, 0, 0)")
+        );
     }
 
     #[test]

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -59,7 +59,10 @@ use std::collections::HashSet;
 /// Update this list when new token-type schemas are introduced; both rules
 /// pick up the change automatically.
 pub(super) const DOMAIN_SCHEMAS: &[(&str, &[&str])] = &[
-    ("color", &["color.json", "color-set.json", "gradient-stop.json"]),
+    (
+        "color",
+        &["color.json", "color-set.json", "gradient-stop.json"],
+    ),
     (
         "typography",
         &[
@@ -73,7 +76,12 @@ pub(super) const DOMAIN_SCHEMAS: &[(&str, &[&str])] = &[
     ),
     (
         "motion",
-        &["duration.json", "easing.json", "motion.json", "motion-set.json"],
+        &[
+            "duration.json",
+            "easing.json",
+            "motion.json",
+            "motion-set.json",
+        ],
     ),
 ];
 

--- a/sdk/core/src/validate/rules/spec014.rs
+++ b/sdk/core/src/validate/rules/spec014.rs
@@ -36,10 +36,8 @@ impl ValidationRule for Rule {
 
             // Skip check if either version string can't be parsed — don't emit false positives
             // for unexpected formats; a separate structural rule can flag unparseable versions.
-            let (Ok(lm), Ok(intro)) = (
-                Version::parse(last_modified),
-                Version::parse(introduced),
-            ) else {
+            let (Ok(lm), Ok(intro)) = (Version::parse(last_modified), Version::parse(introduced))
+            else {
                 continue;
             };
 

--- a/sdk/core/src/validate/rules/spec015.rs
+++ b/sdk/core/src/validate/rules/spec015.rs
@@ -51,13 +51,21 @@ struct CompositeDescriptor {
 /// below, not a code-path change in `validate`.
 static DESCRIPTORS: LazyLock<HashMap<&'static str, CompositeDescriptor>> = LazyLock::new(|| {
     let entries: &[(&str, &str, bool)] = &[
-        ("value-types/typography.schema.json", TYPOGRAPHY_SCHEMA, false),
+        (
+            "value-types/typography.schema.json",
+            TYPOGRAPHY_SCHEMA,
+            false,
+        ),
         (
             "value-types/typography-scale.schema.json",
             TYPOGRAPHY_SCALE_SCHEMA,
             false,
         ),
-        ("value-types/drop-shadow.schema.json", DROP_SHADOW_SCHEMA, true),
+        (
+            "value-types/drop-shadow.schema.json",
+            DROP_SHADOW_SCHEMA,
+            true,
+        ),
     ];
 
     let mut map: HashMap<&'static str, CompositeDescriptor> = HashMap::new();
@@ -79,9 +87,10 @@ static DESCRIPTORS: LazyLock<HashMap<&'static str, CompositeDescriptor>> = LazyL
         for (sub_key, prop_schema) in props {
             let types: Vec<String> = match prop_schema.get("x-valueType") {
                 Some(Value::String(s)) => vec![s.clone()],
-                Some(Value::Array(arr)) => {
-                    arr.iter().filter_map(|v| v.as_str().map(String::from)).collect()
-                }
+                Some(Value::Array(arr)) => arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect(),
                 _ => continue,
             };
             sub_key_types.insert(sub_key.clone(), types);
@@ -89,7 +98,10 @@ static DESCRIPTORS: LazyLock<HashMap<&'static str, CompositeDescriptor>> = LazyL
 
         map.insert(
             key,
-            CompositeDescriptor { value_is_array: *value_is_array, sub_key_types },
+            CompositeDescriptor {
+                value_is_array: *value_is_array,
+                sub_key_types,
+            },
         );
     }
     map
@@ -255,11 +267,18 @@ mod tests {
         g
     }
 
-    fn run(tokens: Vec<(String, serde_json::Value, Option<String>)>) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        tokens: Vec<(String, serde_json::Value, Option<String>)>,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(tokens);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec018.rs
+++ b/sdk/core/src/validate/rules/spec018.rs
@@ -75,7 +75,10 @@ mod tests {
     use crate::validate::rule::{ValidationContext, ValidationRule};
     use crate::validate::rules::spec018::Rule;
 
-    fn make_graph(tokens: Vec<serde_json::Value>, components: Vec<serde_json::Value>) -> TokenGraph {
+    fn make_graph(
+        tokens: Vec<serde_json::Value>,
+        components: Vec<serde_json::Value>,
+    ) -> TokenGraph {
         let mut g = TokenGraph::default();
         for (i, raw) in tokens.into_iter().enumerate() {
             g.tokens.insert(
@@ -107,11 +110,19 @@ mod tests {
         g
     }
 
-    fn run(tokens: Vec<serde_json::Value>, components: Vec<serde_json::Value>) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        tokens: Vec<serde_json::Value>,
+        components: Vec<serde_json::Value>,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(tokens, components);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec021.rs
+++ b/sdk/core/src/validate/rules/spec021.rs
@@ -13,8 +13,8 @@
 //! Component slot declarations with a name outside the canonical slot vocabulary
 //! SHOULD include a description.
 
-use std::sync::LazyLock;
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
@@ -119,7 +119,12 @@ mod tests {
         let g = make_graph(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec023.rs
+++ b/sdk/core/src/validate/rules/spec023.rs
@@ -122,7 +122,12 @@ mod tests {
         let g = make_graph(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec024.rs
+++ b/sdk/core/src/validate/rules/spec024.rs
@@ -93,7 +93,12 @@ mod tests {
         let g = make_graph(comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec027.rs
+++ b/sdk/core/src/validate/rules/spec027.rs
@@ -35,11 +35,7 @@ impl ValidationRule for Rule {
             .graph
             .tokens
             .values()
-            .filter_map(|t| {
-                t.raw
-                    .get("name")
-                    .and_then(|n| n.as_str())
-            })
+            .filter_map(|t| t.raw.get("name").and_then(|n| n.as_str()))
             .collect();
 
         for comp in &ctx.graph.components {
@@ -113,11 +109,19 @@ mod tests {
         g
     }
 
-    fn run(tokens: Vec<serde_json::Value>, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        tokens: Vec<serde_json::Value>,
+        comp_raw: serde_json::Value,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(tokens, comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec030.rs
+++ b/sdk/core/src/validate/rules/spec030.rs
@@ -87,7 +87,12 @@ mod tests {
         });
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec031.rs
+++ b/sdk/core/src/validate/rules/spec031.rs
@@ -92,7 +92,12 @@ mod tests {
         });
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
-        let ctx = ValidationContext { graph: &g, naming_exceptions: &exceptions, registry: &registry, manifest: None };
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
         Rule.validate(&ctx)
     }
 

--- a/sdk/core/src/validate/rules/spec032.rs
+++ b/sdk/core/src/validate/rules/spec032.rs
@@ -52,7 +52,12 @@ impl ValidationRule for Rule {
             .collect();
 
         // Check every non-Foundation token against the Foundation type for its UUID.
-        for t in ctx.graph.tokens.values().filter(|t| t.layer > Layer::Foundation) {
+        for t in ctx
+            .graph
+            .tokens
+            .values()
+            .filter(|t| t.layer > Layer::Foundation)
+        {
             let Some(uuid) = t.uuid.as_deref() else {
                 continue;
             };

--- a/sdk/core/src/validate/rules/spec035.rs
+++ b/sdk/core/src/validate/rules/spec035.rs
@@ -109,10 +109,7 @@ mod tests {
 
     #[test]
     fn valid_canonical_name_no_warning() {
-        let g = graph_with_anatomy(
-            "button",
-            json!([{"name": "label"}, {"name": "icon"}]),
-        );
+        let g = graph_with_anatomy("button", json!([{"name": "label"}, {"name": "icon"}]));
         assert!(diagnostics_for_rule(&g, "SPEC-035").is_empty());
     }
 
@@ -128,7 +125,10 @@ mod tests {
 
     #[test]
     fn unknown_name_warns() {
-        let g = graph_with_anatomy("widget", json!([{"name": "wibble", "description": "Custom."}]));
+        let g = graph_with_anatomy(
+            "widget",
+            json!([{"name": "wibble", "description": "Custom."}]),
+        );
         let diags = diagnostics_for_rule(&g, "SPEC-035");
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("wibble"));

--- a/sdk/core/src/validate/rules/spec036.rs
+++ b/sdk/core/src/validate/rules/spec036.rs
@@ -121,7 +121,10 @@ mod tests {
         g
     }
 
-    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        token_raw: serde_json::Value,
+        comp_raw: serde_json::Value,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(token_raw, comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();

--- a/sdk/core/src/validate/rules/spec037.rs
+++ b/sdk/core/src/validate/rules/spec037.rs
@@ -61,9 +61,8 @@ impl ValidationRule for Rule {
                     .get("anatomy")
                     .and_then(|v| v.as_array())
                     .and_then(|arr| {
-                        arr.iter().find(|p| {
-                            p.get("name").and_then(|n| n.as_str()) == Some(part_name)
-                        })
+                        arr.iter()
+                            .find(|p| p.get("name").and_then(|n| n.as_str()) == Some(part_name))
                     })
                     .and_then(|p| p.get("lifecycle"))
                     .and_then(|l| l.get("deprecated"))
@@ -94,9 +93,8 @@ impl ValidationRule for Rule {
                     .get("states")
                     .and_then(|v| v.as_array())
                     .and_then(|arr| {
-                        arr.iter().find(|s| {
-                            s.get("name").and_then(|n| n.as_str()) == Some(state_name)
-                        })
+                        arr.iter()
+                            .find(|s| s.get("name").and_then(|n| n.as_str()) == Some(state_name))
                     })
                     .and_then(|s| s.get("lifecycle"))
                     .and_then(|l| l.get("deprecated"))
@@ -212,7 +210,10 @@ mod tests {
         g
     }
 
-    fn run(token_raw: serde_json::Value, comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+    fn run(
+        token_raw: serde_json::Value,
+        comp_raw: serde_json::Value,
+    ) -> Vec<crate::report::Diagnostic> {
         let g = make_graph(token_raw, comp_raw);
         let exceptions = std::collections::HashSet::new();
         let registry = RegistryData::embedded();
@@ -370,7 +371,9 @@ mod tests {
         );
         assert_eq!(diags.len(), 2);
         assert!(diags.iter().all(|d| d.severity == Severity::Warning));
-        assert!(diags.iter().all(|d| d.rule_id.as_deref() == Some("SPEC-037")));
+        assert!(diags
+            .iter()
+            .all(|d| d.rule_id.as_deref() == Some("SPEC-037")));
         let paths: std::collections::HashSet<&str> = diags
             .iter()
             .filter_map(|d| d.instance_path.as_deref())

--- a/sdk/core/src/validate/rules/spec038.rs
+++ b/sdk/core/src/validate/rules/spec038.rs
@@ -162,7 +162,9 @@ mod tests {
         }));
         assert_eq!(diags.len(), 2);
         assert!(diags.iter().all(|d| d.severity == Severity::Warning));
-        assert!(diags.iter().all(|d| d.rule_id.as_deref() == Some("SPEC-038")));
+        assert!(diags
+            .iter()
+            .all(|d| d.rule_id.as_deref() == Some("SPEC-038")));
     }
 
     #[test]

--- a/sdk/core/src/validate/rules/spec040.rs
+++ b/sdk/core/src/validate/rules/spec040.rs
@@ -32,9 +32,9 @@ use crate::validate::rule::{ValidationContext, ValidationRule};
 const RESERVED: &[&str] = &[
     "property",
     "component",
-    "variant",      // SPEC-019: component-variant-valid (Error)
-    "state",        // SPEC-022: component-state-valid (Error) — validated against states[], not options
-    "anatomy",      // SPEC-020: component-anatomy-valid (Error)
+    "variant", // SPEC-019: component-variant-valid (Error)
+    "state",   // SPEC-022: component-state-valid (Error) — validated against states[], not options
+    "anatomy", // SPEC-020: component-anatomy-valid (Error)
     "colorScheme",
     "scale",
     "contrast",
@@ -282,7 +282,10 @@ mod tests {
                 }
             }),
         );
-        assert!(run(&g).is_empty(), "variant must be skipped (owned by SPEC-019)");
+        assert!(
+            run(&g).is_empty(),
+            "variant must be skipped (owned by SPEC-019)"
+        );
     }
 
     #[test]

--- a/sdk/core/src/validate/rules/spec041.rs
+++ b/sdk/core/src/validate/rules/spec041.rs
@@ -54,8 +54,12 @@ impl ValidationRule for Rule {
             return Vec::new();
         };
 
-        let mode_set_names: Vec<&str> =
-            ctx.graph.mode_sets.iter().map(|ms| ms.name.as_str()).collect();
+        let mode_set_names: Vec<&str> = ctx
+            .graph
+            .mode_sets
+            .iter()
+            .map(|ms| ms.name.as_str())
+            .collect();
 
         let mut out = Vec::new();
 
@@ -270,7 +274,10 @@ mod tests {
             }
         });
         let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
-        assert!(Rule.validate(&ctx).is_empty(), "wildcard token covers the restriction");
+        assert!(
+            Rule.validate(&ctx).is_empty(),
+            "wildcard token covers the restriction"
+        );
     }
 
     #[test]
@@ -365,7 +372,12 @@ mod tests {
         let ctx = make_ctx(&g, &manifest, &registry, &exceptions);
         let diags = Rule.validate(&ctx);
         // Must detect the gap even though each restriction individually had a survivor.
-        assert_eq!(diags.len(), 1, "expected 1 coverage-gap error, got: {:?}", diags);
+        assert_eq!(
+            diags.len(),
+            1,
+            "expected 1 coverage-gap error, got: {:?}",
+            diags
+        );
         assert_eq!(diags[0].severity, Severity::Error);
     }
 

--- a/sdk/core/src/validate/rules/spec042.rs
+++ b/sdk/core/src/validate/rules/spec042.rs
@@ -249,10 +249,7 @@ mod tests {
 
     // ── Alias-target resolution ────────────────────────────────────────────────
 
-    fn make_alias_graph(
-        alias_name_obj: serde_json::Value,
-        target_schema: &str,
-    ) -> TokenGraph {
+    fn make_alias_graph(alias_name_obj: serde_json::Value, target_schema: &str) -> TokenGraph {
         TokenGraph::from_pairs(vec![
             (
                 "alias-token".into(),

--- a/sdk/core/src/validate/rules/spec043.rs
+++ b/sdk/core/src/validate/rules/spec043.rs
@@ -43,9 +43,7 @@ fn has_required_fields(
     domain: &str,
 ) -> bool {
     match domain {
-        "color" => {
-            name_obj.contains_key("colorFamily") || name_obj.contains_key("scaleIndex")
-        }
+        "color" => name_obj.contains_key("colorFamily") || name_obj.contains_key("scaleIndex"),
         "typography" => {
             name_obj.contains_key("family")
                 || name_obj.contains_key("weight")
@@ -53,9 +51,7 @@ fn has_required_fields(
                 || name_obj.contains_key("scaleIndex")
                 || name_obj.contains_key("structure")
         }
-        "motion" => {
-            name_obj.contains_key("motionRole") || name_obj.contains_key("easing")
-        }
+        "motion" => name_obj.contains_key("motionRole") || name_obj.contains_key("easing"),
         _ => true,
     }
 }
@@ -136,16 +132,11 @@ mod tests {
         )])
     }
 
-    const COLOR_SCHEMA: &str =
-        "https://example.com/schemas/token-types/color.json";
-    const FONT_WEIGHT_SCHEMA: &str =
-        "https://example.com/schemas/token-types/font-weight.json";
-    const DURATION_SCHEMA: &str =
-        "https://example.com/schemas/token-types/duration.json";
-    const EASING_SCHEMA: &str =
-        "https://example.com/schemas/token-types/easing.json";
-    const DIMENSION_SCHEMA: &str =
-        "https://example.com/schemas/token-types/dimension.json";
+    const COLOR_SCHEMA: &str = "https://example.com/schemas/token-types/color.json";
+    const FONT_WEIGHT_SCHEMA: &str = "https://example.com/schemas/token-types/font-weight.json";
+    const DURATION_SCHEMA: &str = "https://example.com/schemas/token-types/duration.json";
+    const EASING_SCHEMA: &str = "https://example.com/schemas/token-types/easing.json";
+    const DIMENSION_SCHEMA: &str = "https://example.com/schemas/token-types/dimension.json";
 
     #[test]
     fn color_with_color_family_no_warning() {
@@ -196,10 +187,7 @@ mod tests {
 
     #[test]
     fn typography_missing_domain_fields_warns() {
-        let g = make_token(
-            FONT_WEIGHT_SCHEMA,
-            json!({ "property": "font-weight" }),
-        );
+        let g = make_token(FONT_WEIGHT_SCHEMA, json!({ "property": "font-weight" }));
         let diags = diagnostics_for_rule(&g, "SPEC-043");
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("family"));
@@ -225,10 +213,7 @@ mod tests {
 
     #[test]
     fn motion_missing_domain_fields_warns() {
-        let g = make_token(
-            DURATION_SCHEMA,
-            json!({ "property": "duration" }),
-        );
+        let g = make_token(DURATION_SCHEMA, json!({ "property": "duration" }));
         let diags = diagnostics_for_rule(&g, "SPEC-043");
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("motionRole"));
@@ -237,10 +222,7 @@ mod tests {
     #[test]
     fn easing_schema_is_motion_domain() {
         // easing.json tokens are motion-domain; missing motionRole/easing should warn.
-        let g = make_token(
-            EASING_SCHEMA,
-            json!({ "property": "easing" }),
-        );
+        let g = make_token(EASING_SCHEMA, json!({ "property": "easing" }));
         let diags = diagnostics_for_rule(&g, "SPEC-043");
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("motionRole"));
@@ -258,8 +240,7 @@ mod tests {
     #[test]
     fn typography_multiplier_with_scale_index_no_warning() {
         // multiplier.json is in the typography domain; scaleIndex satisfies the check.
-        const MULTIPLIER_SCHEMA: &str =
-            "https://example.com/schemas/token-types/multiplier.json";
+        const MULTIPLIER_SCHEMA: &str = "https://example.com/schemas/token-types/multiplier.json";
         let g = make_token(
             MULTIPLIER_SCHEMA,
             json!({ "property": "line-height-multiplier", "scaleIndex": 100 }),
@@ -269,8 +250,7 @@ mod tests {
 
     #[test]
     fn typography_multiplier_with_structure_no_warning() {
-        const MULTIPLIER_SCHEMA: &str =
-            "https://example.com/schemas/token-types/multiplier.json";
+        const MULTIPLIER_SCHEMA: &str = "https://example.com/schemas/token-types/multiplier.json";
         let g = make_token(
             MULTIPLIER_SCHEMA,
             json!({ "structure": "body", "property": "margin" }),
@@ -280,12 +260,8 @@ mod tests {
 
     #[test]
     fn typography_multiplier_missing_domain_fields_warns() {
-        const MULTIPLIER_SCHEMA: &str =
-            "https://example.com/schemas/token-types/multiplier.json";
-        let g = make_token(
-            MULTIPLIER_SCHEMA,
-            json!({ "property": "some-multiplier" }),
-        );
+        const MULTIPLIER_SCHEMA: &str = "https://example.com/schemas/token-types/multiplier.json";
+        let g = make_token(MULTIPLIER_SCHEMA, json!({ "property": "some-multiplier" }));
         let diags = diagnostics_for_rule(&g, "SPEC-043");
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("family"));
@@ -294,10 +270,7 @@ mod tests {
     #[test]
     fn unrecognized_schema_skipped() {
         // dimension.json is not a known domain — no SPEC-043 diagnostic.
-        let g = make_token(
-            DIMENSION_SCHEMA,
-            json!({ "property": "width" }),
-        );
+        let g = make_token(DIMENSION_SCHEMA, json!({ "property": "width" }));
         assert!(diagnostics_for_rule(&g, "SPEC-043").is_empty());
     }
 

--- a/sdk/core/src/write.rs
+++ b/sdk/core/src/write.rs
@@ -62,8 +62,15 @@ pub fn write_token(
     registry: &SchemaRegistry,
 ) -> Result<WriteTokenResult, CoreError> {
     // Destructure so it's clear only `token` is mutated.
-    let WriteTokenInput { key, mut token, target, product_context, rationale, created_at, is_override } =
-        input;
+    let WriteTokenInput {
+        key,
+        mut token,
+        target,
+        product_context,
+        rationale,
+        created_at,
+        is_override,
+    } = input;
 
     // Inject rationale into the token object if supplied.
     if let Some(ref r) = rationale {
@@ -302,8 +309,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn test_registry() -> SchemaRegistry {
-        let schemas = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../packages/tokens/schemas");
+        let schemas = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/schemas");
         SchemaRegistry::load_legacy_token_schemas(&schemas).expect("schemas load")
     }
 
@@ -456,10 +462,7 @@ mod tests {
         assert_eq!(pc["createdAt"].as_str(), Some("2026-05-19T00:00:00Z"));
         let tokens = &pc["extensions"]["tokens"];
         assert!(tokens.as_array().map(|a| !a.is_empty()).unwrap_or(false));
-        assert_eq!(
-            tokens[0]["rationale"].as_str(),
-            Some("New brand color")
-        );
+        assert_eq!(tokens[0]["rationale"].as_str(), Some("New brand color"));
     }
 
     #[test]
@@ -522,7 +525,10 @@ mod tests {
 
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("unknown"), "error should mention unknown schema: {msg}");
+        assert!(
+            msg.contains("unknown"),
+            "error should mention unknown schema: {msg}"
+        );
     }
 
     #[test]
@@ -546,7 +552,10 @@ mod tests {
 
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("$schema"), "error should mention $schema: {msg}");
+        assert!(
+            msg.contains("$schema"),
+            "error should mention $schema: {msg}"
+        );
     }
 
     #[test]

--- a/sdk/core/tests/suggest_calibration.rs
+++ b/sdk/core/tests/suggest_calibration.rs
@@ -55,14 +55,46 @@ fn positive_intents_score_above_threshold() {
     let threshold = alias_threshold();
 
     let cases: &[Case] = &[
-        Case { intent: "neutral content color", expected_top: "neutral-content-color", min_confidence: 0.70 },
-        Case { intent: "accent content color default", expected_top: "accent-content-color-default", min_confidence: 0.90 },
-        Case { intent: "card background color", expected_top: "card-background", min_confidence: 0.70 },
-        Case { intent: "spacing 100", expected_top: "spacing-100", min_confidence: 0.90 },
-        Case { intent: "body font size", expected_top: "body", min_confidence: 0.60 },
-        Case { intent: "static black text", expected_top: "static-black-text", min_confidence: 0.70 },
-        Case { intent: "icon color cyan", expected_top: "icon-color-cyan", min_confidence: 0.55 },
-        Case { intent: "drop zone background", expected_top: "drop-zone-background", min_confidence: 0.70 },
+        Case {
+            intent: "neutral content color",
+            expected_top: "neutral-content-color",
+            min_confidence: 0.70,
+        },
+        Case {
+            intent: "accent content color default",
+            expected_top: "accent-content-color-default",
+            min_confidence: 0.90,
+        },
+        Case {
+            intent: "card background color",
+            expected_top: "card-background",
+            min_confidence: 0.70,
+        },
+        Case {
+            intent: "spacing 100",
+            expected_top: "spacing-100",
+            min_confidence: 0.90,
+        },
+        Case {
+            intent: "body font size",
+            expected_top: "body",
+            min_confidence: 0.60,
+        },
+        Case {
+            intent: "static black text",
+            expected_top: "static-black-text",
+            min_confidence: 0.70,
+        },
+        Case {
+            intent: "icon color cyan",
+            expected_top: "icon-color-cyan",
+            min_confidence: 0.55,
+        },
+        Case {
+            intent: "drop zone background",
+            expected_top: "drop-zone-background",
+            min_confidence: 0.70,
+        },
     ];
 
     let mut all_pass = true;
@@ -78,20 +110,31 @@ fn positive_intents_score_above_threshold() {
         );
 
         if score < case.min_confidence {
-            eprintln!("  FAIL: expected score >= {:.2}, got {:.3}", case.min_confidence, score);
+            eprintln!(
+                "  FAIL: expected score >= {:.2}, got {:.3}",
+                case.min_confidence, score
+            );
             all_pass = false;
         }
         if !name.contains(case.expected_top) {
-            eprintln!("  FAIL: expected top match to contain {:?}, got {:?}", case.expected_top, name);
+            eprintln!(
+                "  FAIL: expected top match to contain {:?}, got {:?}",
+                case.expected_top, name
+            );
             all_pass = false;
         }
         assert!(
             score >= threshold,
             "intent {:?}: top score {:.3} is below alias_threshold() {:.2}",
-            case.intent, score, threshold
+            case.intent,
+            score,
+            threshold
         );
     }
-    assert!(all_pass, "one or more positive calibration cases failed — see output above");
+    assert!(
+        all_pass,
+        "one or more positive calibration cases failed — see output above"
+    );
 }
 
 #[test]
@@ -117,7 +160,9 @@ fn negative_intents_score_below_threshold() {
         assert!(
             top_score < threshold,
             "negative intent {:?} should score below {:.2}, got {:.3}",
-            intent, threshold, top_score
+            intent,
+            threshold,
+            top_score
         );
     }
 }
@@ -131,8 +176,14 @@ fn threshold_sits_in_calibrated_gap() {
     // Note: single-word queries matching a 2-segment token name can score ~0.5 and
     // DO legitimately trigger the banner — correct behavior, not a false positive.
     let threshold = alias_threshold();
-    eprintln!("[gap-check] alias_threshold()={:.2} should be in (0.0, 0.60)", threshold);
-    assert!(threshold > 0.0, "threshold must be above pure noise (0.0), got {threshold}");
+    eprintln!(
+        "[gap-check] alias_threshold()={:.2} should be in (0.0, 0.60)",
+        threshold
+    );
+    assert!(
+        threshold > 0.0,
+        "threshold must be above pure noise (0.0), got {threshold}"
+    );
     assert!(
         threshold < 0.60,
         "threshold must be below the positive-match floor (0.60), got {threshold}"

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -14,8 +14,8 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use design_data_core::cascade::ResolutionContext;
 use ratatui::layout::Rect;
 use ratatui::widgets::TableState;
-use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
 
 use crate::find::FindEvent;
 use crate::naming::NamingEvent;
@@ -130,9 +130,10 @@ impl App {
                                     self.palette_input = Input::from(format!("{} ", matches[0]));
                                 }
                                 _ => {
-                                    self.status_message = Some(StatusMessage::info(
-                                        format!("matches: {}", matches.join(" | ")),
-                                    ));
+                                    self.status_message = Some(StatusMessage::info(format!(
+                                        "matches: {}",
+                                        matches.join(" | ")
+                                    )));
                                 }
                             }
                         }
@@ -154,7 +155,11 @@ impl App {
                 }
                 KeyCode::Down if self.palette_mode == PaletteMode::Command => {
                     let next = self.palette_history_cursor.and_then(|i| {
-                        if i == 0 { None } else { Some(i - 1) }
+                        if i == 0 {
+                            None
+                        } else {
+                            Some(i - 1)
+                        }
                     });
                     self.palette_history_cursor = next;
                     match next {
@@ -172,7 +177,8 @@ impl App {
                     // Any character input resets the history position so the next ↑ starts
                     // from the head again (mirrors bash/zsh behavior).
                     self.palette_history_cursor = None;
-                    self.palette_input.handle_event(&crossterm::event::Event::Key(key));
+                    self.palette_input
+                        .handle_event(&crossterm::event::Event::Key(key));
                 }
             }
             return;
@@ -194,9 +200,9 @@ impl App {
                         self.sel_end = None;
                     }
                     let label = if self.selection_mode { "on" } else { "off" };
-                    self.status_message = Some(StatusMessage::info(
-                        format!("selection mode {label}  (drag to select, release to copy)"),
-                    ));
+                    self.status_message = Some(StatusMessage::info(format!(
+                        "selection mode {label}  (drag to select, release to copy)"
+                    )));
                 }
                 KeyCode::Char(':') => {
                     self.palette_open = true;
@@ -280,8 +286,7 @@ impl App {
                 }
                 NamingEvent::Copy(name) => {
                     self.pending_yank = Some(name.clone());
-                    self.status_message =
-                        Some(StatusMessage::info(format!("copied: {name}")));
+                    self.status_message = Some(StatusMessage::info(format!("copied: {name}")));
                 }
                 NamingEvent::Continue => {}
             }
@@ -417,7 +422,11 @@ impl App {
     fn click_at(&mut self, row: u16, col: u16) {
         // Collect matching actions first to avoid borrow issues.
         let action = self.hit_regions.iter().find_map(|r| {
-            if rect_contains(r.rect, row, col) { Some(&r.action) } else { None }
+            if rect_contains(r.rect, row, col) {
+                Some(&r.action)
+            } else {
+                None
+            }
         });
         match action {
             Some(HitAction::SelectListRow(i)) => {
@@ -457,7 +466,11 @@ impl App {
                 lines.push(&region.text);
             }
         }
-        if lines.is_empty() { None } else { Some(lines.join("\n")) }
+        if lines.is_empty() {
+            None
+        } else {
+            Some(lines.join("\n"))
+        }
     }
 
     // ── View key routing ─────────────────────────────────────────────────────
@@ -587,7 +600,9 @@ pub fn history_path() -> Option<PathBuf> {
 }
 
 pub(crate) fn load_palette_history() -> Vec<String> {
-    let Some(path) = history_path() else { return Vec::new() };
+    let Some(path) = history_path() else {
+        return Vec::new();
+    };
     std::fs::read_to_string(&path)
         .map(|s| {
             s.lines()
@@ -626,10 +641,7 @@ pub fn move_table_selection(state: &mut TableState, len: usize, delta: i64) {
 
 /// Test whether `(row, col)` is inside `rect`.
 pub(crate) fn rect_contains(rect: Rect, row: u16, col: u16) -> bool {
-    col >= rect.x
-        && col < rect.x + rect.width
-        && row >= rect.y
-        && row < rect.y + rect.height
+    col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
 }
 
 pub(crate) fn parse_resolve_args(rest: &str) -> Result<(String, ResolutionContext), String> {

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -258,7 +258,7 @@ impl App {
 
         // Find wizard modal.
         if let Some(Modal::Find(ref mut fs)) = self.modal {
-            let event = fs.handle_key(key, ctx.graph);
+            let event = fs.handle_key(key, ctx.graph, &ctx.token_index);
             match event {
                 FindEvent::Cancel => {
                     self.modal = None;

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -665,3 +665,13 @@ pub(crate) fn parse_resolve_args(rest: &str) -> Result<(String, ResolutionContex
     }
     Ok((prop, ctx))
 }
+
+/// Layer platform manifest mode-set restrictions onto a parsed resolve context.
+pub(crate) fn resolve_context_with_restrictions(
+    ctx: ResolutionContext,
+    restrictions: &std::collections::HashMap<String, Vec<String>>,
+) -> ResolutionContext {
+    restrictions.iter().fold(ctx, |acc, (mode_set, allowed)| {
+        acc.with_restriction(mode_set.clone(), allowed.clone())
+    })
+}

--- a/sdk/tui/src/app_launch.rs
+++ b/sdk/tui/src/app_launch.rs
@@ -26,6 +26,7 @@ use crossterm::{
 };
 use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::graph::TokenGraph;
+use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use ratatui::{backend::CrosstermBackend, Terminal};
@@ -73,6 +74,7 @@ struct DatasetHandle {
     token_count: usize,
     dataset_path: PathBuf,
     graph: TokenGraph,
+    token_index: TokenIndex,
     components_dir: Option<PathBuf>,
     mode_sets_dir: Option<PathBuf>,
     schema_registry: Option<SchemaRegistry>,
@@ -90,7 +92,7 @@ impl DatasetHandle {
         allow_write: bool,
         theme: Theme,
     ) -> Result<Self> {
-        let mut graph = TokenGraph::open_cached(&path)
+        let (mut graph, token_index) = TokenGraph::open_cached_with_index(&path)
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
@@ -138,6 +140,7 @@ impl DatasetHandle {
             token_count: graph.tokens.len(),
             dataset_path: path,
             graph,
+            token_index,
             components_dir,
             mode_sets_dir,
             schema_registry,
@@ -161,6 +164,7 @@ impl DatasetHandle {
             components_dir: self.components_dir.as_deref(),
             schema_registry: self.schema_registry.as_ref(),
             mode_sets_dir: self.mode_sets_dir.as_deref(),
+            token_index: self.token_index.clone(),
             allow_write: self.allow_write,
         }
     }

--- a/sdk/tui/src/app_launch.rs
+++ b/sdk/tui/src/app_launch.rs
@@ -15,6 +15,7 @@
 //! and restores the terminal on exit.  All other items in this module are
 //! implementation details moved here from the former standalone binary.
 
+use std::collections::HashMap;
 use std::io::{stderr, BufRead as _, BufReader};
 use std::path::PathBuf;
 
@@ -26,6 +27,7 @@ use crossterm::{
 };
 use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::graph::TokenGraph;
+use design_data_core::manifest;
 use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
@@ -75,6 +77,8 @@ struct DatasetHandle {
     dataset_path: PathBuf,
     graph: TokenGraph,
     token_index: TokenIndex,
+    mode_set_restrictions: HashMap<String, Vec<String>>,
+    platform_manifest_active: bool,
     components_dir: Option<PathBuf>,
     mode_sets_dir: Option<PathBuf>,
     schema_registry: Option<SchemaRegistry>,
@@ -92,7 +96,7 @@ impl DatasetHandle {
         allow_write: bool,
         theme: Theme,
     ) -> Result<Self> {
-        let (mut graph, token_index) = TokenGraph::open_cached_with_index(&path)
+        let (mut graph, mut token_index) = TokenGraph::open_cached_with_index(&path)
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
@@ -109,7 +113,7 @@ impl DatasetHandle {
         )
         .into_diagnostic()?;
 
-        let components_dir = resolved.components;
+        let components_dir = resolved.components.clone();
         if let Some(ref dir) = components_dir {
             if dir.is_dir() {
                 let comps = TokenGraph::load_spec_components(dir)
@@ -121,7 +125,7 @@ impl DatasetHandle {
             }
         }
 
-        let mode_sets_dir = resolved.mode_sets;
+        let mode_sets_dir = resolved.mode_sets.clone();
         if let Some(ref dir) = mode_sets_dir {
             if dir.is_dir() {
                 let mode_sets = TokenGraph::load_spec_mode_sets(dir)
@@ -129,6 +133,15 @@ impl DatasetHandle {
                     .wrap_err_with(|| format!("failed to load mode sets from {}", dir.display()))?;
                 graph = graph.with_mode_sets(mode_sets);
             }
+        }
+
+        // Apply a configured platform manifest (Foundation→Platform cascade), matching CLI query/resolve.
+        let platform_manifest_active = resolved.platform_manifest.is_some();
+        let mode_set_restrictions = manifest::apply_configured(&mut graph, &resolved)
+            .into_diagnostic()
+            .wrap_err("failed to apply platform manifest cascade")?;
+        if platform_manifest_active {
+            token_index = TokenIndex::build(&graph);
         }
 
         // Load schema registry for `:validate`. Silently skip if schema dir is absent
@@ -141,6 +154,8 @@ impl DatasetHandle {
             dataset_path: path,
             graph,
             token_index,
+            mode_set_restrictions,
+            platform_manifest_active,
             components_dir,
             mode_sets_dir,
             schema_registry,
@@ -150,8 +165,13 @@ impl DatasetHandle {
     }
 
     fn primer_line(&self) -> String {
+        let scope = if self.platform_manifest_active {
+            "platform"
+        } else {
+            "tokens"
+        };
         format!(
-            " {} tokens  ·  {}",
+            " {} {scope}  ·  {}",
             self.token_count,
             self.dataset_path.display()
         )
@@ -165,6 +185,7 @@ impl DatasetHandle {
             schema_registry: self.schema_registry.as_ref(),
             mode_sets_dir: self.mode_sets_dir.as_deref(),
             token_index: self.token_index.clone(),
+            mode_set_restrictions: self.mode_set_restrictions.clone(),
             allow_write: self.allow_write,
         }
     }

--- a/sdk/tui/src/app_launch.rs
+++ b/sdk/tui/src/app_launch.rs
@@ -15,24 +15,24 @@
 //! and restores the terminal on exit.  All other items in this module are
 //! implementation details moved here from the former standalone binary.
 
-use std::io::{BufRead as _, BufReader, stderr};
+use std::io::{stderr, BufRead as _, BufReader};
 use std::path::PathBuf;
 
 use clap::ValueEnum;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use design_data_core::data_source::{self, CliPathOverrides};
 use design_data_core::graph::TokenGraph;
 use design_data_core::schema::SchemaRegistry;
 use miette::{IntoDiagnostic, Result, WrapErr};
-use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{backend::CrosstermBackend, Terminal};
 
+use crate::runtime::{replay as tui_replay, run as tui_run};
 use crate::theme::Theme;
 use crate::{Message, Model, UpdateCtx};
-use crate::runtime::{run as tui_run, replay as tui_replay};
 
 /// Which visual palette to use.
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -90,18 +90,21 @@ impl DatasetHandle {
         allow_write: bool,
         theme: Theme,
     ) -> Result<Self> {
-        let mut graph = TokenGraph::from_json_dir(&path)
+        let mut graph = TokenGraph::open_cached(&path)
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
         // Resolve spec paths via the central data_source resolver.
         // The dataset path is already explicit; we only need spec catalog dirs + schema.
         let cwd = std::env::current_dir().into_diagnostic()?;
-        let resolved = data_source::resolve(&cwd, &CliPathOverrides {
-            components: components_arg,
-            mode_sets: mode_sets_arg,
-            ..Default::default()
-        })
+        let resolved = data_source::resolve(
+            &cwd,
+            &CliPathOverrides {
+                components: components_arg,
+                mode_sets: mode_sets_arg,
+                ..Default::default()
+            },
+        )
         .into_diagnostic()?;
 
         let components_dir = resolved.components;
@@ -121,9 +124,7 @@ impl DatasetHandle {
             if dir.is_dir() {
                 let mode_sets = TokenGraph::load_spec_mode_sets(dir)
                     .into_diagnostic()
-                    .wrap_err_with(|| {
-                        format!("failed to load mode sets from {}", dir.display())
-                    })?;
+                    .wrap_err_with(|| format!("failed to load mode sets from {}", dir.display()))?;
                 graph = graph.with_mode_sets(mode_sets);
             }
         }
@@ -201,11 +202,21 @@ pub fn launch(opts: LaunchOptions) -> miette::Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).into_diagnostic()?;
 
-    let result = drive_terminal(&mut terminal, &handle, resume_wizard, record_path, replay_path);
+    let result = drive_terminal(
+        &mut terminal,
+        &handle,
+        resume_wizard,
+        record_path,
+        replay_path,
+    );
 
     // Best-effort cleanup — continue even if individual steps fail.
     let _ = disable_raw_mode();
-    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture);
+    let _ = execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    );
     let _ = terminal.show_cursor();
 
     result
@@ -231,8 +242,12 @@ fn drive_terminal<B: ratatui::backend::Backend>(
         let mut skipped = 0usize;
         let mut messages: Vec<Message> = Vec::new();
         for line_result in BufReader::new(file).lines() {
-            let line = line_result.into_diagnostic().wrap_err("replay: read error")?;
-            if line.trim().is_empty() { continue; }
+            let line = line_result
+                .into_diagnostic()
+                .wrap_err("replay: read error")?;
+            if line.trim().is_empty() {
+                continue;
+            }
             match serde_json::from_str::<Message>(&line) {
                 Ok(m) => messages.push(m),
                 Err(_) => skipped += 1,
@@ -246,7 +261,11 @@ fn drive_terminal<B: ratatui::backend::Backend>(
         }
         let model = Model::new_with_options(false);
         tui_replay(
-            terminal, model, &ctx, &handle.theme, &handle.primer_line(),
+            terminal,
+            model,
+            &ctx,
+            &handle.theme,
+            &handle.primer_line(),
             messages.into_iter(),
         )?;
         // Print the final buffer as plain text.
@@ -254,7 +273,11 @@ fn drive_terminal<B: ratatui::backend::Backend>(
         let area = buf.area();
         for y in 0..area.height {
             let row: String = (0..area.width)
-                .map(|x| buf.cell((x, y)).map(|c| c.symbol().to_string()).unwrap_or_default())
+                .map(|x| {
+                    buf.cell((x, y))
+                        .map(|c| c.symbol().to_string())
+                        .unwrap_or_default()
+                })
                 .collect();
             println!("{}", row.trim_end());
         }
@@ -269,7 +292,11 @@ fn drive_terminal<B: ratatui::backend::Backend>(
         .into_diagnostic()
         .wrap_err("failed to create record file")?;
     tui_run(
-        terminal, model, &ctx, &handle.theme, &handle.primer_line(),
+        terminal,
+        model,
+        &ctx,
+        &handle.theme,
+        &handle.primer_line(),
         record_file.as_mut().map(|f| f as &mut dyn std::io::Write),
     )
 }

--- a/sdk/tui/src/app_palette.rs
+++ b/sdk/tui/src/app_palette.rs
@@ -26,9 +26,9 @@ use design_data_core::validate;
 use tui_input::Input;
 
 use crate::app::{
-    App, ActiveView, DescribeView, DiagnosticRow, Modal, PaletteMode, QueryRow, QueryView,
-    ResolvedRow, ResolveView, StatusMessage, SubmitContext, ValidateView,
-    HISTORY_CAP, layer_str, parse_resolve_args, save_palette_history,
+    layer_str, parse_resolve_args, save_palette_history, ActiveView, App, DescribeView,
+    DiagnosticRow, Modal, PaletteMode, QueryRow, QueryView, ResolveView, ResolvedRow,
+    StatusMessage, SubmitContext, ValidateView, HISTORY_CAP,
 };
 use crate::find::FindWizardState;
 use crate::naming::NamingWizardState;
@@ -49,8 +49,7 @@ impl App {
         self.palette_history_cursor = None;
 
         // Append to history (dedupe head, cap at HISTORY_CAP).
-        if !raw.is_empty()
-            && self.palette_history.first().map(|s| s.as_str()) != Some(raw.as_str())
+        if !raw.is_empty() && self.palette_history.first().map(|s| s.as_str()) != Some(raw.as_str())
         {
             self.palette_history.insert(0, raw.clone());
             self.palette_history.truncate(HISTORY_CAP);
@@ -93,8 +92,7 @@ impl App {
                 let (prop, res_ctx) = match parse_resolve_args(&rest) {
                     Ok(v) => v,
                     Err(e) => {
-                        self.status_message =
-                            Some(StatusMessage::error(format!("resolve: {e}")));
+                        self.status_message = Some(StatusMessage::error(format!("resolve: {e}")));
                         return;
                     }
                 };
@@ -173,8 +171,7 @@ impl App {
                     .collect();
                 let count = rows.len();
                 self.active_view = ActiveView::Resolve(ResolveView::new(prop, rows));
-                self.status_message =
-                    Some(StatusMessage::info(format!("{count} candidate(s)")));
+                self.status_message = Some(StatusMessage::info(format!("{count} candidate(s)")));
             }
             "describe" | "component" => {
                 if rest.is_empty() {
@@ -202,38 +199,42 @@ impl App {
                 let file_path = comp_dir.join(format!("{id}.json"));
                 if file_path.is_file() {
                     match std::fs::read_to_string(&file_path) {
-                        Ok(raw_text) => match serde_json::from_str::<serde_json::Value>(&raw_text)
-                        {
-                            Ok(doc) => match serde_json::to_string_pretty(&doc) {
-                                Ok(pretty) => {
-                                    self.active_view = ActiveView::Describe(DescribeView {
-                                        component: id.to_string(),
-                                        pretty_json: pretty,
-                                        scroll: 0,
-                                    });
-                                    self.status_message = None;
-                                }
+                        Ok(raw_text) => {
+                            match serde_json::from_str::<serde_json::Value>(&raw_text) {
+                                Ok(doc) => match serde_json::to_string_pretty(&doc) {
+                                    Ok(pretty) => {
+                                        self.active_view = ActiveView::Describe(DescribeView {
+                                            component: id.to_string(),
+                                            pretty_json: pretty,
+                                            scroll: 0,
+                                        });
+                                        self.status_message = None;
+                                    }
+                                    Err(e) => {
+                                        self.status_message = Some(StatusMessage::error(format!(
+                                            "describe: render error: {e}"
+                                        )));
+                                    }
+                                },
                                 Err(e) => {
                                     self.status_message = Some(StatusMessage::error(format!(
-                                        "describe: render error: {e}"
+                                        "describe: parse error: {e}"
                                     )));
                                 }
-                            },
-                            Err(e) => {
-                                self.status_message = Some(StatusMessage::error(format!(
-                                    "describe: parse error: {e}"
-                                )));
                             }
-                        },
+                        }
                         Err(e) => {
-                            self.status_message = Some(StatusMessage::error(format!(
-                                "describe: read error: {e}"
-                            )));
+                            self.status_message =
+                                Some(StatusMessage::error(format!("describe: read error: {e}")));
                         }
                     }
                 } else {
-                    let available: Vec<&str> =
-                        ctx.graph.components.iter().map(|c| c.name.as_str()).collect();
+                    let available: Vec<&str> = ctx
+                        .graph
+                        .components
+                        .iter()
+                        .map(|c| c.name.as_str())
+                        .collect();
                     let suggestion = if available.is_empty() {
                         String::new()
                     } else {
@@ -266,8 +267,7 @@ impl App {
                 }
             }
             "validate" => {
-                let (Some(dataset_path), Some(registry)) =
-                    (ctx.dataset_path, ctx.schema_registry)
+                let (Some(dataset_path), Some(registry)) = (ctx.dataset_path, ctx.schema_registry)
                 else {
                     self.status_message = Some(StatusMessage::error(
                         "validate: dataset or schema registry unavailable",
@@ -305,8 +305,7 @@ impl App {
                             Some(StatusMessage::info(format!("{count} finding(s)")));
                     }
                     Err(e) => {
-                        self.status_message =
-                            Some(StatusMessage::error(format!("validate: {e}")));
+                        self.status_message = Some(StatusMessage::error(format!("validate: {e}")));
                     }
                 }
             }

--- a/sdk/tui/src/app_palette.rs
+++ b/sdk/tui/src/app_palette.rs
@@ -18,16 +18,14 @@
 
 use std::collections::HashSet;
 
-use design_data_core::cascade::{self, specificity};
-use design_data_core::diff::display_name;
-use design_data_core::graph::{TokenGraph, TokenRecord};
+use design_data_core::cascade::resolve_property;
 use design_data_core::query;
 use design_data_core::validate;
 use tui_input::Input;
 
 use crate::app::{
-    layer_str, parse_resolve_args, save_palette_history, ActiveView, App, DescribeView,
-    DiagnosticRow, Modal, PaletteMode, QueryRow, QueryView, ResolveView, ResolvedRow,
+    parse_resolve_args, resolve_context_with_restrictions, save_palette_history, ActiveView, App,
+    DescribeView, DiagnosticRow, Modal, PaletteMode, QueryRow, QueryView, ResolveView, ResolvedRow,
     StatusMessage, SubmitContext, ValidateView, HISTORY_CAP,
 };
 use crate::find::FindWizardState;
@@ -96,79 +94,16 @@ impl App {
                         return;
                     }
                 };
-                let candidates: Vec<TokenRecord> = ctx
-                    .graph
-                    .tokens
-                    .values()
-                    .filter(|t| {
-                        t.raw
-                            .get("name")
-                            .and_then(|v| v.as_object())
-                            .and_then(|n| n.get("property"))
-                            .and_then(|v| v.as_str())
-                            == Some(prop.as_str())
-                    })
-                    .cloned()
-                    .collect();
+                let res_ctx =
+                    resolve_context_with_restrictions(res_ctx, &ctx.mode_set_restrictions);
+                let candidates = resolve_property(ctx.graph, &prop, &res_ctx);
                 if candidates.is_empty() {
                     self.active_view = ActiveView::Resolve(ResolveView::new(prop, vec![]));
                     self.status_message = Some(StatusMessage::info("no match"));
                     return;
                 }
-                let filtered_graph = TokenGraph::from_records(candidates)
-                    .with_mode_sets(ctx.graph.mode_sets.clone());
-                let mut with_spec: Vec<(&TokenRecord, u32)> = filtered_graph
-                    .tokens
-                    .values()
-                    .map(|t| {
-                        let s = t
-                            .raw
-                            .get("name")
-                            .and_then(|v| v.as_object())
-                            .map(|n| specificity(n, &filtered_graph.mode_sets))
-                            .unwrap_or(0);
-                        (t, s)
-                    })
-                    .collect();
-                with_spec.sort_by(|(a, sa), (b, sb)| {
-                    b.layer
-                        .cmp(&a.layer)
-                        .then_with(|| sb.cmp(sa))
-                        .then_with(|| a.file.cmp(&b.file))
-                        .then_with(|| a.index.cmp(&b.index))
-                });
-                let winner = cascade::resolve(&filtered_graph, &res_ctx);
-                let rows: Vec<ResolvedRow> = with_spec
-                    .iter()
-                    .map(|(t, spec)| {
-                        let value = t
-                            .raw
-                            .get("value")
-                            .map(|v| {
-                                if v.is_string() {
-                                    v.as_str().unwrap_or("").to_string()
-                                } else {
-                                    v.to_string()
-                                }
-                            })
-                            .or_else(|| t.alias_target.clone())
-                            .unwrap_or_default();
-                        let file = t
-                            .file
-                            .file_name()
-                            .map(|f| f.to_string_lossy().into_owned())
-                            .unwrap_or_default();
-                        let is_winner = winner.map(|w| w.name == t.name).unwrap_or(false);
-                        ResolvedRow {
-                            name: display_name(t),
-                            value,
-                            file,
-                            layer: layer_str(t.layer).to_string(),
-                            specificity: *spec,
-                            is_winner,
-                        }
-                    })
-                    .collect();
+                let rows: Vec<ResolvedRow> =
+                    candidates.iter().map(ResolvedRow::from_candidate).collect();
                 let count = rows.len();
                 self.active_view = ActiveView::Resolve(ResolveView::new(prop, rows));
                 self.status_message = Some(StatusMessage::info(format!("{count} candidate(s)")));

--- a/sdk/tui/src/app_palette.rs
+++ b/sdk/tui/src/app_palette.rs
@@ -69,7 +69,7 @@ impl App {
                 }
                 match query::parse(&rest) {
                     Ok(expr) => {
-                        let records = query::filter(ctx.graph, &expr);
+                        let records = query::filter_with_index(ctx.graph, &ctx.token_index, &expr);
                         let rows: Vec<QueryRow> =
                             records.iter().map(|r| QueryRow::from_record(r)).collect();
                         let count = rows.len();

--- a/sdk/tui/src/app_views.rs
+++ b/sdk/tui/src/app_views.rs
@@ -30,8 +30,9 @@ use crate::wizard::{WizardScreen, WizardState};
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /// Command names for Tab autocomplete.
-pub(crate) const KNOWN_COMMANDS: &[&str] =
-    &["find", "name", "new", "query", "resolve", "describe", "validate"];
+pub(crate) const KNOWN_COMMANDS: &[&str] = &[
+    "find", "name", "new", "query", "resolve", "describe", "validate",
+];
 
 /// Max palette history entries persisted to disk.
 pub(crate) const HISTORY_CAP: usize = 200;
@@ -63,10 +64,16 @@ pub struct StatusMessage {
 
 impl StatusMessage {
     pub fn info(text: impl Into<String>) -> Self {
-        Self { text: text.into(), kind: StatusKind::Info }
+        Self {
+            text: text.into(),
+            kind: StatusKind::Info,
+        }
     }
     pub fn error(text: impl Into<String>) -> Self {
-        Self { text: text.into(), kind: StatusKind::Error }
+        Self {
+            text: text.into(),
+            kind: StatusKind::Error,
+        }
     }
 }
 
@@ -95,8 +102,17 @@ impl QueryRow {
             })
             .or_else(|| t.alias_target.clone())
             .unwrap_or_default();
-        let file = t.file.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or_default();
-        Self { name: display_name(t), value, file, layer: layer_str(t.layer).to_string() }
+        let file = t
+            .file
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        Self {
+            name: display_name(t),
+            value,
+            file,
+            layer: layer_str(t.layer).to_string(),
+        }
     }
 }
 
@@ -113,7 +129,11 @@ impl QueryView {
         if !rows.is_empty() {
             table_state.select(Some(0));
         }
-        Self { expr_text, rows, table_state }
+        Self {
+            expr_text,
+            rows,
+            table_state,
+        }
     }
 
     pub(crate) fn selected_row(&self) -> Option<&QueryRow> {
@@ -145,7 +165,11 @@ impl ResolveView {
         if !rows.is_empty() {
             table_state.select(Some(0));
         }
-        Self { property, rows, table_state }
+        Self {
+            property,
+            rows,
+            table_state,
+        }
     }
 
     pub(crate) fn selected_row(&self) -> Option<&ResolvedRow> {

--- a/sdk/tui/src/app_views.rs
+++ b/sdk/tui/src/app_views.rs
@@ -15,14 +15,16 @@
 //! it) and the private `apply_scroll_delta` helper used by `Modal::on_scroll`.
 //! `app.rs` re-exports everything here via `pub use crate::app_views::*;`.
 
+use std::collections::HashMap;
+use std::path::Path;
+
+use design_data_core::cascade::ResolvedCandidate;
 use design_data_core::diff::display_name;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use ratatui::layout::Rect;
 use ratatui::widgets::TableState;
-
-use std::path::Path;
 
 use crate::find::{FindScreen, FindWizardState};
 use crate::naming::{NamingScreen, NamingWizardState};
@@ -151,6 +153,38 @@ pub struct ResolvedRow {
     pub layer: String,
     pub specificity: u32,
     pub is_winner: bool,
+}
+
+impl ResolvedRow {
+    /// Map a core [`ResolvedCandidate`] into a TUI table row.
+    pub fn from_candidate(c: &ResolvedCandidate) -> Self {
+        let t = &c.record;
+        let value = t
+            .raw
+            .get("value")
+            .map(|v| {
+                if v.is_string() {
+                    v.as_str().unwrap_or("").to_string()
+                } else {
+                    v.to_string()
+                }
+            })
+            .or_else(|| t.alias_target.clone())
+            .unwrap_or_default();
+        let file = t
+            .file
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        Self {
+            name: display_name(t),
+            value,
+            file,
+            layer: layer_str(t.layer).to_string(),
+            specificity: c.specificity,
+            is_winner: c.is_winner,
+        }
+    }
 }
 
 /// State for a resolve results view (winner + ranked candidates).
@@ -324,6 +358,7 @@ pub struct HitRegion {
 pub struct SubmitContext<'a> {
     pub graph: &'a TokenGraph,
     pub token_index: TokenIndex,
+    pub mode_set_restrictions: HashMap<String, Vec<String>>,
     pub dataset_path: Option<&'a Path>,
     pub components_dir: Option<&'a Path>,
     pub schema_registry: Option<&'a SchemaRegistry>,
@@ -336,6 +371,7 @@ impl<'a> SubmitContext<'a> {
         Self {
             graph,
             token_index: TokenIndex::build(graph),
+            mode_set_restrictions: HashMap::new(),
             dataset_path: None,
             components_dir: None,
             schema_registry: None,

--- a/sdk/tui/src/app_views.rs
+++ b/sdk/tui/src/app_views.rs
@@ -17,6 +17,7 @@
 
 use design_data_core::diff::display_name;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use ratatui::layout::Rect;
 use ratatui::widgets::TableState;
@@ -322,6 +323,7 @@ pub struct HitRegion {
 /// describe and validate commands.
 pub struct SubmitContext<'a> {
     pub graph: &'a TokenGraph,
+    pub token_index: TokenIndex,
     pub dataset_path: Option<&'a Path>,
     pub components_dir: Option<&'a Path>,
     pub schema_registry: Option<&'a SchemaRegistry>,
@@ -333,6 +335,7 @@ impl<'a> SubmitContext<'a> {
     pub fn new(graph: &'a TokenGraph) -> Self {
         Self {
             graph,
+            token_index: TokenIndex::build(graph),
             dataset_path: None,
             components_dir: None,
             schema_registry: None,

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -19,8 +19,8 @@ use crossterm::event::{KeyCode, KeyEvent};
 use design_data_core::graph::{Layer, TokenGraph};
 use design_data_core::registry::RegistryData;
 use design_data_core::{query, suggest};
-use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
 
 use crate::app::{QueryRow, QueryView};
 pub use crate::wizard_common::caps::{MAX_PROPERTY_SUGGESTIONS, MAX_SUGGEST_RESULTS};
@@ -141,7 +141,11 @@ impl FindWizardState {
             parts.push(format!("state={st}"));
         }
 
-        if parts.is_empty() { None } else { Some(parts.join(",")) }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(","))
+        }
     }
 
     /// Refresh `preview_rows`, `preview_count`, and `preview_error`.
@@ -154,8 +158,7 @@ impl FindWizardState {
                 Ok(filter) => {
                     let records = query::filter(graph, &filter);
                     self.preview_count = records.len();
-                    self.preview_rows =
-                        records.iter().map(|r| QueryRow::from_record(r)).collect();
+                    self.preview_rows = records.iter().map(|r| QueryRow::from_record(r)).collect();
                     self.preview_error = None;
                 }
                 Err(e) => {
@@ -193,8 +196,11 @@ impl FindWizardState {
             return;
         }
         if let Some(terms) = RegistryData::embedded().for_field("property") {
-            let mut matching: Vec<String> =
-                terms.iter().filter(|t| t.to_lowercase().contains(&typed)).cloned().collect();
+            let mut matching: Vec<String> = terms
+                .iter()
+                .filter(|t| t.to_lowercase().contains(&typed))
+                .cloned()
+                .collect();
             matching.sort();
             matching.truncate(MAX_PROPERTY_SUGGESTIONS);
             self.property_suggestions = matching;
@@ -244,8 +250,7 @@ impl FindWizardState {
             }
             KeyCode::Down if self.focused_field == 0 => {
                 if !self.property_suggestions.is_empty()
-                    && self.selected_property_suggestion
-                        < self.property_suggestions.len() - 1
+                    && self.selected_property_suggestion < self.property_suggestions.len() - 1
                 {
                     self.selected_property_suggestion += 1;
                 }
@@ -264,11 +269,21 @@ impl FindWizardState {
     fn dispatch_to_focused_field(&mut self, key: KeyEvent) {
         let ev = crossterm::event::Event::Key(key);
         match self.focused_field {
-            0 => { self.property.handle_event(&ev); }
-            1 => { self.component.handle_event(&ev); }
-            2 => { self.variant.handle_event(&ev); }
-            3 => { self.state.handle_event(&ev); }
-            4 => { self.intent.handle_event(&ev); }
+            0 => {
+                self.property.handle_event(&ev);
+            }
+            1 => {
+                self.component.handle_event(&ev);
+            }
+            2 => {
+                self.variant.handle_event(&ev);
+            }
+            3 => {
+                self.state.handle_event(&ev);
+            }
+            4 => {
+                self.intent.handle_event(&ev);
+            }
             _ => {}
         }
     }
@@ -305,15 +320,27 @@ fn suggestion_to_row(s: &suggest::SuggestionResult) -> QueryRow {
         .value
         .as_ref()
         .map(|v| {
-            if v.is_string() { v.as_str().unwrap_or("").to_string() } else { v.to_string() }
+            if v.is_string() {
+                v.as_str().unwrap_or("").to_string()
+            } else {
+                v.to_string()
+            }
         })
         .unwrap_or_default();
-    let file =
-        s.file.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or_default();
+    let file = s
+        .file
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_default();
     let layer = match s.layer {
         Layer::Foundation => "foundation",
         Layer::Platform => "platform",
         Layer::Product => "product",
     };
-    QueryRow { name: s.token_name.clone(), value, file, layer: layer.to_string() }
+    QueryRow {
+        name: s.token_name.clone(),
+        value,
+        file,
+        layer: layer.to_string(),
+    }
 }

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -152,11 +152,11 @@ impl FindWizardState {
     ///
     /// Uses structured-filter path when any filter field is non-empty;
     /// falls back to `suggest::suggest` when only `intent` is filled.
-    pub fn refresh_preview(&mut self, graph: &TokenGraph) {
+    pub fn refresh_preview(&mut self, graph: &TokenGraph, index: &query::TokenIndex) {
         if let Some(expr_str) = self.assemble_expr() {
             match query::parse(&expr_str) {
                 Ok(filter) => {
-                    let records = query::filter(graph, &filter);
+                    let records = query::filter_with_index(graph, index, &filter);
                     self.preview_count = records.len();
                     self.preview_rows = records.iter().map(|r| QueryRow::from_record(r)).collect();
                     self.preview_error = None;
@@ -214,22 +214,32 @@ impl FindWizardState {
 
     // ── Dispatch ─────────────────────────────────────────────────────────────
 
-    pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> FindEvent {
+    pub fn handle_key(
+        &mut self,
+        key: KeyEvent,
+        graph: &TokenGraph,
+        index: &query::TokenIndex,
+    ) -> FindEvent {
         if key.code == KeyCode::Esc {
             return FindEvent::Cancel;
         }
         match self.screen {
-            FindScreen::Filters => self.handle_filters_key(key, graph),
+            FindScreen::Filters => self.handle_filters_key(key, graph, index),
             FindScreen::Preview => self.handle_preview_key(key),
         }
     }
 
     // ── Screen 1: Filters ────────────────────────────────────────────────────
 
-    fn handle_filters_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> FindEvent {
+    fn handle_filters_key(
+        &mut self,
+        key: KeyEvent,
+        graph: &TokenGraph,
+        index: &query::TokenIndex,
+    ) -> FindEvent {
         match key.code {
             KeyCode::Enter => {
-                self.refresh_preview(graph);
+                self.refresh_preview(graph, index);
                 self.screen = FindScreen::Preview;
                 FindEvent::Continue
             }

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -10,8 +10,8 @@
 
 pub mod app;
 pub mod app_launch;
-pub mod app_views;
 pub(crate) mod app_palette;
+pub mod app_views;
 pub(crate) mod clipboard;
 pub mod find;
 pub mod help;
@@ -32,7 +32,7 @@ pub mod wizard_draft;
 
 pub use app_launch::{launch, LaunchOptions, ThemeChoice};
 pub use message::Message;
-pub use mode::{BrowsingState, Mode, ModalState, MouseMode, PaletteState};
+pub use mode::{BrowsingState, ModalState, Mode, MouseMode, PaletteState};
 pub use model::Model;
 pub use runtime::{replay, run};
 pub use task::Task;

--- a/sdk/tui/src/mode.rs
+++ b/sdk/tui/src/mode.rs
@@ -49,10 +49,7 @@ pub enum MouseMode {
     /// Selection mode enabled (`v` key was pressed) but no drag has started yet.
     SelectionEnabled,
     /// A drag-selection is in progress (mouse Down → Drag).
-    Selecting {
-        start: (u16, u16),
-        end: (u16, u16),
-    },
+    Selecting { start: (u16, u16), end: (u16, u16) },
 }
 
 // ── Modal state ───────────────────────────────────────────────────────────────
@@ -76,12 +73,20 @@ pub struct PaletteState {
 impl PaletteState {
     /// Open the palette in command (`:`) mode.
     pub fn command() -> Self {
-        Self { mode: PaletteMode::Command, input: Input::default(), history_cursor: None }
+        Self {
+            mode: PaletteMode::Command,
+            input: Input::default(),
+            history_cursor: None,
+        }
     }
 
     /// Open the palette in fuzzy-find (`/`) mode.
     pub fn fuzzy() -> Self {
-        Self { mode: PaletteMode::FuzzyFind, input: Input::default(), history_cursor: None }
+        Self {
+            mode: PaletteMode::FuzzyFind,
+            input: Input::default(),
+            history_cursor: None,
+        }
     }
 
     /// The prompt prefix character for this palette mode.

--- a/sdk/tui/src/model.rs
+++ b/sdk/tui/src/model.rs
@@ -15,7 +15,7 @@
 //! combinations become compile-time errors.
 
 use crate::app::{ActiveView, HitRegion, Modal, StatusMessage};
-use crate::mode::{BrowsingState, Mode, ModalState, MouseMode, PaletteState};
+use crate::mode::{BrowsingState, ModalState, Mode, MouseMode, PaletteState};
 
 /// Top-level application state for the TEA runtime.
 pub struct Model {
@@ -42,7 +42,11 @@ impl Model {
         use crate::wizard_draft::{from_draft, load_wizard_draft};
         let mode = if resume_wizard {
             load_wizard_draft()
-                .map(|d| Mode::InModal(ModalState { modal: Modal::Wizard(Box::new(from_draft(d))) }))
+                .map(|d| {
+                    Mode::InModal(ModalState {
+                        modal: Modal::Wizard(Box::new(from_draft(d))),
+                    })
+                })
                 .unwrap_or_else(|| Mode::Browsing(BrowsingState::default()))
         } else {
             Mode::Browsing(BrowsingState::default())
@@ -89,12 +93,20 @@ impl Model {
 
     /// Return the palette prompt prefix (`:` or `/`), or `""` if closed.
     pub fn palette_prefix(&self) -> &'static str {
-        if let Mode::InPalette(ref ps) = self.mode { ps.prefix() } else { "" }
+        if let Mode::InPalette(ref ps) = self.mode {
+            ps.prefix()
+        } else {
+            ""
+        }
     }
 
     /// Return the current palette input text, or `""` if palette is closed.
     pub fn palette_input_value(&self) -> &str {
-        if let Mode::InPalette(ref ps) = self.mode { ps.input.value() } else { "" }
+        if let Mode::InPalette(ref ps) = self.mode {
+            ps.input.value()
+        } else {
+            ""
+        }
     }
 
     // ── Modal helpers ─────────────────────────────────────────────────────────
@@ -117,12 +129,20 @@ impl Model {
 
     /// Immutable reference to the active modal, if any.
     pub fn modal(&self) -> Option<&Modal> {
-        if let Mode::InModal(ref ms) = self.mode { Some(&ms.modal) } else { None }
+        if let Mode::InModal(ref ms) = self.mode {
+            Some(&ms.modal)
+        } else {
+            None
+        }
     }
 
     /// Mutable reference to the active modal, if any.
     pub fn modal_mut(&mut self) -> Option<&mut Modal> {
-        if let Mode::InModal(ref mut ms) = self.mode { Some(&mut ms.modal) } else { None }
+        if let Mode::InModal(ref mut ms) = self.mode {
+            Some(&mut ms.modal)
+        } else {
+            None
+        }
     }
 
     // ── Palette accessors ─────────────────────────────────────────────────────
@@ -130,12 +150,20 @@ impl Model {
     /// Return the palette history cursor position (`None` = fresh input), or
     /// `None` if the palette is closed.
     pub fn palette_history_cursor(&self) -> Option<usize> {
-        if let Mode::InPalette(ref ps) = self.mode { ps.history_cursor } else { None }
+        if let Mode::InPalette(ref ps) = self.mode {
+            ps.history_cursor
+        } else {
+            None
+        }
     }
 
     /// Mutable access to the active `PaletteState`, or `None` if the palette is closed.
     pub fn palette_state_mut(&mut self) -> Option<&mut PaletteState> {
-        if let Mode::InPalette(ref mut ps) = self.mode { Some(ps) } else { None }
+        if let Mode::InPalette(ref mut ps) = self.mode {
+            Some(ps)
+        } else {
+            None
+        }
     }
 
     /// Return the current `PaletteMode`, or `None` if the palette is closed.
@@ -143,7 +171,11 @@ impl Model {
     /// Guard with `is_palette_open()` before calling this to avoid confusing
     /// "palette closed" with "palette open in Command mode".
     pub fn palette_mode(&self) -> Option<crate::app::PaletteMode> {
-        if let Mode::InPalette(ref ps) = self.mode { Some(ps.mode) } else { None }
+        if let Mode::InPalette(ref ps) = self.mode {
+            Some(ps.mode)
+        } else {
+            None
+        }
     }
 
     // ── Selection helpers ─────────────────────────────────────────────────────
@@ -163,20 +195,26 @@ impl Model {
     pub fn is_selecting(&self) -> bool {
         matches!(
             self.mode,
-            Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { .. } })
+            Mode::Browsing(BrowsingState {
+                mouse: MouseMode::Selecting { .. }
+            })
         )
     }
 
     /// Begin a drag-selection at `pos`. Transitions `SelectionEnabled → Selecting`.
     pub fn start_selection(&mut self, pos: (u16, u16)) {
         if let Mode::Browsing(ref mut bs) = self.mode {
-            bs.mouse = MouseMode::Selecting { start: pos, end: pos };
+            bs.mouse = MouseMode::Selecting {
+                start: pos,
+                end: pos,
+            };
         }
     }
 
     pub fn update_selection_end(&mut self, pos: (u16, u16)) {
-        if let Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { ref mut end, .. } }) =
-            self.mode
+        if let Mode::Browsing(BrowsingState {
+            mouse: MouseMode::Selecting { ref mut end, .. },
+        }) = self.mode
         {
             *end = pos;
         }
@@ -196,8 +234,9 @@ impl Model {
 
     /// Return the selection start position, if a drag is in progress.
     pub fn selection_start(&self) -> Option<(u16, u16)> {
-        if let Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { start, .. } }) =
-            self.mode
+        if let Mode::Browsing(BrowsingState {
+            mouse: MouseMode::Selecting { start, .. },
+        }) = self.mode
         {
             Some(start)
         } else {
@@ -207,8 +246,9 @@ impl Model {
 
     /// Return the selection end position, if a drag is in progress.
     pub fn selection_end(&self) -> Option<(u16, u16)> {
-        if let Mode::Browsing(BrowsingState { mouse: MouseMode::Selecting { end, .. } }) =
-            self.mode
+        if let Mode::Browsing(BrowsingState {
+            mouse: MouseMode::Selecting { end, .. },
+        }) = self.mode
         {
             Some(end)
         } else {

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -17,12 +17,12 @@
 use crossterm::event::{KeyCode, KeyEvent};
 use design_data_core::graph::TokenGraph;
 use design_data_core::suggest::{self, SuggestionResult};
-use tui_input::Input;
 use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
 
 use crate::wizard_common::classification::{
-    ClassificationDraft, NameField, assemble_name_from_classification,
-    cycle_layer_backward, cycle_layer_forward,
+    assemble_name_from_classification, cycle_layer_backward, cycle_layer_forward,
+    ClassificationDraft, NameField,
 };
 use design_data_core::authoring::session::alias_threshold;
 
@@ -196,8 +196,7 @@ impl NamingWizardState {
             }
             KeyCode::Tab => {
                 let count = self.classification.field_count();
-                self.classification.focused_field =
-                    (self.classification.focused_field + 1) % count;
+                self.classification.focused_field = (self.classification.focused_field + 1) % count;
                 NamingEvent::Continue
             }
             KeyCode::BackTab => {

--- a/sdk/tui/src/runtime.rs
+++ b/sdk/tui/src/runtime.rs
@@ -20,8 +20,8 @@ use std::io::Write;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use miette::{IntoDiagnostic, Result};
 use ratatui::{
-    Terminal,
     layout::{Constraint, Direction, Layout, Rect},
+    Terminal,
 };
 
 use crate::app::{ActiveView, HitAction, HitRegion};
@@ -82,7 +82,10 @@ pub fn run<B: ratatui::backend::Backend>(
                     if let Some(text) = palette_text {
                         if !model.is_palette_open() {
                             dispatch_and_record(
-                                &mut model, Message::PaletteSubmit(text), ctx, &mut record,
+                                &mut model,
+                                Message::PaletteSubmit(text),
+                                ctx,
+                                &mut record,
                             );
                         }
                     }
@@ -203,7 +206,12 @@ fn compute_hit_regions(model: &Model, status_height: u16, frame_area: Rect) -> V
                     break;
                 }
                 regions.push(HitRegion {
-                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    rect: Rect {
+                        x: view_area.x,
+                        y,
+                        width: view_area.width,
+                        height: 1,
+                    },
                     action: HitAction::SelectListRow(i),
                     text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
                 });
@@ -216,7 +224,12 @@ fn compute_hit_regions(model: &Model, status_height: u16, frame_area: Rect) -> V
                     break;
                 }
                 regions.push(HitRegion {
-                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    rect: Rect {
+                        x: view_area.x,
+                        y,
+                        width: view_area.width,
+                        height: 1,
+                    },
                     action: HitAction::SelectListRow(i),
                     text: format!("{}\t{}\t{}\t{}", row.name, row.value, row.file, row.layer),
                 });
@@ -229,7 +242,12 @@ fn compute_hit_regions(model: &Model, status_height: u16, frame_area: Rect) -> V
                     break;
                 }
                 regions.push(HitRegion {
-                    rect: Rect { x: view_area.x, y, width: view_area.width, height: 1 },
+                    rect: Rect {
+                        x: view_area.x,
+                        y,
+                        width: view_area.width,
+                        height: 1,
+                    },
                     action: HitAction::SelectListRow(i),
                     text: format!(
                         "{}\t{}\t{}\t{}",
@@ -246,8 +264,8 @@ fn compute_hit_regions(model: &Model, status_height: u16, frame_area: Rect) -> V
 #[cfg(test)]
 mod tests {
     use super::*;
-    use design_data_core::graph::TokenGraph;
     use crate::update::UpdateCtx;
+    use design_data_core::graph::TokenGraph;
 
     #[test]
     fn execute_task_handles_deeply_nested_batch_without_stack_overflow() {
@@ -263,4 +281,3 @@ mod tests {
         execute_task(deep, &mut model, &ctx);
     }
 }
-

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -19,6 +19,7 @@
 //! and `--allow-write` wizard writes still execute inline; they are tagged with
 //! `// TODO(#1023)` comments.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEventKind};
@@ -54,6 +55,7 @@ pub struct UpdateCtx<'a> {
     pub schema_registry: Option<&'a SchemaRegistry>,
     pub mode_sets_dir: Option<&'a Path>,
     pub token_index: TokenIndex,
+    pub mode_set_restrictions: HashMap<String, Vec<String>>,
     pub allow_write: bool,
 }
 
@@ -67,6 +69,7 @@ impl<'a> UpdateCtx<'a> {
             schema_registry: None,
             mode_sets_dir: None,
             token_index: TokenIndex::build(graph),
+            mode_set_restrictions: HashMap::new(),
             allow_write: false,
         }
     }

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -22,15 +22,15 @@
 use std::path::Path;
 
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEventKind};
-use tui_input::backend::crossterm::EventHandler;
 use design_data_core::graph::TokenGraph;
 use design_data_core::schema::SchemaRegistry;
+use tui_input::backend::crossterm::EventHandler;
 
-use crate::clipboard::write_clipboard;
 use crate::app::{
-    ActiveView, HitAction, Modal, PaletteMode, StatusMessage, KNOWN_COMMANDS,
-    move_table_selection, rect_contains,
+    move_table_selection, rect_contains, ActiveView, HitAction, Modal, PaletteMode, StatusMessage,
+    KNOWN_COMMANDS,
 };
+use crate::clipboard::write_clipboard;
 use crate::find::FindEvent;
 use crate::message::Message;
 use crate::model::Model;
@@ -125,8 +125,9 @@ pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Mess
         | Message::Tick
         | Message::ClipboardDone(None) => Task::none(),
         Message::ClipboardDone(Some(err)) => {
-            model.status_message =
-                Some(StatusMessage::error(format!("clipboard unavailable: {err}")));
+            model.status_message = Some(StatusMessage::error(format!(
+                "clipboard unavailable: {err}"
+            )));
             Task::none()
         }
     }
@@ -170,9 +171,9 @@ fn handle_key(
             let was_selecting = model.is_selecting();
             model.toggle_selection_mode();
             let label = if !was_selecting { "on" } else { "off" };
-            model.status_message = Some(StatusMessage::info(
-                format!("selection mode {label}  (drag to select, release to copy)"),
-            ));
+            model.status_message = Some(StatusMessage::info(format!(
+                "selection mode {label}  (drag to select, release to copy)"
+            )));
         }
         KeyCode::Char(':') => {
             model.open_command_palette();
@@ -188,10 +189,7 @@ fn handle_key(
     Task::none()
 }
 
-fn handle_palette_key(
-    model: &mut Model,
-    key: crossterm::event::KeyEvent,
-) -> Task<Message> {
+fn handle_palette_key(model: &mut Model, key: crossterm::event::KeyEvent) -> Task<Message> {
     let palette_cmd_mode = model.palette_mode() == Some(PaletteMode::Command);
 
     match key.code {
@@ -220,9 +218,10 @@ fn handle_palette_key(
                         }
                     }
                     _ => {
-                        model.status_message = Some(StatusMessage::info(
-                            format!("matches: {}", matches.join(" | ")),
-                        ));
+                        model.status_message = Some(StatusMessage::info(format!(
+                            "matches: {}",
+                            matches.join(" | ")
+                        )));
                     }
                 }
             }
@@ -414,8 +413,7 @@ fn route_modal_key(
                 model.status_message = Some(StatusMessage::info("naming wizard cancelled"));
             }
             NamingEvent::Copy(name) => {
-                model.status_message =
-                    Some(StatusMessage::info(format!("copied: {name}")));
+                model.status_message = Some(StatusMessage::info(format!("copied: {name}")));
                 let text = name.clone();
                 return Task::cmd(move || {
                     let err = write_clipboard(&text).err().map(|e| e.to_string());
@@ -438,7 +436,10 @@ fn route_modal_key(
         WizardEvent::Cancel => {
             model.close_modal();
             model.status_message = Some(StatusMessage::info("wizard cancelled"));
-            Task::cmd(|| { clear_wizard_draft(); Message::Tick })
+            Task::cmd(|| {
+                clear_wizard_draft();
+                Message::Tick
+            })
         }
         WizardEvent::Submit => {
             if !ctx.allow_write {
@@ -446,7 +447,10 @@ fn route_modal_key(
                 model.status_message = Some(StatusMessage::info(
                     "wizard preview ready — pass --allow-write to enable writes",
                 ));
-                Task::cmd(|| { clear_wizard_draft(); Message::Tick })
+                Task::cmd(|| {
+                    clear_wizard_draft();
+                    Message::Tick
+                })
             } else {
                 // TODO(#1023): extract perform_write into Task::Cmd once WizardState
                 // exposes owned submit-data that can be moved into a 'static closure.
@@ -458,10 +462,13 @@ fn route_modal_key(
                 match write_result {
                     Some((name, Ok(written_path))) => {
                         model.close_modal();
-                        model.status_message = Some(StatusMessage::info(
-                            format!("wrote {name} → {written_path}"),
-                        ));
-                        Task::cmd(|| { clear_wizard_draft(); Message::Tick })
+                        model.status_message = Some(StatusMessage::info(format!(
+                            "wrote {name} → {written_path}"
+                        )));
+                        Task::cmd(|| {
+                            clear_wizard_draft();
+                            Message::Tick
+                        })
                     }
                     Some((_, Err(e))) => {
                         if let Some(Modal::Wizard(ref mut ws)) = model.modal_mut() {
@@ -480,7 +487,10 @@ fn route_modal_key(
                 None
             };
             match draft {
-                Some(d) => Task::cmd(move || { save_wizard_draft(&d); Message::Tick }),
+                Some(d) => Task::cmd(move || {
+                    save_wizard_draft(&d);
+                    Message::Tick
+                }),
                 None => Task::none(),
             }
         }
@@ -557,15 +567,25 @@ fn scroll_active(model: &mut Model, delta: i32) {
 
 fn click_at(model: &mut Model, row: u16, col: u16) {
     let action = model.hit_regions.iter().find_map(|r| {
-        if rect_contains(r.rect, row, col) { Some(&r.action) } else { None }
+        if rect_contains(r.rect, row, col) {
+            Some(&r.action)
+        } else {
+            None
+        }
     });
     match action {
         Some(HitAction::SelectListRow(i)) => {
             let i = *i;
             match &mut model.active_view {
-                ActiveView::Query(qv) => { qv.table_state.select(Some(i)); }
-                ActiveView::Resolve(rv) => { rv.table_state.select(Some(i)); }
-                ActiveView::Validate(vv) => { vv.table_state.select(Some(i)); }
+                ActiveView::Query(qv) => {
+                    qv.table_state.select(Some(i));
+                }
+                ActiveView::Resolve(rv) => {
+                    rv.table_state.select(Some(i));
+                }
+                ActiveView::Validate(vv) => {
+                    vv.table_state.select(Some(i));
+                }
                 _ => {}
             }
         }
@@ -594,7 +614,11 @@ fn extract_selection_from_regions(
             lines.push(&region.text);
         }
     }
-    if lines.is_empty() { None } else { Some(lines.join("\n")) }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEventKind};
 use design_data_core::graph::TokenGraph;
+use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use tui_input::backend::crossterm::EventHandler;
 
@@ -52,6 +53,7 @@ pub struct UpdateCtx<'a> {
     pub components_dir: Option<&'a Path>,
     pub schema_registry: Option<&'a SchemaRegistry>,
     pub mode_sets_dir: Option<&'a Path>,
+    pub token_index: TokenIndex,
     pub allow_write: bool,
 }
 
@@ -64,6 +66,7 @@ impl<'a> UpdateCtx<'a> {
             components_dir: None,
             schema_registry: None,
             mode_sets_dir: None,
+            token_index: TokenIndex::build(graph),
             allow_write: false,
         }
     }
@@ -71,6 +74,7 @@ impl<'a> UpdateCtx<'a> {
     fn as_wizard_ctx(&self) -> WizardCtx<'_> {
         WizardCtx {
             graph: self.graph,
+            token_index: self.token_index.clone(),
             dataset_path: self.dataset_path,
             schema_registry: self.schema_registry,
             allow_write: self.allow_write,
@@ -386,7 +390,7 @@ fn route_modal_key(
 
     // Find modal.
     if let Some(Modal::Find(ref mut fs)) = model.modal_mut() {
-        let event = fs.handle_key(key, ctx.graph);
+        let event = fs.handle_key(key, ctx.graph, &ctx.token_index);
         match event {
             FindEvent::Cancel => {
                 model.close_modal();

--- a/sdk/tui/src/update_command.rs
+++ b/sdk/tui/src/update_command.rs
@@ -19,13 +19,12 @@
 
 use std::collections::HashSet;
 
-use design_data_core::cascade::{self, specificity};
-use design_data_core::diff::display_name;
-use design_data_core::graph::{TokenGraph, TokenRecord};
+use design_data_core::cascade::resolve_property;
 
 use crate::app::{
-    layer_str, parse_resolve_args, save_palette_history, ActiveView, DescribeView, DiagnosticRow,
-    Modal, QueryRow, QueryView, ResolveView, ResolvedRow, StatusMessage, ValidateView, HISTORY_CAP,
+    parse_resolve_args, resolve_context_with_restrictions, save_palette_history, ActiveView,
+    DescribeView, DiagnosticRow, Modal, QueryRow, QueryView, ResolveView, ResolvedRow,
+    StatusMessage, ValidateView, HISTORY_CAP,
 };
 use crate::find::FindWizardState;
 use crate::message::Message;
@@ -135,79 +134,15 @@ fn dispatch_command(
                     return Task::none();
                 }
             };
-            let candidates: Vec<TokenRecord> = ctx
-                .graph
-                .tokens
-                .values()
-                .filter(|t| {
-                    t.raw
-                        .get("name")
-                        .and_then(|v| v.as_object())
-                        .and_then(|n| n.get("property"))
-                        .and_then(|v| v.as_str())
-                        == Some(prop.as_str())
-                })
-                .cloned()
-                .collect();
+            let res_ctx = resolve_context_with_restrictions(res_ctx, &ctx.mode_set_restrictions);
+            let candidates = resolve_property(ctx.graph, &prop, &res_ctx);
             if candidates.is_empty() {
                 model.active_view = ActiveView::Resolve(ResolveView::new(prop, vec![]));
                 model.status_message = Some(StatusMessage::info("no match"));
                 return Task::none();
             }
-            let filtered_graph =
-                TokenGraph::from_records(candidates).with_mode_sets(ctx.graph.mode_sets.clone());
-            let mut with_spec: Vec<(&TokenRecord, u32)> = filtered_graph
-                .tokens
-                .values()
-                .map(|t| {
-                    let s = t
-                        .raw
-                        .get("name")
-                        .and_then(|v| v.as_object())
-                        .map(|n| specificity(n, &filtered_graph.mode_sets))
-                        .unwrap_or(0);
-                    (t, s)
-                })
-                .collect();
-            with_spec.sort_by(|(a, sa), (b, sb)| {
-                b.layer
-                    .cmp(&a.layer)
-                    .then_with(|| sb.cmp(sa))
-                    .then_with(|| a.file.cmp(&b.file))
-                    .then_with(|| a.index.cmp(&b.index))
-            });
-            let winner = cascade::resolve(&filtered_graph, &res_ctx);
-            let rows: Vec<ResolvedRow> = with_spec
-                .iter()
-                .map(|(t, spec)| {
-                    let value = t
-                        .raw
-                        .get("value")
-                        .map(|v| {
-                            if v.is_string() {
-                                v.as_str().unwrap_or("").to_string()
-                            } else {
-                                v.to_string()
-                            }
-                        })
-                        .or_else(|| t.alias_target.clone())
-                        .unwrap_or_default();
-                    let file = t
-                        .file
-                        .file_name()
-                        .map(|f| f.to_string_lossy().into_owned())
-                        .unwrap_or_default();
-                    let is_winner = winner.map(|w| w.name == t.name).unwrap_or(false);
-                    ResolvedRow {
-                        name: display_name(t),
-                        value,
-                        file,
-                        layer: layer_str(t.layer).to_string(),
-                        specificity: *spec,
-                        is_winner,
-                    }
-                })
-                .collect();
+            let rows: Vec<ResolvedRow> =
+                candidates.iter().map(ResolvedRow::from_candidate).collect();
             let count = rows.len();
             model.active_view = ActiveView::Resolve(ResolveView::new(prop, rows));
             model.status_message = Some(StatusMessage::info(format!("{count} candidate(s)")));

--- a/sdk/tui/src/update_command.rs
+++ b/sdk/tui/src/update_command.rs
@@ -104,7 +104,11 @@ fn dispatch_command(
             }
             match design_data_core::query::parse(rest) {
                 Ok(expr) => {
-                    let records = design_data_core::query::filter(ctx.graph, &expr);
+                    let records = design_data_core::query::filter_with_index(
+                        ctx.graph,
+                        &ctx.token_index,
+                        &expr,
+                    );
                     let rows: Vec<QueryRow> =
                         records.iter().map(|r| QueryRow::from_record(r)).collect();
                     let count = rows.len();

--- a/sdk/tui/src/update_command.rs
+++ b/sdk/tui/src/update_command.rs
@@ -24,8 +24,8 @@ use design_data_core::diff::display_name;
 use design_data_core::graph::{TokenGraph, TokenRecord};
 
 use crate::app::{
-    ActiveView, DescribeView, DiagnosticRow, Modal, QueryRow, QueryView, ResolvedRow, ResolveView,
-    StatusMessage, ValidateView, HISTORY_CAP, layer_str, parse_resolve_args, save_palette_history,
+    layer_str, parse_resolve_args, save_palette_history, ActiveView, DescribeView, DiagnosticRow,
+    Modal, QueryRow, QueryView, ResolveView, ResolvedRow, StatusMessage, ValidateView, HISTORY_CAP,
 };
 use crate::find::FindWizardState;
 use crate::message::Message;
@@ -66,7 +66,10 @@ pub(crate) fn handle_palette_submit(
         model.palette_history.insert(0, raw.clone());
         model.palette_history.truncate(HISTORY_CAP);
         let snap = model.palette_history.clone();
-        Task::cmd(move || { save_palette_history(&snap); Message::Tick })
+        Task::cmd(move || {
+            save_palette_history(&snap);
+            Message::Tick
+        })
     } else {
         Task::none()
     };
@@ -96,8 +99,7 @@ fn dispatch_command(
     match cmd {
         "query" => {
             if rest.is_empty() {
-                model.status_message =
-                    Some(StatusMessage::error("query: expression required"));
+                model.status_message = Some(StatusMessage::error("query: expression required"));
                 return Task::none();
             }
             match design_data_core::query::parse(rest) {
@@ -106,14 +108,12 @@ fn dispatch_command(
                     let rows: Vec<QueryRow> =
                         records.iter().map(|r| QueryRow::from_record(r)).collect();
                     let count = rows.len();
-                    model.active_view =
-                        ActiveView::Query(QueryView::new(rest.to_string(), rows));
+                    model.active_view = ActiveView::Query(QueryView::new(rest.to_string(), rows));
                     model.status_message =
                         Some(StatusMessage::info(format!("{count} token(s) matched")));
                 }
                 Err(e) => {
-                    model.status_message =
-                        Some(StatusMessage::error(format!("query error: {e}")));
+                    model.status_message = Some(StatusMessage::error(format!("query error: {e}")));
                 }
             }
             Task::none()
@@ -127,8 +127,7 @@ fn dispatch_command(
             let (prop, res_ctx) = match parse_resolve_args(rest) {
                 Ok(v) => v,
                 Err(e) => {
-                    model.status_message =
-                        Some(StatusMessage::error(format!("resolve: {e}")));
+                    model.status_message = Some(StatusMessage::error(format!("resolve: {e}")));
                     return Task::none();
                 }
             };
@@ -147,13 +146,12 @@ fn dispatch_command(
                 .cloned()
                 .collect();
             if candidates.is_empty() {
-                model.active_view =
-                    ActiveView::Resolve(ResolveView::new(prop, vec![]));
+                model.active_view = ActiveView::Resolve(ResolveView::new(prop, vec![]));
                 model.status_message = Some(StatusMessage::info("no match"));
                 return Task::none();
             }
-            let filtered_graph = TokenGraph::from_records(candidates)
-                .with_mode_sets(ctx.graph.mode_sets.clone());
+            let filtered_graph =
+                TokenGraph::from_records(candidates).with_mode_sets(ctx.graph.mode_sets.clone());
             let mut with_spec: Vec<(&TokenRecord, u32)> = filtered_graph
                 .tokens
                 .values()
@@ -208,8 +206,7 @@ fn dispatch_command(
                 .collect();
             let count = rows.len();
             model.active_view = ActiveView::Resolve(ResolveView::new(prop, rows));
-            model.status_message =
-                Some(StatusMessage::info(format!("{count} candidate(s)")));
+            model.status_message = Some(StatusMessage::info(format!("{count} candidate(s)")));
             Task::none()
         }
         "describe" | "component" => {
@@ -223,7 +220,9 @@ fn dispatch_command(
             let id = rest.trim();
             if id.is_empty()
                 || !id.chars().next().is_some_and(|c| c.is_ascii_lowercase())
-                || !id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+                || !id
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
             {
                 model.status_message =
                     Some(StatusMessage::error(format!("invalid component ID '{id}'")));
@@ -249,26 +248,28 @@ fn dispatch_command(
                                 model.status_message = None;
                             }
                             Err(e) => {
-                                model.status_message = Some(StatusMessage::error(
-                                    format!("describe: render error: {e}"),
-                                ));
+                                model.status_message = Some(StatusMessage::error(format!(
+                                    "describe: render error: {e}"
+                                )));
                             }
                         },
                         Err(e) => {
-                            model.status_message = Some(StatusMessage::error(
-                                format!("describe: parse error: {e}"),
-                            ));
+                            model.status_message =
+                                Some(StatusMessage::error(format!("describe: parse error: {e}")));
                         }
                     },
                     Err(e) => {
-                        model.status_message = Some(StatusMessage::error(
-                            format!("describe: read error: {e}"),
-                        ));
+                        model.status_message =
+                            Some(StatusMessage::error(format!("describe: read error: {e}")));
                     }
                 }
             } else {
-                let available: Vec<&str> =
-                    ctx.graph.components.iter().map(|c| c.name.as_str()).collect();
+                let available: Vec<&str> = ctx
+                    .graph
+                    .components
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect();
                 let suggestion = build_did_you_mean(id, &available);
                 model.status_message = Some(StatusMessage::error(format!(
                     "component '{id}' not found{suggestion}"
@@ -314,12 +315,10 @@ fn dispatch_command(
                         .collect();
                     let count = rows.len();
                     model.active_view = ActiveView::Validate(ValidateView::new(rows));
-                    model.status_message =
-                        Some(StatusMessage::info(format!("{count} finding(s)")));
+                    model.status_message = Some(StatusMessage::info(format!("{count} finding(s)")));
                 }
                 Err(e) => {
-                    model.status_message =
-                        Some(StatusMessage::error(format!("validate: {e}")));
+                    model.status_message = Some(StatusMessage::error(format!("validate: {e}")));
                 }
             }
             Task::none()
@@ -345,8 +344,7 @@ fn dispatch_command(
             Task::none()
         }
         other => {
-            model.status_message =
-                Some(StatusMessage::error(format!("unknown command: {other}")));
+            model.status_message = Some(StatusMessage::error(format!("unknown command: {other}")));
             Task::none()
         }
     }

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -9,21 +9,21 @@
 // governing permissions and limitations under the License.
 
 use ratatui::{
-    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table},
+    Frame,
 };
 
 use crate::app::{
     ActiveView, DescribeView, Modal, QueryView, ResolveView, StatusKind, ValidateView,
 };
-use crate::model::Model;
-use crate::view_find::render_find;
 use crate::help::HELP_TEXT;
+use crate::model::Model;
 use crate::naming::{NamingScreen, NamingWizardState};
 use crate::theme::Theme;
+use crate::view_find::render_find;
 use crate::wizard::{ClassificationDraft, ValueKind, WizardScreen, WizardState};
 
 /// Return a centered `Rect` covering `percent_x` × `percent_y` of `area`.
@@ -74,7 +74,9 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
     // Active view.
     match &mut model.active_view {
         ActiveView::Empty => {
-            let block = Block::default().borders(Borders::ALL).title(" Active View ");
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title(" Active View ");
             frame.render_widget(block, chunks[1]);
         }
         ActiveView::Query(ref mut qv) => render_query(frame, qv, chunks[1], theme),
@@ -257,7 +259,11 @@ fn render_help_modal(f: &mut Frame<'_>, scroll: u16, area: Rect) {
     let popup_area = centered_rect(80, 90, area);
     f.render_widget(Clear, popup_area);
     let para = Paragraph::new(HELP_TEXT)
-        .block(Block::default().borders(Borders::ALL).title(" Help  ?/Esc to close "))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Help  ?/Esc to close "),
+        )
         .scroll((scroll, 0));
     f.render_widget(para, popup_area);
 }
@@ -347,7 +353,9 @@ fn render_intent_content(
     f.render_widget(Paragraph::new(intent_line), chunks[0]);
 
     if can_alias {
-        let accent = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
+        let accent = Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD);
         let banner = Paragraph::new(vec![
             Line::from(Span::styled(
                 "  These tokens already exist for similar intents.",
@@ -369,7 +377,10 @@ fn render_intent_content(
                 list_area,
             );
         } else {
-            f.render_widget(Paragraph::new("  Type to search for existing tokens…"), list_area);
+            f.render_widget(
+                Paragraph::new("  Type to search for existing tokens…"),
+                list_area,
+            );
         }
     } else {
         let rows: Vec<Row> = suggestions
@@ -385,7 +396,11 @@ fn render_intent_content(
                 ])
             })
             .collect();
-        let widths = [Constraint::Length(2), Constraint::Min(0), Constraint::Length(5)];
+        let widths = [
+            Constraint::Length(2),
+            Constraint::Min(0),
+            Constraint::Length(5),
+        ];
         let table =
             Table::new(rows, widths).highlight_style(Style::default().bg(theme.selection_bg));
         f.render_widget(table, list_area);
@@ -423,7 +438,11 @@ fn render_classification_content(
 
     for (i, field) in classification.name_fields.iter().enumerate() {
         let marker = if focused == i + 2 { "▶" } else { " " };
-        lines.push(Line::from(format!("{marker} {}: {}", field.key, field.value.value())));
+        lines.push(Line::from(format!(
+            "{marker} {}: {}",
+            field.key,
+            field.value.value()
+        )));
     }
 
     lines.push(Line::from(""));
@@ -438,9 +457,10 @@ fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &
     let screen_num = ns.screen.number();
     let screen_name = ns.screen.name();
 
-    let outer = Block::default()
-        .borders(Borders::ALL)
-        .title(format!(" Name · {screen_num}/{} · {screen_name} ", NamingScreen::SCREEN_COUNT));
+    let outer = Block::default().borders(Borders::ALL).title(format!(
+        " Name · {screen_num}/{} · {screen_name} ",
+        NamingScreen::SCREEN_COUNT
+    ));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 
@@ -481,12 +501,7 @@ fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &
     }
 }
 
-fn render_naming_result(
-    f: &mut Frame<'_>,
-    ns: &NamingWizardState,
-    area: Rect,
-    theme: &Theme,
-) {
+fn render_naming_result(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &Theme) {
     let name = ns.assembled_name();
     let display = if name.is_empty() {
         "(no name assembled — go back and fill in Property)".to_string()
@@ -499,10 +514,14 @@ fn render_naming_result(
         .constraints([Constraint::Length(3), Constraint::Min(0)])
         .split(area);
 
-    let name_block = Block::default().borders(Borders::ALL).title(" Assembled name ");
+    let name_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Assembled name ");
     let name_para = Paragraph::new(Span::styled(
         display,
-        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD),
     ))
     .block(name_block);
     f.render_widget(name_para, chunks[0]);
@@ -574,7 +593,7 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme:
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),            // schema URL / editor
+            Constraint::Length(1), // schema URL / editor
             Constraint::Length(rationale_height),
             Constraint::Min(0),               // diff preview
             Constraint::Length(error_height), // write error
@@ -598,7 +617,9 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme:
     f.render_widget(Paragraph::new(schema_line), chunks[0]);
 
     // Rationale input.
-    let rationale_block = Block::default().borders(Borders::ALL).title(" Rationale (required) ");
+    let rationale_block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Rationale (required) ");
     let rationale_text = ws.rationale.value();
     let rationale_line = if rationale_text.len() > 280 {
         Line::from(vec![
@@ -608,14 +629,22 @@ fn render_confirm_screen(f: &mut Frame<'_>, ws: &WizardState, area: Rect, theme:
     } else {
         Line::from(Span::raw(rationale_text))
     };
-    f.render_widget(Paragraph::new(rationale_line).block(rationale_block), chunks[1]);
+    f.render_widget(
+        Paragraph::new(rationale_line).block(rationale_block),
+        chunks[1],
+    );
 
     // Diff preview.
-    let diff_text = ws.diff_preview.as_deref().unwrap_or(
-        "(diff will appear here once rationale is added and Enter pressed)",
-    );
+    let diff_text = ws
+        .diff_preview
+        .as_deref()
+        .unwrap_or("(diff will appear here once rationale is added and Enter pressed)");
     let diff_para = Paragraph::new(diff_text)
-        .block(Block::default().borders(Borders::ALL).title(" Diff preview "))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Diff preview "),
+        )
         .scroll((ws.diff_scroll, 0));
     f.render_widget(diff_para, chunks[2]);
 

--- a/sdk/tui/src/view_find.rs
+++ b/sdk/tui/src/view_find.rs
@@ -13,10 +13,10 @@
 //! within the 800-LOC budget enforced by `tests/budget.rs` (GH #1018).
 
 use ratatui::{
-    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
+    Frame,
 };
 
 use crate::find::{FindScreen, FindWizardState, MAX_PROPERTY_SUGGESTIONS, MAX_SUGGEST_RESULTS};
@@ -28,9 +28,10 @@ pub(crate) fn render_find(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, t
     let screen_num = fs.screen.number();
     let screen_name = fs.screen.name();
 
-    let outer = Block::default()
-        .borders(Borders::ALL)
-        .title(format!(" Find · {screen_num}/{} · {screen_name} ", FindScreen::SCREEN_COUNT));
+    let outer = Block::default().borders(Borders::ALL).title(format!(
+        " Find · {screen_num}/{} · {screen_name} ",
+        FindScreen::SCREEN_COUNT
+    ));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 
@@ -67,11 +68,11 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),         // property label
+            Constraint::Length(1),          // property label
             Constraint::Length(dropdown_h), // suggestion dropdown (0 when empty)
             Constraint::Length(field_rows), // component / variant / state / intent
-            Constraint::Length(1),         // match count
-            Constraint::Min(0),            // padding
+            Constraint::Length(1),          // match count
+            Constraint::Min(0),             // padding
         ])
         .split(area);
 
@@ -94,13 +95,18 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
             .iter()
             .enumerate()
             .map(|(i, term)| {
-                let marker = if i == fs.selected_property_suggestion { "  ▸" } else { "   " };
-                Row::new(vec![Cell::from(format!("{marker} {term}"))])
-                    .style(if i == fs.selected_property_suggestion {
+                let marker = if i == fs.selected_property_suggestion {
+                    "  ▸"
+                } else {
+                    "   "
+                };
+                Row::new(vec![Cell::from(format!("{marker} {term}"))]).style(
+                    if i == fs.selected_property_suggestion {
                         Style::default().bg(theme.selection_bg)
                     } else {
                         Style::default().fg(theme.muted)
-                    })
+                    },
+                )
             })
             .collect();
         let widths = [Constraint::Min(0)];

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
+use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use design_data_core::suggest::{self, SuggestionResult};
 use design_data_core::write::{write_token, WriteTokenInput};
@@ -28,6 +29,7 @@ use uuid::Uuid;
 /// Minimal graph context passed to wizard key handlers.
 pub struct WizardCtx<'a> {
     pub graph: &'a TokenGraph,
+    pub token_index: TokenIndex,
     pub dataset_path: Option<&'a Path>,
     pub schema_registry: Option<&'a SchemaRegistry>,
     /// When true, Screen 4 Submit writes to disk via `write_token`.

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -20,10 +20,10 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
 use design_data_core::schema::SchemaRegistry;
 use design_data_core::suggest::{self, SuggestionResult};
-use design_data_core::write::{WriteTokenInput, write_token};
-use uuid::Uuid;
-use tui_input::Input;
+use design_data_core::write::{write_token, WriteTokenInput};
 use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
+use uuid::Uuid;
 
 /// Minimal graph context passed to wizard key handlers.
 pub struct WizardCtx<'a> {
@@ -45,8 +45,8 @@ use design_data_core::authoring::session::alias_threshold;
 // them without reaching into this module.  The re-exports keep every existing
 // call-site (tests, wizard_draft.rs, main.rs) working unchanged.
 pub use crate::wizard_common::classification::{
-    ClassificationDraft, NameField, assemble_name_from_classification, cycle_layer_backward,
-    cycle_layer_forward,
+    assemble_name_from_classification, cycle_layer_backward, cycle_layer_forward,
+    ClassificationDraft, NameField,
 };
 
 /// One row in Screen 3's values table.
@@ -66,7 +66,11 @@ impl ValueRow {
         if self.mode_combo.is_empty() {
             "default".to_string()
         } else {
-            self.mode_combo.iter().map(|(k, v)| format!("{k}={v}")).collect::<Vec<_>>().join(", ")
+            self.mode_combo
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(", ")
         }
     }
 }
@@ -81,7 +85,11 @@ pub struct ValuesDraft {
 
 impl ValuesDraft {
     fn new() -> Self {
-        Self { rows: Vec::new(), selected: 0, editing: false }
+        Self {
+            rows: Vec::new(),
+            selected: 0,
+            editing: false,
+        }
     }
 }
 
@@ -192,7 +200,9 @@ impl WizardState {
             }
             KeyCode::Tab => {
                 if !self.suggestions.is_empty() {
-                    let name = self.suggestions[self.selected_suggestion].token_name.clone();
+                    let name = self.suggestions[self.selected_suggestion]
+                        .token_name
+                        .clone();
                     // Infer schema URL from the reuse target's token record.
                     if self.schema_url.is_none() {
                         if let Some(token) = ctx.graph.tokens.get(&name) {
@@ -260,8 +270,7 @@ impl WizardState {
             }
             KeyCode::Tab => {
                 let count = self.classification.field_count();
-                self.classification.focused_field =
-                    (self.classification.focused_field + 1) % count;
+                self.classification.focused_field = (self.classification.focused_field + 1) % count;
                 WizardEvent::Continue
             }
             KeyCode::BackTab => {
@@ -289,7 +298,9 @@ impl WizardState {
             _ => {
                 let focused = self.classification.focused_field;
                 if focused == 1 {
-                    self.classification.property.handle_event(&crossterm::event::Event::Key(key));
+                    self.classification
+                        .property
+                        .handle_event(&crossterm::event::Event::Key(key));
                 } else if focused >= 2 {
                     let idx = focused - 2;
                     if let Some(field) = self.classification.name_fields.get_mut(idx) {
@@ -335,8 +346,7 @@ impl WizardState {
                 WizardEvent::Continue
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                if !self.values.rows.is_empty()
-                    && self.values.selected < self.values.rows.len() - 1
+                if !self.values.rows.is_empty() && self.values.selected < self.values.rows.len() - 1
                 {
                     self.values.selected += 1;
                 }
@@ -380,7 +390,8 @@ impl WizardState {
                     self.editing_schema_url = false;
                 }
                 _ => {
-                    self.schema_url_input.handle_event(&crossterm::event::Event::Key(key));
+                    self.schema_url_input
+                        .handle_event(&crossterm::event::Event::Key(key));
                 }
             }
             return WizardEvent::Continue;
@@ -405,7 +416,8 @@ impl WizardState {
                 WizardEvent::Continue
             }
             _ => {
-                self.rationale.handle_event(&crossterm::event::Event::Key(key));
+                self.rationale
+                    .handle_event(&crossterm::event::Event::Key(key));
                 // Regenerate diff on each keystroke so rationale is reflected immediately.
                 self.build_diff(ctx.dataset_path);
                 WizardEvent::Continue
@@ -451,11 +463,12 @@ impl WizardState {
     /// the modal open so the user can correct the error.
     pub fn perform_write(&self, ctx: &WizardCtx<'_>) -> Result<String, String> {
         let registry = ctx.schema_registry.ok_or_else(|| {
-            "no schema registry available — run from the repo root or pass --schema-path".to_string()
+            "no schema registry available — run from the repo root or pass --schema-path"
+                .to_string()
         })?;
-        let dataset_path = ctx.dataset_path.ok_or_else(|| {
-            "no dataset path available".to_string()
-        })?;
+        let dataset_path = ctx
+            .dataset_path
+            .ok_or_else(|| "no dataset path available".to_string())?;
 
         let key = self.assembled_name();
         if key.is_empty() {
@@ -488,7 +501,11 @@ impl WizardState {
         let is_override = ctx.graph.tokens.contains_key(&key);
 
         let pc_path = dataset_path.join("product-context.json");
-        let product_context = if pc_path.exists() { Some(pc_path) } else { None };
+        let product_context = if pc_path.exists() {
+            Some(pc_path)
+        } else {
+            None
+        };
 
         write_token(
             WriteTokenInput {
@@ -540,7 +557,11 @@ impl WizardState {
 
         // Build the new token object.
         let key = self.assembled_name();
-        let key = if key.is_empty() { "new-token".to_string() } else { key };
+        let key = if key.is_empty() {
+            "new-token".to_string()
+        } else {
+            key
+        };
 
         // Preview uses the first value row; full per-mode shape is deferred.
         let token_value = build_token_value(&self.values.rows);
@@ -570,7 +591,11 @@ impl WizardState {
             .to_string();
 
         // Cap at 200 lines.
-        let capped: String = diff_text.lines().take(200).collect::<Vec<&str>>().join("\n");
+        let capped: String = diff_text
+            .lines()
+            .take(200)
+            .collect::<Vec<&str>>()
+            .join("\n");
         self.diff_preview = Some(capped);
     }
 }
@@ -615,7 +640,11 @@ fn infer_schema_url(graph: &TokenGraph, property: &str) -> Option<String> {
             .and_then(|n| n.get("property"))
             .and_then(|v| v.as_str())
             == Some(property);
-        if prop_matches { t.schema_url.clone() } else { None }
+        if prop_matches {
+            t.schema_url.clone()
+        } else {
+            None
+        }
     })
 }
 
@@ -664,11 +693,7 @@ fn build_value_rows(
             ValueRow {
                 mode_combo: combo,
                 kind: ValueKind::Alias,
-                alias_target: seed_alias(
-                    graph,
-                    intent,
-                    property_hint.as_deref(),
-                ),
+                alias_target: seed_alias(graph, intent, property_hint.as_deref()),
                 literal: Input::default(),
             }
         })
@@ -700,4 +725,3 @@ fn cartesian_product(mode_sets: &[ModeSetRecord]) -> Vec<Vec<(String, String)>> 
     }
     result
 }
-

--- a/sdk/tui/src/wizard_draft.rs
+++ b/sdk/tui/src/wizard_draft.rs
@@ -88,7 +88,10 @@ pub fn from_draft(d: WizardDraft) -> WizardState {
                 .classification
                 .name_fields
                 .into_iter()
-                .map(|f| NameField { key: f.key, value: Input::from(f.value) })
+                .map(|f| NameField {
+                    key: f.key,
+                    value: Input::from(f.value),
+                })
                 .collect(),
             focused_field: d.classification.focused_field,
         },
@@ -146,7 +149,9 @@ pub fn load_wizard_draft() -> Option<WizardDraft> {
 
 /// Write the wizard draft to disk atomically (write to `.tmp`, then rename).
 pub fn save_wizard_draft(draft: &WizardDraft) {
-    let Some(path) = wizard_draft_path() else { return };
+    let Some(path) = wizard_draft_path() else {
+        return;
+    };
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -162,6 +167,8 @@ pub fn save_wizard_draft(draft: &WizardDraft) {
 
 /// Remove the wizard draft file.  Ignores `NotFound`.
 pub fn clear_wizard_draft() {
-    let Some(path) = wizard_draft_path() else { return };
+    let Some(path) = wizard_draft_path() else {
+        return;
+    };
     let _ = std::fs::remove_file(&path);
 }

--- a/sdk/tui/tests/autocomplete.rs
+++ b/sdk/tui/tests/autocomplete.rs
@@ -73,8 +73,15 @@ fn ambiguous_prefix_sets_status_and_leaves_buffer_unchanged() {
     // Empty prefix matches all commands → ambiguous.
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
     assert_eq!(model.palette_input_value(), "");
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("matches:"), "expected 'matches:' in status: {msg}");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("matches:"),
+        "expected 'matches:' in status: {msg}"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/budget.rs
+++ b/sdk/tui/tests/budget.rs
@@ -60,7 +60,9 @@ fn no_source_file_exceeds_loc_cap() {
             let content = fs::read_to_string(path).unwrap_or_default();
             let lines = content.lines().count();
             if lines > CAP {
-                let rel = path.strip_prefix(env!("CARGO_MANIFEST_DIR")).unwrap_or(path);
+                let rel = path
+                    .strip_prefix(env!("CARGO_MANIFEST_DIR"))
+                    .unwrap_or(path);
                 Some(format!("{}: {} lines (cap {})", rel.display(), lines, CAP))
             } else {
                 None
@@ -103,8 +105,7 @@ fn no_async_in_render_path() {
 
     for path in &render_files {
         let name = path.file_name().unwrap().to_string_lossy();
-        let content = fs::read_to_string(path)
-            .unwrap_or_else(|_| panic!("could not read {name}"));
+        let content = fs::read_to_string(path).unwrap_or_else(|_| panic!("could not read {name}"));
         assert!(
             !content.contains("async fn"),
             "{name} must not contain `async fn` (render path must stay synchronous)"

--- a/sdk/tui/tests/common/mod.rs
+++ b/sdk/tui/tests/common/mod.rs
@@ -12,8 +12,8 @@ use crossterm::event::{
     KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
 };
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
-use design_data_tui::{Model, UpdateCtx};
 use design_data_tui::theme::Theme;
+use design_data_tui::{Model, UpdateCtx};
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::Terminal;
@@ -32,12 +32,20 @@ pub fn key(code: KeyCode) -> KeyEvent {
 
 /// Build a mouse event at the given terminal cell.
 pub fn mouse(kind: MouseEventKind, row: u16, col: u16) -> MouseEvent {
-    MouseEvent { kind, row, column: col, modifiers: KeyModifiers::NONE }
+    MouseEvent {
+        kind,
+        row,
+        column: col,
+        modifiers: KeyModifiers::NONE,
+    }
 }
 
 /// Standard 2-token graph used across most test suites.
 pub fn make_graph() -> TokenGraph {
-    make_graph_with_tokens(&["accent-background-color-default", "neutral-background-color-default"])
+    make_graph_with_tokens(&[
+        "accent-background-color-default",
+        "neutral-background-color-default",
+    ])
 }
 
 /// Build a graph from a list of token names. Each token gets `value = "red"` and

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -13,6 +13,7 @@ use common::key;
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{ComponentRecord, TokenGraph};
+use design_data_core::query::TokenIndex;
 use design_data_tui::app::ActiveView;
 use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
@@ -38,6 +39,7 @@ fn describe_ctx<'a>(graph: &'a TokenGraph, dir: &'a PathBuf) -> UpdateCtx<'a> {
         components_dir: Some(dir.as_path()),
         schema_registry: None,
         mode_sets_dir: None,
+        token_index: TokenIndex::build(graph),
         allow_write: false,
     }
 }

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -40,6 +40,7 @@ fn describe_ctx<'a>(graph: &'a TokenGraph, dir: &'a PathBuf) -> UpdateCtx<'a> {
         schema_registry: None,
         mode_sets_dir: None,
         token_index: TokenIndex::build(graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     }
 }

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -53,7 +53,10 @@ fn describe_known_component_returns_describe_view() {
     let ctx = describe_ctx(&graph, &dir);
     let mut model = Model::new();
     submit_describe(&mut model, &ctx, "button");
-    assert!(matches!(model.active_view, ActiveView::Describe(_)), "expected Describe view");
+    assert!(
+        matches!(model.active_view, ActiveView::Describe(_)),
+        "expected Describe view"
+    );
 }
 
 #[test]
@@ -79,8 +82,15 @@ fn describe_unknown_component_sets_error_status() {
     let mut model = Model::new();
     submit_describe(&mut model, &ctx, "nonexistent");
     assert!(matches!(model.active_view, ActiveView::Empty));
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("not found"), "expected 'not found' in error message: {msg}");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("not found"),
+        "expected 'not found' in error message: {msg}"
+    );
 }
 
 #[test]
@@ -90,8 +100,15 @@ fn describe_unknown_with_components_suggests_match() {
     let ctx = describe_ctx(&graph, &dir);
     let mut model = Model::new();
     submit_describe(&mut model, &ctx, "but");
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("button"), "expected suggestion for 'button' in: {msg}");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("button"),
+        "expected suggestion for 'button' in: {msg}"
+    );
 }
 
 #[test]
@@ -101,7 +118,11 @@ fn describe_invalid_id_sets_error_status() {
     let ctx = describe_ctx(&graph, &dir);
     let mut model = Model::new();
     submit_describe(&mut model, &ctx, "Button");
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(msg.contains("invalid"), "expected 'invalid' in: {msg}");
 }
 
@@ -110,9 +131,20 @@ fn describe_no_components_dir_sets_error_status() {
     let graph = TokenGraph::default();
     let ctx = UpdateCtx::minimal(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("describe button".into()), &ctx);
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("no components directory"), "expected 'no components directory': {msg}");
+    update(
+        &mut model,
+        Message::PaletteSubmit("describe button".into()),
+        &ctx,
+    );
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("no components directory"),
+        "expected 'no components directory': {msg}"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -13,6 +13,7 @@ use common::{key, update_ctx};
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_core::query::TokenIndex;
 use design_data_tui::app::{ActiveView, Modal};
 use design_data_tui::find::{FindEvent, FindScreen, FindWizardState};
 use design_data_tui::{update, Message, Model, UpdateCtx};
@@ -89,13 +90,14 @@ fn new_with_empty_intent_leaves_focus_at_property() {
 fn assemble_expr_from_property_and_variant() {
     let mut fs = FindWizardState::new();
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     for c in "background-color".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.handle_key(key(KeyCode::Tab), &graph);
-    fs.handle_key(key(KeyCode::Tab), &graph);
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
     for c in "accent".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
     let expr = fs.assemble_expr().unwrap();
     assert_eq!(expr, "property=background-color,variant=accent");
@@ -110,11 +112,12 @@ fn assemble_expr_returns_none_when_all_fields_empty() {
 #[test]
 fn refresh_preview_populates_rows_for_structured_filter() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     for c in "background-color".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.refresh_preview(&graph);
+    fs.refresh_preview(&graph, &index);
     assert_eq!(fs.preview_count, 2);
     assert!(fs.preview_error.is_none());
 }
@@ -122,8 +125,9 @@ fn refresh_preview_populates_rows_for_structured_filter() {
 #[test]
 fn refresh_preview_uses_suggest_when_only_intent_filled() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new_with_intent("accent background");
-    fs.refresh_preview(&graph);
+    fs.refresh_preview(&graph, &index);
     assert!(fs.preview_count > 0);
     assert!(fs.preview_rows.iter().any(|r| r.name.contains("accent")));
     assert!(fs.preview_error.is_none());
@@ -132,8 +136,9 @@ fn refresh_preview_uses_suggest_when_only_intent_filled() {
 #[test]
 fn refresh_preview_is_empty_when_nothing_filled() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.refresh_preview(&graph);
+    fs.refresh_preview(&graph, &index);
     assert_eq!(fs.preview_count, 0);
     assert!(fs.preview_rows.is_empty());
     assert!(fs.preview_error.is_none());
@@ -142,8 +147,9 @@ fn refresh_preview_is_empty_when_nothing_filled() {
 #[test]
 fn enter_on_filters_advances_to_preview() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert!(matches!(event, FindEvent::Continue));
     assert_eq!(fs.screen, FindScreen::Preview);
 }
@@ -151,25 +157,27 @@ fn enter_on_filters_advances_to_preview() {
 #[test]
 fn enter_on_preview_emits_open_results() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     for c in "background-color".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.handle_key(key(KeyCode::Enter), &graph);
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert_eq!(fs.screen, FindScreen::Preview);
-    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert!(matches!(event, FindEvent::OpenResults(_)));
 }
 
 #[test]
 fn open_results_view_has_correct_row_count() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     for c in "background-color".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.handle_key(key(KeyCode::Enter), &graph);
-    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     if let FindEvent::OpenResults(view) = event {
         assert!(view.rows.len() >= 1);
         assert_eq!(view.expr_text, "property=background-color");
@@ -181,9 +189,10 @@ fn open_results_view_has_correct_row_count() {
 #[test]
 fn e_on_preview_goes_back_to_filters() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph);
-    let event = fs.handle_key(key(KeyCode::Char('e')), &graph);
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    let event = fs.handle_key(key(KeyCode::Char('e')), &graph, &index);
     assert!(matches!(event, FindEvent::Continue));
     assert_eq!(fs.screen, FindScreen::Filters);
 }
@@ -191,51 +200,56 @@ fn e_on_preview_goes_back_to_filters() {
 #[test]
 fn esc_cancels_on_filters_screen() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    let event = fs.handle_key(key(KeyCode::Esc), &graph);
+    let event = fs.handle_key(key(KeyCode::Esc), &graph, &index);
     assert!(matches!(event, FindEvent::Cancel));
 }
 
 #[test]
 fn esc_cancels_on_preview_screen() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph);
-    let event = fs.handle_key(key(KeyCode::Esc), &graph);
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    let event = fs.handle_key(key(KeyCode::Esc), &graph, &index);
     assert!(matches!(event, FindEvent::Cancel));
 }
 
 #[test]
 fn q_cancels_on_preview_screen() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph);
-    let event = fs.handle_key(key(KeyCode::Char('q')), &graph);
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    let event = fs.handle_key(key(KeyCode::Char('q')), &graph, &index);
     assert!(matches!(event, FindEvent::Cancel));
 }
 
 #[test]
 fn tab_cycles_through_fields() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     assert_eq!(fs.focused_field, 0);
-    fs.handle_key(key(KeyCode::Tab), &graph);
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
     assert_eq!(fs.focused_field, 1);
-    fs.handle_key(key(KeyCode::Tab), &graph);
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
     assert_eq!(fs.focused_field, 2);
-    fs.handle_key(key(KeyCode::BackTab), &graph);
+    fs.handle_key(key(KeyCode::BackTab), &graph, &index);
     assert_eq!(fs.focused_field, 1);
 }
 
 #[test]
 fn tab_wraps_around_from_last_to_first_field() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     for _ in 0..4 {
-        fs.handle_key(key(KeyCode::Tab), &graph);
+        fs.handle_key(key(KeyCode::Tab), &graph, &index);
     }
     assert_eq!(fs.focused_field, 4);
-    fs.handle_key(key(KeyCode::Tab), &graph);
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
     assert_eq!(fs.focused_field, 0);
 }
 
@@ -243,8 +257,9 @@ fn tab_wraps_around_from_last_to_first_field() {
 fn property_suggestions_filter_by_typed_prefix() {
     let mut fs = FindWizardState::new();
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     for c in "background".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
     assert!(!fs.property_suggestions.is_empty());
     assert!(fs
@@ -257,8 +272,9 @@ fn property_suggestions_filter_by_typed_prefix() {
 fn up_down_navigate_property_suggestions() {
     let mut fs = FindWizardState::new();
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     for c in "color".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
     assert!(
         fs.property_suggestions.len() > 1,
@@ -266,18 +282,19 @@ fn up_down_navigate_property_suggestions() {
         fs.property_suggestions.len()
     );
     let initial = fs.selected_property_suggestion;
-    fs.handle_key(key(KeyCode::Down), &graph);
+    fs.handle_key(key(KeyCode::Down), &graph, &index);
     assert_eq!(fs.selected_property_suggestion, initial + 1);
-    fs.handle_key(key(KeyCode::Up), &graph);
+    fs.handle_key(key(KeyCode::Up), &graph, &index);
     assert_eq!(fs.selected_property_suggestion, initial);
 }
 
 #[test]
 fn refresh_preview_sets_error_on_invalid_expression() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     fs.property = tui_input::Input::from("foo,bar".to_string());
-    fs.refresh_preview(&graph);
+    fs.refresh_preview(&graph, &index);
     assert!(
         fs.preview_error.is_some(),
         "expected parse error for condition missing operator"
@@ -289,11 +306,12 @@ fn refresh_preview_sets_error_on_invalid_expression() {
 #[test]
 fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     for c in "background-color".chars() {
-        fs.handle_key(key(KeyCode::Char(c)), &graph);
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.refresh_preview(&graph);
+    fs.refresh_preview(&graph, &index);
     assert!(
         fs.preview_error.is_none(),
         "parse error: {:?}",
@@ -308,20 +326,22 @@ fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
 #[test]
 fn backtab_wraps_from_first_to_last_field() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     assert_eq!(fs.focused_field, 0);
-    fs.handle_key(key(KeyCode::BackTab), &graph);
+    fs.handle_key(key(KeyCode::BackTab), &graph, &index);
     assert_eq!(fs.focused_field, FindWizardState::FIELD_COUNT - 1);
 }
 
 #[test]
 fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new_with_intent("accent background");
-    fs.handle_key(key(KeyCode::Enter), &graph);
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert_eq!(fs.screen, FindScreen::Preview);
     assert!(fs.preview_count > 0);
-    let event = fs.handle_key(key(KeyCode::Enter), &graph);
+    let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     if let FindEvent::OpenResults(view) = event {
         assert_eq!(view.expr_text, "accent background");
         assert!(!view.rows.is_empty());
@@ -339,6 +359,7 @@ fn submit(model: &mut Model, ctx: &UpdateCtx<'_>, cmd: &str) {
 #[test]
 fn find_command_opens_find_modal() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -348,6 +369,7 @@ fn find_command_opens_find_modal() {
 #[test]
 fn find_command_with_args_seeds_intent() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find accent background");
@@ -361,6 +383,7 @@ fn find_command_with_args_seeds_intent() {
 #[test]
 fn find_command_no_args_opens_modal_with_empty_fields() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -375,6 +398,7 @@ fn find_command_no_args_opens_modal_with_empty_fields() {
 #[test]
 fn tab_autocompletes_find_command() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
@@ -388,6 +412,7 @@ fn tab_autocompletes_find_command() {
 #[test]
 fn esc_in_find_modal_closes_it() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -399,6 +424,7 @@ fn esc_in_find_modal_closes_it() {
 #[test]
 fn accepting_preview_opens_query_view_and_closes_modal() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -428,6 +454,7 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
 #[test]
 fn e_on_preview_keeps_modal_open_and_returns_to_filters() {
     let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -247,7 +247,10 @@ fn property_suggestions_filter_by_typed_prefix() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
     assert!(!fs.property_suggestions.is_empty());
-    assert!(fs.property_suggestions.iter().all(|s| s.contains("background")));
+    assert!(fs
+        .property_suggestions
+        .iter()
+        .all(|s| s.contains("background")));
 }
 
 #[test]
@@ -275,7 +278,10 @@ fn refresh_preview_sets_error_on_invalid_expression() {
     let mut fs = FindWizardState::new();
     fs.property = tui_input::Input::from("foo,bar".to_string());
     fs.refresh_preview(&graph);
-    assert!(fs.preview_error.is_some(), "expected parse error for condition missing operator");
+    assert!(
+        fs.preview_error.is_some(),
+        "expected parse error for condition missing operator"
+    );
     assert_eq!(fs.preview_count, 0);
     assert!(fs.preview_rows.is_empty());
 }
@@ -288,8 +294,15 @@ fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
         fs.handle_key(key(KeyCode::Char(c)), &graph);
     }
     fs.refresh_preview(&graph);
-    assert!(fs.preview_error.is_none(), "parse error: {:?}", fs.preview_error);
-    assert!(fs.preview_count >= 1, "expected at least one match for property=background-color");
+    assert!(
+        fs.preview_error.is_none(),
+        "parse error: {:?}",
+        fs.preview_error
+    );
+    assert!(
+        fs.preview_count >= 1,
+        "expected at least one match for property=background-color"
+    );
 }
 
 #[test]
@@ -401,8 +414,15 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
 
     assert!(!model.is_modal_open());
     assert!(matches!(model.active_view, ActiveView::Query(_)));
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("matched"), "expected 'matched' in status: {msg}");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("matched"),
+        "expected 'matched' in status: {msg}"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -359,7 +359,6 @@ fn submit(model: &mut Model, ctx: &UpdateCtx<'_>, cmd: &str) {
 #[test]
 fn find_command_opens_find_modal() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -369,7 +368,6 @@ fn find_command_opens_find_modal() {
 #[test]
 fn find_command_with_args_seeds_intent() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find accent background");
@@ -383,7 +381,6 @@ fn find_command_with_args_seeds_intent() {
 #[test]
 fn find_command_no_args_opens_modal_with_empty_fields() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -398,7 +395,6 @@ fn find_command_no_args_opens_modal_with_empty_fields() {
 #[test]
 fn tab_autocompletes_find_command() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char(':'))), &ctx);
@@ -412,7 +408,6 @@ fn tab_autocompletes_find_command() {
 #[test]
 fn esc_in_find_modal_closes_it() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -424,7 +419,6 @@ fn esc_in_find_modal_closes_it() {
 #[test]
 fn accepting_preview_opens_query_view_and_closes_modal() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
@@ -454,7 +448,6 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
 #[test]
 fn e_on_preview_keeps_modal_open_and_returns_to_filters() {
     let graph = make_find_graph();
-    let index = TokenIndex::build(&graph);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -14,8 +14,9 @@ mod common;
 use common::{empty_graph, key, mouse, update_ctx};
 
 use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
-use design_data_tui::app::{ActiveView, DescribeView, HitAction, HitRegion, Modal, QueryRow,
-    QueryView};
+use design_data_tui::app::{
+    ActiveView, DescribeView, HitAction, HitRegion, Modal, QueryRow, QueryView,
+};
 use design_data_tui::theme::Theme;
 use design_data_tui::{update, Message, Model};
 use ratatui::layout::Rect;
@@ -28,7 +29,10 @@ fn question_mark_opens_help_modal() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
-    assert!(matches!(model.modal(), Some(Modal::Help(_))), "? should open help modal");
+    assert!(
+        matches!(model.modal(), Some(Modal::Help(_))),
+        "? should open help modal"
+    );
 }
 
 #[test]
@@ -89,7 +93,10 @@ fn submit_palette_appends_to_history() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::PaletteSubmit("query *".into()), &ctx);
-    assert_eq!(model.palette_history.first().map(|s| s.as_str()), Some("query *"));
+    assert_eq!(
+        model.palette_history.first().map(|s| s.as_str()),
+        Some("query *")
+    );
 }
 
 #[test]
@@ -117,7 +124,11 @@ fn history_dedupes_consecutive_duplicates() {
     let mut model = Model::new();
     model.palette_history = vec!["query *".to_string()];
     update(&mut model, Message::PaletteSubmit("query *".into()), &ctx);
-    assert_eq!(model.palette_history.len(), 1, "same command should not be duplicated");
+    assert_eq!(
+        model.palette_history.len(),
+        1,
+        "same command should not be duplicated"
+    );
 }
 
 /// History dedup is head-only: only consecutive duplicates are suppressed.
@@ -134,7 +145,11 @@ fn history_dedup_is_head_only_not_global() {
     model.palette_history = vec!["query B".to_string(), "query A".to_string()];
     update(&mut model, Message::PaletteSubmit("query A".into()), &ctx);
     assert_eq!(model.palette_history[0], "query A");
-    assert_eq!(model.palette_history.len(), 3, "non-consecutive duplicate should be added");
+    assert_eq!(
+        model.palette_history.len(),
+        3,
+        "non-consecutive duplicate should be added"
+    );
     assert_eq!(model.palette_history, vec!["query A", "query B", "query A"]);
 }
 
@@ -144,7 +159,11 @@ fn history_caps_at_200_entries() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     model.palette_history = (0..199).map(|i| format!("query token-{i}")).collect();
-    update(&mut model, Message::PaletteSubmit("query new-token".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query new-token".into()),
+        &ctx,
+    );
     assert_eq!(model.palette_history.len(), 200);
     assert_eq!(model.palette_history[0], "query new-token");
 }
@@ -161,7 +180,11 @@ fn typing_resets_history_cursor() {
     assert_eq!(model.palette_history_cursor(), Some(0));
 
     update(&mut model, Message::Key(key(KeyCode::Char('x'))), &ctx);
-    assert_eq!(model.palette_history_cursor(), None, "typing should reset history cursor");
+    assert_eq!(
+        model.palette_history_cursor(),
+        None,
+        "typing should reset history cursor"
+    );
 
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
     assert_eq!(model.palette_history_cursor(), Some(0));
@@ -180,7 +203,11 @@ fn wheel_scroll_down_increments_describe_scroll() {
         pretty_json: "{}".to_string(),
         scroll: 0,
     });
-    update(&mut model, Message::Mouse(mouse(MouseEventKind::ScrollDown, 5, 5)), &ctx);
+    update(
+        &mut model,
+        Message::Mouse(mouse(MouseEventKind::ScrollDown, 5, 5)),
+        &ctx,
+    );
     if let ActiveView::Describe(ref dv) = model.active_view {
         assert!(dv.scroll > 0, "scroll down should advance describe scroll");
     }
@@ -194,19 +221,69 @@ fn click_on_hit_region_selects_row() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     let rows = vec![
-        QueryRow { name: "a".into(), value: "1".into(), file: "f".into(), layer: "foundation".into() },
-        QueryRow { name: "b".into(), value: "2".into(), file: "f".into(), layer: "foundation".into() },
-        QueryRow { name: "c".into(), value: "3".into(), file: "f".into(), layer: "foundation".into() },
+        QueryRow {
+            name: "a".into(),
+            value: "1".into(),
+            file: "f".into(),
+            layer: "foundation".into(),
+        },
+        QueryRow {
+            name: "b".into(),
+            value: "2".into(),
+            file: "f".into(),
+            layer: "foundation".into(),
+        },
+        QueryRow {
+            name: "c".into(),
+            value: "3".into(),
+            file: "f".into(),
+            layer: "foundation".into(),
+        },
     ];
     model.active_view = ActiveView::Query(QueryView::new("*".to_string(), rows));
     model.hit_regions = vec![
-        HitRegion { rect: Rect { x: 0, y: 2, width: 80, height: 1 }, action: HitAction::SelectListRow(0), text: "a".into() },
-        HitRegion { rect: Rect { x: 0, y: 3, width: 80, height: 1 }, action: HitAction::SelectListRow(1), text: "b".into() },
-        HitRegion { rect: Rect { x: 0, y: 4, width: 80, height: 1 }, action: HitAction::SelectListRow(2), text: "c".into() },
+        HitRegion {
+            rect: Rect {
+                x: 0,
+                y: 2,
+                width: 80,
+                height: 1,
+            },
+            action: HitAction::SelectListRow(0),
+            text: "a".into(),
+        },
+        HitRegion {
+            rect: Rect {
+                x: 0,
+                y: 3,
+                width: 80,
+                height: 1,
+            },
+            action: HitAction::SelectListRow(1),
+            text: "b".into(),
+        },
+        HitRegion {
+            rect: Rect {
+                x: 0,
+                y: 4,
+                width: 80,
+                height: 1,
+            },
+            action: HitAction::SelectListRow(2),
+            text: "c".into(),
+        },
     ];
-    update(&mut model, Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 10)), &ctx);
+    update(
+        &mut model,
+        Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 3, 10)),
+        &ctx,
+    );
     if let ActiveView::Query(ref qv) = model.active_view {
-        assert_eq!(qv.table_state.selected(), Some(1), "click should select row 1");
+        assert_eq!(
+            qv.table_state.selected(),
+            Some(1),
+            "click should select row 1"
+        );
     }
 }
 
@@ -218,7 +295,10 @@ fn v_key_enters_selection_mode() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
-    assert!(model.is_selection_mode_enabled(), "v should enable selection mode");
+    assert!(
+        model.is_selection_mode_enabled(),
+        "v should enable selection mode"
+    );
 }
 
 #[test]
@@ -228,7 +308,10 @@ fn v_key_toggles_selection_mode_off() {
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
-    assert!(!model.is_selection_mode_enabled(), "second v should disable selection mode");
+    assert!(
+        !model.is_selection_mode_enabled(),
+        "second v should disable selection mode"
+    );
 }
 
 #[test]
@@ -237,8 +320,16 @@ fn drag_records_selection_endpoints() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::Key(key(KeyCode::Char('v'))), &ctx);
-    update(&mut model, Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0)), &ctx);
-    update(&mut model, Message::Mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 10)), &ctx);
+    update(
+        &mut model,
+        Message::Mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 0)),
+        &ctx,
+    );
+    update(
+        &mut model,
+        Message::Mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 4, 10)),
+        &ctx,
+    );
     assert_eq!(model.selection_start(), Some((2, 0)));
     assert_eq!(model.selection_end(), Some((4, 10)));
 }
@@ -249,14 +340,22 @@ fn drag_records_selection_endpoints() {
 fn theme_terminal_has_reset_fg() {
     use ratatui::style::Color;
     let t = Theme::terminal();
-    assert_eq!(t.fg, Color::Reset, "terminal theme fg should be Color::Reset");
+    assert_eq!(
+        t.fg,
+        Color::Reset,
+        "terminal theme fg should be Color::Reset"
+    );
 }
 
 #[test]
 fn theme_spectrum_overrides_accent() {
     use ratatui::style::Color;
     let t = Theme::spectrum();
-    assert_eq!(t.accent, Color::Rgb(64, 70, 202), "spectrum theme accent should be Indigo 700");
+    assert_eq!(
+        t.accent,
+        Color::Rgb(64, 70, 202),
+        "spectrum theme accent should be Indigo 700"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/manifest.rs
+++ b/sdk/tui/tests/manifest.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use design_data_core::cascade::{resolve_property, ResolutionContext};
 use design_data_core::data_source::{self, CliPathOverrides};
@@ -68,8 +68,8 @@ fn setup_project(manifest: serde_json::Value) -> tempfile::TempDir {
 
 /// Mirror `DatasetHandle::load` manifest application for integration tests.
 fn load_session(
-    project_path: &PathBuf,
-    tokens_path: &PathBuf,
+    project_path: &Path,
+    tokens_path: &Path,
 ) -> (TokenGraph, TokenIndex, HashMap<String, Vec<String>>) {
     let (mut graph, mut token_index) =
         TokenGraph::open_cached_with_index(tokens_path).expect("open cached graph");
@@ -161,6 +161,9 @@ fn resolve_respects_manifest_restrictions() {
             assert!(!view.rows.is_empty());
             assert!(view.rows.iter().any(|r| r.is_winner));
         }
-        other => panic!("expected resolve view, got {:?}", std::mem::discriminant(other)),
+        other => panic!(
+            "expected resolve view, got {:?}",
+            std::mem::discriminant(other)
+        ),
     }
 }

--- a/sdk/tui/tests/manifest.rs
+++ b/sdk/tui/tests/manifest.rs
@@ -1,0 +1,166 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! TUI session load applies the platform manifest the same way as the CLI.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use design_data_core::cascade::{resolve_property, ResolutionContext};
+use design_data_core::data_source::{self, CliPathOverrides};
+use design_data_core::graph::TokenGraph;
+use design_data_core::manifest;
+use design_data_core::query::{self, TokenIndex};
+use design_data_tui::app::ActiveView;
+use design_data_tui::message::Message;
+use design_data_tui::model::Model;
+use design_data_tui::update::{update, UpdateCtx};
+use serde_json::json;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root canonicalizes")
+}
+
+fn setup_project(manifest: serde_json::Value) -> tempfile::TempDir {
+    let project = tempfile::tempdir().expect("temp project dir");
+    let tokens_dir = project.path().join("tokens");
+    fs::create_dir_all(&tokens_dir).expect("create tokens dir");
+
+    fs::write(
+        tokens_dir.join("tokens.json"),
+        json!({
+            "btn-bg": {"name": {"property": "background-color", "component": "button"}, "value": "#aaa", "uuid": "u-btn-bg"},
+            "btn-fg": {"name": {"property": "color", "component": "button"}, "value": "#111", "uuid": "u-btn-fg"},
+            "chk-bg": {"name": {"property": "background-color", "component": "checkbox"}, "value": "#bbb", "uuid": "u-chk-bg"}
+        })
+        .to_string(),
+    )
+    .expect("write tokens");
+
+    fs::write(
+        project.path().join("manifest.json"),
+        serde_json::to_string_pretty(&manifest).expect("serialize manifest"),
+    )
+    .expect("write manifest");
+
+    fs::write(
+        project.path().join(".design-data.toml"),
+        format!(
+            "[source]\ntype = \"path\"\nroot = \"{}\"\nmanifest = \"manifest.json\"\n",
+            repo_root().display()
+        ),
+    )
+    .expect("write config");
+
+    project
+}
+
+/// Mirror `DatasetHandle::load` manifest application for integration tests.
+fn load_session(
+    project_path: &PathBuf,
+    tokens_path: &PathBuf,
+) -> (TokenGraph, TokenIndex, HashMap<String, Vec<String>>) {
+    let (mut graph, mut token_index) =
+        TokenGraph::open_cached_with_index(tokens_path).expect("open cached graph");
+
+    let resolved =
+        data_source::resolve(project_path, &CliPathOverrides::default()).expect("resolve");
+
+    if let Some(ref dir) = resolved.mode_sets {
+        if dir.is_dir() {
+            let mode_sets = TokenGraph::load_spec_mode_sets(dir).expect("mode sets");
+            graph = graph.with_mode_sets(mode_sets);
+        }
+    }
+
+    let mode_set_restrictions =
+        manifest::apply_configured(&mut graph, &resolved).expect("manifest");
+    if resolved.platform_manifest.is_some() {
+        token_index = TokenIndex::build(&graph);
+    }
+
+    (graph, token_index, mode_set_restrictions)
+}
+
+#[test]
+fn session_load_applies_manifest_include_filter() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["component=button"]
+    }));
+
+    let project_path = project.path().to_path_buf();
+    let tokens_dir = project_path.join("tokens");
+    let (graph, token_index, restrictions) = load_session(&project_path, &tokens_dir);
+
+    assert!(restrictions.is_empty());
+    assert_eq!(graph.tokens.len(), 2);
+
+    let expr = query::parse("").expect("empty filter");
+    let matched = query::filter_with_index(&graph, &token_index, &expr);
+    assert_eq!(matched.len(), 2);
+    assert!(matched
+        .iter()
+        .all(|t| { t.raw["name"]["component"].as_str() == Some("button") }));
+}
+
+#[test]
+fn resolve_respects_manifest_restrictions() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0",
+        "include": ["component=button"],
+        "modeSetRestrictions": {
+            "colorScheme": {"allowed": ["light"]}
+        }
+    }));
+
+    let project_path = project.path().to_path_buf();
+    let tokens_dir = project_path.join("tokens");
+    let (graph, token_index, restrictions) = load_session(&project_path, &tokens_dir);
+
+    let prop = "background-color".to_string();
+    let ctx = ResolutionContext::new().with("colorScheme", "light");
+    let ctx = restrictions.iter().fold(ctx, |acc, (mode_set, allowed)| {
+        acc.with_restriction(mode_set.clone(), allowed.clone())
+    });
+    let candidates = resolve_property(&graph, prop.as_str(), &ctx);
+    assert!(!candidates.is_empty());
+    assert!(candidates.iter().any(|c| c.is_winner));
+
+    let ctx = UpdateCtx {
+        graph: &graph,
+        dataset_path: Some(&tokens_dir),
+        components_dir: None,
+        schema_registry: None,
+        mode_sets_dir: None,
+        token_index,
+        mode_set_restrictions: restrictions,
+        allow_write: false,
+    };
+    let mut model = Model::new();
+    update(
+        &mut model,
+        Message::PaletteSubmit("resolve property=background-color,colorScheme=light".into()),
+        &ctx,
+    );
+    match &model.active_view {
+        ActiveView::Resolve(view) => {
+            assert!(!view.rows.is_empty());
+            assert!(view.rows.iter().any(|r| r.is_winner));
+        }
+        other => panic!("expected resolve view, got {:?}", std::mem::discriminant(other)),
+    }
+}

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -90,7 +90,11 @@ fn e_on_result_screen_goes_back_to_classification() {
 #[test]
 fn esc_on_any_screen_cancels() {
     let graph = make_graph();
-    for start_screen in [NamingScreen::Intent, NamingScreen::Classification, NamingScreen::Result] {
+    for start_screen in [
+        NamingScreen::Intent,
+        NamingScreen::Classification,
+        NamingScreen::Result,
+    ] {
         let mut ns = NamingWizardState::new();
         ns.screen = start_screen;
         let event = ns.handle_key(key(KeyCode::Esc), &graph);
@@ -201,11 +205,24 @@ fn copy_event_sets_pending_yank_and_status() {
     // Press 'c' → Copy; should return Task::Cmd (clipboard write) instead of setting pending_yank.
     let task = update(&mut model, Message::Key(key(KeyCode::Char('c'))), &ctx);
 
-    assert!(task.is_cmd(), "Copy should return Task::Cmd for clipboard write");
-    assert!(model.pending_yank.is_none(), "pending_yank should not be set — clipboard is via Task::Cmd");
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(
+        task.is_cmd(),
+        "Copy should return Task::Cmd for clipboard write"
+    );
+    assert!(
+        model.pending_yank.is_none(),
+        "pending_yank should not be set — clipboard is via Task::Cmd"
+    );
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
-    assert!(model.is_modal_open(), "Copy should not close the Naming modal");
+    assert!(
+        model.is_modal_open(),
+        "Copy should not close the Naming modal"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -20,7 +20,11 @@ fn submit_valid_query_populates_query_view() {
     let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=accent-color".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=accent-color".into()),
+        &ctx,
+    );
     assert!(!model.is_palette_open());
     assert!(matches!(model.active_view, ActiveView::Query(_)));
 }
@@ -30,7 +34,11 @@ fn submit_query_resets_selection_to_zero() {
     let graph = make_graph_with_tokens(&["accent-color", "background-color"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
     } else {
@@ -43,10 +51,18 @@ fn submit_invalid_query_sets_status_message() {
     let graph = empty_graph();
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query ===bad===".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query ===bad===".into()),
+        &ctx,
+    );
     assert!(!model.is_palette_open());
     assert!(matches!(model.active_view, ActiveView::Empty));
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(
         msg.contains("query error") || msg.contains("error"),
         "expected error message, got: {msg}"
@@ -59,8 +75,15 @@ fn submit_unknown_command_sets_status_message() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     update(&mut model, Message::PaletteSubmit("foobar".into()), &ctx);
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("unknown command"), "expected 'unknown command' in: {msg}");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("unknown command"),
+        "expected 'unknown command' in: {msg}"
+    );
 }
 
 #[test]
@@ -68,7 +91,11 @@ fn down_j_moves_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
     if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(1));
@@ -82,7 +109,11 @@ fn up_k_moves_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
     update(&mut model, Message::Key(key(KeyCode::Char('k'))), &ctx);
     if let ActiveView::Query(ref qv) = model.active_view {
@@ -97,7 +128,11 @@ fn selection_clamps_at_bounds() {
     let graph = make_graph_with_tokens(&["a", "b"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     update(&mut model, Message::Key(key(KeyCode::Up)), &ctx);
     if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
@@ -118,11 +153,21 @@ fn y_sets_yank_pending_with_selected_name() {
     let graph = make_graph_with_tokens(&["accent-color"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     let task = update(&mut model, Message::Key(key(KeyCode::Char('y'))), &ctx);
     // 'y' now returns Task::Cmd (clipboard write) instead of setting pending_yank.
-    assert!(task.is_cmd(), "'y' should return Task::Cmd for clipboard write");
-    assert!(model.pending_yank.is_none(), "pending_yank should not be set");
+    assert!(
+        task.is_cmd(),
+        "'y' should return Task::Cmd for clipboard write"
+    );
+    assert!(
+        model.pending_yank.is_none(),
+        "pending_yank should not be set"
+    );
 }
 
 #[test]
@@ -130,7 +175,11 @@ fn esc_from_query_view_returns_to_empty() {
     let graph = make_graph_with_tokens(&["a"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     assert!(matches!(model.active_view, ActiveView::Query(_)));
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
     assert!(matches!(model.active_view, ActiveView::Empty));
@@ -141,9 +190,17 @@ fn re_query_replaces_results_and_resets_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
-    update(&mut model, Message::PaletteSubmit("query property=*".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
     if let ActiveView::Query(ref qv) = model.active_view {
         assert_eq!(qv.table_state.selected(), Some(0));
     } else {

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -27,7 +27,9 @@ const H: u16 = 24;
 
 /// Collect a single row of the buffer as a `String`.
 fn row_str(buf: &Buffer, y: u16, w: u16) -> String {
-    (0..w).map(|x| buf.cell((x, y)).unwrap().symbol().to_string()).collect()
+    (0..w)
+        .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect()
 }
 
 /// Scan all rows for the first one whose text contains `needle`. Returns that
@@ -72,7 +74,10 @@ fn empty_app_renders_active_view_border() {
     let mut model = Model::new();
     let buf = render_to_buffer(&mut model, W, H);
     let border_row = (1..H).find(|&y| buf.cell((0, y)).unwrap().symbol() == "┌");
-    assert!(border_row.is_some(), "expected a '┌' border somewhere in rows 1..{H}");
+    assert!(
+        border_row.is_some(),
+        "expected a '┌' border somewhere in rows 1..{H}"
+    );
 }
 
 #[test]
@@ -97,7 +102,10 @@ fn query_view_renders_column_headers() {
 
     let buf = render_to_buffer(&mut model, W, H);
     let header_row = find_row_containing(&buf, "Name", W, H);
-    assert!(header_row.contains("Value"), "header should also contain 'Value': {header_row}");
+    assert!(
+        header_row.contains("Value"),
+        "header should also contain 'Value': {header_row}"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/replay.rs
+++ b/sdk/tui/tests/replay.rs
@@ -20,12 +20,22 @@ use ratatui::Terminal;
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 
-fn replay_messages(messages: Vec<Message>, graph: &design_data_core::graph::TokenGraph) -> ratatui::buffer::Buffer {
+fn replay_messages(
+    messages: Vec<Message>,
+    graph: &design_data_core::graph::TokenGraph,
+) -> ratatui::buffer::Buffer {
     let ctx = update_ctx(graph);
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).unwrap();
-    replay(&mut terminal, Model::new(), &ctx, &Theme::terminal(), TEST_PRIMER,
-           messages.into_iter()).unwrap();
+    replay(
+        &mut terminal,
+        Model::new(),
+        &ctx,
+        &Theme::terminal(),
+        TEST_PRIMER,
+        messages.into_iter(),
+    )
+    .unwrap();
     terminal.backend().buffer().clone()
 }
 
@@ -84,14 +94,19 @@ fn replay_query_command_shows_token_in_buffer() {
             .collect();
         row.contains("accent-color")
     });
-    assert!(found, "replayed buffer should show 'accent-color' after query");
+    assert!(
+        found,
+        "replayed buffer should show 'accent-color' after query"
+    );
 }
 
 #[test]
 fn replay_palette_open_shows_colon_prompt() {
     let graph = make_graph_with_tokens(&[]);
     let buf = replay_messages(
-        vec![Message::Key(common::key(crossterm::event::KeyCode::Char(':')))],
+        vec![Message::Key(common::key(crossterm::event::KeyCode::Char(
+            ':',
+        )))],
         &graph,
     );
     assert_eq!(
@@ -114,11 +129,17 @@ fn replay_produces_same_buffer_as_direct_update() {
     // whether or not the task is executed. This verifies render output parity,
     // not side-effect parity (which is tested elsewhere).
     let mut model_direct = Model::new();
-    update(&mut model_direct, Message::PaletteSubmit("query property=accent-color".into()), &ctx);
+    update(
+        &mut model_direct,
+        Message::PaletteSubmit("query property=accent-color".into()),
+        &ctx,
+    );
     let buf_direct = {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| design_data_tui::draw(&mut model_direct, f, &Theme::terminal(), TEST_PRIMER)).unwrap();
+        terminal
+            .draw(|f| design_data_tui::draw(&mut model_direct, f, &Theme::terminal(), TEST_PRIMER))
+            .unwrap();
         terminal.backend().buffer().clone()
     };
 
@@ -128,5 +149,8 @@ fn replay_produces_same_buffer_as_direct_update() {
         &graph,
     );
 
-    assert!(buf_direct == buf_replay, "replay must produce byte-identical buffer to direct update");
+    assert!(
+        buf_direct == buf_replay,
+        "replay must produce byte-identical buffer to direct update"
+    );
 }

--- a/sdk/tui/tests/resolve.rs
+++ b/sdk/tui/tests/resolve.rs
@@ -70,7 +70,10 @@ fn resolve_with_matching_property_returns_resolve_view() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     submit(&mut model, &ctx, "resolve property=background-color");
-    assert!(matches!(model.active_view, ActiveView::Resolve(_)), "expected Resolve view");
+    assert!(
+        matches!(model.active_view, ActiveView::Resolve(_)),
+        "expected Resolve view"
+    );
 }
 
 #[test]
@@ -94,8 +97,15 @@ fn resolve_no_args_sets_error_status() {
     let mut model = Model::new();
     submit(&mut model, &ctx, "resolve");
     assert!(matches!(model.active_view, ActiveView::Empty));
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("required") || msg.contains("error"), "expected error: {msg}");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("required") || msg.contains("error"),
+        "expected error: {msg}"
+    );
 }
 
 #[test]
@@ -109,7 +119,11 @@ fn resolve_unknown_property_returns_empty_candidates() {
     } else {
         panic!("expected Resolve view");
     }
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(msg.contains("no match"), "expected 'no match': {msg}");
 }
 
@@ -118,7 +132,11 @@ fn resolve_with_color_scheme_context_selects_dark_winner() {
     let graph = make_resolve_graph();
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    submit(&mut model, &ctx, "resolve property=background-color,colorScheme=dark");
+    submit(
+        &mut model,
+        &ctx,
+        "resolve property=background-color,colorScheme=dark",
+    );
     if let ActiveView::Resolve(ref rv) = model.active_view {
         assert!(!rv.rows.is_empty());
         let winner = rv.rows.iter().find(|r| r.is_winner);
@@ -174,8 +192,14 @@ fn resolve_y_sets_pending_yank() {
     let mut model = Model::new();
     submit(&mut model, &ctx, "resolve property=background-color");
     let task = update(&mut model, Message::Key(key(KeyCode::Char('y'))), &ctx);
-    assert!(task.is_cmd(), "'y' should return Task::Cmd for clipboard write");
-    assert!(model.pending_yank.is_none(), "pending_yank should not be set — clipboard is via Task::Cmd");
+    assert!(
+        task.is_cmd(),
+        "'y' should return Task::Cmd for clipboard write"
+    );
+    assert!(
+        model.pending_yank.is_none(),
+        "pending_yank should not be set — clipboard is via Task::Cmd"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/runtime.rs
+++ b/sdk/tui/tests/runtime.rs
@@ -72,19 +72,30 @@ fn smoke_render_after_query_shows_data_row() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
 
-    update(&mut model, Message::PaletteSubmit("query property=accent-color".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=accent-color".into()),
+        &ctx,
+    );
 
     let buf = render_to_buffer(&mut model, 80, 24);
     let found = (0..24u16).any(|y| {
-        let row: String =
-            (0..80u16).map(|x| buf.cell((x, y)).unwrap().symbol().to_string()).collect();
+        let row: String = (0..80u16)
+            .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
         row.contains("accent-color")
     });
-    assert!(found, "query result 'accent-color' should appear somewhere in the rendered buffer");
+    assert!(
+        found,
+        "query result 'accent-color' should appear somewhere in the rendered buffer"
+    );
 }
 
 #[test]
 fn smoke_model_new_with_options_resume_false_has_no_modal() {
     let model = Model::new_with_options(false);
-    assert!(!model.is_modal_open(), "resume_wizard=false should yield no modal");
+    assert!(
+        !model.is_modal_open(),
+        "resume_wizard=false should yield no modal"
+    );
 }

--- a/sdk/tui/tests/validate.rs
+++ b/sdk/tui/tests/validate.rs
@@ -55,6 +55,7 @@ fn validate_ctx<'a>(
         schema_registry: Some(registry),
         mode_sets_dir: None,
         token_index: TokenIndex::build(graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     }
 }
@@ -74,6 +75,7 @@ fn validate_without_registry_sets_error_status() {
         schema_registry: None,
         mode_sets_dir: None,
         token_index: TokenIndex::build(&graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     };
     let mut model = Model::new();

--- a/sdk/tui/tests/validate.rs
+++ b/sdk/tui/tests/validate.rs
@@ -13,6 +13,7 @@ use common::key;
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::TokenGraph;
+use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use design_data_tui::app::ActiveView;
 use design_data_tui::{update, Message, Model, UpdateCtx};
@@ -53,6 +54,7 @@ fn validate_ctx<'a>(
         components_dir: None,
         schema_registry: Some(registry),
         mode_sets_dir: None,
+        token_index: TokenIndex::build(graph),
         allow_write: false,
     }
 }
@@ -71,6 +73,7 @@ fn validate_without_registry_sets_error_status() {
         components_dir: None,
         schema_registry: None,
         mode_sets_dir: None,
+        token_index: TokenIndex::build(&graph),
         allow_write: false,
     };
     let mut model = Model::new();

--- a/sdk/tui/tests/validate.rs
+++ b/sdk/tui/tests/validate.rs
@@ -76,7 +76,11 @@ fn validate_without_registry_sets_error_status() {
     let mut model = Model::new();
     update(&mut model, Message::PaletteSubmit("validate".into()), &ctx);
     assert!(matches!(model.active_view, ActiveView::Empty));
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(
         msg.contains("requires") || msg.contains("error"),
         "expected error: {msg}"
@@ -85,18 +89,25 @@ fn validate_without_registry_sets_error_status() {
 
 #[test]
 fn validate_good_tokens_produces_validate_view() {
-    let Some(registry) = try_load_registry() else { return };
+    let Some(registry) = try_load_registry() else {
+        return;
+    };
     let tokens_dir = tokens_good_dir();
     let graph = TokenGraph::from_json_dir(&tokens_dir).expect("graph load");
     let ctx = validate_ctx(&graph, &tokens_dir, &registry);
     let mut model = Model::new();
     submit_validate(&mut model, &ctx);
-    assert!(matches!(model.active_view, ActiveView::Validate(_)), "expected Validate view");
+    assert!(
+        matches!(model.active_view, ActiveView::Validate(_)),
+        "expected Validate view"
+    );
 }
 
 #[test]
 fn validate_good_tokens_zero_findings() {
-    let Some(registry) = try_load_registry() else { return };
+    let Some(registry) = try_load_registry() else {
+        return;
+    };
     let tokens_dir = tokens_good_dir();
     let graph = TokenGraph::from_json_dir(&tokens_dir).expect("graph load");
     let ctx = validate_ctx(&graph, &tokens_dir, &registry);
@@ -111,14 +122,19 @@ fn validate_good_tokens_zero_findings() {
 
 #[test]
 fn validate_bad_tokens_produces_findings() {
-    let Some(registry) = try_load_registry() else { return };
+    let Some(registry) = try_load_registry() else {
+        return;
+    };
     let tokens_dir = tokens_bad_dir();
     let graph = TokenGraph::from_json_dir(&tokens_dir).expect("graph load");
     let ctx = validate_ctx(&graph, &tokens_dir, &registry);
     let mut model = Model::new();
     submit_validate(&mut model, &ctx);
     if let ActiveView::Validate(ref vv) = model.active_view {
-        assert!(vv.rows.len() >= 1, "expected at least 1 finding for bad tokens");
+        assert!(
+            vv.rows.len() >= 1,
+            "expected at least 1 finding for bad tokens"
+        );
     } else {
         panic!("expected Validate view");
     }
@@ -126,14 +142,18 @@ fn validate_bad_tokens_produces_findings() {
 
 #[test]
 fn validate_j_k_navigate() {
-    let Some(registry) = try_load_registry() else { return };
+    let Some(registry) = try_load_registry() else {
+        return;
+    };
     let tokens_dir = tokens_bad_dir();
     let graph = TokenGraph::from_json_dir(&tokens_dir).expect("graph load");
     let ctx = validate_ctx(&graph, &tokens_dir, &registry);
     let mut model = Model::new();
     submit_validate(&mut model, &ctx);
     if let ActiveView::Validate(ref vv) = model.active_view {
-        if vv.rows.is_empty() { return; }
+        if vv.rows.is_empty() {
+            return;
+        }
     }
     update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
     if let ActiveView::Validate(ref vv) = model.active_view {
@@ -149,23 +169,35 @@ fn validate_j_k_navigate() {
 
 #[test]
 fn validate_y_returns_clipboard_task() {
-    let Some(registry) = try_load_registry() else { return };
+    let Some(registry) = try_load_registry() else {
+        return;
+    };
     let tokens_dir = tokens_bad_dir();
     let graph = TokenGraph::from_json_dir(&tokens_dir).expect("graph load");
     let ctx = validate_ctx(&graph, &tokens_dir, &registry);
     let mut model = Model::new();
     submit_validate(&mut model, &ctx);
     if let ActiveView::Validate(ref vv) = model.active_view {
-        if vv.rows.is_empty() { return; }
+        if vv.rows.is_empty() {
+            return;
+        }
     }
     let task = update(&mut model, Message::Key(key(KeyCode::Char('y'))), &ctx);
-    assert!(task.is_cmd(), "'y' should return Task::Cmd for clipboard write");
-    assert!(model.pending_yank.is_none(), "pending_yank should not be set");
+    assert!(
+        task.is_cmd(),
+        "'y' should return Task::Cmd for clipboard write"
+    );
+    assert!(
+        model.pending_yank.is_none(),
+        "pending_yank should not be set"
+    );
 }
 
 #[test]
 fn esc_from_validate_view_returns_to_empty() {
-    let Some(registry) = try_load_registry() else { return };
+    let Some(registry) = try_load_registry() else {
+        return;
+    };
     let tokens_dir = tokens_good_dir();
     let graph = TokenGraph::from_json_dir(&tokens_dir).expect("graph load");
     let ctx = validate_ctx(&graph, &tokens_dir, &registry);

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -15,7 +15,7 @@ use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
 use design_data_tui::app::{App, Modal, SubmitContext};
 use design_data_tui::wizard::{ValueKind, WizardCtx, WizardPath, WizardScreen};
-use design_data_tui::{Task, UpdateCtx, update, Message, Model};
+use design_data_tui::{update, Message, Model, Task, UpdateCtx};
 use std::path::PathBuf;
 
 fn make_graph_with_modes() -> TokenGraph {
@@ -56,9 +56,19 @@ fn esc_cancels_wizard() {
     open_wizard(&mut model, &ctx, "accent background");
     let task = update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
     assert!(!model.is_modal_open(), "modal should close on Esc");
-    assert!(matches!(task, Task::Cmd(_)), "cancel should return Task::Cmd (draft clear)");
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
-    assert!(msg.contains("cancelled"), "status should say cancelled: {msg}");
+    assert!(
+        matches!(task, Task::Cmd(_)),
+        "cancel should return Task::Cmd (draft clear)"
+    );
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("cancelled"),
+        "status should say cancelled: {msg}"
+    );
 }
 
 #[test]
@@ -68,7 +78,10 @@ fn intent_populates_suggestions_on_open() {
     let mut model = Model::new();
     open_wizard(&mut model, &ctx, "accent background");
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert!(!ws.suggestions.is_empty(), "suggestions should be populated from intent");
+        assert!(
+            !ws.suggestions.is_empty(),
+            "suggestions should be populated from intent"
+        );
     } else {
         panic!("expected wizard modal");
     }
@@ -82,7 +95,11 @@ fn enter_on_screen_1_advances_to_screen_2() {
     open_wizard(&mut model, &ctx, "accent background");
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.screen, WizardScreen::Classification, "should advance to Screen 2");
+        assert_eq!(
+            ws.screen,
+            WizardScreen::Classification,
+            "should advance to Screen 2"
+        );
     } else {
         panic!("expected wizard modal after Enter on Screen 1");
     }
@@ -96,7 +113,11 @@ fn tab_with_suggestion_sets_alias_path_and_jumps_to_confirm() {
     open_wizard(&mut model, &ctx, "accent background");
     update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.screen, WizardScreen::Confirm, "Tab should jump to Confirm");
+        assert_eq!(
+            ws.screen,
+            WizardScreen::Confirm,
+            "Tab should jump to Confirm"
+        );
         assert!(
             matches!(ws.chosen_path, WizardPath::AliasToExisting(_)),
             "chosen_path should be AliasToExisting"
@@ -115,13 +136,21 @@ fn screen_2_layer_cycles_with_arrow_keys() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Right)), &ctx);
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.classification.layer, Layer::Platform, "Right should advance layer");
+        assert_eq!(
+            ws.classification.layer,
+            Layer::Platform,
+            "Right should advance layer"
+        );
     } else {
         panic!("expected wizard modal");
     }
     update(&mut model, Message::Key(key(KeyCode::Left)), &ctx);
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.classification.layer, Layer::Foundation, "Left should reverse layer");
+        assert_eq!(
+            ws.classification.layer,
+            Layer::Foundation,
+            "Left should reverse layer"
+        );
     }
 }
 
@@ -134,7 +163,11 @@ fn screen_2_enter_advances_to_screen_3() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.screen, WizardScreen::Values, "should advance to Screen 3");
+        assert_eq!(
+            ws.screen,
+            WizardScreen::Values,
+            "should advance to Screen 3"
+        );
     } else {
         panic!("expected wizard modal");
     }
@@ -149,7 +182,11 @@ fn screen_3_mode_rows_match_cartesian_product() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.values.rows.len(), 2, "should have one row per mode combo");
+        assert_eq!(
+            ws.values.rows.len(),
+            2,
+            "should have one row per mode combo"
+        );
     } else {
         panic!("expected wizard modal");
     }
@@ -165,11 +202,19 @@ fn screen_3_a_l_toggle_value_kind() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.values.rows[0].kind, ValueKind::Literal, "'l' should set Literal");
+        assert_eq!(
+            ws.values.rows[0].kind,
+            ValueKind::Literal,
+            "'l' should set Literal"
+        );
     }
     update(&mut model, Message::Key(key(KeyCode::Char('a'))), &ctx);
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.values.rows[0].kind, ValueKind::Alias, "'a' should restore Alias");
+        assert_eq!(
+            ws.values.rows[0].kind,
+            ValueKind::Alias,
+            "'a' should restore Alias"
+        );
     }
 }
 
@@ -191,7 +236,11 @@ fn screen_3_enter_advances_to_screen_4() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
-        assert_eq!(ws.screen, WizardScreen::Confirm, "should advance to Screen 4");
+        assert_eq!(
+            ws.screen,
+            WizardScreen::Confirm,
+            "should advance to Screen 4"
+        );
     } else {
         panic!("expected wizard modal");
     }
@@ -215,7 +264,10 @@ fn screen_4_empty_rationale_blocks_submit() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 3
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // Submit with empty rationale
-    assert!(model.is_modal_open(), "modal should stay open when rationale is empty");
+    assert!(
+        model.is_modal_open(),
+        "modal should stay open when rationale is empty"
+    );
 }
 
 #[test]
@@ -241,7 +293,10 @@ fn screen_4_diff_preview_is_populated_on_enter() {
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 4
     if let Some(Modal::Wizard(ref ws)) = model.modal() {
         assert_eq!(ws.screen, WizardScreen::Confirm);
-        let diff = ws.diff_preview.as_ref().expect("diff_preview should be populated");
+        let diff = ws
+            .diff_preview
+            .as_ref()
+            .expect("diff_preview should be populated");
         assert!(diff.contains('+'), "diff should contain '+' lines");
     } else {
         panic!("expected wizard modal");
@@ -270,8 +325,15 @@ fn screen_4_submit_closes_modal_and_sets_status() {
     }
     let task = update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
     assert!(!model.is_modal_open(), "modal should close after submit");
-    assert!(matches!(task, Task::Cmd(_)), "submit should return Task::Cmd (draft clear)");
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    assert!(
+        matches!(task, Task::Cmd(_)),
+        "submit should return Task::Cmd (draft clear)"
+    );
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(
         msg.contains("write disabled") || msg.contains("preview"),
         "status should mention preview/write disabled: {msg}"
@@ -305,7 +367,10 @@ fn submit_does_not_create_foundation_json_without_allow_write() {
         app.handle_modal_key(key(KeyCode::Char(c)), &ctx);
     }
     app.handle_modal_key(key(KeyCode::Enter), &ctx);
-    assert!(!foundation_file.exists(), "wizard submit without --allow-write must NOT write");
+    assert!(
+        !foundation_file.exists(),
+        "wizard submit without --allow-write must NOT write"
+    );
 }
 
 // ── WizardState unit test ─────────────────────────────────────────────────────
@@ -316,9 +381,11 @@ fn assembled_name_joins_property_and_fields() {
     let mut ws = WizardState::new();
     use tui_input::Input;
     ws.classification.property = Input::from("background-color".to_string());
-    ws.classification.name_fields.push(design_data_tui::wizard::NameField {
-        key: "variant".into(),
-        value: Input::from("hover".to_string()),
-    });
+    ws.classification
+        .name_fields
+        .push(design_data_tui::wizard::NameField {
+            key: "variant".into(),
+            value: Input::from("hover".to_string()),
+        });
     assert_eq!(ws.assembled_name(), "background-color-hover");
 }

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -229,6 +229,7 @@ fn screen_3_enter_advances_to_screen_4() {
         schema_registry: None,
         mode_sets_dir: None,
         token_index: design_data_core::query::TokenIndex::build(&graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -258,6 +259,7 @@ fn screen_4_empty_rationale_blocks_submit() {
         schema_registry: None,
         mode_sets_dir: None,
         token_index: design_data_core::query::TokenIndex::build(&graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -283,6 +285,7 @@ fn screen_4_diff_preview_is_populated_on_enter() {
         schema_registry: None,
         mode_sets_dir: None,
         token_index: design_data_core::query::TokenIndex::build(&graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -317,6 +320,7 @@ fn screen_4_submit_closes_modal_and_sets_status() {
         schema_registry: None,
         mode_sets_dir: None,
         token_index: design_data_core::query::TokenIndex::build(&graph),
+        mode_set_restrictions: std::collections::HashMap::new(),
         allow_write: false,
     };
     let mut model = Model::new();

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -228,6 +228,7 @@ fn screen_3_enter_advances_to_screen_4() {
         components_dir: None,
         schema_registry: None,
         mode_sets_dir: None,
+        token_index: design_data_core::query::TokenIndex::build(&graph),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -256,6 +257,7 @@ fn screen_4_empty_rationale_blocks_submit() {
         components_dir: None,
         schema_registry: None,
         mode_sets_dir: None,
+        token_index: design_data_core::query::TokenIndex::build(&graph),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -280,6 +282,7 @@ fn screen_4_diff_preview_is_populated_on_enter() {
         components_dir: None,
         schema_registry: None,
         mode_sets_dir: None,
+        token_index: design_data_core::query::TokenIndex::build(&graph),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -313,6 +316,7 @@ fn screen_4_submit_closes_modal_and_sets_status() {
         components_dir: None,
         schema_registry: None,
         mode_sets_dir: None,
+        token_index: design_data_core::query::TokenIndex::build(&graph),
         allow_write: false,
     };
     let mut model = Model::new();
@@ -350,6 +354,7 @@ fn submit_does_not_create_foundation_json_without_allow_write() {
     let foundation_file = tmpdir.path().join("foundation.json");
     let ctx = WizardCtx {
         graph: &graph,
+        token_index: design_data_core::query::TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: None,
         allow_write: false,

--- a/sdk/tui/tests/wizard_persistence.rs
+++ b/sdk/tui/tests/wizard_persistence.rs
@@ -128,7 +128,10 @@ fn model_new_with_options_false_ignores_draft() {
             "--no-resume-wizard: modal should be None even if draft exists on disk"
         );
         let path = wizard_draft_path().unwrap();
-        assert!(path.exists(), "draft file should remain untouched with --no-resume-wizard");
+        assert!(
+            path.exists(),
+            "draft file should remain untouched with --no-resume-wizard"
+        );
     });
 }
 
@@ -150,21 +153,36 @@ fn cancelling_wizard_returns_draft_clear_task() {
         let mut model = Model::new();
 
         // Open wizard and persist a draft manually.
-        update(&mut model, Message::PaletteSubmit("new test token".into()), &ctx);
+        update(
+            &mut model,
+            Message::PaletteSubmit("new test token".into()),
+            &ctx,
+        );
         assert!(model.is_modal_open(), "wizard should be open");
         if let Some(Modal::Wizard(ref ws)) = model.modal() {
             save_wizard_draft(&to_draft(ws));
         }
-        assert!(wizard_draft_path().unwrap().exists(), "draft should be on disk");
+        assert!(
+            wizard_draft_path().unwrap().exists(),
+            "draft should be on disk"
+        );
 
         // Cancel — should return Task::Cmd that clears the draft.
         let task = update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
         assert!(!model.is_modal_open(), "modal should be closed after Esc");
-        assert!(task.is_cmd(), "cancel should return Task::Cmd for draft clear");
+        assert!(
+            task.is_cmd(),
+            "cancel should return Task::Cmd for draft clear"
+        );
 
         // Execute the task to verify it clears the draft file.
-        if let Task::Cmd(f) = task { f(); }
-        assert!(!wizard_draft_path().unwrap().exists(), "draft should be cleared after cancel");
+        if let Task::Cmd(f) = task {
+            f();
+        }
+        assert!(
+            !wizard_draft_path().unwrap().exists(),
+            "draft should be cleared after cancel"
+        );
     });
 }
 
@@ -184,18 +202,32 @@ fn wizard_keystroke_returns_persist_task() {
         // should return Task::Cmd (save_wizard_draft).
         let task = update(&mut model, Message::Key(key(KeyCode::Char('a'))), &ctx);
         // WizardEvent::Continue → Task::Cmd(save_wizard_draft)
-        assert!(task.is_cmd(), "wizard keystroke should return Task::Cmd (save_wizard_draft)");
+        assert!(
+            task.is_cmd(),
+            "wizard keystroke should return Task::Cmd (save_wizard_draft)"
+        );
 
         // Execute any task so the draft lands on disk.
-        if let Task::Cmd(f) = task { f(); }
+        if let Task::Cmd(f) = task {
+            f();
+        }
         let task2 = update(&mut model, Message::Key(key(KeyCode::Char('b'))), &ctx);
-        if let Task::Cmd(f) = task2 { f(); }
+        if let Task::Cmd(f) = task2 {
+            f();
+        }
 
         let draft_path = wizard_draft_path().unwrap();
-        assert!(draft_path.exists(), "wizard keystrokes should auto-save draft via Task::Cmd");
+        assert!(
+            draft_path.exists(),
+            "wizard keystrokes should auto-save draft via Task::Cmd"
+        );
 
         let loaded = load_wizard_draft().expect("draft should be loadable");
         let restored = from_draft(loaded);
-        assert_eq!(restored.intent.value(), "ab", "persisted intent should match typed text");
+        assert_eq!(
+            restored.intent.value(),
+            "ab",
+            "persisted intent should match typed text"
+        );
     });
 }

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -89,10 +89,14 @@ fn submit_without_allow_write_does_not_create_file() {
         allow_write: false,
     };
     let mut model = Model::new();
-    update(&mut model, Message::PaletteSubmit("new background-color".into()), &ctx);
+    update(
+        &mut model,
+        Message::PaletteSubmit("new background-color".into()),
+        &ctx,
+    );
 
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Screen 2
-    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);   // focus property
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx); // focus property
     for c in "background-color".chars() {
         update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
@@ -103,17 +107,30 @@ fn submit_without_allow_write_does_not_create_file() {
     }
     let task = update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
 
-    assert!(!model.is_modal_open(), "modal should close without --allow-write");
-    assert!(task.is_cmd(), "submit without allow_write should return Task::Cmd (draft clear)");
+    assert!(
+        !model.is_modal_open(),
+        "modal should close without --allow-write"
+    );
+    assert!(
+        task.is_cmd(),
+        "submit without allow_write should return Task::Cmd (draft clear)"
+    );
 
-    let msg = model.status_message.as_ref().map(|m| m.text.as_str()).unwrap_or("");
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
     assert!(
         msg.contains("allow-write") || msg.contains("preview"),
         "status should mention --allow-write: {msg}"
     );
 
     let foundation = tmpdir.path().join("foundation.json");
-    assert!(!foundation.exists(), "foundation.json must NOT be created without --allow-write");
+    assert!(
+        !foundation.exists(),
+        "foundation.json must NOT be created without --allow-write"
+    );
 }
 
 #[test]
@@ -131,11 +148,17 @@ fn submit_with_allow_write_creates_token_file() {
     // Build wizard state directly: property=background-color, literal value.
     let ws = wizard_at_confirm_literal("background-color", "rgb(2, 100, 220)", COLOR_SCHEMA);
     let written_path = ws.perform_write(&ctx).expect("write should succeed");
-    assert!(written_path.ends_with("foundation.json"), "should write to foundation.json: {written_path}");
+    assert!(
+        written_path.ends_with("foundation.json"),
+        "should write to foundation.json: {written_path}"
+    );
 
     // foundation.json must now exist and contain the new key.
     let foundation = tmpdir.path().join("foundation.json");
-    assert!(foundation.exists(), "foundation.json should be created by write_token");
+    assert!(
+        foundation.exists(),
+        "foundation.json should be created by write_token"
+    );
 
     let content = std::fs::read_to_string(&foundation).expect("read foundation.json");
     let doc: serde_json::Value = serde_json::from_str(&content).expect("parse foundation.json");
@@ -176,7 +199,10 @@ fn submit_with_allow_write_updates_product_context() {
         .and_then(|e| e.get("tokens"))
         .and_then(|t| t.as_array())
         .expect("extensions.tokens array");
-    assert!(!tokens.is_empty(), "product-context.json should have an entry after write");
+    assert!(
+        !tokens.is_empty(),
+        "product-context.json should have an entry after write"
+    );
 }
 
 #[test]
@@ -212,7 +238,10 @@ fn submit_with_allow_write_missing_schema_returns_error() {
     );
 
     // No files written.
-    assert!(!tmpdir.path().join("foundation.json").exists(), "no file on failure");
+    assert!(
+        !tmpdir.path().join("foundation.json").exists(),
+        "no file on failure"
+    );
 }
 
 #[test]
@@ -262,7 +291,10 @@ fn is_override_detected_when_token_name_exists_in_graph() {
     assert!(foundation.exists(), "foundation.json should be created");
     let doc: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&foundation).unwrap()).unwrap();
-    assert!(doc.get("background-color").is_some(), "token key should be present");
+    assert!(
+        doc.get("background-color").is_some(),
+        "token key should be present"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -21,6 +21,7 @@ use common::key;
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
+use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
 use design_data_tui::wizard::{ValueKind, ValueRow, WizardCtx, WizardState};
 use design_data_tui::{update, Message, Model, UpdateCtx};
@@ -82,6 +83,7 @@ fn submit_without_allow_write_does_not_create_file() {
     let tmpdir = tempfile::TempDir::new().expect("tempdir");
     let ctx = UpdateCtx {
         graph: &graph,
+        token_index: TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: Some(&registry),
         components_dir: None,
@@ -140,6 +142,7 @@ fn submit_with_allow_write_creates_token_file() {
     let tmpdir = tempfile::TempDir::new().expect("tempdir");
     let ctx = WizardCtx {
         graph: &graph,
+        token_index: TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: Some(&registry),
         allow_write: true,
@@ -184,6 +187,7 @@ fn submit_with_allow_write_updates_product_context() {
 
     let ctx = WizardCtx {
         graph: &graph,
+        token_index: TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: Some(&registry),
         allow_write: true,
@@ -212,6 +216,7 @@ fn submit_with_allow_write_missing_schema_returns_error() {
     let tmpdir = tempfile::TempDir::new().expect("tempdir");
     let ctx = WizardCtx {
         graph: &graph,
+        token_index: TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: Some(&registry),
         allow_write: true,
@@ -278,6 +283,7 @@ fn is_override_detected_when_token_name_exists_in_graph() {
     let tmpdir = tempfile::TempDir::new().expect("tempdir");
     let ctx = WizardCtx {
         graph: &graph,
+        token_index: TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: Some(&registry),
         allow_write: true,
@@ -317,6 +323,7 @@ fn resolve_target_file_foundation_maps_to_foundation_json() {
 
     let ctx = WizardCtx {
         graph: &graph,
+        token_index: TokenIndex::build(&graph),
         dataset_path: Some(tmpdir.path()),
         schema_registry: Some(&registry),
         allow_write: true,

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -14,6 +14,7 @@
 //! Tests that exercise the real `write_token` path load `SchemaRegistry` from
 //! `packages/tokens/schemas` (relative to the repo root via `CARGO_MANIFEST_DIR`).
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 mod common;
@@ -88,6 +89,7 @@ fn submit_without_allow_write_does_not_create_file() {
         schema_registry: Some(&registry),
         components_dir: None,
         mode_sets_dir: None,
+        mode_set_restrictions: HashMap::new(),
         allow_write: false,
     };
     let mut model = Model::new();


### PR DESCRIPTION
## Description

Two related SDK improvements on the CLI/TUI data path:

### 1. Embedded-database cache layer

Adds a derived, content-addressed embedded-database cache (redb) over the canonical token JSON so the CLI/TUI skip re-parsing JSON on every invocation and gain indexed equality queries. JSON on the filesystem remains the single source of truth; the cache is rebuildable, never authoritative, and falls back to JSON on any error.

- **`sdk/core/src/cache/`** — redb schema (`tokens`, `uuid_index`, per-field `idx_*` multimap tables, `meta`), MessagePack-encoded values, content hashing, atomic tmp+rename writes, stale-version eviction
- **`TokenGraph::open_cached` / `open_cached_with_index`** — drop-in replacements for `from_json_dir`; the latter hydrates the persisted query index on cache hit
- **`query::TokenIndex` + `filter_with_index`** — index-backed fast path for single-field equality (lands #783), with equivalence tests vs the scan path
- **`cache::MemBackend`** — in-memory redb backend for read-only WASM web tools
- **`design-data cache-build`** — emits a portable `index.redb` static asset
- **TUI** — session loads graph + index once at launch; find wizard and palette `:query` reuse the session index

### 2. Shared manifest + resolve logic (CLI/TUI parity)

Extracts platform manifest application and property resolution into pure `design-data-core` functions so both surfaces call identical code (TEA-style thin shells):

- **`manifest::apply_configured`** — reads/validates `[source].manifest`, applies the Foundation→Platform cascade, returns mode-set restrictions
- **`cascade::resolve_property` + `ResolvedCandidate`** — shared property-filter → subgraph → specificity sort → winner flagging
- **CLI** — `query`/`resolve` call the shared helpers; duplicate manifest helpers removed
- **TUI** — applies manifest once at session load, rebuilds the query index, threads `mode_set_restrictions` through `UpdateCtx`, and uses `resolve_property` for `:resolve`

The TUI header shows `N platform` (vs `N tokens`) when a manifest is active. CLI `primer` still reports raw on-disk counts.

Dependencies: `redb` pinned to 2.6.x (MSRV 1.85) and `rmp-serde` (self-describing; postcard cannot round-trip `serde_json::Value`).

### Known limitations (cache schema v1)

- Inline mode-set JSON co-located in the token tree is not cached (canonical layout uses `design-data-spec/mode-sets`).
- Cache invalidation uses size + mtime, not a full content hash (documented in `cache/mod.rs` and `sdk/README.md`).

## Related Issue

spectrum-design-data-15a

## Motivation and Context

Every CLI subcommand previously called `TokenGraph::from_json_dir`, walking and re-parsing ~2 MB of JSON on each run. Query filtering was an O(n) scan over all tokens. The cache layer cuts cold-start cost and accelerates single-field equality queries while keeping JSON canonical.

Separately, the CLI applied platform manifests but the TUI did not, and property resolution logic was duplicated three times across CLI and TUI. Moving manifest application and `resolve_property` into core gives the TUI manifest parity and removes duplicated resolve implementations.

## How Has This Been Tested?

- `cargo test --workspace` (all SDK unit + integration tests pass)
- `cargo fmt --all` and `cargo clippy --workspace --all-targets`
- Cache unit tests + `filter_with_index` equivalence tests
- Core tests for `manifest::apply_configured` and `cascade::resolve_property`
- TUI integration tests in `sdk/tui/tests/manifest.rs`
- Manual smoke: `design-data cache-build`, `design-data primer` cache hit at OS cache dir
- Changeset lint: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (`sdk/README.md`).
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.