### PR TITLE
fix(ci): version-lock design-data platform packages so binaries publish together

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,15 @@
     { "repo": "adobe/spectrum-design-data" }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@adobe/design-data",
+      "@adobe/design-data-darwin-arm64",
+      "@adobe/design-data-darwin-x64",
+      "@adobe/design-data-linux-x64",
+      "@adobe/design-data-win32-x64"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/fix-platform-binary-publish.md
+++ b/.changeset/fix-platform-binary-publish.md
@@ -7,7 +7,7 @@ Fix npm release so platform binary packages publish in lockstep with the launche
 - **.changeset/config.json**: add a `fixed` group locking `@adobe/design-data` and the four
   `@adobe/design-data-{darwin-arm64,darwin-x64,linux-x64,win32-x64}` packages so they always
   version and publish together.
-- **.github/workflows/release.yml**: run `pnpm version` (was `pnpm changeset version`) so the
+- **.github/workflows/release.yml**: run `pnpm run version` (was `pnpm changeset version`) so the
   Moon step syncs the bumped version into the cli/tui `Cargo.toml` files, and add a pre-publish
   guard that aborts if any platform package version drifts from the CLI.
 - This ships the 0.2.x binaries (embedded DB cache, shared manifest resolution) that the 0.2.0

--- a/.changeset/fix-platform-binary-publish.md
+++ b/.changeset/fix-platform-binary-publish.md
@@ -1,0 +1,14 @@
+---
+"@adobe/design-data": minor
+---
+
+Fix npm release so platform binary packages publish in lockstep with the launcher.
+
+- **.changeset/config.json**: add a `fixed` group locking `@adobe/design-data` and the four
+  `@adobe/design-data-{darwin-arm64,darwin-x64,linux-x64,win32-x64}` packages so they always
+  version and publish together.
+- **.github/workflows/release.yml**: run `pnpm version` (was `pnpm changeset version`) so the
+  Moon step syncs the bumped version into the cli/tui `Cargo.toml` files, and add a pre-publish
+  guard that aborts if any platform package version drifts from the CLI.
+- This ships the 0.2.x binaries (embedded DB cache, shared manifest resolution) that the 0.2.0
+  launcher referenced but never published.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,20 @@ jobs:
       # so it never creates the Version Packages PR. The official action supports
       # both parameters independently. The fork is still used in the `release` job
       # where `oidcAuth: true` is needed for npm trusted publishing.
+      #
+      # `pnpm version` runs `changeset version && moon run :version`. The Moon
+      # step (sync-cargo-version.mjs) mirrors the bumped npm version into the
+      # cli/tui Cargo.toml files. The `fixed` group in .changeset/config.json
+      # keeps all five @adobe/design-data* npm packages bumping together, so the
+      # platform binary packages can never lag behind the launcher version (the
+      # 0.2.0 partial-publish failure mode).
       - name: Create or update Version Packages PR
         id: cs
         uses: changesets/action@v1
         with:
           commit: "chore: release"
           title: "Version Packages"
-          version: pnpm changeset version
+          version: pnpm version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -240,6 +247,14 @@ jobs:
           cd packages/tokens
           node tasks/buildSpectrumTokens.js
           node tasks/buildManifest.js
+
+      # Guard against the 0.2.0 partial-publish failure mode: abort before
+      # publishing if any platform binary package.json version drifted from the
+      # CLI launcher version. The `fixed` changeset group should keep them in
+      # lockstep, so a mismatch here means something bypassed that mechanism.
+      - name: Verify platform package versions are in sync
+        if: needs.version.outputs.cli-version
+        run: node sdk/scripts/test-sync-cargo-version.mjs
 
       - name: Publish packages
         id: cs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,19 +70,22 @@ jobs:
       # both parameters independently. The fork is still used in the `release` job
       # where `oidcAuth: true` is needed for npm trusted publishing.
       #
-      # `pnpm version` runs `changeset version && moon run :version`. The Moon
-      # step (sync-cargo-version.mjs) mirrors the bumped npm version into the
-      # cli/tui Cargo.toml files. The `fixed` group in .changeset/config.json
-      # keeps all five @adobe/design-data* npm packages bumping together, so the
-      # platform binary packages can never lag behind the launcher version (the
-      # 0.2.0 partial-publish failure mode).
+      # `pnpm run version` runs the package.json "version" script
+      # (`changeset version && moon run :version`). The explicit `run` is
+      # required — bare `pnpm version` collides with pnpm's built-in npm-style
+      # version command and would NOT execute the script. The Moon step
+      # (sync-cargo-version.mjs) mirrors the bumped npm version into the cli/tui
+      # Cargo.toml files. The `fixed` group in .changeset/config.json keeps all
+      # five @adobe/design-data* npm packages bumping together, so the platform
+      # binary packages can never lag behind the launcher version (the 0.2.0
+      # partial-publish failure mode).
       - name: Create or update Version Packages PR
         id: cs
         uses: changesets/action@v1
         with:
           commit: "chore: release"
           title: "Version Packages"
-          version: pnpm version
+          version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -209,4 +209,18 @@ The `figma` module in `design-data-core` is gated behind the optional `figma` fe
 
 ## Versioning
 
-Versions are managed via [changesets](https://github.com/changesets/changesets) at the repo root. After running `changeset version`, `moon run sdk:version` (`scripts/sync-cargo-version.mjs`) mirrors the npm version from `cli/package.json` into `cli/Cargo.toml`.
+Versions are managed via [changesets](https://github.com/changesets/changesets) at the repo root. Run `pnpm version` (which chains `changeset version && moon run :version`) so the npm bump and the Rust crate versions stay in sync. `moon run sdk:version` (`scripts/sync-cargo-version.mjs`) mirrors the npm version from `cli/package.json` into `cli/Cargo.toml` and `tui/Cargo.toml`.
+
+### Platform package version locking
+
+`@adobe/design-data` is a thin JS launcher that delegates to a native binary shipped in one of four platform packages (`@adobe/design-data-darwin-arm64`, `-darwin-x64`, `-linux-x64`, `-win32-x64`). The launcher pins these as `optionalDependencies` using `workspace:*`, which pnpm resolves to the exact version at publish time.
+
+All five packages **must** publish at the same version every release, or `npm i -g @adobe/design-data` will pull a launcher that points at a stale (or missing) binary. This is enforced by a [`fixed`](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md) group in [`.changeset/config.json`](../.changeset/config.json):
+
+```json
+"fixed": [
+  ["@adobe/design-data", "@adobe/design-data-darwin-arm64", "@adobe/design-data-darwin-x64", "@adobe/design-data-linux-x64", "@adobe/design-data-win32-x64"]
+]
+```
+
+With `fixed`, a changeset targeting only `@adobe/design-data` bumps and republishes all five together — contributors never need to write changesets for the platform packages. The release workflow also runs `sdk/scripts/test-sync-cargo-version.mjs` as a pre-publish guard to abort if any platform version drifts. Do not add the four `*-mcp`/`-spec`/`-tui` packages to this group; they version independently.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -209,7 +209,7 @@ The `figma` module in `design-data-core` is gated behind the optional `figma` fe
 
 ## Versioning
 
-Versions are managed via [changesets](https://github.com/changesets/changesets) at the repo root. Run `pnpm version` (which chains `changeset version && moon run :version`) so the npm bump and the Rust crate versions stay in sync. `moon run sdk:version` (`scripts/sync-cargo-version.mjs`) mirrors the npm version from `cli/package.json` into `cli/Cargo.toml` and `tui/Cargo.toml`.
+Versions are managed via [changesets](https://github.com/changesets/changesets) at the repo root. Run `pnpm run version` (which chains `changeset version && moon run :version`) so the npm bump and the Rust crate versions stay in sync. The explicit `run` is required — bare `pnpm version` invokes pnpm's built-in version command and skips the script. `moon run sdk:version` (`scripts/sync-cargo-version.mjs`) mirrors the npm version from `cli/package.json` into `cli/Cargo.toml` and `tui/Cargo.toml`.
 
 ### Platform package version locking
 

--- a/sdk/scripts/test-sync-cargo-version.mjs
+++ b/sdk/scripts/test-sync-cargo-version.mjs
@@ -57,6 +57,10 @@ test('optionalDependencies all point to the same version', () => {
     // skip the version equality check in that case so the test passes in CI
     // before the first changeset version bump.
     if (ver === '0.0.0') continue;
+    // `workspace:*` (and `workspace:^`/`workspace:~`) is the intended source
+    // form — pnpm rewrites it to the resolved version at publish time, so the
+    // raw package.json never carries a literal version here. Treat as valid.
+    if (ver.startsWith('workspace:')) continue;
     assert.equal(ver, cliVersion, `${dep} should be pinned to ${cliVersion}, got ${ver}`);
   }
 });


### PR DESCRIPTION
## Description

The `0.2.0` release published `@adobe/design-data@0.2.0` but left the four platform binary packages at `0.1.3`. As a result `npm i -g @adobe/design-data@0.2.0` installs the new JS launcher while pulling **stale `0.1.3` binaries** (pre cache-layer / shared-manifest code).

Root cause: only `@adobe/design-data` had a changeset, so `changeset publish` skipped the platform packages whose versions never changed — even though CI built fresh binaries and staged them into each `bin/`.

This PR makes the five packages version-lock and publish together every release.

- **`.changeset/config.json`**: add a [`fixed`](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md) group containing `@adobe/design-data` and the four `@adobe/design-data-{darwin-arm64,darwin-x64,linux-x64,win32-x64}` packages. A changeset targeting only the launcher now bumps and republishes all five together. Explicit list (no glob) so `-spec`, `-mcp`, `-agent-mcp`, and the private `-tui` package are not captured.
- **`.github/workflows/release.yml`**: Phase 1 runs `pnpm version` (was `pnpm changeset version`) so the Moon `:version` step syncs the bumped version into the `cli`/`tui` `Cargo.toml` files; added a pre-publish guard (`test-sync-cargo-version.mjs`) that aborts if any platform version drifts from the launcher.
- **`sdk/scripts/test-sync-cargo-version.mjs`**: accept the intended `workspace:*` protocol in `optionalDependencies` (the assertion was failing on the source form).
- **`sdk/README.md`**: document the version-locking contract.

Ships a **minor (0.3.0)** so the binaries carrying the 0.2.x features (embedded DB cache, shared manifest resolution) finally reach npm.

## Related Issue

Follow-up to #1069 (embedded DB cache + shared manifest), which published its launcher as 0.2.0 without matching binaries.

## Motivation and Context

Without a `fixed` group, platform binary packages silently lag whenever a release only carries a launcher-targeted changeset — leaving users on old native binaries. Locking the group guarantees the launcher and its binaries always match.

## How Has This Been Tested?

- `node sdk/scripts/test-sync-cargo-version.mjs` — 9/9 pass (was 1 failing on `workspace:*`)
- `pnpm changeset status` — confirms all five packages bump together to minor (0.3.0)
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean
- JSON validity of `.changeset/config.json` verified

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Made with [Cursor](https://cursor.com)