### PR TITLE
feat(sdk): cache schema v2 with mode-sets and catalog tables

### DIFF
--- a/.changeset/cache-schema-v2.md
+++ b/.changeset/cache-schema-v2.md
@@ -1,0 +1,15 @@
+---
+"@adobe/design-data": minor
+---
+
+Extend the embedded-database cache to schema v2: persist inline mode-sets and
+spec catalog tables (closes spectrum-design-data-opm).
+
+- **sdk/core/src/cache/mod.rs**: bump `CACHE_SCHEMA_VERSION` to 2; add
+  `mode_sets`/`components` redb tables; catalog-aware `*_with_catalogs` APIs.
+- **sdk/core/src/graph.rs**: `from_json_dir_with_catalogs` and catalog-aware
+  `open_cached_*` wrappers.
+- **sdk/cli/src/main.rs**: `cache-build` gains `--mode-sets-path` /
+  `--components-path`; query/resolve/primer use catalog-aware cache.
+- **sdk/tui/src/app_launch.rs**: session load hydrates catalogs from cache.
+- **sdk/README.md**: document schema v2 tables and new cache-build flags.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-cli"
-version = "0.3.0"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-cli"
-version = "0.1.2"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -114,6 +114,10 @@ Build a portable `.redb` cache asset from a token dataset (for WASM web tools or
 
 ```bash
 design-data cache-build packages/tokens/src -o index.redb
+design-data cache-build packages/tokens/src \
+  --mode-sets-path packages/design-data-spec/mode-sets \
+  --components-path packages/design-data-spec/components \
+  -o index.redb
 ```
 
 ### Derived cache (CLI/TUI)
@@ -125,10 +129,14 @@ The SDK builds a **derived, content-addressed redb cache** over the canonical JS
 | `DESIGN_DATA_CACHE_DIR`   | Override the OS cache root (default: `dirs::cache_dir()/design-data`) |
 | `DESIGN_DATA_LOG=debug`   | Log cache miss/rebuild/fallback events to stderr                      |
 | `design-data cache-build` | Emit a portable `index.redb` blob for WASM or CI artifacts            |
+| `--mode-sets-path`        | Include spec mode-sets catalog in cache build (resolved by default)   |
+| `--components-path`       | Include spec components catalog in cache build (resolved by default)  |
 
-Cache files live at `<cache_root>/cache/<tokens-version>/<dataset-key>.redb` and are gitignored (`*.redb`).
+Cache files live at `<cache_root>/cache/<tokens-version>/<dataset-key>.redb` and are gitignored (`*.redb`). The dataset key incorporates the tokens root and any configured catalog directories.
 
-**Invalidation** uses per-file size + mtime (not a full content hash) for speed. A stale miss only forces a rebuild. **Known limitation (schema v1):** inline mode-set JSON files co-located in the token tree are not persisted in the cache; the canonical Spectrum layout (mode sets under `design-data-spec/mode-sets`) is unaffected.
+**Schema v2** persists tokens, query indexes (`idx_*`), inline mode-set docs co-located in the token tree, and spec catalog `mode_sets` / `components` tables. Stale v1 caches auto-invalidate on upgrade.
+
+**Invalidation** uses per-file size + mtime (not a full content hash) for speed. A stale miss only forces a rebuild. **Known limitation:** sidecar name directories merged by `from_json_dir_with_names` are not part of the cache build path.
 
 **Platform manifest (CLI/TUI):** Both surfaces apply a configured `[source].manifest` at session start via the shared `design-data-core::manifest::apply_configured` helper. Query/find use the platform-scoped token set and index; `:resolve` layers manifest mode-set restrictions through `cascade::resolve_property`. The TUI header shows `N platform` (vs `N tokens`) when a manifest is active. CLI `primer` still reports raw on-disk counts.
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -138,7 +138,9 @@ Cache files live at `<cache_root>/cache/<tokens-version>/<dataset-key>.redb` and
 
 **Invalidation** uses per-file size + mtime (not a full content hash) for speed. A stale miss only forces a rebuild. **Known limitation:** sidecar name directories merged by `from_json_dir_with_names` are not part of the cache build path.
 
-**Platform manifest (CLI/TUI):** Both surfaces apply a configured `[source].manifest` at session start via the shared `design-data-core::manifest::apply_configured` helper. Query/find use the platform-scoped token set and index; `:resolve` layers manifest mode-set restrictions through `cascade::resolve_property`. The TUI header shows `N platform` (vs `N tokens`) when a manifest is active. CLI `primer` still reports raw on-disk counts.
+**Cache file keys:** `open_cached` (tokens only) and `open_cached_with_catalogs` produce different on-disk files for the same tokens root. CLI/TUI pass catalogs; WASM/tools using plain `build_bytes` / `open_cached` get a separate entry unless they use the `*_with_catalogs` variants.
+
+**Platform manifest (CLI/TUI):** Both surfaces apply a configured `[source].manifest` at session start via the shared `design-data-core::manifest::apply_configured` helper. Query/find use the platform-scoped token set and index; `:resolve` layers manifest mode-set restrictions through `cascade::resolve_property`. The TUI header shows `N platform` (vs `N tokens`) when a manifest is active. CLI `primer` reports token count from the hydrated graph (catalogs included); it does not apply a platform manifest filter.
 
 Opt out of the cache layer when depending on `design-data-core` as a library:
 

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1031,11 +1031,8 @@ fn run_primer(
         })
         .collect();
 
-    let components = resolved
-        .components
-        .as_deref()
-        .map(scan_json_name_field)
-        .unwrap_or_default();
+    let mut components: Vec<String> = graph.components.iter().map(|c| c.name.clone()).collect();
+    components.sort();
 
     let taxonomy_fields: Vec<serde_json::Value> = resolved
         .fields

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -284,6 +284,12 @@ enum Commands {
         /// Output .redb file path
         #[arg(short, long, value_name = "FILE", default_value = "index.redb")]
         output: PathBuf,
+        /// Mode sets catalog directory
+        #[arg(long, value_name = "DIR")]
+        mode_sets_path: Option<PathBuf>,
+        /// Components catalog directory
+        #[arg(long, value_name = "DIR")]
+        components_path: Option<PathBuf>,
     },
     /// Manage token authoring sessions (MCP parity, RFC #973 Q4)
     #[command(name = "authoring-session")]
@@ -432,12 +438,7 @@ fn run_resolve(
         resolve_ctx = resolve_ctx.with("contrast", m);
     }
 
-    // Load token graph (via the embedded-database cache when fresh).
-    let mut graph = TokenGraph::open_cached(path)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
-
-    // Load mode sets from spec catalog.
+    // Resolve catalog paths first so the cache can hydrate them on hit.
     let cwd = std::env::current_dir().into_diagnostic()?;
     let resolved = data_source::resolve(
         &cwd,
@@ -447,15 +448,15 @@ fn run_resolve(
         },
     )
     .into_diagnostic()?;
-    let ms_dir = resolved.mode_sets.clone();
-    if let Some(dir) = ms_dir {
-        if dir.is_dir() {
-            let mode_sets = TokenGraph::load_spec_mode_sets(&dir)
-                .into_diagnostic()
-                .wrap_err_with(|| format!("failed to load mode sets from {}", dir.display()))?;
-            graph = graph.with_mode_sets(mode_sets);
-        }
-    }
+
+    // Load token graph (via the embedded-database cache when fresh).
+    let mut graph = TokenGraph::open_cached_with_catalogs(
+        path,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
     // Apply a configured platform manifest (Foundation→Platform cascade): filter the
     // token set, layer in overrides/extensions, and capture mode-set restrictions.
@@ -772,7 +773,11 @@ fn run_query(
     let cwd = std::env::current_dir().into_diagnostic()?;
     let resolved = data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
 
-    let (mut graph, mut index) = TokenGraph::open_cached_with_index(path)
+    let (mut graph, mut index) = TokenGraph::open_cached_with_index_with_catalogs(
+        path,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
         .into_diagnostic()
         .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
@@ -1006,26 +1011,25 @@ fn run_primer(
     // Dataset path: explicit arg wins; otherwise use the resolved tokens root (which
     // comes from the config source, embedded snapshot, or in-repo CWD probing).
     let path = resolved.tokens_root.clone();
-    let graph = TokenGraph::open_cached(&path)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
+    let graph = TokenGraph::open_cached_with_catalogs(
+        &path,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
     let token_count = graph.tokens.len();
-    let ms_dir = resolved.mode_sets;
-    let mode_sets: Vec<serde_json::Value> = if let Some(dir) = ms_dir {
-        TokenGraph::load_spec_mode_sets(&dir)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|d| {
-                serde_json::json!({
-                    "name": d.name,
-                    "modes": d.modes,
-                    "defaultMode": d.default_mode,
-                })
+    let mode_sets: Vec<serde_json::Value> = graph
+        .mode_sets
+        .iter()
+        .map(|d| {
+            serde_json::json!({
+                "name": d.name,
+                "modes": d.modes,
+                "defaultMode": d.default_mode,
             })
-            .collect()
-    } else {
-        vec![]
-    };
+        })
+        .collect();
 
     let components = resolved
         .components
@@ -1268,27 +1272,40 @@ fn run_suggest(
     Ok(ExitCode::SUCCESS)
 }
 
-fn run_cache_build(explicit_path: Option<&Path>, output: &Path) -> miette::Result<ExitCode> {
+fn run_cache_build(
+    explicit_path: Option<&Path>,
+    output: &Path,
+    mode_sets_path: Option<&Path>,
+    components_path: Option<&Path>,
+) -> miette::Result<ExitCode> {
     // Resolve the dataset: explicit arg wins, else the canonical resolved root.
-    let tokens_root = match explicit_path {
-        Some(p) => p.to_path_buf(),
-        None => {
-            let cwd = std::env::current_dir().into_diagnostic()?;
-            let resolved =
-                data_source::resolve(&cwd, &CliPathOverrides::default()).into_diagnostic()?;
-            resolved.tokens_root
-        }
-    };
+    let cwd = std::env::current_dir().into_diagnostic()?;
+    let resolved = data_source::resolve(
+        &cwd,
+        &CliPathOverrides {
+            tokens_root: explicit_path.map(|p| p.to_path_buf()),
+            mode_sets: mode_sets_path.map(|p| p.to_path_buf()),
+            components: components_path.map(|p| p.to_path_buf()),
+            ..Default::default()
+        },
+    )
+    .into_diagnostic()?;
+    let tokens_root = resolved.tokens_root;
 
-    cache::build_file(&tokens_root, output)
-        .into_diagnostic()
-        .wrap_err_with(|| {
-            format!(
-                "failed to build cache from {} into {}",
-                tokens_root.display(),
-                output.display()
-            )
-        })?;
+    cache::build_file_with_catalogs(
+        &tokens_root,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+        output,
+    )
+    .into_diagnostic()
+    .wrap_err_with(|| {
+        format!(
+            "failed to build cache from {} into {}",
+            tokens_root.display(),
+            output.display()
+        )
+    })?;
 
     println!(
         "Built cache from {} → {}",
@@ -1611,7 +1628,17 @@ fn main() -> ExitCode {
                 schema_path: schema_path.as_deref(),
             },
         ),
-        Commands::CacheBuild { path, output } => run_cache_build(path.as_deref(), &output),
+        Commands::CacheBuild {
+            path,
+            output,
+            mode_sets_path,
+            components_path,
+        } => run_cache_build(
+            path.as_deref(),
+            &output,
+            mode_sets_path.as_deref(),
+            components_path.as_deref(),
+        ),
         Commands::AuthoringSession { cmd } => {
             return authoring::run(cmd);
         }

--- a/sdk/core/src/cache/mod.rs
+++ b/sdk/core/src/cache/mod.rs
@@ -31,8 +31,9 @@
 //!
 //! - `cache_base`: `DESIGN_DATA_CACHE_DIR` env override, else `dirs::cache_dir()/design-data`.
 //! - `tokens_version`: [`EMBEDDED_TOKENS_VERSION`] — upgrades self-invalidate.
-//! - `dataset_key`: hash of the dataset's absolute path, so distinct datasets do
-//!   not thrash a single shared cache file.
+//! - `dataset_key`: hash of the tokens root absolute path plus any configured
+//!   catalog directory paths (`mode-sets`, `components`), so distinct datasets
+//!   and catalog configurations do not thrash a single shared cache file.
 //!
 //! ## redb schema (v2)
 //!
@@ -76,6 +77,13 @@
 //! - Sidecar name directories merged by [`TokenGraph::from_json_dir_with_names`] are
 //!   not part of the cache build path; callers using sidecars should keep loading
 //!   from JSON or extend the cache inputs explicitly.
+//! - [`open_cached`] (no catalog dirs) and [`open_cached_with_catalogs`] write
+//!   separate cache files for the same tokens root. CLI/TUI always pass catalogs;
+//!   WASM/tools using plain [`build_bytes`] / [`open_cached`] maintain a distinct
+//!   entry unless they adopt the `*_with_catalogs` APIs.
+//! - `dataset_key` uses [`std::collections::hash_map::DefaultHasher`] (not stable
+//!   across Rust versions). Fine for local dev caches; do not share cache dirs
+//!   across heterogeneous CI runners expecting identical keys.
 
 mod mem_backend;
 

--- a/sdk/core/src/cache/mod.rs
+++ b/sdk/core/src/cache/mod.rs
@@ -34,16 +34,19 @@
 //! - `dataset_key`: hash of the dataset's absolute path, so distinct datasets do
 //!   not thrash a single shared cache file.
 //!
-//! ## redb schema
+//! ## redb schema (v2)
 //!
 //! | table          | kind        | key            | value                          |
 //! |----------------|-------------|----------------|--------------------------------|
 //! | `meta`         | table       | `"meta"`       | MessagePack [`CacheMeta`]      |
 //! | `tokens`       | table       | graph key      | MessagePack [`TokenRecord`]    |
 //! | `uuid_index`   | table       | uuid           | graph key                      |
+//! | `mode_sets`    | table       | ordinal        | MessagePack [`ModeSetRecord`]  |
+//! | `components`   | table       | ordinal        | MessagePack [`ComponentRecord`]|
 //! | `idx_<field>`  | multimap    | field value    | graph keys (one per query key) |
 //!
-//! `tokens` drives hydration; the `uuid_index` / `idx_*` tables exist so a
+//! `tokens` drives hydration; `mode_sets` / `components` preserve inline mode-set
+//! docs and spec catalog entries; the `uuid_index` / `idx_*` tables exist so a
 //! read-only consumer (e.g. a WASM web tool via [`load_index_from_bytes`]) can
 //! answer indexed equality queries without materializing the whole graph.
 //!
@@ -60,14 +63,19 @@
 //! same-size edit with an unchanged mtime — unlikely in normal editor/git
 //! workflows, but possible in CI that preserves mtimes aggressively.
 //!
-//! ## Known limitations (schema v1)
+//! ## Catalog-aware caching
 //!
-//! - **Inline mode sets** discovered by [`TokenGraph::from_json_dir`] inside the
-//!   tokens tree are not persisted; hydration uses [`TokenGraph::from_records`],
-//!   which clears `mode_sets`. The canonical Spectrum layout (mode sets under
-//!   `design-data-spec/mode-sets`) is unaffected.
-//! - **`components` / `mode_sets` catalog tables** from the plan are deferred;
-//!   only tokens and query indexes are cached today.
+//! [`open_cached_with_catalogs`] / [`open_cached_with_index_with_catalogs`] accept
+//! optional `mode-sets` and `components` catalog directories (resolved separately
+//! from `tokens_root`). Catalog JSON files are folded into the content hash and
+//! the cache file key so edits self-invalidate. Inline mode-set docs co-located in
+//! the tokens tree are persisted automatically.
+//!
+//! ## Known limitations (schema v2)
+//!
+//! - Sidecar name directories merged by [`TokenGraph::from_json_dir_with_names`] are
+//!   not part of the cache build path; callers using sidecars should keep loading
+//!   from JSON or extend the cache inputs explicitly.
 
 mod mem_backend;
 
@@ -83,7 +91,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::data_source::embedded::EMBEDDED_TOKENS_VERSION;
 use crate::discovery::discover_json_files;
-use crate::graph::{TokenGraph, TokenRecord};
+use crate::graph::{ComponentRecord, ModeSetRecord, TokenGraph, TokenRecord};
 use crate::query::{self, TokenIndex, ALLOWED_KEYS};
 use crate::CoreError;
 
@@ -96,11 +104,13 @@ pub struct CachedDataset {
 
 /// Bump when the on-disk schema or value encoding changes, to invalidate caches
 /// written by older binaries (in addition to the tokens-version namespace).
-const CACHE_SCHEMA_VERSION: u32 = 1;
+const CACHE_SCHEMA_VERSION: u32 = 2;
 
 const META: TableDefinition<&str, &[u8]> = TableDefinition::new("meta");
 const TOKENS: TableDefinition<&str, &[u8]> = TableDefinition::new("tokens");
 const UUID_INDEX: TableDefinition<&str, &str> = TableDefinition::new("uuid_index");
+const MODE_SETS: TableDefinition<&str, &[u8]> = TableDefinition::new("mode_sets");
+const COMPONENTS: TableDefinition<&str, &[u8]> = TableDefinition::new("components");
 
 // One multimap index table per query field (see `query::ALLOWED_KEYS`).
 const IDX_PROPERTY: MultimapTableDefinition<&str, &str> =
@@ -188,10 +198,21 @@ fn debug_log(args: std::fmt::Arguments<'_>) {
 ///
 /// Drop-in replacement for [`TokenGraph::from_json_dir`]. Prefer
 /// [`open_cached_with_index`] when you also need the persisted query index.
+/// For spec catalog dirs, use [`open_cached_with_catalogs`].
 ///
 /// Never fails because of the cache; only a JSON load error propagates.
 pub fn open_cached(tokens_root: &Path) -> Result<TokenGraph, CoreError> {
-    open_cached_with_index(tokens_root).map(|loaded| loaded.graph)
+    open_cached_with_catalogs(tokens_root, None, None)
+}
+
+/// Load a graph with optional spec catalog directories.
+pub fn open_cached_with_catalogs(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+) -> Result<TokenGraph, CoreError> {
+    open_cached_with_index_with_catalogs(tokens_root, mode_sets_dir, components_dir)
+        .map(|loaded| loaded.graph)
 }
 
 /// Load a graph **and** its query index for `tokens_root`.
@@ -201,15 +222,28 @@ pub fn open_cached(tokens_root: &Path) -> Result<TokenGraph, CoreError> {
 /// cache error the graph is built from JSON (source of truth), the index is
 /// built from that graph, and the cache is rewritten best-effort.
 pub fn open_cached_with_index(tokens_root: &Path) -> Result<CachedDataset, CoreError> {
-    match load_from_disk(tokens_root) {
+    open_cached_with_index_with_catalogs(tokens_root, None, None)
+}
+
+/// Load a graph and query index with optional spec catalog directories.
+pub fn open_cached_with_index_with_catalogs(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+) -> Result<CachedDataset, CoreError> {
+    match load_from_disk(tokens_root, mode_sets_dir, components_dir) {
         Ok(Some(loaded)) => return Ok(loaded),
         Ok(None) => {}
         Err(e) => debug_log(format_args!("read failed ({e}); rebuilding from json")),
     }
 
-    let graph = TokenGraph::from_json_dir(tokens_root)?;
+    let graph = TokenGraph::from_json_dir_with_catalogs(
+        tokens_root,
+        mode_sets_dir,
+        components_dir,
+    )?;
     let index = TokenIndex::build(&graph);
-    if let Err(e) = write_to_disk(tokens_root, &graph) {
+    if let Err(e) = write_to_disk(tokens_root, mode_sets_dir, components_dir, &graph) {
         debug_log(format_args!("write failed ({e}); cache not updated"));
     }
     Ok(CachedDataset { graph, index })
@@ -219,8 +253,21 @@ pub fn open_cached_with_index(tokens_root: &Path) -> Result<CachedDataset, CoreE
 /// buffer (no filesystem). Use this as a build step to emit a `index.redb`
 /// static asset for WASM web tools.
 pub fn build_bytes(tokens_root: &Path) -> Result<Vec<u8>, CoreError> {
-    let graph = TokenGraph::from_json_dir(tokens_root)?;
-    let hash = content_hash(tokens_root).map_err(CoreError::Io)?;
+    build_bytes_with_catalogs(tokens_root, None, None)
+}
+
+/// Build cache bytes including optional spec catalog directories.
+pub fn build_bytes_with_catalogs(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+) -> Result<Vec<u8>, CoreError> {
+    let graph = TokenGraph::from_json_dir_with_catalogs(
+        tokens_root,
+        mode_sets_dir,
+        components_dir,
+    )?;
+    let hash = content_hash(tokens_root, mode_sets_dir, components_dir).map_err(CoreError::Io)?;
     build_bytes_from_graph(&graph, hash).map_err(into_core)
 }
 
@@ -230,8 +277,22 @@ pub fn build_bytes(tokens_root: &Path) -> Result<Vec<u8>, CoreError> {
 /// [`open_cached`], the destination is caller-controlled rather than the OS
 /// cache directory.
 pub fn build_file(tokens_root: &Path, out_path: &Path) -> Result<(), CoreError> {
-    let graph = TokenGraph::from_json_dir(tokens_root)?;
-    let hash = content_hash(tokens_root).map_err(CoreError::Io)?;
+    build_file_with_catalogs(tokens_root, None, None, out_path)
+}
+
+/// Build a cache file including optional spec catalog directories.
+pub fn build_file_with_catalogs(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+    out_path: &Path,
+) -> Result<(), CoreError> {
+    let graph = TokenGraph::from_json_dir_with_catalogs(
+        tokens_root,
+        mode_sets_dir,
+        components_dir,
+    )?;
+    let hash = content_hash(tokens_root, mode_sets_dir, components_dir).map_err(CoreError::Io)?;
     write_db_file(out_path, &graph, hash).map_err(into_core)
 }
 
@@ -264,18 +325,30 @@ pub fn load_index_from_bytes(bytes: &[u8]) -> Result<TokenIndex, CoreError> {
 // Disk path resolution + invalidation
 // ---------------------------------------------------------------------------
 
-fn cache_db_path(tokens_root: &Path) -> Option<PathBuf> {
+fn cache_db_path(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+) -> Option<PathBuf> {
     let base = if let Ok(p) = std::env::var("DESIGN_DATA_CACHE_DIR") {
         PathBuf::from(p)
     } else {
         dirs::cache_dir()?.join("design-data")
     };
-    // Namespace by absolute dataset path so distinct datasets get distinct files.
+    // Namespace by absolute dataset + catalog paths so distinct configs get distinct files.
     let abs = tokens_root
         .canonicalize()
         .unwrap_or_else(|_| tokens_root.to_path_buf());
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     abs.to_string_lossy().hash(&mut hasher);
+    if let Some(dir) = mode_sets_dir {
+        let abs_ms = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+        abs_ms.to_string_lossy().hash(&mut hasher);
+    }
+    if let Some(dir) = components_dir {
+        let abs_c = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+        abs_c.to_string_lossy().hash(&mut hasher);
+    }
     let dataset_key = format!("{:016x}", hasher.finish());
     Some(
         base.join("cache")
@@ -284,23 +357,45 @@ fn cache_db_path(tokens_root: &Path) -> Option<PathBuf> {
     )
 }
 
+fn hash_json_dir(
+    hasher: &mut std::collections::hash_map::DefaultHasher,
+    root: &Path,
+) -> std::io::Result<()> {
+    let mut paths = discover_json_files(root)?;
+    paths.sort();
+    for p in &paths {
+        p.to_string_lossy().hash(hasher);
+        let meta = std::fs::metadata(p)?;
+        meta.len().hash(hasher);
+        if let Ok(modified) = meta.modified() {
+            if let Ok(dur) = modified.duration_since(std::time::UNIX_EPOCH) {
+                dur.as_nanos().hash(hasher);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Content hash of the canonical inputs: per-file `(path, len, mtime)`, sorted.
 /// `mtime + len` is used (rather than full content) for speed; a false-positive
 /// match is impossible in practice and a false miss only forces a rebuild.
-fn content_hash(tokens_root: &Path) -> std::io::Result<u64> {
+fn content_hash(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+) -> std::io::Result<u64> {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     CACHE_SCHEMA_VERSION.hash(&mut hasher);
     EMBEDDED_TOKENS_VERSION.hash(&mut hasher);
-    let mut paths = discover_json_files(tokens_root)?;
-    paths.sort();
-    for p in &paths {
-        p.to_string_lossy().hash(&mut hasher);
-        let meta = std::fs::metadata(p)?;
-        meta.len().hash(&mut hasher);
-        if let Ok(modified) = meta.modified() {
-            if let Ok(dur) = modified.duration_since(std::time::UNIX_EPOCH) {
-                dur.as_nanos().hash(&mut hasher);
-            }
+    hash_json_dir(&mut hasher, tokens_root)?;
+    if let Some(dir) = mode_sets_dir {
+        if dir.is_dir() {
+            hash_json_dir(&mut hasher, dir)?;
+        }
+    }
+    if let Some(dir) = components_dir {
+        if dir.is_dir() {
+            hash_json_dir(&mut hasher, dir)?;
         }
     }
     Ok(hasher.finish())
@@ -312,14 +407,18 @@ fn content_hash(tokens_root: &Path) -> std::io::Result<u64> {
 
 /// Returns `Ok(Some(loaded))` on a fresh cache hit, `Ok(None)` on a miss
 /// (absent/stale), or `Err` on a real cache error.
-fn load_from_disk(tokens_root: &Path) -> Result<Option<CachedDataset>, CacheError> {
-    let Some(path) = cache_db_path(tokens_root) else {
+fn load_from_disk(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+) -> Result<Option<CachedDataset>, CacheError> {
+    let Some(path) = cache_db_path(tokens_root, mode_sets_dir, components_dir) else {
         return Ok(None);
     };
     if !path.exists() {
         return Ok(None);
     }
-    let expected = content_hash(tokens_root)?;
+    let expected = content_hash(tokens_root, mode_sets_dir, components_dir)?;
     let db = Database::open(&path)?;
     let rtx = db.begin_read()?;
 
@@ -347,7 +446,7 @@ fn read_meta(rtx: &redb::ReadTransaction) -> Result<Option<CacheMeta>, CacheErro
     Ok(Some(rmp_serde::from_slice(bytes.value())?))
 }
 
-/// Rebuild the in-memory [`TokenGraph`] from the `tokens` table. `from_records`
+/// Rebuild the in-memory [`TokenGraph`] from persisted tables. `from_records`
 /// rebuilds the UUID index, so the cached `uuid_index` table is not needed here.
 fn hydrate(rtx: &redb::ReadTransaction) -> Result<TokenGraph, CacheError> {
     let table = rtx.open_table(TOKENS)?;
@@ -357,7 +456,29 @@ fn hydrate(rtx: &redb::ReadTransaction) -> Result<TokenGraph, CacheError> {
         let record: TokenRecord = rmp_serde::from_slice(value.value())?;
         records.push(record);
     }
-    Ok(TokenGraph::from_records(records))
+    let mut graph = TokenGraph::from_records(records);
+    graph.mode_sets = read_ordinal_table::<ModeSetRecord>(rtx, MODE_SETS)?;
+    graph.components = read_ordinal_table::<ComponentRecord>(rtx, COMPONENTS)?;
+    Ok(graph)
+}
+
+fn read_ordinal_table<T: serde::de::DeserializeOwned>(
+    rtx: &redb::ReadTransaction,
+    def: TableDefinition<'static, &str, &[u8]>,
+) -> Result<Vec<T>, CacheError> {
+    let table = match rtx.open_table(def) {
+        Ok(t) => t,
+        Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut entries: Vec<(String, T)> = Vec::new();
+    for item in table.iter()? {
+        let (key, value) = item?;
+        let record: T = rmp_serde::from_slice(value.value())?;
+        entries.push((key.value().to_string(), record));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries.into_iter().map(|(_, record)| record).collect())
 }
 
 fn read_index(rtx: &redb::ReadTransaction) -> Result<TokenIndex, CacheError> {
@@ -388,9 +509,15 @@ fn read_index(rtx: &redb::ReadTransaction) -> Result<TokenIndex, CacheError> {
 // Write path
 // ---------------------------------------------------------------------------
 
-fn write_to_disk(tokens_root: &Path, graph: &TokenGraph) -> Result<(), CacheError> {
-    let path = cache_db_path(tokens_root).ok_or(CacheError::NoCacheDir)?;
-    let hash = content_hash(tokens_root)?;
+fn write_to_disk(
+    tokens_root: &Path,
+    mode_sets_dir: Option<&Path>,
+    components_dir: Option<&Path>,
+    graph: &TokenGraph,
+) -> Result<(), CacheError> {
+    let path = cache_db_path(tokens_root, mode_sets_dir, components_dir)
+        .ok_or(CacheError::NoCacheDir)?;
+    let hash = content_hash(tokens_root, mode_sets_dir, components_dir)?;
     write_db_file(&path, graph, hash)?;
     evict_stale_versions(&path);
     Ok(())
@@ -453,6 +580,22 @@ fn write_tables(db: &Database, graph: &TokenGraph, hash: u64) -> Result<(), Cach
                     uuid_t.insert(uuid.as_str(), key.as_str())?;
                 }
             }
+        }
+    }
+    {
+        let mut table = wtx.open_table(MODE_SETS)?;
+        for (idx, record) in graph.mode_sets.iter().enumerate() {
+            let key = format!("{idx:020}");
+            let bytes = rmp_serde::to_vec(record)?;
+            table.insert(key.as_str(), bytes.as_slice())?;
+        }
+    }
+    {
+        let mut table = wtx.open_table(COMPONENTS)?;
+        for (idx, record) in graph.components.iter().enumerate() {
+            let key = format!("{idx:020}");
+            let bytes = rmp_serde::to_vec(record)?;
+            table.insert(key.as_str(), bytes.as_slice())?;
         }
     }
     for field in ALLOWED_KEYS {
@@ -559,7 +702,7 @@ mod tests {
 
         // First load builds + writes the cache (miss).
         let g1 = open_cached(&root).unwrap();
-        let path = cache_db_path(&root).unwrap();
+        let path = cache_db_path(&root, None, None).unwrap();
         assert!(path.exists(), "cache file should be written on first load");
 
         // Second load is a hit; graph must match the JSON-built one.
@@ -583,7 +726,7 @@ mod tests {
 
         // load_from_disk must report a genuine hit (Some) — proving the redb
         // read + MessagePack hydration path works, not the JSON fallback.
-        let hit = load_from_disk(&root).unwrap();
+        let hit = load_from_disk(&root, None, None).unwrap();
         let loaded = hit.expect("expected a cache hit after priming");
         assert_eq!(loaded.graph.tokens.len(), 2);
         assert!(loaded.graph.tokens.contains_key("blue-100"));
@@ -640,7 +783,7 @@ mod tests {
 
         // Prime the cache, then corrupt the file.
         let _ = open_cached(&root).unwrap();
-        let path = cache_db_path(&root).unwrap();
+        let path = cache_db_path(&root, None, None).unwrap();
         std::fs::write(&path, b"not a redb database").unwrap();
 
         // Must not error — falls back to JSON and rewrites the cache.
@@ -681,5 +824,188 @@ mod tests {
             via_index[0].uuid.as_deref(),
             Some("22222222-2222-4222-8222-222222222222")
         );
+    }
+
+    #[test]
+    fn inline_mode_set_survives_roundtrip() {
+        let _env = crate::data_source::test_support::env_lock();
+        let data = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+        write_tokens(
+            data.path(),
+            "tokens.json",
+            json!({
+                "blue-100": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#00f",
+                    "uuid": "11111111-1111-4111-8111-111111111111",
+                    "name": {"property": "background-color", "component": "button"}
+                }
+            }),
+        );
+        write_tokens(
+            data.path(),
+            "color-scheme.json",
+            json!({
+                "name": "colorScheme",
+                "modes": ["light", "dark"],
+                "default": "light"
+            }),
+        );
+        let root = data.path().to_path_buf();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        let _ = open_cached(&root).unwrap();
+        let cached = open_cached(&root).unwrap();
+        assert_eq!(cached.mode_sets.len(), 1);
+        assert_eq!(cached.mode_sets[0].name, "colorScheme");
+        assert_eq!(cached.mode_sets[0].modes, vec!["light", "dark"]);
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn catalog_mode_sets_and_components_roundtrip() {
+        let _env = crate::data_source::test_support::env_lock();
+        let data = TempDir::new().unwrap();
+        let mode_sets = TempDir::new().unwrap();
+        let components = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+
+        write_tokens(
+            data.path(),
+            "color.json",
+            json!({
+                "blue-100": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#00f",
+                    "uuid": "11111111-1111-4111-8111-111111111111",
+                    "name": {"property": "background-color", "component": "button"}
+                }
+            }),
+        );
+        write_tokens(
+            mode_sets.path(),
+            "color-scheme.json",
+            json!({
+                "name": "colorScheme",
+                "modes": ["light", "dark"],
+                "default": "light"
+            }),
+        );
+        write_tokens(
+            components.path(),
+            "button.json",
+            json!({
+                "name": "button",
+                "description": "Primary action"
+            }),
+        );
+
+        let root = data.path().to_path_buf();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        let _ = open_cached_with_catalogs(
+            &root,
+            Some(mode_sets.path()),
+            Some(components.path()),
+        )
+        .unwrap();
+        let cached = open_cached_with_catalogs(
+            &root,
+            Some(mode_sets.path()),
+            Some(components.path()),
+        )
+        .unwrap();
+        assert_eq!(cached.mode_sets.len(), 1);
+        assert_eq!(cached.mode_sets[0].name, "colorScheme");
+        assert_eq!(cached.components.len(), 1);
+        assert_eq!(cached.components[0].name, "button");
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn catalog_edit_invalidates_cache() {
+        let _env = crate::data_source::test_support::env_lock();
+        let data = TempDir::new().unwrap();
+        let mode_sets = TempDir::new().unwrap();
+        let cache = TempDir::new().unwrap();
+
+        write_tokens(
+            data.path(),
+            "color.json",
+            json!({
+                "blue-100": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#00f",
+                    "uuid": "11111111-1111-4111-8111-111111111111",
+                    "name": {"property": "background-color", "component": "button"}
+                }
+            }),
+        );
+        write_tokens(
+            mode_sets.path(),
+            "color-scheme.json",
+            json!({
+                "name": "colorScheme",
+                "modes": ["light"],
+                "default": "light"
+            }),
+        );
+
+        let root = data.path().to_path_buf();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        let g1 = open_cached_with_catalogs(&root, Some(mode_sets.path()), None).unwrap();
+        assert_eq!(g1.mode_sets[0].modes, vec!["light"]);
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_tokens(
+            mode_sets.path(),
+            "scale.json",
+            json!({
+                "name": "scale",
+                "modes": ["medium", "large"],
+                "default": "medium"
+            }),
+        );
+
+        let g2 = open_cached_with_catalogs(&root, Some(mode_sets.path()), None).unwrap();
+        assert_eq!(g2.mode_sets.len(), 2);
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
+    }
+
+    #[test]
+    fn stale_v1_cache_is_treated_as_miss() {
+        let _env = crate::data_source::test_support::env_lock();
+        let (_data, cache, root) = fixture();
+        std::env::set_var("DESIGN_DATA_CACHE_DIR", cache.path());
+
+        let _ = open_cached(&root).unwrap();
+        let path = cache_db_path(&root, None, None).unwrap();
+
+        {
+            let db = Database::open(&path).unwrap();
+            let wtx = db.begin_write().unwrap();
+            {
+                let mut meta_t = wtx.open_table(META).unwrap();
+                let meta_bytes = meta_t.get("meta").unwrap().unwrap().value().to_vec();
+                let mut meta: CacheMeta = rmp_serde::from_slice(&meta_bytes).unwrap();
+                meta.schema_version = 1;
+                let bytes = rmp_serde::to_vec(&meta).unwrap();
+                meta_t.insert("meta", bytes.as_slice()).unwrap();
+            }
+            wtx.commit().unwrap();
+        }
+
+        let hit = load_from_disk(&root, None, None).unwrap();
+        assert!(hit.is_none(), "v1 schema_version must invalidate cache");
+
+        let g = open_cached(&root).unwrap();
+        assert_eq!(g.tokens.len(), 2);
+
+        std::env::remove_var("DESIGN_DATA_CACHE_DIR");
     }
 }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -135,19 +135,51 @@ impl TokenGraph {
         Self::from_json_dir_with_names(root, None)
     }
 
+    /// Load tokens plus optional spec catalog directories.
+    ///
+    /// Inline mode-set docs in the tokens tree are preserved; catalog mode sets
+    /// are appended (not replaced).
+    pub fn from_json_dir_with_catalogs(
+        root: &Path,
+        mode_sets_dir: Option<&Path>,
+        components_dir: Option<&Path>,
+    ) -> Result<Self, CoreError> {
+        let mut graph = Self::from_json_dir(root)?;
+        if let Some(dir) = mode_sets_dir {
+            if dir.is_dir() {
+                graph.mode_sets.extend(Self::load_spec_mode_sets(dir)?);
+            }
+        }
+        if let Some(dir) = components_dir {
+            if dir.is_dir() {
+                graph.components = Self::load_spec_components(dir)?;
+            }
+        }
+        Ok(graph)
+    }
+
     /// Load a graph for `root`, using the derived embedded-database cache when
     /// the `cache` feature is enabled.
     ///
     /// Drop-in replacement for [`Self::from_json_dir`]. See also
     /// [`Self::open_cached_with_index`] when the persisted query index is needed.
     pub fn open_cached(root: &Path) -> Result<Self, CoreError> {
+        Self::open_cached_with_catalogs(root, None, None)
+    }
+
+    /// Load a graph with optional spec catalog directories from cache or JSON.
+    pub fn open_cached_with_catalogs(
+        root: &Path,
+        mode_sets_dir: Option<&Path>,
+        components_dir: Option<&Path>,
+    ) -> Result<Self, CoreError> {
         #[cfg(feature = "cache")]
         {
-            crate::cache::open_cached(root)
+            crate::cache::open_cached_with_catalogs(root, mode_sets_dir, components_dir)
         }
         #[cfg(not(feature = "cache"))]
         {
-            Self::from_json_dir(root)
+            Self::from_json_dir_with_catalogs(root, mode_sets_dir, components_dir)
         }
     }
 
@@ -157,14 +189,27 @@ impl TokenGraph {
     /// in-memory rebuild. When the `cache` feature is disabled this builds the
     /// index from the JSON-loaded graph.
     pub fn open_cached_with_index(root: &Path) -> Result<(Self, query::TokenIndex), CoreError> {
+        Self::open_cached_with_index_with_catalogs(root, None, None)
+    }
+
+    /// Load a graph and query index with optional spec catalog directories.
+    pub fn open_cached_with_index_with_catalogs(
+        root: &Path,
+        mode_sets_dir: Option<&Path>,
+        components_dir: Option<&Path>,
+    ) -> Result<(Self, query::TokenIndex), CoreError> {
         #[cfg(feature = "cache")]
         {
-            let loaded = crate::cache::open_cached_with_index(root)?;
+            let loaded = crate::cache::open_cached_with_index_with_catalogs(
+                root,
+                mode_sets_dir,
+                components_dir,
+            )?;
             Ok((loaded.graph, loaded.index))
         }
         #[cfg(not(feature = "cache"))]
         {
-            let graph = Self::from_json_dir(root)?;
+            let graph = Self::from_json_dir_with_catalogs(root, mode_sets_dir, components_dir)?;
             let index = query::TokenIndex::build(&graph);
             Ok((graph, index))
         }

--- a/sdk/tui/src/app_launch.rs
+++ b/sdk/tui/src/app_launch.rs
@@ -96,10 +96,6 @@ impl DatasetHandle {
         allow_write: bool,
         theme: Theme,
     ) -> Result<Self> {
-        let (mut graph, mut token_index) = TokenGraph::open_cached_with_index(&path)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
-
         // Resolve spec paths via the central data_source resolver.
         // The dataset path is already explicit; we only need spec catalog dirs + schema.
         let cwd = std::env::current_dir().into_diagnostic()?;
@@ -114,26 +110,15 @@ impl DatasetHandle {
         .into_diagnostic()?;
 
         let components_dir = resolved.components.clone();
-        if let Some(ref dir) = components_dir {
-            if dir.is_dir() {
-                let comps = TokenGraph::load_spec_components(dir)
-                    .into_diagnostic()
-                    .wrap_err_with(|| {
-                        format!("failed to load components from {}", dir.display())
-                    })?;
-                graph = graph.with_components(comps);
-            }
-        }
-
         let mode_sets_dir = resolved.mode_sets.clone();
-        if let Some(ref dir) = mode_sets_dir {
-            if dir.is_dir() {
-                let mode_sets = TokenGraph::load_spec_mode_sets(dir)
-                    .into_diagnostic()
-                    .wrap_err_with(|| format!("failed to load mode sets from {}", dir.display()))?;
-                graph = graph.with_mode_sets(mode_sets);
-            }
-        }
+
+        let (mut graph, mut token_index) = TokenGraph::open_cached_with_index_with_catalogs(
+            &path,
+            mode_sets_dir.as_deref(),
+            components_dir.as_deref(),
+        )
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to load tokens from {}", path.display()))?;
 
         // Apply a configured platform manifest (Foundation→Platform cascade), matching CLI query/resolve.
         let platform_manifest_active = resolved.platform_manifest.is_some();

--- a/sdk/tui/tests/manifest.rs
+++ b/sdk/tui/tests/manifest.rs
@@ -71,18 +71,15 @@ fn load_session(
     project_path: &Path,
     tokens_path: &Path,
 ) -> (TokenGraph, TokenIndex, HashMap<String, Vec<String>>) {
-    let (mut graph, mut token_index) =
-        TokenGraph::open_cached_with_index(tokens_path).expect("open cached graph");
-
     let resolved =
         data_source::resolve(project_path, &CliPathOverrides::default()).expect("resolve");
 
-    if let Some(ref dir) = resolved.mode_sets {
-        if dir.is_dir() {
-            let mode_sets = TokenGraph::load_spec_mode_sets(dir).expect("mode sets");
-            graph = graph.with_mode_sets(mode_sets);
-        }
-    }
+    let (mut graph, mut token_index) = TokenGraph::open_cached_with_index_with_catalogs(
+        tokens_path,
+        resolved.mode_sets.as_deref(),
+        resolved.components.as_deref(),
+    )
+    .expect("open cached graph");
 
     let mode_set_restrictions =
         manifest::apply_configured(&mut graph, &resolved).expect("manifest");
@@ -166,4 +163,24 @@ fn resolve_respects_manifest_restrictions() {
             std::mem::discriminant(other)
         ),
     }
+}
+
+#[test]
+fn session_load_hydrates_catalog_mode_sets_from_cache() {
+    let project = setup_project(json!({
+        "specVersion": "1.0.0-draft",
+        "foundationVersion": "1.0.0"
+    }));
+
+    let project_path = project.path().to_path_buf();
+    let tokens_dir = project_path.join("tokens");
+    let (graph, _, _) = load_session(&project_path, &tokens_dir);
+
+    let color_scheme = graph
+        .mode_sets
+        .iter()
+        .find(|ms| ms.name == "colorScheme")
+        .expect("colorScheme mode set from repo catalog");
+    assert!(color_scheme.modes.contains(&"light".to_string()));
+    assert!(color_scheme.modes.contains(&"dark".to_string()));
 }


### PR DESCRIPTION
## Description

Extend the redb derived-cache from schema v1 to v2 so inline mode-sets and spec
catalog tables (`components`, `mode-sets`) persist through cache round-trips.
Adds catalog-aware `open_cached_*` / `build_*` entry points, wires CLI/TUI callers,
and bumps `CACHE_SCHEMA_VERSION` (stale v1 caches auto-invalidate).

## Related Issue

Follow-up to spectrum-design-data-opm (closes spectrum-design-data-15a cache limitations).

## Motivation and Context

Schema v1 only cached tokens and query indexes. Hydration via `TokenGraph::from_records`
cleared `mode_sets` and omitted catalog tables, so cache hits dropped inline mode-set
docs and forced callers to reload catalogs separately after every `open_cached`.

## How Has This Been Tested?

- `cargo test -p design-data-core --features cache cache::` — 10 tests including inline
  mode-set round-trip, catalog persistence, catalog-edit invalidation, v1 stale miss
- `cargo test -p design-data-tui --test manifest` — manifest + catalog hydration tests
- `cargo build -p design-data-cli`
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Made with [Cursor](https://cursor.com)