### PR TITLE
feat(sdk): catalog-aware validate graph load preserves inline mode sets

### DIFF
--- a/.changeset/validate-catalog-aware.md
+++ b/.changeset/validate-catalog-aware.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data": minor
+---
+
+Make validation catalog-aware so inline mode sets are preserved when a mode-sets
+catalog is passed (closes spectrum-design-data-ydg).
+
+- **sdk/core/src/graph.rs**: add `from_json_dir_with_names_and_catalogs` (sidecar
+  names + catalog extend); `from_json_dir_with_catalogs` now delegates to it.
+- **sdk/core/src/validate/mod.rs**: `validate_all_with_options_and_names` extends
+  (no longer replaces) `mode_sets`, so inline mode-set docs co-located in the
+  token tree are seen by SPEC-005/008/041 alongside catalog mode sets.

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -144,7 +144,23 @@ impl TokenGraph {
         mode_sets_dir: Option<&Path>,
         components_dir: Option<&Path>,
     ) -> Result<Self, CoreError> {
-        let mut graph = Self::from_json_dir(root)?;
+        Self::from_json_dir_with_names_and_catalogs(root, None, mode_sets_dir, components_dir)
+    }
+
+    /// Load tokens with optional sidecar names **and** spec catalog directories.
+    ///
+    /// Combines [`Self::from_json_dir_with_names`] (sidecar name merge) with
+    /// catalog loading: inline mode-set docs discovered in the tokens tree are
+    /// preserved and catalog mode sets are appended (not replaced), matching the
+    /// cache/query/resolve graph. Components are loaded from `components_dir`
+    /// (replace) since `from_json_dir_with_names` never discovers components.
+    pub fn from_json_dir_with_names_and_catalogs(
+        root: &Path,
+        names_dir: Option<&Path>,
+        mode_sets_dir: Option<&Path>,
+        components_dir: Option<&Path>,
+    ) -> Result<Self, CoreError> {
+        let mut graph = Self::from_json_dir_with_names(root, names_dir)?;
         if let Some(dir) = mode_sets_dir {
             if dir.is_dir() {
                 graph.mode_sets.extend(Self::load_spec_mode_sets(dir)?);
@@ -943,6 +959,72 @@ mod tests {
         let name = token.raw.get("name").expect("name merged from sidecar");
         assert_eq!(name["colorFamily"], "blue");
         assert_eq!(name["scaleIndex"], 100);
+    }
+
+    #[test]
+    fn names_and_catalogs_extends_inline_mode_sets_and_merges_sidecar() {
+        let tokens_dir = tempdir().unwrap();
+        let names_dir = tempdir().unwrap();
+        let mode_sets_dir = tempdir().unwrap();
+        let components_dir = tempdir().unwrap();
+
+        // Token plus an inline mode-set doc co-located in the tokens tree.
+        write_json(
+            &tokens_dir,
+            "color.json",
+            json!({
+                "blue-100": { "$schema": "https://example.com/color-set.json", "value": "#0000ff" }
+            }),
+        );
+        write_json(
+            &tokens_dir,
+            "inline-mode-set.json",
+            json!({ "name": "scale", "modes": ["desktop", "mobile"], "default": "desktop" }),
+        );
+        // Sidecar name for the token.
+        write_json(
+            &names_dir,
+            "color.json",
+            json!({
+                "blue-100": { "property": "color", "colorFamily": "blue" }
+            }),
+        );
+        // Catalog mode-set + component in separate dirs.
+        write_json(
+            &mode_sets_dir,
+            "color-scheme.json",
+            json!({ "name": "colorScheme", "modes": ["light", "dark"], "default": "light" }),
+        );
+        write_json(
+            &components_dir,
+            "button.json",
+            json!({ "name": "button", "description": "Primary action" }),
+        );
+
+        let g = TokenGraph::from_json_dir_with_names_and_catalogs(
+            tokens_dir.path(),
+            Some(names_dir.path()),
+            Some(mode_sets_dir.path()),
+            Some(components_dir.path()),
+        )
+        .unwrap();
+
+        // Inline mode set is preserved AND catalog mode set is appended (extend).
+        let names: Vec<&str> = g.mode_sets.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"scale"), "inline mode set must be kept");
+        assert!(
+            names.contains(&"colorScheme"),
+            "catalog mode set must be appended"
+        );
+        assert_eq!(g.mode_sets.len(), 2);
+
+        // Catalog component is loaded.
+        assert_eq!(g.components.len(), 1);
+        assert_eq!(g.components[0].name, "button");
+
+        // Sidecar name merged into the token raw.
+        let token = g.tokens.get("blue-100").unwrap();
+        assert_eq!(token.raw["name"]["colorFamily"], "blue");
     }
 
     #[test]

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -154,6 +154,11 @@ impl TokenGraph {
     /// preserved and catalog mode sets are appended (not replaced), matching the
     /// cache/query/resolve graph. Components are loaded from `components_dir`
     /// (replace) since `from_json_dir_with_names` never discovers components.
+    ///
+    /// Mode sets are not deduplicated: an inline and a catalog mode set sharing
+    /// the same `name` both remain in `mode_sets` (intentional consistency with
+    /// the cache/query/resolve graph). The canonical Spectrum layout keeps mode
+    /// sets only in the catalog, so this overlap does not arise there.
     pub fn from_json_dir_with_names_and_catalogs(
         root: &Path,
         names_dir: Option<&Path>,

--- a/sdk/core/src/validate/mod.rs
+++ b/sdk/core/src/validate/mod.rs
@@ -90,19 +90,12 @@ pub fn validate_all_with_options_and_names(
     names_dir: Option<&Path>,
 ) -> Result<ValidationReport, CoreError> {
     let mut report = structural::validate_structural(data_path, schema_registry)?;
-    let mut graph = TokenGraph::from_json_dir_with_names(data_path, names_dir)?;
-    if let Some(dir) = mode_sets_path {
-        if dir.is_dir() {
-            let mode_sets = TokenGraph::load_spec_mode_sets(dir)?;
-            graph = graph.with_mode_sets(mode_sets);
-        }
-    }
-    if let Some(dir) = components_path {
-        if dir.is_dir() {
-            let comps = TokenGraph::load_spec_components(dir)?;
-            graph = graph.with_components(comps);
-        }
-    }
+    let graph = TokenGraph::from_json_dir_with_names_and_catalogs(
+        data_path,
+        names_dir,
+        mode_sets_path,
+        components_path,
+    )?;
     // Load manifest.json from the data directory when present.
     let manifest: Option<serde_json::Value> = if data_path.is_dir() {
         let mp = data_path.join("manifest.json");
@@ -119,4 +112,76 @@ pub fn validate_all_with_options_and_names(
     let rel = relational::validate_relational(&graph, naming_exceptions, manifest.as_ref());
     report.merge(rel);
     Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_json(dir: &Path, file: &str, value: serde_json::Value) {
+        let mut f = std::fs::File::create(dir.join(file)).unwrap();
+        write!(f, "{value}").unwrap();
+    }
+
+    /// Inline mode sets co-located in the token tree must survive even when a
+    /// separate mode-sets catalog is also passed (extend, not replace). A broken
+    /// inline mode set (default outside modes) must still trip SPEC-005.
+    #[test]
+    fn inline_mode_set_retained_when_catalog_passed() {
+        let data = TempDir::new().unwrap();
+        let catalog = TempDir::new().unwrap();
+
+        write_json(
+            data.path(),
+            "color.json",
+            json!({
+                "blue-100": {
+                    "$schema": "https://example.com/color.json",
+                    "value": "#00f",
+                    "name": {"property": "background-color"}
+                }
+            }),
+        );
+        // Inline mode set with default NOT in modes → SPEC-005 violation.
+        write_json(
+            data.path(),
+            "broken-mode-set.json",
+            json!({ "name": "scale", "modes": ["medium"], "default": "large" }),
+        );
+        // Valid catalog mode set (default in modes) → no SPEC-005 violation.
+        write_json(
+            catalog.path(),
+            "color-scheme.json",
+            json!({ "name": "colorScheme", "modes": ["light", "dark"], "default": "light" }),
+        );
+
+        let report = validate_all_with_options(
+            data.path(),
+            &SchemaRegistry::new_stub(),
+            &HashSet::new(),
+            Some(catalog.path()),
+            None,
+        )
+        .unwrap();
+
+        let spec005: Vec<_> = report
+            .errors
+            .iter()
+            .chain(report.warnings.iter())
+            .filter(|d| d.rule_id.as_deref() == Some("SPEC-005"))
+            .collect();
+        assert_eq!(
+            spec005.len(),
+            1,
+            "inline mode set must be retained and trip SPEC-005"
+        );
+        assert!(
+            spec005[0].message.contains("scale"),
+            "diagnostic should name the inline 'scale' mode set, got: {}",
+            spec005[0].message
+        );
+    }
 }


### PR DESCRIPTION
## Description

Make validation's graph load catalog-aware so inline mode-set docs co-located in
the token tree are preserved (extended) rather than replaced when a mode-sets
catalog is passed. Adds a unified `TokenGraph::from_json_dir_with_names_and_catalogs`
builder (sidecar names + catalog extend) and routes `validate_all_with_options_and_names`
through it; `from_json_dir_with_catalogs` now delegates to the same builder.

## Related Issue

Closes spectrum-design-data-ydg (follow-up from cache schema v2 PR #1073).

## Motivation and Context

`validate_all_with_options_and_names` built the graph with `from_json_dir_with_names`
(which discovers inline mode sets) and then called `with_mode_sets(...)`, which
**replaces** the whole vec — silently dropping inline mode sets whenever a catalog
dir was passed. Query/resolve already use the extend semantics via the cache path,
so validation saw a different graph. Validation can't reuse the cache path because
it depends on sidecar `names_dir` merge, which the v2 cache build path does not
support, so the fix consolidates the load into one builder and switches to extend.

## How Has This Been Tested?

- `cargo test -p design-data-core --features cache` — 429 tests pass, including two new:
  - `graph::tests::names_and_catalogs_extends_inline_mode_sets_and_merges_sidecar`
  - `validate::tests::inline_mode_set_retained_when_catalog_passed` (broken inline
    mode set still trips SPEC-005 when a valid catalog is also passed)
- `cargo clippy -p design-data-core --features cache --all-targets` (no new warnings)
- `cargo build -p design-data-cli -p design-data-tui`
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Made with [Cursor](https://cursor.com)