### PR TITLE
feat(tools): distribute design-data agent surface for Claude Code and Cursor

### DIFF
--- a/.changeset/agent-surface-distribution.md
+++ b/.changeset/agent-surface-distribution.md
@@ -1,0 +1,11 @@
+---
+"@adobe/design-data-agent-mcp": minor
+"@adobe/design-data-skill": minor
+---
+
+Publish design-data agent surface for Claude Code and Cursor distribution.
+
+- **tools/design-data-agent-mcp**: publish to npm with bundled `skills/` and
+  `.claude-plugin/`; register as `design-data-agent` marketplace plugin.
+- **tools/design-data-skill**: add `@adobe/design-data-skill` npm package for
+  versioned Spectrum skill installs.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,11 @@
       "name": "design-data",
       "description": "Spectrum design tokens and component schemas via the design-data CLI.",
       "source": "./tools/design-data-skill"
+    },
+    {
+      "name": "design-data-agent",
+      "description": "Spec-conformant design token lookup, validation, diff, and authoring for any dataset.",
+      "source": "./tools/design-data-agent-mcp"
     }
   ]
 }

--- a/docs/markdown/pages/ai.md
+++ b/docs/markdown/pages/ai.md
@@ -7,9 +7,9 @@ source_url: https://opensource.adobe.com/spectrum-design-data/pages/ai/
 
 # Using with AI
 
-Spectrum Design Data publishes Model Context Protocol (MCP) servers and an Agent Skill so AI assistants can query design tokens, component schemas, and Spectrum 2 documentation directly from tools like Claude Code and Cursor.
+Spectrum Design Data publishes Model Context Protocol (MCP) servers and Agent Skills so AI assistants can query design tokens, component schemas, and Spectrum 2 documentation directly from tools like Claude Code and Cursor.
 
-## Agent Skill (recommended for prototyping)
+## S2 docs skill (recommended for prototyping)
 
 The `s2-docs` Agent Skill fetches S2 component docs on-demand — only when the AI is working on Spectrum components — without loading a persistent MCP server into every session. This keeps context lean during long prototype sessions.
 
@@ -47,11 +47,116 @@ Then invoke the skill in an Agent session via `/s2-docs get <component>` or ask 
 
 Both can run together. The skill is a lightweight companion; the MCP is the full integration.
 
+## Design Data agent surface
+
+Two Agent Skills cover design tokens and component schemas. Both shell out to the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI — only the skill description loads into session context until invoked.
+
+| Need | Skill | MCP fallback |
+|------|-------|--------------|
+| Spectrum tokens, zero setup (embedded snapshot) | `design-data` | `@adobe/design-data-mcp` |
+| Custom dataset on disk, validate/diff/write, spec tool names | `design-data-agent` | `@adobe/design-data-agent-mcp` |
+| Minimal session context cost | Skill (either above) | — |
+| Always-on tool access in agent pipelines | — | MCP (either above) |
+
+### `design-data` — Spectrum tokens (zero config)
+
+Look up token values, query by component/property, suggest tokens from natural language, and read component schemas. Uses the embedded Spectrum snapshot automatically — no dataset paths required.
+
+**Claude Code:**
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install design-data@spectrum-design-data
+```
+
+**Cursor** — Settings → Rules → **Add Rule** → **Remote Rule (GitHub)**:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
+```
+
+### `design-data-agent` — spec-conformant / custom datasets
+
+Validate, query, resolve, diff, and author tokens against a local dataset. Tool names match the [agent surface spec](https://github.com/adobe/spectrum-design-data/blob/main/packages/design-data-spec/spec/agent-surface.md). Requires `DESIGN_DATA_PATH` (and spec catalog paths for components/fields/dimensions).
+
+**Claude Code:**
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install design-data-agent@spectrum-design-data
+```
+
+**Cursor** — Settings → Rules → **Add Rule** → **Remote Rule (GitHub)**:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
+```
+
+### Skill vs MCP — design data
+
+| | Agent Skill | MCP Server |
+|---|---|---|
+| **Context cost** | Description only until invoked | All tool schemas loaded every session |
+| **Best for** | Prototyping, on-demand lookups | Always-available access, agent pipelines |
+| **Setup** | `/plugin install` or Cursor remote rule | Add to `mcp.json`, restart editor |
+
 ## MCP Servers
 
-### @adobe/spectrum-design-data-mcp
+### @adobe/design-data-mcp
+
+Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Zero-config embedded snapshot. Prefer the [`design-data` skill](#design-data--spectrum-tokens-zero-config) for prototyping.
+
+**npm:** `@adobe/design-data-mcp`
+
+**Tools:** `design-data-primer`, `design-data-query`, `design-data-suggest`, `design-data-component`, `design-data-resolve`
+
+**Cursor config:**
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    }
+  }
+}
+```
+
+### @adobe/design-data-agent-mcp
+
+Spec-conformant agent surface for any local dataset. Tool names match the agent surface spec (`primer`, `resolve_token`, `query_tokens`, `validate_usage`, etc.). Prefer the [`design-data-agent` skill](#design-data-agent--spec-conformant--custom-datasets) for prototyping.
+
+**npm:** `@adobe/design-data-agent-mcp`
+
+**Tools:** `primer`, `resolve_token`, `query_tokens`, `describe_component`, `validate_usage`, `diff_datasets`, `write`, plus authoring-session tools
+
+**Cursor config:**
+
+```json
+{
+  "mcpServers": {
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_PATH": "./packages/tokens/src",
+        "DESIGN_DATA_COMPONENTS": "./packages/design-data-spec/components",
+        "DESIGN_DATA_FIELDS": "./packages/design-data-spec/fields",
+        "DESIGN_DATA_DIMENSIONS": "./packages/design-data-spec/dimensions"
+      }
+    }
+  }
+}
+```
+
+Adjust paths to match your dataset layout.
+
+### @adobe/spectrum-design-data-mcp (legacy)
 
 Design tokens and component API schemas. Enables AI to look up token values, find tokens by use case, validate component props, and get schema definitions.
+
+**Prefer [`@adobe/design-data-mcp`](#adobedesign-data-mcp)** for new projects — it wraps the current `@adobe/design-data` CLI with an embedded Spectrum snapshot.
 
 **npm:** `@adobe/spectrum-design-data-mcp`
 
@@ -74,7 +179,7 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 
 ### @adobe/s2-docs-mcp
 
-Spectrum 2 component documentation and design guidelines. For prototyping, consider the [Agent Skill](#agent-skill-recommended-for-prototyping) above instead — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
+Spectrum 2 component documentation and design guidelines. For prototyping, consider the [S2 docs skill](#s2-docs-skill-recommended-for-prototyping) above instead — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
 
 **npm:** `@adobe/s2-docs-mcp`
 
@@ -97,7 +202,42 @@ If you run from source, point `args` to `tools/s2-docs-mcp/src/cli.js` inside yo
 
 ## Cursor IDE setup
 
-Add both servers to `.cursor/mcp.json` so the AI can use tokens, schemas, and S2 docs in the same session:
+Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remote rules) are lighter for prototyping — see sections above.
+
+**Spectrum prototyping (tokens + S2 docs):**
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    },
+    "s2-docs": {
+      "command": "npx",
+      "args": ["-y", "@adobe/s2-docs-mcp"]
+    }
+  }
+}
+```
+
+**Spec / custom dataset work:**
+
+```json
+{
+  "mcpServers": {
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_PATH": "./packages/tokens/src"
+      }
+    }
+  }
+}
+```
+
+**Legacy (spectrum-design-data-mcp):**
 
 ```json
 {

--- a/docs/site/src/pages/ai.md
+++ b/docs/site/src/pages/ai.md
@@ -6,9 +6,9 @@ permalink: /ai/
 
 # Using with AI
 
-Spectrum Design Data publishes Model Context Protocol (MCP) servers and an Agent Skill so AI assistants can query design tokens, component schemas, and Spectrum 2 documentation directly from tools like Claude Code and Cursor.
+Spectrum Design Data publishes Model Context Protocol (MCP) servers and Agent Skills so AI assistants can query design tokens, component schemas, and Spectrum 2 documentation directly from tools like Claude Code and Cursor.
 
-## Agent Skill (recommended for prototyping)
+## S2 docs skill (recommended for prototyping)
 
 The `s2-docs` Agent Skill fetches S2 component docs on-demand — only when the AI is working on Spectrum components — without loading a persistent MCP server into every session. This keeps context lean during long prototype sessions.
 
@@ -46,11 +46,116 @@ Then invoke the skill in an Agent session via `/s2-docs get <component>` or ask 
 
 Both can run together. The skill is a lightweight companion; the MCP is the full integration.
 
+## Design Data agent surface
+
+Two Agent Skills cover design tokens and component schemas. Both shell out to the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI — only the skill description loads into session context until invoked.
+
+| Need | Skill | MCP fallback |
+|------|-------|--------------|
+| Spectrum tokens, zero setup (embedded snapshot) | `design-data` | `@adobe/design-data-mcp` |
+| Custom dataset on disk, validate/diff/write, spec tool names | `design-data-agent` | `@adobe/design-data-agent-mcp` |
+| Minimal session context cost | Skill (either above) | — |
+| Always-on tool access in agent pipelines | — | MCP (either above) |
+
+### `design-data` — Spectrum tokens (zero config)
+
+Look up token values, query by component/property, suggest tokens from natural language, and read component schemas. Uses the embedded Spectrum snapshot automatically — no dataset paths required.
+
+**Claude Code:**
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install design-data@spectrum-design-data
+```
+
+**Cursor** — Settings → Rules → **Add Rule** → **Remote Rule (GitHub)**:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
+```
+
+### `design-data-agent` — spec-conformant / custom datasets
+
+Validate, query, resolve, diff, and author tokens against a local dataset. Tool names match the [agent surface spec](https://github.com/adobe/spectrum-design-data/blob/main/packages/design-data-spec/spec/agent-surface.md). Requires `DESIGN_DATA_PATH` (and spec catalog paths for components/fields/dimensions).
+
+**Claude Code:**
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install design-data-agent@spectrum-design-data
+```
+
+**Cursor** — Settings → Rules → **Add Rule** → **Remote Rule (GitHub)**:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
+```
+
+### Skill vs MCP — design data
+
+| | Agent Skill | MCP Server |
+|---|---|---|
+| **Context cost** | Description only until invoked | All tool schemas loaded every session |
+| **Best for** | Prototyping, on-demand lookups | Always-available access, agent pipelines |
+| **Setup** | `/plugin install` or Cursor remote rule | Add to `mcp.json`, restart editor |
+
 ## MCP Servers
 
-### @adobe/spectrum-design-data-mcp
+### @adobe/design-data-mcp
+
+Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Zero-config embedded snapshot. Prefer the [`design-data` skill](#design-data--spectrum-tokens-zero-config) for prototyping.
+
+**npm:** `@adobe/design-data-mcp`
+
+**Tools:** `design-data-primer`, `design-data-query`, `design-data-suggest`, `design-data-component`, `design-data-resolve`
+
+**Cursor config:**
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    }
+  }
+}
+```
+
+### @adobe/design-data-agent-mcp
+
+Spec-conformant agent surface for any local dataset. Tool names match the agent surface spec (`primer`, `resolve_token`, `query_tokens`, `validate_usage`, etc.). Prefer the [`design-data-agent` skill](#design-data-agent--spec-conformant--custom-datasets) for prototyping.
+
+**npm:** `@adobe/design-data-agent-mcp`
+
+**Tools:** `primer`, `resolve_token`, `query_tokens`, `describe_component`, `validate_usage`, `diff_datasets`, `write`, plus authoring-session tools
+
+**Cursor config:**
+
+```json
+{
+  "mcpServers": {
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_PATH": "./packages/tokens/src",
+        "DESIGN_DATA_COMPONENTS": "./packages/design-data-spec/components",
+        "DESIGN_DATA_FIELDS": "./packages/design-data-spec/fields",
+        "DESIGN_DATA_DIMENSIONS": "./packages/design-data-spec/dimensions"
+      }
+    }
+  }
+}
+```
+
+Adjust paths to match your dataset layout.
+
+### @adobe/spectrum-design-data-mcp (legacy)
 
 Design tokens and component API schemas. Enables AI to look up token values, find tokens by use case, validate component props, and get schema definitions.
+
+**Prefer [`@adobe/design-data-mcp`](#adobedesign-data-mcp)** for new projects — it wraps the current `@adobe/design-data` CLI with an embedded Spectrum snapshot.
 
 **npm:** `@adobe/spectrum-design-data-mcp`
 
@@ -73,7 +178,7 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 
 ### @adobe/s2-docs-mcp
 
-Spectrum 2 component documentation and design guidelines. For prototyping, consider the [Agent Skill](#agent-skill-recommended-for-prototyping) above instead — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
+Spectrum 2 component documentation and design guidelines. For prototyping, consider the [S2 docs skill](#s2-docs-skill-recommended-for-prototyping) above instead — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
 
 **npm:** `@adobe/s2-docs-mcp`
 
@@ -96,7 +201,42 @@ If you run from source, point `args` to `tools/s2-docs-mcp/src/cli.js` inside yo
 
 ## Cursor IDE setup
 
-Add both servers to `.cursor/mcp.json` so the AI can use tokens, schemas, and S2 docs in the same session:
+Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remote rules) are lighter for prototyping — see sections above.
+
+**Spectrum prototyping (tokens + S2 docs):**
+
+```json
+{
+  "mcpServers": {
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-mcp"]
+    },
+    "s2-docs": {
+      "command": "npx",
+      "args": ["-y", "@adobe/s2-docs-mcp"]
+    }
+  }
+}
+```
+
+**Spec / custom dataset work:**
+
+```json
+{
+  "mcpServers": {
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_PATH": "./packages/tokens/src"
+      }
+    }
+  }
+}
+```
+
+**Legacy (spectrum-design-data-mcp):**
 
 ```json
 {

--- a/packages/design-data-spec/spec/agent-surface.md
+++ b/packages/design-data-spec/spec/agent-surface.md
@@ -84,6 +84,8 @@ A reference MCP server is RECOMMENDED to ship as `@adobe/design-data-agent-mcp` 
 
 A reference Claude Code Agent Skill is RECOMMENDED at `tools/design-data-agent-mcp/skills/design-data/SKILL.md`. The skill SHOULD trigger on intent words covering all three [Goals](#goals) — for example "design system", "design tokens", "drift", "spec-conformant", and explicit Spectrum mentions when the active manifest binds Spectrum.
 
+A separate Spectrum-oriented skill (embedded snapshot, zero config) lives at `tools/design-data-skill/skills/design-data/SKILL.md`. Install both via the `spectrum-design-data` Claude Code marketplace as `design-data-agent@spectrum-design-data` and `design-data@spectrum-design-data` respectively.
+
 **RECOMMENDED:** The skill SHOULD shell out to the CLI rather than embedding tool calls, so its description (the only persistent context cost) stays small and the heavy lifting happens out-of-band.
 
 ## `describe_component` return shape

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,8 @@ importers:
         specifier: ^6.0.1
         version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
+  tools/design-data-skill: {}
+
   tools/diff-generator:
     dependencies:
       "@adobe/optimized-diff":

--- a/tools/design-data-agent-mcp/.claude-plugin/plugin.json
+++ b/tools/design-data-agent-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "design-data-agent",
   "description": "Spec-conformant design token lookup, validation, diff, and authoring for any dataset via the design-data CLI.",
-  "version": "1.2.0",
   "author": {
     "name": "Adobe"
   },

--- a/tools/design-data-agent-mcp/.claude-plugin/plugin.json
+++ b/tools/design-data-agent-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "design-data-agent",
+  "description": "Spec-conformant design token lookup, validation, diff, and authoring for any dataset via the design-data CLI.",
+  "version": "1.2.0",
+  "author": {
+    "name": "Adobe"
+  },
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp",
+  "repository": "https://github.com/adobe/spectrum-design-data",
+  "license": "Apache-2.0"
+}

--- a/tools/design-data-agent-mcp/LICENSE
+++ b/tools/design-data-agent-mcp/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -2,25 +2,44 @@
 
 MCP server and Claude Code skill for the [Spectrum Design Data](../../packages/design-data-spec/) agent surface. Shells out to the `design-data` CLI — all logic stays in the Rust SDK.
 
-## Claude Code skill
+## Install
 
-Install by symlinking the `skill/` directory into your Claude Code skills folder:
+### Claude Code (skill + optional MCP)
 
-```bash
-ln -s "$(pwd)/tools/design-data-agent-mcp/skill" ~/.claude/skills/design-data
+Add the Spectrum Design Data marketplace, then install the spec-generic skill:
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install design-data-agent@spectrum-design-data
 ```
 
-Then add the skill to your `~/.claude/CLAUDE.md`:
+For Spectrum tokens with zero setup (embedded snapshot), install `design-data@spectrum-design-data` instead — see [`tools/design-data-skill/`](../design-data-skill/).
 
-```markdown
-### design-data
-- **design-data** (`~/.claude/skills/design-data/SKILL.md`) — design token lookup, validation, and authoring via the design-data CLI. Trigger: `/design-data`
-When the user types `/design-data`, invoke the Skill tool with `skill: "design-data"` before doing anything else.
+### Cursor (skill)
+
+Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste:
+
 ```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
+```
+
+### npm (MCP server)
+
+```sh
+npx @adobe/design-data-agent-mcp
+```
+
+Requires the `@adobe/design-data` CLI on `PATH` (or set `DESIGN_DATA_BIN`).
 
 ## MCP server
 
 Configure your MCP client to run:
+
+```sh
+npx -y @adobe/design-data-agent-mcp
+```
+
+Or from a repo clone:
 
 ```bash
 node tools/design-data-agent-mcp/src/index.js
@@ -38,16 +57,35 @@ node tools/design-data-agent-mcp/src/index.js
 | `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)     |
 | `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`) |
 
+### Example (Cursor `.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_PATH": "./packages/tokens/src",
+        "DESIGN_DATA_COMPONENTS": "./packages/design-data-spec/components",
+        "DESIGN_DATA_FIELDS": "./packages/design-data-spec/fields",
+        "DESIGN_DATA_DIMENSIONS": "./packages/design-data-spec/dimensions"
+      }
+    }
+  }
+}
+```
+
 ### Example (Claude Desktop `claude_desktop_config.json`)
 
 ```json
 {
   "mcpServers": {
-    "design-data": {
-      "command": "node",
-      "args": ["/path/to/spectrum-design-data/tools/design-data-agent-mcp/src/index.js"],
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
       "env": {
-        "DESIGN_DATA_BIN": "/path/to/design-data",
+        "DESIGN_DATA_BIN": "design-data",
         "DESIGN_DATA_PATH": "/path/to/your/dataset"
       }
     }
@@ -66,3 +104,11 @@ node tools/design-data-agent-mcp/src/index.js
 | `validate_usage`     | Validate token usage and return a diagnostic report             |
 | `diff_datasets`      | Compare two datasets and return a semantic diff                 |
 | `write`              | Write agent-generated product context to the dataset            |
+
+## Skill
+
+The Claude Code skill lives at [`skills/design-data/SKILL.md`](skills/design-data/SKILL.md). It shells out to `npx @adobe/design-data` for validate, query, resolve, diff, and write operations against local datasets.
+
+## License
+
+Apache-2.0

--- a/tools/design-data-agent-mcp/package.json
+++ b/tools/design-data-agent-mcp/package.json
@@ -1,16 +1,36 @@
 {
   "name": "@adobe/design-data-agent-mcp",
   "version": "1.2.0",
-  "description": "MCP server for design-data — shells out to the design-data CLI",
+  "description": "MCP server and Claude Code skill for the design-data agent surface — shells out to the design-data CLI",
   "type": "module",
-  "private": true,
   "main": "./src/index.js",
   "bin": {
     "design-data-agent-mcp": "./src/index.js"
   },
+  "files": [
+    "src/",
+    ".claude-plugin/",
+    "skills/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "start": "node src/index.js",
     "test": "ava"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-design-data.git",
+    "directory": "tools/design-data-agent-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
+  },
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1"
@@ -19,8 +39,16 @@
     "ava": "^6.0.1"
   },
   "engines": {
-    "node": ">=20.12.0",
-    "pnpm": ">=10.17.1"
+    "node": ">=20.12.0"
   },
+  "keywords": [
+    "mcp",
+    "design-system",
+    "design-tokens",
+    "design-data",
+    "agent-surface",
+    "cli"
+  ],
+  "author": "Adobe",
   "license": "Apache-2.0"
 }

--- a/tools/design-data-agent-mcp/skills/design-data/SKILL.md
+++ b/tools/design-data-agent-mcp/skills/design-data/SKILL.md
@@ -1,12 +1,17 @@
 ---
-name: design-data
+name: design-data-agent
 description: >
-  Validate, query, resolve, and author spec-conformant design tokens and components using the
-  design-data CLI. Use when the user asks about design tokens, a design system, Spectrum, token
-  lookup, spec-conformance, drift detection, or token authoring.
+  Validate, query, resolve, diff, and author spec-conformant design tokens and components using the
+  design-data CLI against a local dataset. Use when the user asks about design tokens, a design
+  system, token lookup, spec-conformance, drift detection, or token authoring on custom data.
+when_to_use: >
+  Trigger on: design system, design tokens, spec-conformant, drift, validate tokens, token
+  authoring, custom dataset, DESIGN_DATA_PATH, design-data validate, design-data diff,
+  design-data write, product-context.json.
+allowed-tools: Bash(npx @adobe/design-data *)
 ---
 
-# design-data CLI skill
+# design-data agent skill
 
 `design-data` is the reference CLI for the Spectrum Design Data specification. It validates, queries, resolves, and authors spec-conformant tokens and components from any dataset on the local filesystem.
 
@@ -17,6 +22,16 @@ export DESIGN_DATA_PATH=./packages/tokens/src
 export DESIGN_DATA_SPEC_PATH=./packages/design-data-spec
 ```
 
+For Spectrum tokens with zero setup (embedded snapshot), use the `design-data` skill instead — this skill targets custom or repo-local datasets.
+
+## Bootstrap
+
+On first use, ensure the CLI is available:
+
+```
+npx @adobe/design-data --version
+```
+
 ***
 
 ## Session start — call `primer` first
@@ -24,7 +39,7 @@ export DESIGN_DATA_SPEC_PATH=./packages/design-data-spec
 Call `primer` at the start of every session that touches design data. It returns the active dimensions, component list, taxonomy fields, and token count — structural context that scopes all subsequent lookups.
 
 ```bash
-design-data primer "$DESIGN_DATA_PATH" --format json \
+npx @adobe/design-data primer "$DESIGN_DATA_PATH" --format json \
   --components-dir "$DESIGN_DATA_SPEC_PATH/components" \
   --fields-dir     "$DESIGN_DATA_SPEC_PATH/fields" \
   --dimensions-dir "$DESIGN_DATA_SPEC_PATH/dimensions"
@@ -41,7 +56,7 @@ The payload includes `specVersion`, `manifest`, `dimensions`, `components`, `tax
 ### Resolve a token to its literal value
 
 ```bash
-design-data resolve <property> "$DESIGN_DATA_PATH" --format json \
+npx @adobe/design-data resolve <property> "$DESIGN_DATA_PATH" --format json \
   [--color-scheme light|dark] \
   [--scale desktop|mobile] \
   [--contrast regular|high]
@@ -50,14 +65,14 @@ design-data resolve <property> "$DESIGN_DATA_PATH" --format json \
 Example:
 
 ```bash
-design-data resolve accent-background-color-default "$DESIGN_DATA_PATH" \
+npx @adobe/design-data resolve accent-background-color-default "$DESIGN_DATA_PATH" \
   --format json --color-scheme dark --scale desktop
 ```
 
 ### Query tokens by filter expression
 
 ```bash
-design-data query "$DESIGN_DATA_PATH" --filter "<expr>" --format json
+npx @adobe/design-data query "$DESIGN_DATA_PATH" --filter "<expr>" --format json
 ```
 
 Valid filter keys: `property`, `component`, `variant`, `state`, `colorScheme`, `scale`, `contrast`, `uuid`, `$schema`. Any other key is a parse error. The dimension keys (`colorScheme`, `scale`, `contrast`) accept the same enum values as the `resolve` flags (`light`/`dark`, `desktop`/`mobile`, `regular`/`high`).
@@ -80,7 +95,7 @@ $schema=https://spectrum.adobe.com/page/design-token/
 ## Component info
 
 ```bash
-design-data component <id> --components-dir "$DESIGN_DATA_SPEC_PATH/components"
+npx @adobe/design-data component <id> --components-dir "$DESIGN_DATA_SPEC_PATH/components"
 ```
 
 Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`. Output is always JSON; there is no `--format` flag on this subcommand.
@@ -90,7 +105,7 @@ Pass `--components-dir` explicitly for the same reason as `primer` — the defau
 Example:
 
 ```bash
-design-data component button --components-dir "$DESIGN_DATA_SPEC_PATH/components"
+npx @adobe/design-data component button --components-dir "$DESIGN_DATA_SPEC_PATH/components"
 ```
 
 ***
@@ -98,7 +113,7 @@ design-data component button --components-dir "$DESIGN_DATA_SPEC_PATH/components
 ## Validation
 
 ```bash
-design-data validate "$DESIGN_DATA_PATH" --format json \
+npx @adobe/design-data validate "$DESIGN_DATA_PATH" --format json \
   [--schema-path <path>] \
   [--exceptions-path <path>] \
   [--strict]
@@ -111,7 +126,7 @@ Returns a `ValidationReport` object: `{ layer: 1|2, errors: [...], warnings: [..
 ## Dataset diff
 
 ```bash
-design-data diff <old-path> <new-path> --format json [--filter <expr>]
+npx @adobe/design-data diff <old-path> <new-path> --format json [--filter <expr>]
 ```
 
 > **Exit codes:** `0` = no changes; `1` = differences found (returns JSON diff — not an error); `>1` = error.
@@ -123,7 +138,7 @@ design-data diff <old-path> <new-path> --format json [--filter <expr>]
 Write or update the product context document in the dataset:
 
 ```bash
-design-data write \
+npx @adobe/design-data write \
   --output "$DESIGN_DATA_PATH/product-context.json" \
   --rationale "Why these overrides exist"
 ```
@@ -141,3 +156,32 @@ Generates a product-context scaffold at the output path (`specVersion`, `layer: 
 * **`query` exit 1** means no matches and still emits `[]`. Only `>1` is an error.
 * **`diff` exit 1** means changes were found. The JSON diff is in stdout — still a success result.
 * **`--format json`** — always pass this in agent and script contexts; the CLI pretty-prints when stdout is a TTY.
+
+## When working in Cursor
+
+Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste this URL:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
+```
+
+For always-available tool access (higher context cost), add `@adobe/design-data-agent-mcp` to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "design-data-agent": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_PATH": "./packages/tokens/src",
+        "DESIGN_DATA_COMPONENTS": "./packages/design-data-spec/components",
+        "DESIGN_DATA_FIELDS": "./packages/design-data-spec/fields",
+        "DESIGN_DATA_DIMENSIONS": "./packages/design-data-spec/dimensions"
+      }
+    }
+  }
+}
+```
+
+Adjust paths to match your dataset layout.

--- a/tools/design-data-skill/.claude-plugin/plugin.json
+++ b/tools/design-data-skill/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "design-data",
   "description": "Spectrum design tokens, component schemas, and design-system insights for Claude Code.",
-  "version": "1.0.0",
   "author": { "name": "Adobe" },
   "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill",
   "repository": "https://github.com/adobe/spectrum-design-data",

--- a/tools/design-data-skill/LICENSE
+++ b/tools/design-data-skill/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/tools/design-data-skill/README.md
+++ b/tools/design-data-skill/README.md
@@ -3,36 +3,47 @@
 A Claude Code plugin that gives agents access to Spectrum design tokens,
 component schemas, and design-system data via the `@adobe/design-data` CLI.
 
+Also published on npm as `@adobe/design-data-skill` for versioned skill installs.
+
 ## Structure
 
 ```
 tools/design-data-skill/
   .claude-plugin/plugin.json    Plugin manifest (name, description, version)
+  package.json                  npm package (@adobe/design-data-skill)
   skills/design-data/SKILL.md   Skill definition (frontmatter + workflow docs)
   README.md                     This file
 ```
 
-**No `package.json`** — this is a pure-skills plugin with no build step or
-Node.js dependencies. It wraps an external CLI (`@adobe/design-data`) that
-users install separately via npm. This is intentional and consistent with
-the plugin format: the `.claude-plugin/plugin.json` manifest is the only
-metadata file needed. Compare with `tools/s2-docs-mcp/` which bundles its
-own Node.js server and therefore needs a full package.
+This is a pure-skills plugin with no build step or Node.js runtime dependencies.
+It wraps the external `@adobe/design-data` CLI that `npx` installs on first use.
 
 ## Installation
 
-In Claude Code, install from the marketplace:
+### Claude Code
+
+Add the marketplace, then install the Spectrum skill:
 
 ```
-claude plugin install spectrum-design-data
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install design-data@spectrum-design-data
 ```
 
-Or point directly at this repository.
+For custom or repo-local datasets (validate, diff, write), install
+`design-data-agent@spectrum-design-data` instead — see
+[`tools/design-data-agent-mcp/`](../design-data-agent-mcp/).
+
+### Cursor
+
+Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
+```
+
+For always-available MCP tool access, see [`@adobe/design-data-mcp`](../design-data-mcp/).
 
 ## Usage
 
 See [`skills/design-data/SKILL.md`](skills/design-data/SKILL.md) for the
 full command reference and workflow.
-
-For Cursor users (native agent, not Claude Code), use the
-[`@adobe/design-data-mcp`](../design-data-mcp/) MCP server instead.

--- a/tools/design-data-skill/package.json
+++ b/tools/design-data-skill/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@adobe/design-data-skill",
+  "version": "1.0.0",
+  "description": "Claude Code skill for Spectrum design tokens and component schemas via the design-data CLI",
+  "type": "module",
+  "files": [
+    "skills/",
+    ".claude-plugin/",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-design-data.git",
+    "directory": "tools/design-data-skill"
+  },
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
+  },
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "keywords": [
+    "claude-code",
+    "skill",
+    "spectrum",
+    "design-system",
+    "design-tokens",
+    "design-data"
+  ],
+  "author": "Adobe",
+  "license": "Apache-2.0"
+}

--- a/tools/design-data-skill/package.json
+++ b/tools/design-data-skill/package.json
@@ -6,7 +6,8 @@
   "files": [
     "skills/",
     ".claude-plugin/",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "repository": {
     "type": "git",

--- a/tools/design-data-skill/skills/design-data/SKILL.md
+++ b/tools/design-data-skill/skills/design-data/SKILL.md
@@ -110,9 +110,16 @@ Example: `npx @adobe/design-data resolve background-color-default --format json 
 
 ## When working in Cursor
 
-Cursor's native agent does not support Claude Code Skills. For Cursor users,
-recommend the `@adobe/design-data-mcp` MCP server instead — add to
-`.cursor/mcp-servers.json` in the project root:
+Install this skill as a **Remote Rule (GitHub)** — same pattern as the s2-docs skill:
+
+Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
+```
+
+For always-available tool access (higher context cost), add `@adobe/design-data-mcp` to
+`.cursor/mcp.json` in your project root:
 
 ```json
 {
@@ -124,6 +131,10 @@ recommend the `@adobe/design-data-mcp` MCP server instead — add to
   }
 }
 ```
+
+For custom datasets with validate/diff/write, use the `design-data-agent` skill or
+`@adobe/design-data-agent-mcp` instead — see
+[`tools/design-data-agent-mcp/skills/design-data/SKILL.md`](../../design-data-agent-mcp/skills/design-data/SKILL.md).
 
 ## Using a custom dataset
 


### PR DESCRIPTION
## Description

Makes the design-data agent surface easy to install on Claude Code and Cursor, as recommended in [`packages/design-data-spec/spec/agent-surface.md`](packages/design-data-spec/spec/agent-surface.md). Ships two published paths:

- **Spectrum users** (zero config, embedded snapshot): `design-data` skill + `@adobe/design-data-mcp`
- **Spec / custom datasets** (validate, diff, write): `design-data-agent` skill + `@adobe/design-data-agent-mcp`

Changes:

- **`@adobe/design-data-agent-mcp`**: removed `"private": true`, added `publishConfig`/`repository`/`homepage`/`keywords`, and bundled `skills/` + `.claude-plugin/` + `LICENSE` in `files`. Relocated the skill to the spec-recommended path `skills/design-data/SKILL.md` and added a `.claude-plugin/plugin.json` manifest.
- **`.claude-plugin/marketplace.json`**: registered the new `design-data-agent` plugin alongside `design-data` and `s2-docs`.
- **`@adobe/design-data-skill`**: added a minimal `package.json` so the Spectrum skill is npm-installable (skills + manifest only, no runtime deps).
- **Docs (`docs/site/src/pages/ai.md`, regenerated `docs/markdown/pages/ai.md`)**: new "Design Data agent surface" section with Claude Code and Cursor (Remote Rule + MCP) install instructions and skill-vs-MCP guidance; fixed the incorrect "Cursor can't use skills" note.
- **`packages/design-data-spec/spec/agent-surface.md`**: noted the dual skill paths (spec-generic vs Spectrum-oriented).
- Added a changeset (minor bumps for both packages).

## Related Issue

Relates to the agent-readable surface epic [#830](https://github.com/adobe/spectrum-design-data/issues/830) (RFC-C / Phase 8 distribution).

## Motivation and Context

Phase 8 shipped the CLI, MCP server, and skill, but distribution was fragmented: the agent MCP was `private` (repo-only), the skill required a manual symlink, and the AI docs didn't cover the design-data stack or a Cursor path. This PR closes those gaps so users can install via one marketplace command or one Cursor remote rule, mirroring the working `s2-docs` pattern.

## How Has This Been Tested?

- `pnpm test` in `tools/design-data-agent-mcp` (9 tests passing)
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` (clean)
- `moon run markdown-generator:generate` to regenerate `docs/markdown/pages/ai.md` from source (unrelated upstream drift reverted to keep this PR focused)
- `pnpm install` to refresh the lockfile for the new package

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
