### PR TITLE
fix(tui): make / fuzzy-find palette filter token names live

### DIFF
--- a/.changeset/tui-fuzzy-find-palette.md
+++ b/.changeset/tui-fuzzy-find-palette.md
@@ -1,0 +1,15 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Make the TUI `/` fuzzy-find palette filter token names live instead of being a
+no-op (closes #1079).
+
+- **sdk/tui/src/fuzzy.rs**: new fzf-style `subsequence_score` + `rank_token_rows`
+  (case-insensitive, consecutive-run and word-boundary bonuses).
+- **sdk/tui/src/update.rs**: `/` seeds an all-tokens results table and stashes the
+  prior view; each keystroke re-ranks live; Enter commits, Esc restores.
+- **sdk/tui/src/mode.rs**: `PaletteState` gains `saved_view` for Esc restore.
+- **sdk/tui/src/runtime.rs**: only Command-mode Enter dispatches `PaletteSubmit`,
+  so fuzzy input never hits the command router.
+- **sdk/tui/src/update_command.rs**: drop the now-unreachable fuzzy early-return.

--- a/sdk/tui/src/app_views.rs
+++ b/sdk/tui/src/app_views.rs
@@ -124,10 +124,23 @@ pub struct QueryView {
     pub expr_text: String,
     pub rows: Vec<QueryRow>,
     pub table_state: TableState,
+    /// `true` when this view came from the `/` fuzzy-find palette rather than a
+    /// `:query` expression. Controls only the rendered title label (`Fuzzy:` vs
+    /// `Query:`); `expr_text` holds the raw search string either way.
+    pub is_fuzzy: bool,
 }
 
 impl QueryView {
     pub fn new(expr_text: String, rows: Vec<QueryRow>) -> Self {
+        Self::build(expr_text, rows, false)
+    }
+
+    /// Build a view for fuzzy-find results (titled `Fuzzy:` instead of `Query:`).
+    pub fn fuzzy(query: String, rows: Vec<QueryRow>) -> Self {
+        Self::build(query, rows, true)
+    }
+
+    fn build(expr_text: String, rows: Vec<QueryRow>, is_fuzzy: bool) -> Self {
         let mut table_state = TableState::default();
         if !rows.is_empty() {
             table_state.select(Some(0));
@@ -136,6 +149,7 @@ impl QueryView {
             expr_text,
             rows,
             table_state,
+            is_fuzzy,
         }
     }
 

--- a/sdk/tui/src/fuzzy.rs
+++ b/sdk/tui/src/fuzzy.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! fzf-style subsequence matching for the `/` fuzzy-find palette (GH #1079).
+//!
+//! [`subsequence_score`] scores a needle against a haystack, returning `None`
+//! when the needle is not a subsequence of the haystack. [`rank_token_rows`]
+//! applies that scorer across every token's display name and returns the
+//! matching [`QueryRow`]s ranked best-first, ready to drop into a `QueryView`.
+
+use design_data_core::diff::display_name;
+use design_data_core::graph::TokenGraph;
+
+use crate::app_views::QueryRow;
+
+/// Characters that mark a word boundary in a token name. A match immediately
+/// after one of these (or at the start of the string) earns a boundary bonus.
+const BOUNDARY_CHARS: &[char] = &['-', '_', '.', '[', ']', ' ', ',', '='];
+
+/// Score `needle` as a subsequence of `haystack` (both matched case-insensitively).
+///
+/// Returns `None` when `needle` is not a subsequence of `haystack`. An empty
+/// needle matches everything with a score of `0`. Higher scores indicate
+/// tighter matches: each matched character scores `1`, with a `+3` bonus for
+/// runs of consecutive matches and a `+5` bonus for matches landing on a word
+/// boundary (so `btnbg` ranks `button-background` above incidental hits).
+pub fn subsequence_score(haystack: &str, needle: &str) -> Option<i32> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    let hay: Vec<char> = haystack.chars().flat_map(char::to_lowercase).collect();
+    let pat: Vec<char> = needle.chars().flat_map(char::to_lowercase).collect();
+
+    let mut score: i32 = 0;
+    let mut hi: usize = 0;
+    let mut last_match: Option<usize> = None;
+
+    for &pc in &pat {
+        let mut found = false;
+        while hi < hay.len() {
+            let idx = hi;
+            let hc = hay[idx];
+            hi += 1;
+            if hc == pc {
+                score += 1;
+                let at_boundary = idx == 0 || BOUNDARY_CHARS.contains(&hay[idx - 1]);
+                if at_boundary {
+                    score += 5;
+                }
+                if idx > 0 && last_match == Some(idx - 1) {
+                    score += 3;
+                }
+                last_match = Some(idx);
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return None;
+        }
+    }
+
+    Some(score)
+}
+
+/// Rank every token in `graph` against `query`, returning matching rows best-first.
+///
+/// An empty (or whitespace-only) query returns all tokens sorted by name. A
+/// non-empty query keeps only tokens whose display name contains `query` as a
+/// subsequence, sorted by descending score and then name for stable ordering.
+pub fn rank_token_rows(graph: &TokenGraph, query: &str) -> Vec<QueryRow> {
+    let q = query.trim();
+    if q.is_empty() {
+        let mut rows: Vec<QueryRow> = graph.tokens.values().map(QueryRow::from_record).collect();
+        rows.sort_by(|a, b| a.name.cmp(&b.name));
+        return rows;
+    }
+
+    let mut scored: Vec<(i32, QueryRow)> = graph
+        .tokens
+        .values()
+        .filter_map(|t| {
+            let name = display_name(t);
+            subsequence_score(&name, q).map(|s| (s, QueryRow::from_record(t)))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.name.cmp(&b.1.name)));
+    scored.into_iter().map(|(_, row)| row).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_needle_matches_with_zero_score() {
+        assert_eq!(subsequence_score("button-background", ""), Some(0));
+    }
+
+    #[test]
+    fn subsequence_matches_across_word_boundaries() {
+        // b-t-n from "button", b-g from "background".
+        assert!(subsequence_score("button-background", "btnbg").is_some());
+    }
+
+    #[test]
+    fn non_subsequence_returns_none() {
+        assert_eq!(subsequence_score("button-background", "xyz"), None);
+        // Right characters, wrong order.
+        assert_eq!(subsequence_score("abc", "cba"), None);
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        assert!(subsequence_score("Button-Background", "btn").is_some());
+        assert!(subsequence_score("button-background", "BTN").is_some());
+    }
+
+    #[test]
+    fn consecutive_run_outscores_scattered_match() {
+        // Same characters, no boundary differences (no separators): a consecutive
+        // run ("xbackx") must outscore the scattered spelling ("xbxaxcxkx").
+        let tight = subsequence_score("xbackx", "back").unwrap();
+        let loose = subsequence_score("xbxaxcxkx", "back").unwrap();
+        assert!(tight > loose, "tight {tight} should beat loose {loose}");
+    }
+
+    #[test]
+    fn boundary_match_outscores_mid_word_match() {
+        let boundary = subsequence_score("color-accent", "a").unwrap();
+        let mid_word = subsequence_score("character", "a").unwrap();
+        assert!(
+            boundary > mid_word,
+            "boundary {boundary} should beat mid-word {mid_word}"
+        );
+    }
+}

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod app_palette;
 pub mod app_views;
 pub(crate) mod clipboard;
 pub mod find;
+pub(crate) mod fuzzy;
 pub mod help;
 pub mod message;
 pub mod mode;

--- a/sdk/tui/src/mode.rs
+++ b/sdk/tui/src/mode.rs
@@ -17,7 +17,7 @@
 
 use tui_input::Input;
 
-use crate::app::{Modal, PaletteMode};
+use crate::app::{ActiveView, Modal, PaletteMode};
 
 // ── Top-level mode ────────────────────────────────────────────────────────────
 
@@ -62,12 +62,18 @@ pub struct ModalState {
 // ── Palette state ─────────────────────────────────────────────────────────────
 
 /// State carried while the command palette is open.
-#[derive(Debug)]
+///
+/// `saved_view` holds the `ActiveView` that was on screen when a fuzzy-find
+/// palette opened, so cancelling with `Esc` can restore it. It stays `None`
+/// for command mode and is cleared on commit (`Enter`). `ActiveView` carries
+/// ratatui `TableState`s that are not `Debug`, so this struct cannot derive it.
 pub struct PaletteState {
     pub mode: PaletteMode,
     pub input: Input,
     /// Index into `Model::palette_history`; `None` = fresh input.
     pub history_cursor: Option<usize>,
+    /// View to restore if a fuzzy-find session is cancelled; `None` otherwise.
+    pub saved_view: Option<ActiveView>,
 }
 
 impl PaletteState {
@@ -77,6 +83,7 @@ impl PaletteState {
             mode: PaletteMode::Command,
             input: Input::default(),
             history_cursor: None,
+            saved_view: None,
         }
     }
 
@@ -86,6 +93,7 @@ impl PaletteState {
             mode: PaletteMode::FuzzyFind,
             input: Input::default(),
             history_cursor: None,
+            saved_view: None,
         }
     }
 

--- a/sdk/tui/src/runtime.rs
+++ b/sdk/tui/src/runtime.rs
@@ -24,7 +24,7 @@ use ratatui::{
     Terminal,
 };
 
-use crate::app::{ActiveView, HitAction, HitRegion};
+use crate::app::{ActiveView, HitAction, HitRegion, PaletteMode};
 use crate::message::Message;
 use crate::model::Model;
 use crate::task::Task;
@@ -70,7 +70,14 @@ pub fn run<B: ratatui::backend::Backend>(
                     // ever defers closing (e.g., for validation), palette_text is Some but
                     // the guard `!model.palette_open` will be false, so PaletteSubmit is
                     // correctly suppressed.
-                    let palette_text = if model.is_palette_open() && key.code == KeyCode::Enter {
+                    //
+                    // Only Command mode submits a command. FuzzyFind filters live on every
+                    // keystroke and commits its results on Enter inside update(), so its
+                    // input text must never reach the command dispatcher.
+                    let palette_text = if model.is_palette_open()
+                        && key.code == KeyCode::Enter
+                        && model.palette_mode() == Some(PaletteMode::Command)
+                    {
                         Some(model.palette_input_value().to_string())
                     } else {
                         None

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -155,7 +155,7 @@ fn handle_key(
 
     // While the palette is open all keys are consumed here.
     if model.is_palette_open() {
-        return handle_palette_key(model, key);
+        return handle_palette_key(model, key, ctx);
     }
 
     // Modal captures all key input when present.
@@ -186,7 +186,14 @@ fn handle_key(
             model.open_command_palette();
         }
         KeyCode::Char('/') => {
+            // Stash the current view so Esc can restore it, then seed the
+            // results table with all tokens (empty query matches everything).
+            let saved = std::mem::replace(&mut model.active_view, ActiveView::Empty);
             model.open_fuzzy_palette();
+            if let Some(ps) = model.palette_state_mut() {
+                ps.saved_view = Some(saved);
+            }
+            apply_fuzzy_filter(model, "", ctx);
         }
         KeyCode::Char('q') => {
             model.quit = true;
@@ -196,16 +203,30 @@ fn handle_key(
     Task::none()
 }
 
-fn handle_palette_key(model: &mut Model, key: crossterm::event::KeyEvent) -> Task<Message> {
+fn handle_palette_key(
+    model: &mut Model,
+    key: crossterm::event::KeyEvent,
+    ctx: &UpdateCtx<'_>,
+) -> Task<Message> {
     let palette_cmd_mode = model.palette_mode() == Some(PaletteMode::Command);
+    let palette_fuzzy_mode = model.palette_mode() == Some(PaletteMode::FuzzyFind);
 
     match key.code {
         KeyCode::Esc => {
+            // Cancel: restore the view that was on screen before fuzzy-find opened.
+            let saved = model.palette_state_mut().and_then(|ps| ps.saved_view.take());
             model.close_palette();
+            if let Some(view) = saved {
+                model.active_view = view;
+            }
         }
         KeyCode::Enter => {
-            // Close the palette. The runtime sends a separate Message::PaletteSubmit
-            // after detecting this transition; submit is NOT dispatched here.
+            // Commit: keep the live fuzzy results, discard the saved view. The
+            // runtime sends a separate Message::PaletteSubmit after detecting this
+            // transition; for fuzzy mode it is gated off so no command dispatches.
+            if let Some(ps) = model.palette_state_mut() {
+                ps.saved_view = None;
+            }
             model.close_palette();
         }
         KeyCode::Tab if palette_cmd_mode => {
@@ -244,9 +265,22 @@ fn handle_palette_key(model: &mut Model, key: crossterm::event::KeyEvent) -> Tas
                 ps.history_cursor = None;
                 ps.input.handle_event(&crossterm::event::Event::Key(key));
             }
+            // Re-run the live name filter on every edit (typing, Backspace, …).
+            if palette_fuzzy_mode {
+                let query = model.palette_input_value().to_string();
+                apply_fuzzy_filter(model, &query, ctx);
+            }
         }
     }
     Task::none()
+}
+
+/// Rebuild the results table from a fuzzy-find `query`, ranking token names with
+/// `fuzzy::rank_token_rows`. Sets `active_view` to a `Query` view so the table,
+/// navigation, yank, and mouse hit-regions all work for the filtered results.
+fn apply_fuzzy_filter(model: &mut Model, query: &str, ctx: &UpdateCtx<'_>) {
+    let rows = crate::fuzzy::rank_token_rows(ctx.graph, query);
+    model.active_view = ActiveView::Query(crate::app::QueryView::new(query.to_string(), rows));
 }
 
 fn handle_history_nav(model: &mut Model, older: bool) {

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -280,7 +280,7 @@ fn handle_palette_key(
 /// navigation, yank, and mouse hit-regions all work for the filtered results.
 fn apply_fuzzy_filter(model: &mut Model, query: &str, ctx: &UpdateCtx<'_>) {
     let rows = crate::fuzzy::rank_token_rows(ctx.graph, query);
-    model.active_view = ActiveView::Query(crate::app::QueryView::new(query.to_string(), rows));
+    model.active_view = ActiveView::Query(crate::app::QueryView::fuzzy(query.to_string(), rows));
 }
 
 fn handle_history_nav(model: &mut Model, older: bool) {

--- a/sdk/tui/src/update_command.rs
+++ b/sdk/tui/src/update_command.rs
@@ -46,15 +46,9 @@ pub(crate) fn handle_palette_submit(
     raw: String,
     ctx: &UpdateCtx<'_>,
 ) -> Task<Message> {
-    // FuzzyFind mode: close without dispatching.
-    // When the model is in Browsing mode (e.g. direct PaletteSubmit from tests or replay),
-    // treat as command mode — the submit should always dispatch.
-    let is_fuzzy = model.palette_mode() == Some(crate::app::PaletteMode::FuzzyFind);
-    if is_fuzzy {
-        model.close_palette();
-        return Task::none();
-    }
-
+    // FuzzyFind never reaches here: it filters live on each keystroke (see
+    // `apply_fuzzy_filter` in `update.rs`) and the runtime only dispatches
+    // `PaletteSubmit` for Command-mode Enter. This path is command dispatch only.
     let raw = raw.trim().to_string();
     model.close_palette();
 

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -157,13 +157,14 @@ fn render_query(f: &mut Frame<'_>, qv: &mut QueryView, area: Rect, theme: &Theme
         Constraint::Percentage(20),
         Constraint::Percentage(10),
     ];
+    let title = if qv.is_fuzzy {
+        format!(" Fuzzy: /{} ", qv.expr_text)
+    } else {
+        format!(" Query: {} ", qv.expr_text)
+    };
     let table = Table::new(rows, widths)
         .header(header)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!(" Query: {} ", qv.expr_text)),
-        )
+        .block(Block::default().borders(Borders::ALL).title(title))
         .highlight_style(Style::default().bg(theme.selection_bg));
     f.render_stateful_widget(table, area, &mut qv.table_state);
 }

--- a/sdk/tui/tests/fuzzy.rs
+++ b/sdk/tui/tests/fuzzy.rs
@@ -1,0 +1,124 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Live `/` fuzzy-find palette behavior (GH #1079).
+
+mod common;
+use common::{key, make_graph_with_tokens, update_ctx};
+
+use crossterm::event::KeyCode;
+use design_data_tui::app::ActiveView;
+use design_data_tui::{update, Message, Model};
+
+/// Drive a string of character keystrokes through `update`.
+fn type_str(model: &mut Model, ctx: &design_data_tui::UpdateCtx<'_>, text: &str) {
+    for c in text.chars() {
+        update(model, Message::Key(key(KeyCode::Char(c))), ctx);
+    }
+}
+
+fn row_names(model: &Model) -> Vec<String> {
+    if let ActiveView::Query(ref qv) = model.active_view {
+        qv.rows.iter().map(|r| r.name.clone()).collect()
+    } else {
+        panic!("expected Query view, got something else");
+    }
+}
+
+#[test]
+fn slash_seeds_all_tokens() {
+    let graph = make_graph_with_tokens(&["accent-background", "neutral-background", "button"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    assert!(model.is_palette_open());
+    assert_eq!(row_names(&model).len(), 3);
+}
+
+#[test]
+fn typing_narrows_results_live() {
+    let graph = make_graph_with_tokens(&["accent-background", "neutral-background", "button"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "bg");
+    // "button" has no 'g' after its 'b', so only the two backgrounds match.
+    let names = row_names(&model);
+    assert_eq!(names.len(), 2);
+    assert!(names.iter().all(|n| n.contains("background")));
+}
+
+#[test]
+fn backspace_widens_results_live() {
+    let graph = make_graph_with_tokens(&["accent-background", "neutral-background", "button"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "bg");
+    assert_eq!(row_names(&model).len(), 2);
+    update(&mut model, Message::Key(key(KeyCode::Backspace)), &ctx);
+    // Query is now just "b" — all three tokens contain a 'b'.
+    assert_eq!(row_names(&model).len(), 3);
+}
+
+#[test]
+fn enter_commits_filtered_view() {
+    let graph = make_graph_with_tokens(&["accent-background", "neutral-background", "button"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "bg");
+    update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
+    assert!(!model.is_palette_open());
+    assert_eq!(row_names(&model).len(), 2);
+    // Committing must not surface an error (e.g. "unknown command").
+    assert!(model.status_message.is_none());
+}
+
+#[test]
+fn esc_restores_previous_view() {
+    let graph = make_graph_with_tokens(&["accent-background", "neutral-background", "button"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    // Establish a prior results view via a command submit.
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
+    let before = match model.active_view {
+        ActiveView::Query(ref qv) => qv.expr_text.clone(),
+        _ => panic!("expected Query view from command submit"),
+    };
+
+    // Open fuzzy-find, narrow to nothing, then cancel.
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "zzz");
+    assert_eq!(row_names(&model).len(), 0);
+    update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
+
+    assert!(!model.is_palette_open());
+    match model.active_view {
+        ActiveView::Query(ref qv) => assert_eq!(qv.expr_text, before),
+        _ => panic!("expected the prior Query view to be restored"),
+    }
+}
+
+#[test]
+fn ranked_best_match_first() {
+    let graph = make_graph_with_tokens(&["color-background", "character-bg"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "bg");
+    // "character-bg" has a consecutive, boundary "bg" run and should rank first.
+    let names = row_names(&model);
+    assert_eq!(names.first().map(String::as_str), Some("character-bg"));
+}

--- a/sdk/tui/tests/fuzzy.rs
+++ b/sdk/tui/tests/fuzzy.rs
@@ -11,7 +11,7 @@
 //! Live `/` fuzzy-find palette behavior (GH #1079).
 
 mod common;
-use common::{key, make_graph_with_tokens, update_ctx};
+use common::{key, make_graph_with_tokens, render_to_buffer, update_ctx};
 
 use crossterm::event::KeyCode;
 use design_data_tui::app::ActiveView;
@@ -109,6 +109,26 @@ fn esc_restores_previous_view() {
         ActiveView::Query(ref qv) => assert_eq!(qv.expr_text, before),
         _ => panic!("expected the prior Query view to be restored"),
     }
+}
+
+#[test]
+fn fuzzy_view_titled_fuzzy_not_query() {
+    let graph = make_graph_with_tokens(&["accent-background", "neutral-background", "button"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('/'))), &ctx);
+    type_str(&mut model, &ctx, "bg");
+
+    let buf = render_to_buffer(&mut model, 80, 24);
+    let mut all = String::new();
+    for y in 0..24 {
+        for x in 0..80 {
+            all.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        all.push('\n');
+    }
+    assert!(all.contains("Fuzzy: /bg"), "expected 'Fuzzy: /bg' title");
+    assert!(!all.contains("Query: bg"), "must not mislabel as a Query");
 }
 
 #[test]


### PR DESCRIPTION
## Description

The TUI command palette opens in `FuzzyFind` mode when you press `/`, but submitting did nothing: `handle_palette_submit` returned early without dispatching, so `/` accepted input but never filtered tokens.

This wires `/` to a live, fzf-style name filter that narrows the results table on every keystroke:

- **`sdk/tui/src/fuzzy.rs`** (new): `subsequence_score(haystack, needle)` does case-insensitive subsequence matching with `+3` consecutive-run and `+5` word-boundary bonuses; `rank_token_rows(graph, query)` scores every token's display name and returns `QueryRow`s ranked best-first (empty query lists all tokens by name).
- **`sdk/tui/src/update.rs`**: pressing `/` stashes the current view and seeds an all-tokens `QueryView`; `handle_palette_key` re-runs the filter on every edit (typing + Backspace); `Enter` commits the filtered table, `Esc` restores the prior view.
- **`sdk/tui/src/mode.rs`**: `PaletteState` gains a `saved_view` field for the `Esc` restore.
- **`sdk/tui/src/runtime.rs`**: only Command-mode `Enter` dispatches `PaletteSubmit`, so fuzzy input never reaches the command router.
- **`sdk/tui/src/update_command.rs`**: removes the now-unreachable fuzzy early-return.

The existing `QueryView` table is reused, so navigation (`j`/`k`), `y` yank, and mouse hit-regions work for fuzzy results for free.

## Related Issue

Closes #1079

## Motivation and Context

Documentation and muscle-memory suggest `/` is a live fuzzy search, but it was a no-op. Name search previously only worked via `:query <expr>` and `:find <intent>`. This makes `/` behave as expected.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — full TUI suite passes, including:
  - 6 new unit tests in `fuzzy.rs` (subsequence matching, case-insensitivity, consecutive/boundary ranking, non-match returns `None`).
  - 6 new integration tests in `tests/fuzzy.rs` (live narrowing, Backspace widening, `Enter` commit with no error status, `Esc` restore, ranking order).
- `tests/budget.rs` LOC cap still passes; library `clippy` is clean.
- Added a `minor` changeset for `@adobe/design-data-tui`, validated with the changeset linter (`--fail-on-warnings`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Made with [Cursor](https://cursor.com)