### PR TITLE
fix(changeset): attribute TUI fuzzy-find changeset to @adobe/design-data

### DIFF
--- a/.changeset/tui-fuzzy-find-palette.md
+++ b/.changeset/tui-fuzzy-find-palette.md
@@ -1,5 +1,5 @@
 ---
-"@adobe/design-data-tui": minor
+"@adobe/design-data": minor
 ---
 
 Make the TUI `/` fuzzy-find palette filter token names live instead of being a


### PR DESCRIPTION
## Description

The Release workflow failed on `main` after #1083 merged:

```
🦋  error Found changeset tui-fuzzy-find-palette for package @adobe/design-data-tui which is not in the workspace
```

`sdk/tui` is `"private": true` and is **not** listed in `pnpm-workspace.yaml`, so `@adobe/design-data-tui` is not a changeset-versionable package and `pnpm run version` aborts.

This retargets the changeset to the published umbrella package **`@adobe/design-data`**, matching the existing convention in `.changeset/tui-wizard-multimode-write.md` (which also attributes `sdk/tui` work to `@adobe/design-data`).

## Related Issue

Follow-up to #1083 / #1079 (release pipeline fix).

## Motivation and Context

Unblocks the Changesets "Version Packages" job so the release can proceed.

## How Has This Been Tested?

- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.
- `pnpm changeset status` — now resolves `@adobe/design-data` (plus its fixed-group platform packages) with no "not in workspace" error.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Made with [Cursor](https://cursor.com)