### PR TITLE
feat(tui): emit name object in wizard write for MCP parity (closes #1082)

### DIFF
--- a/.changeset/tui-wizard-name-object-parity.md
+++ b/.changeset/tui-wizard-name-object-parity.md
@@ -1,0 +1,11 @@
+---
+"@adobe/design-data": minor
+---
+
+Emit the structured `name` object from the TUI authoring wizard for MCP parity (closes #1082).
+
+- **sdk/core/authoring/draft**: add shared `build_name_object` next to `build_value_fields`.
+- **sdk/core/authoring/session**: delegate `name`-object assembly to the shared helper.
+- **sdk/tui/wizard**: include `name` in `base_token_map` so writes and Confirm diff match MCP shape.
+- **sdk/tui/tests/write**: assert `name.property` and name fields land on disk with a
+  real schema registry.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/sdk/core/src/authoring/draft.rs
+++ b/sdk/core/src/authoring/draft.rs
@@ -192,6 +192,24 @@ pub fn build_value_fields(rows: &[ValueRowDto]) -> serde_json::Map<String, serde
     fields
 }
 
+/// Build the structured `name` object: `{ "property": ..., <name_fields>... }`.
+///
+/// Single source of truth shared by the MCP authoring session and TUI wizard.
+pub fn build_name_object(property: &str, name_fields: &[NameFieldDto]) -> serde_json::Value {
+    let mut name_obj = serde_json::Map::new();
+    name_obj.insert(
+        "property".into(),
+        serde_json::Value::String(property.to_string()),
+    );
+    for field in name_fields {
+        name_obj.insert(
+            field.key.clone(),
+            serde_json::Value::String(field.value.clone()),
+        );
+    }
+    serde_json::Value::Object(name_obj)
+}
+
 /// Recursively build a `sets` object from a slice of value rows.
 ///
 /// Rows are grouped by their first mode-combo dimension value; each group is
@@ -270,6 +288,28 @@ mod tests {
             alias_target: String::new(),
             literal: value.to_string(),
         }
+    }
+
+    #[test]
+    fn build_name_object_property_only() {
+        let name = build_name_object("background-color", &[]);
+        let obj = name.as_object().unwrap();
+        assert_eq!(obj["property"], "background-color");
+        assert_eq!(obj.len(), 1);
+    }
+
+    #[test]
+    fn build_name_object_includes_name_fields() {
+        let name = build_name_object(
+            "background-color",
+            &[NameFieldDto {
+                key: "variant".into(),
+                value: "accent".into(),
+            }],
+        );
+        let obj = name.as_object().unwrap();
+        assert_eq!(obj["property"], "background-color");
+        assert_eq!(obj["variant"], "accent");
     }
 
     #[test]

--- a/sdk/core/src/authoring/session.rs
+++ b/sdk/core/src/authoring/session.rs
@@ -359,18 +359,13 @@ fn build_token_value(wizard: &WizardDraft, schema_url: &str, rationale: &str) ->
         serde_json::Value::String(schema_url.to_string()),
     );
 
-    let mut name_obj = serde_json::Map::new();
-    name_obj.insert(
-        "property".into(),
-        serde_json::Value::String(wizard.classification.property.clone()),
+    obj.insert(
+        "name".into(),
+        crate::authoring::draft::build_name_object(
+            &wizard.classification.property,
+            &wizard.classification.name_fields,
+        ),
     );
-    for field in &wizard.classification.name_fields {
-        name_obj.insert(
-            field.key.clone(),
-            serde_json::Value::String(field.value.clone()),
-        );
-    }
-    obj.insert("name".into(), serde_json::Value::Object(name_obj));
 
     for (field, value) in build_value_fields(&wizard.values.rows) {
         obj.insert(field, value);

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -524,11 +524,13 @@ impl WizardState {
         assemble_name_from_classification(&self.classification)
     }
 
-    /// Build the `$schema` + value fields shared by the write path and the diff
+    /// Build the `$schema` + `name` + value fields shared by the write path and the diff
     /// preview. Value fields come from [`design_data_core::authoring::draft::build_value_fields`]
     /// over every mode-combo row (flat `$ref`/`value` for a single default row,
     /// nested `sets` otherwise). Callers add `uuid`/`rationale` as needed.
     fn base_token_map(&self) -> serde_json::Map<String, serde_json::Value> {
+        let property = self.classification.property.value().trim().to_string();
+        let name_fields = classification_to_name_dtos(&self.classification);
         let value_fields = design_data_core::authoring::draft::build_value_fields(
             &value_rows_to_dtos(&self.values.rows),
         );
@@ -536,21 +538,22 @@ impl WizardState {
         if let Some(ref url) = self.schema_url {
             map.insert("$schema".into(), serde_json::Value::String(url.clone()));
         }
+        map.insert(
+            "name".into(),
+            design_data_core::authoring::draft::build_name_object(&property, &name_fields),
+        );
         for (field, value) in value_fields {
             map.insert(field, value);
         }
         map
     }
 
-    /// The token JSON object the wizard will write — `$schema` + value fields +
+    /// The token JSON object the wizard will write — `$schema` + `name` + value fields +
     /// rationale — **excluding** the generated `uuid`. Both [`Self::perform_write`]
     /// and the diff preview ([`Self::build_diff`]) derive from this single source,
     /// so what you see in the Confirm diff is exactly what lands on disk (sans
     /// uuid). Exposed so tests can assert on the structured shape (e.g.
     /// `sets.light` / `sets.dark`) rather than the rendered diff string.
-    ///
-    /// Note: unlike the MCP authoring session this does not yet emit a `name`
-    /// object — tracked in adobe/spectrum-design-data#1082.
     pub fn assembled_token(&self) -> serde_json::Value {
         let mut map = self.base_token_map();
         let rationale = self.rationale.value().trim().to_string();
@@ -670,6 +673,21 @@ fn infer_schema_url(graph: &TokenGraph, property: &str) -> Option<String> {
             None
         }
     })
+}
+
+/// Convert TUI classification name fields into the serializable DTO shape consumed by
+/// [`design_data_core::authoring::draft::build_name_object`].
+fn classification_to_name_dtos(
+    classification: &ClassificationDraft,
+) -> Vec<design_data_core::authoring::draft::NameFieldDto> {
+    classification
+        .name_fields
+        .iter()
+        .map(|f| design_data_core::authoring::draft::NameFieldDto {
+            key: f.key.clone(),
+            value: f.value.value().to_string(),
+        })
+        .collect()
 }
 
 /// Convert TUI value rows into the serializable DTO shape consumed by

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -685,7 +685,7 @@ fn classification_to_name_dtos(
         .iter()
         .map(|f| design_data_core::authoring::draft::NameFieldDto {
             key: f.key.clone(),
-            value: f.value.value().to_string(),
+            value: f.value.value().trim().to_string(),
         })
         .collect()
 }

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -171,6 +171,7 @@ fn submit_with_allow_write_creates_token_file() {
         doc.get("background-color").is_some(),
         "foundation.json should contain the new token key: {content}"
     );
+    assert_eq!(doc["background-color"]["name"]["property"], "background-color");
 }
 
 #[test]

--- a/sdk/tui/tests/write.rs
+++ b/sdk/tui/tests/write.rs
@@ -24,7 +24,7 @@ use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_core::query::TokenIndex;
 use design_data_core::schema::SchemaRegistry;
-use design_data_tui::wizard::{ValueKind, ValueRow, WizardCtx, WizardState};
+use design_data_tui::wizard::{NameField, ValueKind, ValueRow, WizardCtx, WizardState};
 use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
 use tui_input::Input;
@@ -171,6 +171,39 @@ fn submit_with_allow_write_creates_token_file() {
         doc.get("background-color").is_some(),
         "foundation.json should contain the new token key: {content}"
     );
+}
+
+#[test]
+fn submit_with_allow_write_includes_name_object() {
+    let registry = load_registry();
+    let graph = make_graph_with_schema();
+    let tmpdir = tempfile::TempDir::new().expect("tempdir");
+    let ctx = WizardCtx {
+        graph: &graph,
+        token_index: TokenIndex::build(&graph),
+        dataset_path: Some(tmpdir.path()),
+        schema_registry: Some(&registry),
+        allow_write: true,
+    };
+
+    let mut ws = wizard_at_confirm_literal("background-color", "rgb(2, 100, 220)", COLOR_SCHEMA);
+    ws.classification.name_fields = vec![NameField {
+        key: "variant".into(),
+        value: Input::from("accent".to_string()),
+    }];
+
+    let written_path = ws.perform_write(&ctx).expect("write should succeed");
+    assert!(
+        written_path.ends_with("foundation.json"),
+        "should write to foundation.json: {written_path}"
+    );
+
+    let foundation = tmpdir.path().join("foundation.json");
+    let content = std::fs::read_to_string(&foundation).expect("read foundation.json");
+    let doc: serde_json::Value = serde_json::from_str(&content).expect("parse foundation.json");
+    let tok = &doc["background-color-accent"];
+    assert_eq!(tok["name"]["property"], "background-color");
+    assert_eq!(tok["name"]["variant"], "accent");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Extract token `name`-object assembly into shared `build_name_object` in
`sdk/core/src/authoring/draft.rs` and call it from both the MCP authoring
session and the TUI wizard. The TUI write path and Confirm diff preview now
emit the same structured `name` object (`property` plus classification name
fields) that MCP authoring already included.

## Related Issue

Closes #1082

## Motivation and Context

PR #1081 shared `build_value_fields` between MCP and TUI authoring, but the
TUI wizard still omitted the `name` object on write. That gap meant TUI writes
could fail real schema validation and diverged from MCP token shape. This
change completes authoring-surface parity for the `name` object.

## How Has This Been Tested?

- `cargo test -p design-data-core -p design-data-tui`
- Added `submit_with_allow_write_includes_name_object` in `sdk/tui/tests/write.rs`
  using the real schema registry; asserts `name.property` and `name.variant`
  land on disk
- Added unit tests for `build_name_object` in `sdk/core/src/authoring/draft.rs`
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.