### PR TITLE
docs(ai): reorganize AI tools page + style markdown tables

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,17 +8,17 @@
   "plugins": [
     {
       "name": "s2-docs",
-      "description": "Spectrum 2 component documentation on-demand. Fetches S2 design guidelines, component options, and usage patterns without loading a persistent MCP server.",
+      "description": "Skill: Spectrum 2 component documentation on-demand. Fetches S2 design guidelines, component options, and usage patterns without loading a persistent MCP server.",
       "source": "./tools/s2-docs-mcp"
     },
     {
       "name": "design-data",
-      "description": "Spectrum design tokens and component schemas via the design-data CLI.",
+      "description": "Skill: Spectrum design tokens and component schemas, zero config. Uses the embedded Spectrum snapshot via the design-data CLI.",
       "source": "./tools/design-data-skill"
     },
     {
       "name": "design-data-agent",
-      "description": "Spec-conformant design token lookup, validation, diff, and authoring for any dataset.",
+      "description": "Skill: spec-conformant design token lookup, validation, diff, and authoring for any custom dataset via the design-data CLI.",
       "source": "./tools/design-data-agent-mcp"
     }
   ]

--- a/docs/markdown/components/table.md
+++ b/docs/markdown/components/table.md
@@ -1,13 +1,13 @@
 ---
 title: Table
 description: "Tables display information in rows and columns, allowing users to compare and scan structured data."
-category: data visualization
+category: data-visualization
 documentationUrl: https://spectrum.adobe.com/page/table/
 source_url: https://opensource.adobe.com/spectrum-design-data/components/table/
 tags:
   - component
   - schema
-  - data visualization
+  - data-visualization
 ---
 
 Tables display information in rows and columns, allowing users to compare and scan structured data.

--- a/docs/markdown/pages/ai.md
+++ b/docs/markdown/pages/ai.md
@@ -9,56 +9,40 @@ source_url: https://opensource.adobe.com/spectrum-design-data/pages/ai/
 
 Spectrum Design Data publishes Model Context Protocol (MCP) servers and Agent Skills so AI assistants can query design tokens, component schemas, and Spectrum 2 documentation directly from tools like Claude Code and Cursor.
 
-## S2 docs skill (recommended for prototyping)
+Every integration comes in two forms: a lightweight **Agent Skill** (recommended for prototyping) and an always-on **MCP server**. The sections below are grouped by what you want to do — design tokens & schemas, or Spectrum 2 docs.
 
-The `s2-docs` Agent Skill fetches S2 component docs on-demand — only when the AI is working on Spectrum components — without loading a persistent MCP server into every session. This keeps context lean during long prototype sessions.
+## Which tool do I need?
 
-The skill auto-triggers when you mention Spectrum, React Spectrum, Spectrum Web Components, or a component name. You can also invoke it directly with `/s2-docs:s2-docs <component>`.
+| Goal | Use this |
+|------|----------|
+| Prototype with Spectrum tokens, zero setup | [`design-data` skill](#design-data-skill--spectrum-tokens-zero-config) |
+| Validate, diff, or author tokens on a custom dataset | [`design-data-agent` skill](#design-data-agent-skill--spec--custom-datasets) |
+| Look up S2 component docs and guidelines | [`s2-docs` skill](#s2-docs-skill-recommended-for-prototyping) |
+| Always-on access or agent pipelines | The matching [MCP server](#mcp-servers) for any of the above |
 
-### Install in Claude Code
+## Skill vs MCP — how to choose
 
-Add the Spectrum Design Data marketplace, then install the skill:
-
-```
-/plugin marketplace add adobe/spectrum-design-data
-/plugin install s2-docs@spectrum-design-data
-```
-
-After install, start a new session and ask something like _"which Spectrum component should I use for a searchable dropdown?"_ — the skill fetches the relevant docs automatically.
-
-### Install in Cursor
-
-Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste this URL:
-
-```
-https://github.com/adobe/spectrum-design-data/tree/main/tools/s2-docs-mcp/skills/s2-docs
-```
-
-Then invoke the skill in an Agent session via `/s2-docs get <component>` or ask a Spectrum question naturally.
-
-### Skill vs MCP — when to use which
+The same capability is available as a skill or an MCP server. They differ only in how they load:
 
 | | Agent Skill | MCP Server |
 |---|---|---|
 | **Context cost** | Description only (~200 chars) until invoked | All tool schemas loaded every session |
 | **Best for** | Prototyping, on-demand lookups | Always-available access, agent pipelines |
-| **Triggers** | Automatically on Spectrum intent, or `/s2-docs:s2-docs` | Called by the AI as a tool whenever needed |
+| **Triggers** | Automatically on intent, or invoked directly | Called by the AI as a tool whenever needed |
 | **Setup** | `/plugin install` or Cursor remote rule | Add to `mcp.json`, restart editor |
 
 Both can run together. The skill is a lightweight companion; the MCP is the full integration.
 
-## Design Data agent surface
+## Design tokens & component schemas
 
-Two Agent Skills cover design tokens and component schemas. Both shell out to the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI — only the skill description loads into session context until invoked.
+Look up token values, query by component/property, suggest tokens from natural language, read component schemas, and (for custom datasets) validate, diff, and author tokens. All of these shell out to the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI — only the skill description loads into session context until invoked.
 
-| Need | Skill | MCP fallback |
-|------|-------|--------------|
-| Spectrum tokens, zero setup (embedded snapshot) | `design-data` | `@adobe/design-data-mcp` |
-| Custom dataset on disk, validate/diff/write, spec tool names | `design-data-agent` | `@adobe/design-data-agent-mcp` |
-| Minimal session context cost | Skill (either above) | — |
-| Always-on tool access in agent pipelines | — | MCP (either above) |
+Pick based on your dataset:
 
-### `design-data` — Spectrum tokens (zero config)
+- **Spectrum tokens, zero config** → `design-data` skill (or `@adobe/design-data-mcp`). Uses the embedded Spectrum snapshot — no paths required.
+- **Custom dataset on disk, with validate/diff/write** → `design-data-agent` skill (or `@adobe/design-data-agent-mcp`). Tool names match the [agent surface spec](https://github.com/adobe/spectrum-design-data/blob/main/packages/design-data-spec/spec/agent-surface.md).
+
+### `design-data` skill — Spectrum tokens (zero config)
 
 Look up token values, query by component/property, suggest tokens from natural language, and read component schemas. Uses the embedded Spectrum snapshot automatically — no dataset paths required.
 
@@ -75,7 +59,7 @@ Look up token values, query by component/property, suggest tokens from natural l
 https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
 ```
 
-### `design-data-agent` — spec-conformant / custom datasets
+### `design-data-agent` skill — spec / custom datasets
 
 Validate, query, resolve, diff, and author tokens against a local dataset. Tool names match the [agent surface spec](https://github.com/adobe/spectrum-design-data/blob/main/packages/design-data-spec/spec/agent-surface.md). Requires `DESIGN_DATA_PATH` (and spec catalog paths for components/fields/dimensions).
 
@@ -92,19 +76,13 @@ Validate, query, resolve, diff, and author tokens against a local dataset. Tool 
 https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
 ```
 
-### Skill vs MCP — design data
+### MCP servers
 
-| | Agent Skill | MCP Server |
-|---|---|---|
-| **Context cost** | Description only until invoked | All tool schemas loaded every session |
-| **Best for** | Prototyping, on-demand lookups | Always-available access, agent pipelines |
-| **Setup** | `/plugin install` or Cursor remote rule | Add to `mcp.json`, restart editor |
+For always-available tool access (higher context cost than the skills above), add the matching MCP server to your editor.
 
-## MCP Servers
+#### @adobe/design-data-mcp
 
-### @adobe/design-data-mcp
-
-Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Zero-config embedded snapshot. Prefer the [`design-data` skill](#design-data--spectrum-tokens-zero-config) for prototyping.
+Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Zero-config embedded snapshot. Prefer the [`design-data` skill](#design-data-skill--spectrum-tokens-zero-config) for prototyping.
 
 **npm:** `@adobe/design-data-mcp`
 
@@ -123,9 +101,9 @@ Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Z
 }
 ```
 
-### @adobe/design-data-agent-mcp
+#### @adobe/design-data-agent-mcp
 
-Spec-conformant agent surface for any local dataset. Tool names match the agent surface spec (`primer`, `resolve_token`, `query_tokens`, `validate_usage`, etc.). Prefer the [`design-data-agent` skill](#design-data-agent--spec-conformant--custom-datasets) for prototyping.
+Spec-conformant agent surface for any local dataset. Tool names match the agent surface spec (`primer`, `resolve_token`, `query_tokens`, `validate_usage`, etc.). Prefer the [`design-data-agent` skill](#design-data-agent-skill--spec--custom-datasets) for prototyping.
 
 **npm:** `@adobe/design-data-agent-mcp`
 
@@ -152,11 +130,11 @@ Spec-conformant agent surface for any local dataset. Tool names match the agent 
 
 Adjust paths to match your dataset layout.
 
-### @adobe/spectrum-design-data-mcp (legacy)
+### Legacy: @adobe/spectrum-design-data-mcp
 
 Design tokens and component API schemas. Enables AI to look up token values, find tokens by use case, validate component props, and get schema definitions.
 
-**Prefer [`@adobe/design-data-mcp`](#adobedesign-data-mcp)** for new projects — it wraps the current `@adobe/design-data` CLI with an embedded Spectrum snapshot.
+**Prefer [`@adobe/design-data-mcp`](#adobedesign-data-mcp)** for new projects — it wraps the current `@adobe/design-data` CLI with an embedded Spectrum snapshot. This package is kept for existing integrations.
 
 **npm:** `@adobe/spectrum-design-data-mcp`
 
@@ -164,7 +142,7 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 
 **Schema tools:** `list-components`, `get-component-schema`, `validate-component-props`, `search-components-by-feature`
 
-**Cursor config (single server):**
+**Cursor config:**
 
 ```json
 {
@@ -177,15 +155,40 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 }
 ```
 
+## Spectrum 2 documentation
+
+### s2-docs skill (recommended for prototyping)
+
+The `s2-docs` Agent Skill fetches S2 component docs on-demand — only when the AI is working on Spectrum components — without loading a persistent MCP server into every session. This keeps context lean during long prototype sessions.
+
+The skill auto-triggers when you mention Spectrum, React Spectrum, Spectrum Web Components, or a component name. You can also invoke it directly with `/s2-docs:s2-docs <component>`.
+
+**Claude Code:**
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install s2-docs@spectrum-design-data
+```
+
+After install, start a new session and ask something like _"which Spectrum component should I use for a searchable dropdown?"_ — the skill fetches the relevant docs automatically.
+
+**Cursor** — Settings → Rules → **Add Rule** → **Remote Rule (GitHub)**:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/s2-docs-mcp/skills/s2-docs
+```
+
+Then invoke the skill in an Agent session via `/s2-docs get <component>` or ask a Spectrum question naturally.
+
 ### @adobe/s2-docs-mcp
 
-Spectrum 2 component documentation and design guidelines. For prototyping, consider the [S2 docs skill](#s2-docs-skill-recommended-for-prototyping) above instead — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
+Spectrum 2 component documentation and design guidelines. For prototyping, prefer the [s2-docs skill](#s2-docs-skill-recommended-for-prototyping) above — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
 
 **npm:** `@adobe/s2-docs-mcp`
 
 **Tools:** `list-s2-components`, `get-s2-component`, `search-s2-docs`, `get-s2-stats`, `find-s2-component-by-use-case`
 
-**Cursor config (single server):** Use a local path to the repo, or install and run from the repo. Example:
+**Cursor config:**
 
 ```json
 {
@@ -202,7 +205,7 @@ If you run from source, point `args` to `tools/s2-docs-mcp/src/cli.js` inside yo
 
 ## Cursor IDE setup
 
-Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remote rules) are lighter for prototyping — see sections above.
+Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remote rules) are lighter for prototyping — see the sections above. Restart Cursor after changing MCP config.
 
 **Spectrum prototyping (tokens + S2 docs):**
 
@@ -237,24 +240,7 @@ Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remot
 }
 ```
 
-**Legacy (spectrum-design-data-mcp):**
-
-```json
-{
-  "mcpServers": {
-    "spectrum-design-data": {
-      "command": "npx",
-      "args": ["-y", "@adobe/spectrum-design-data-mcp"]
-    },
-    "s2-docs": {
-      "command": "npx",
-      "args": ["-y", "@adobe/s2-docs-mcp"]
-    }
-  }
-}
-```
-
-Restart Cursor after changing MCP config.
+For the legacy server, see [`@adobe/spectrum-design-data-mcp`](#legacy-adobespectrum-design-data-mcp) above.
 
 **More context in chat:**
 

--- a/docs/markdown/registry/anatomy-terms.md
+++ b/docs/markdown/registry/anatomy-terms.md
@@ -129,4 +129,7 @@ tags:
 | user-image | User Image | User profile photo displayed within an avatar component | - |
 | initials | Initials | Text initials displayed in an avatar when no image is available | - |
 | guest-icon | Guest Icon | Icon displayed in an avatar representing an unauthenticated guest user | - |
+| disclosure-triangle | Disclosure Triangle | Expand/collapse indicator for accordion, tree, or disclosure components | - |
+| picker | Picker | Dropdown trigger area — the visible affordance, not the overlay | - |
+| progress-bar | Progress Bar | Visual progress fill track indicating completion level | - |
 

--- a/docs/markdown/registry/categories.md
+++ b/docs/markdown/registry/categories.md
@@ -12,7 +12,7 @@ tags:
 | --- | --- | --- | --- |
 | actions | Actions | Components that allow users to perform actions | - |
 | containers | Containers | Components that contain or organize other content | - |
-| data-visualization | Data Visualization | Components for displaying data and charts | data visualization |
+| data-visualization | Data Visualization | Components for displaying data and charts | - |
 | feedback | Feedback | Components that provide feedback to users | - |
 | inputs | Inputs | Components for user input and data entry | - |
 | navigation | Navigation | Components for navigation and wayfinding | - |

--- a/docs/site/eleventy.config.js
+++ b/docs/site/eleventy.config.js
@@ -85,17 +85,11 @@ export default async function (eleventyConfig) {
     );
   });
 
-  // Apply Spectrum table classes to token, component, registry, spec, and AI
-  // pages so markdown tables use @spectrum-css/table
+  // Apply Spectrum table classes to every article page so markdown tables
+  // use @spectrum-css/table. All tables on the site come from markdown
+  // content, so this is safe to run across all HTML output.
   eleventyConfig.addTransform("spectrum-tables", (content, outputPath) => {
-    if (
-      !outputPath ||
-      (!outputPath.includes("/tokens/") &&
-        !outputPath.includes("/components/") &&
-        !outputPath.includes("/registry/") &&
-        !outputPath.includes("/spec/") &&
-        !outputPath.includes("/ai/"))
-    )
+    if (typeof content !== "string" || !outputPath?.endsWith(".html"))
       return content;
     return content
       .replace(

--- a/docs/site/eleventy.config.js
+++ b/docs/site/eleventy.config.js
@@ -85,14 +85,16 @@ export default async function (eleventyConfig) {
     );
   });
 
-  // Apply Spectrum table classes to token, component, and registry pages so markdown tables use @spectrum-css/table
+  // Apply Spectrum table classes to token, component, registry, spec, and AI
+  // pages so markdown tables use @spectrum-css/table
   eleventyConfig.addTransform("spectrum-tables", (content, outputPath) => {
     if (
       !outputPath ||
       (!outputPath.includes("/tokens/") &&
         !outputPath.includes("/components/") &&
         !outputPath.includes("/registry/") &&
-        !outputPath.includes("/spec/"))
+        !outputPath.includes("/spec/") &&
+        !outputPath.includes("/ai/"))
     )
       return content;
     return content

--- a/docs/site/scripts/generate-tools-page.js
+++ b/docs/site/scripts/generate-tools-page.js
@@ -108,7 +108,7 @@ function buildDeveloperToolsSection(toolsDir) {
   const lines = [
     "## Developer Tools",
     "",
-    "Packages under `tools/` in the repo:",
+    "Packages under `tools/` in the repo. For the MCP servers and Agent Skills (S2 docs, design tokens, and schemas), see [Using with AI](/ai/) for setup and usage.",
     "",
   ];
 

--- a/docs/site/src/pages/ai.md
+++ b/docs/site/src/pages/ai.md
@@ -8,56 +8,40 @@ permalink: /ai/
 
 Spectrum Design Data publishes Model Context Protocol (MCP) servers and Agent Skills so AI assistants can query design tokens, component schemas, and Spectrum 2 documentation directly from tools like Claude Code and Cursor.
 
-## S2 docs skill (recommended for prototyping)
+Every integration comes in two forms: a lightweight **Agent Skill** (recommended for prototyping) and an always-on **MCP server**. The sections below are grouped by what you want to do — design tokens & schemas, or Spectrum 2 docs.
 
-The `s2-docs` Agent Skill fetches S2 component docs on-demand — only when the AI is working on Spectrum components — without loading a persistent MCP server into every session. This keeps context lean during long prototype sessions.
+## Which tool do I need?
 
-The skill auto-triggers when you mention Spectrum, React Spectrum, Spectrum Web Components, or a component name. You can also invoke it directly with `/s2-docs:s2-docs <component>`.
+| Goal | Use this |
+|------|----------|
+| Prototype with Spectrum tokens, zero setup | [`design-data` skill](#design-data-skill--spectrum-tokens-zero-config) |
+| Validate, diff, or author tokens on a custom dataset | [`design-data-agent` skill](#design-data-agent-skill--spec--custom-datasets) |
+| Look up S2 component docs and guidelines | [`s2-docs` skill](#s2-docs-skill-recommended-for-prototyping) |
+| Always-on access or agent pipelines | The matching [MCP server](#mcp-servers) for any of the above |
 
-### Install in Claude Code
+## Skill vs MCP — how to choose
 
-Add the Spectrum Design Data marketplace, then install the skill:
-
-```
-/plugin marketplace add adobe/spectrum-design-data
-/plugin install s2-docs@spectrum-design-data
-```
-
-After install, start a new session and ask something like _"which Spectrum component should I use for a searchable dropdown?"_ — the skill fetches the relevant docs automatically.
-
-### Install in Cursor
-
-Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste this URL:
-
-```
-https://github.com/adobe/spectrum-design-data/tree/main/tools/s2-docs-mcp/skills/s2-docs
-```
-
-Then invoke the skill in an Agent session via `/s2-docs get <component>` or ask a Spectrum question naturally.
-
-### Skill vs MCP — when to use which
+The same capability is available as a skill or an MCP server. They differ only in how they load:
 
 | | Agent Skill | MCP Server |
 |---|---|---|
 | **Context cost** | Description only (~200 chars) until invoked | All tool schemas loaded every session |
 | **Best for** | Prototyping, on-demand lookups | Always-available access, agent pipelines |
-| **Triggers** | Automatically on Spectrum intent, or `/s2-docs:s2-docs` | Called by the AI as a tool whenever needed |
+| **Triggers** | Automatically on intent, or invoked directly | Called by the AI as a tool whenever needed |
 | **Setup** | `/plugin install` or Cursor remote rule | Add to `mcp.json`, restart editor |
 
 Both can run together. The skill is a lightweight companion; the MCP is the full integration.
 
-## Design Data agent surface
+## Design tokens & component schemas
 
-Two Agent Skills cover design tokens and component schemas. Both shell out to the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI — only the skill description loads into session context until invoked.
+Look up token values, query by component/property, suggest tokens from natural language, read component schemas, and (for custom datasets) validate, diff, and author tokens. All of these shell out to the [`@adobe/design-data`](https://www.npmjs.com/package/@adobe/design-data) CLI — only the skill description loads into session context until invoked.
 
-| Need | Skill | MCP fallback |
-|------|-------|--------------|
-| Spectrum tokens, zero setup (embedded snapshot) | `design-data` | `@adobe/design-data-mcp` |
-| Custom dataset on disk, validate/diff/write, spec tool names | `design-data-agent` | `@adobe/design-data-agent-mcp` |
-| Minimal session context cost | Skill (either above) | — |
-| Always-on tool access in agent pipelines | — | MCP (either above) |
+Pick based on your dataset:
 
-### `design-data` — Spectrum tokens (zero config)
+- **Spectrum tokens, zero config** → `design-data` skill (or `@adobe/design-data-mcp`). Uses the embedded Spectrum snapshot — no paths required.
+- **Custom dataset on disk, with validate/diff/write** → `design-data-agent` skill (or `@adobe/design-data-agent-mcp`). Tool names match the [agent surface spec](https://github.com/adobe/spectrum-design-data/blob/main/packages/design-data-spec/spec/agent-surface.md).
+
+### `design-data` skill — Spectrum tokens (zero config)
 
 Look up token values, query by component/property, suggest tokens from natural language, and read component schemas. Uses the embedded Spectrum snapshot automatically — no dataset paths required.
 
@@ -74,7 +58,7 @@ Look up token values, query by component/property, suggest tokens from natural l
 https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
 ```
 
-### `design-data-agent` — spec-conformant / custom datasets
+### `design-data-agent` skill — spec / custom datasets
 
 Validate, query, resolve, diff, and author tokens against a local dataset. Tool names match the [agent surface spec](https://github.com/adobe/spectrum-design-data/blob/main/packages/design-data-spec/spec/agent-surface.md). Requires `DESIGN_DATA_PATH` (and spec catalog paths for components/fields/dimensions).
 
@@ -91,19 +75,13 @@ Validate, query, resolve, diff, and author tokens against a local dataset. Tool 
 https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
 ```
 
-### Skill vs MCP — design data
+### MCP servers
 
-| | Agent Skill | MCP Server |
-|---|---|---|
-| **Context cost** | Description only until invoked | All tool schemas loaded every session |
-| **Best for** | Prototyping, on-demand lookups | Always-available access, agent pipelines |
-| **Setup** | `/plugin install` or Cursor remote rule | Add to `mcp.json`, restart editor |
+For always-available tool access (higher context cost than the skills above), add the matching MCP server to your editor.
 
-## MCP Servers
+#### @adobe/design-data-mcp
 
-### @adobe/design-data-mcp
-
-Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Zero-config embedded snapshot. Prefer the [`design-data` skill](#design-data--spectrum-tokens-zero-config) for prototyping.
+Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Zero-config embedded snapshot. Prefer the [`design-data` skill](#design-data-skill--spectrum-tokens-zero-config) for prototyping.
 
 **npm:** `@adobe/design-data-mcp`
 
@@ -122,9 +100,9 @@ Spectrum design tokens and component schemas via the `@adobe/design-data` CLI. Z
 }
 ```
 
-### @adobe/design-data-agent-mcp
+#### @adobe/design-data-agent-mcp
 
-Spec-conformant agent surface for any local dataset. Tool names match the agent surface spec (`primer`, `resolve_token`, `query_tokens`, `validate_usage`, etc.). Prefer the [`design-data-agent` skill](#design-data-agent--spec-conformant--custom-datasets) for prototyping.
+Spec-conformant agent surface for any local dataset. Tool names match the agent surface spec (`primer`, `resolve_token`, `query_tokens`, `validate_usage`, etc.). Prefer the [`design-data-agent` skill](#design-data-agent-skill--spec--custom-datasets) for prototyping.
 
 **npm:** `@adobe/design-data-agent-mcp`
 
@@ -151,11 +129,11 @@ Spec-conformant agent surface for any local dataset. Tool names match the agent 
 
 Adjust paths to match your dataset layout.
 
-### @adobe/spectrum-design-data-mcp (legacy)
+### Legacy: @adobe/spectrum-design-data-mcp
 
 Design tokens and component API schemas. Enables AI to look up token values, find tokens by use case, validate component props, and get schema definitions.
 
-**Prefer [`@adobe/design-data-mcp`](#adobedesign-data-mcp)** for new projects — it wraps the current `@adobe/design-data` CLI with an embedded Spectrum snapshot.
+**Prefer [`@adobe/design-data-mcp`](#adobedesign-data-mcp)** for new projects — it wraps the current `@adobe/design-data` CLI with an embedded Spectrum snapshot. This package is kept for existing integrations.
 
 **npm:** `@adobe/spectrum-design-data-mcp`
 
@@ -163,7 +141,7 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 
 **Schema tools:** `list-components`, `get-component-schema`, `validate-component-props`, `search-components-by-feature`
 
-**Cursor config (single server):**
+**Cursor config:**
 
 ```json
 {
@@ -176,15 +154,40 @@ Design tokens and component API schemas. Enables AI to look up token values, fin
 }
 ```
 
+## Spectrum 2 documentation
+
+### s2-docs skill (recommended for prototyping)
+
+The `s2-docs` Agent Skill fetches S2 component docs on-demand — only when the AI is working on Spectrum components — without loading a persistent MCP server into every session. This keeps context lean during long prototype sessions.
+
+The skill auto-triggers when you mention Spectrum, React Spectrum, Spectrum Web Components, or a component name. You can also invoke it directly with `/s2-docs:s2-docs <component>`.
+
+**Claude Code:**
+
+```
+/plugin marketplace add adobe/spectrum-design-data
+/plugin install s2-docs@spectrum-design-data
+```
+
+After install, start a new session and ask something like _"which Spectrum component should I use for a searchable dropdown?"_ — the skill fetches the relevant docs automatically.
+
+**Cursor** — Settings → Rules → **Add Rule** → **Remote Rule (GitHub)**:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/s2-docs-mcp/skills/s2-docs
+```
+
+Then invoke the skill in an Agent session via `/s2-docs get <component>` or ask a Spectrum question naturally.
+
 ### @adobe/s2-docs-mcp
 
-Spectrum 2 component documentation and design guidelines. For prototyping, consider the [S2 docs skill](#s2-docs-skill-recommended-for-prototyping) above instead — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
+Spectrum 2 component documentation and design guidelines. For prototyping, prefer the [s2-docs skill](#s2-docs-skill-recommended-for-prototyping) above — it loads docs on-demand with less context overhead. Use this MCP when you want always-available access or are building agent pipelines.
 
 **npm:** `@adobe/s2-docs-mcp`
 
 **Tools:** `list-s2-components`, `get-s2-component`, `search-s2-docs`, `get-s2-stats`, `find-s2-component-by-use-case`
 
-**Cursor config (single server):** Use a local path to the repo, or install and run from the repo. Example:
+**Cursor config:**
 
 ```json
 {
@@ -201,7 +204,7 @@ If you run from source, point `args` to `tools/s2-docs-mcp/src/cli.js` inside yo
 
 ## Cursor IDE setup
 
-Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remote rules) are lighter for prototyping — see sections above.
+Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remote rules) are lighter for prototyping — see the sections above. Restart Cursor after changing MCP config.
 
 **Spectrum prototyping (tokens + S2 docs):**
 
@@ -236,24 +239,7 @@ Add MCP servers to `.cursor/mcp.json` for always-available access. Skills (remot
 }
 ```
 
-**Legacy (spectrum-design-data-mcp):**
-
-```json
-{
-  "mcpServers": {
-    "spectrum-design-data": {
-      "command": "npx",
-      "args": ["-y", "@adobe/spectrum-design-data-mcp"]
-    },
-    "s2-docs": {
-      "command": "npx",
-      "args": ["-y", "@adobe/s2-docs-mcp"]
-    }
-  }
-}
-```
-
-Restart Cursor after changing MCP config.
+For the legacy server, see [`@adobe/spectrum-design-data-mcp`](#legacy-adobespectrum-design-data-mcp) above.
 
 **More context in chat:**
 

--- a/docs/site/src/tools.md
+++ b/docs/site/src/tools.md
@@ -19,15 +19,20 @@ Interactive tools deployed with this site:
 
 ## Developer Tools
 
-Packages under `tools/` in the repo:
+Packages under `tools/` in the repo. For the MCP servers and Agent Skills (S2 docs, design tokens, and schemas), see [Using with AI](/ai/) for setup and usage.
 
 * **[@adobe/changeset-linter](https://www.npmjs.com/package/%40adobe%2Fchangeset-linter)** — Linting tool to enforce concise changeset files
+* **[@adobe/design-data-agent-mcp](https://www.npmjs.com/package/%40adobe%2Fdesign-data-agent-mcp)** — MCP server and Claude Code skill for the design-data agent surface — shells out to the design-data CLI
+* **[@adobe/design-data-mcp](https://www.npmjs.com/package/%40adobe%2Fdesign-data-mcp)** — MCP server for Spectrum design tokens and component schemas via the design-data CLI
+* **[@adobe/design-data-skill](https://www.npmjs.com/package/%40adobe%2Fdesign-data-skill)** — Claude Code skill for Spectrum design tokens and component schemas via the design-data CLI
 * **[@adobe/optimized-diff](https://www.npmjs.com/package/%40adobe%2Foptimized-diff)** — High-performance deep object diff algorithm with significant performance improvements over generic libraries
 * **[@adobe/s2-docs-mcp](https://www.npmjs.com/package/%40adobe%2Fs2-docs-mcp)** — MCP server for Spectrum 2 documentation
 * **[@adobe/spectrum-component-diff-generator](https://www.npmjs.com/package/%40adobe%2Fspectrum-component-diff-generator)** — Generates diff reports for Spectrum component schema changes with breaking change analysis
 * **[@adobe/spectrum-design-data-mcp](https://www.npmjs.com/package/%40adobe%2Fspectrum-design-data-mcp)** — Model Context Protocol server for Spectrum design data including tokens, schemas, and component anatomy
 * **[@adobe/spectrum-diff-core](https://www.npmjs.com/package/%40adobe%2Fspectrum-diff-core)** — Shared core library for Spectrum diff generation tools (tokens, component schemas, etc.)
+* **[@adobe/token-corpus-migrate](https://github.com/adobe/spectrum-design-data/tree/main/tools/token-corpus-migrate)** — Migration tool that adds structured name objects to tokens in packages/tokens/src/
 * **[@adobe/token-diff-generator](https://www.npmjs.com/package/%40adobe%2Ftoken-diff-generator)** — Generate comprehensive diffs between design token sets with support for multiple output formats including CLI, JSON, and Markdown. Detects added, deleted, renamed, deprecated, and updated tokens across different schema versions.
+* **[@adobe/token-naming-audit](https://github.com/adobe/spectrum-design-data/tree/main/tools/token-naming-audit)** — Audit tool that reports string-name token debt and overloaded property-field values
 * **[component-options-editor](https://github.com/adobe/spectrum-design-data/tree/main/tools/component-options-editor)** — Figma plugin for authoring Spectrum component option schemas
 * **[markdown-generator](https://github.com/adobe/spectrum-design-data/tree/main/tools/markdown-generator)** — Generate markdown files from tokens, component-schemas, and design-system-registry for docs and chatbot indexing
 * **[release-analyzer](https://github.com/adobe/spectrum-design-data/tree/main/tools/release-analyzer)** — Analyzes Spectrum Tokens release history and generates data for change frequency visualization

--- a/tools/markdown-generator/moon.yml
+++ b/tools/markdown-generator/moon.yml
@@ -24,4 +24,7 @@ tasks:
       - "design-system-registry:test"
     inputs:
       - "@globs(sources)"
+      # Site pages are read directly by src/pages.js and mirrored into docs/markdown/pages.
+      # Token/component/registry data is covered by the deps above.
+      - "/docs/site/src/pages/**/*"
     # Output is docs/markdown/ (outside project); Moon cannot declare parent paths


### PR DESCRIPTION
## Description

Reorganizes the AI integration docs page (`/ai/`) and fixes markdown table styling site-wide. Docs/site-only — no published-package code or behavior changes, and the legacy `@adobe/spectrum-design-data-mcp` is kept.

Content reorg:
- **docs/site/src/pages/ai.md**: regrouped by domain (Design tokens & schemas, Spectrum 2 docs), added a single "Which tool do I need?" decision guide, stated the Skill-vs-MCP tradeoff once (was duplicated three times), merged the duplicated "MCP Servers" + "Design Data agent surface" sections, moved the legacy MCP into a labeled subsection, and trimmed redundant Cursor setup recipes. All in-page anchors verified against `github-slugger`.
- **.claude-plugin/marketplace.json**: clarified the three plugin descriptions as skill entries (names/sources unchanged — non-breaking).
- **docs/site/scripts/generate-tools-page.js**: added a `/ai/` pointer to the Developer Tools listing; `docs/site/src/tools.md` regenerated.
- **docs/markdown/pages/ai.md** (+ incidental `components/table.md`, `registry/anatomy-terms.md`, `registry/categories.md`): regenerated mirror.

Tooling / styling fixes:
- **tools/markdown-generator/moon.yml**: added `/docs/site/src/pages/**/*` to the `generate` task inputs so the `docs/markdown` mirror rebuilds when a page changes (previously only watched its own `src/**/*`, so page edits never busted the cache).
- **docs/site/eleventy.config.js**: the `spectrum-tables` transform that applies `@spectrum-css/table` classes was path-scoped and excluded `/ai/`, so the new comparison tables rendered as unstyled borderless columns. Generalized it to run on all article HTML pages (all site tables come from markdown), fixing the AI page and preventing the regression on future pages.

## Related Issue

N/A — documentation cleanup and site styling fix.

## Motivation and Context

`ai.md` had grown long and repetitive with no single entry point for choosing a tool. Separately, the markdown-generator cache never invalidated on page edits (mirror could go stale), and markdown tables on non-token/component/registry/spec pages were completely unstyled.

## How Has This Been Tested?

- Regenerated the mirror and confirmed `docs/markdown/pages/ai.md` matches the new structure.
- Verified all six in-page anchor slugs with `github-slugger`.
- Confirmed `moon task markdown-generator:generate` now lists `docs/site/src/pages/**/*` as an input.
- Built the site (`moon run site:build`) and visually verified via the local dev server that the AI page tables now render with Spectrum styling (header rule, row separators, cell padding). Confirmed 120 article pages get styled tables and that table-less pages (`/tools/`, `/`) build cleanly and are unaffected.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Made with [Cursor](https://cursor.com)