### PR TITLE
feat(site): add copy button to code blocks

### DIFF
--- a/docs/site/eleventy.config.js
+++ b/docs/site/eleventy.config.js
@@ -46,6 +46,7 @@ export default async function (eleventyConfig) {
   });
   eleventyConfig.addPassthroughCopy({ "public/.nojekyll": ".nojekyll" });
   eleventyConfig.addPassthroughCopy({ "public/schemas": "schemas" });
+  eleventyConfig.addPassthroughCopy({ "src/assets/js": "assets/js" });
 
   eleventyConfig.addCollection("components", function (api) {
     return api.getFilteredByGlob("src/components/**/*.md");

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
+    "@spectrum-css/actionbutton": "^7.2.0",
+    "@spectrum-css/icon": "^9.2.0",
     "@spectrum-css/link": "^7.1.0",
     "@spectrum-css/page": "^9.1.0",
     "@spectrum-css/table": "^6.1.0",

--- a/docs/site/src/assets/css/components/code.css
+++ b/docs/site/src/assets/css/components/code.css
@@ -100,3 +100,43 @@ pre[class*="language-"] code {
 .token.italic {
   font-style: italic;
 }
+
+/* Spectrum quiet ActionButton injected by copy-code.js. */
+.code-block {
+  position: relative;
+}
+
+.code-block-copy {
+  position: absolute;
+  top: var(--spectrum-spacing-100);
+  inset-inline-end: var(--spectrum-spacing-100);
+  opacity: 0;
+  transition: opacity 130ms ease-in-out;
+}
+
+/* The global reset caps svg with max-inline-size: 100%, which collapses an
+   icon-only ActionButton's icon to its tiny content box. Lift the cap and let
+   Spectrum's icon sizing apply. */
+.code-block-copy .spectrum-Icon {
+  max-inline-size: none;
+  inline-size: var(--spectrum-workflow-icon-size-75);
+  block-size: var(--spectrum-workflow-icon-size-75);
+}
+
+.code-block:hover .code-block-copy,
+.code-block:focus-within .code-block-copy {
+  opacity: 1;
+}
+
+/* Confirmation state: tint the checkmark with the Spectrum positive color. */
+.code-block-copy.is-copied {
+  opacity: 1;
+  color: var(--spectrum-green-900);
+}
+
+/* Touch devices have no hover, so keep the button visible. */
+@media (hover: none) {
+  .code-block-copy {
+    opacity: 1;
+  }
+}

--- a/docs/site/src/assets/css/global/global.css
+++ b/docs/site/src/assets/css/global/global.css
@@ -15,6 +15,8 @@ governing permissions and limitations under the License.
 @import "@spectrum-css/typography/dist/index.css";
 @import "@spectrum-css/link/dist/index.css";
 @import "@spectrum-css/table/dist/index.css";
+@import "@spectrum-css/icon/dist/index.css";
+@import "@spectrum-css/actionbutton/dist/index.css";
 
 /* Keep token resolved value and swatch on the same line */
 .spectrum-TokenResolvedValue {

--- a/docs/site/src/assets/js/copy-code.js
+++ b/docs/site/src/assets/js/copy-code.js
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+(function () {
+  // Spectrum 2 workflow icons (Copy, Checkmark). Paths inherit the button's
+  // currentColor via .spectrum-Icon { fill: currentColor }.
+  const COPY_ICON =
+    '<path d="m11.75,18h-7.5c-1.24023,0-2.25-1.00977-2.25-2.25v-7.5c0-1.24023,1.00977-2.25,2.25-2.25.41406,0,.75.33594.75.75s-.33594.75-.75.75c-.41309,0-.75.33691-.75.75v7.5c0,.41309.33691.75.75.75h7.5c.41309,0,.75-.33691.75-.75,0-.41406.33594-.75.75-.75s.75.33594.75.75c0,1.24023-1.00977,2.25-2.25,2.25Z"/><path d="m6.75,5c-.41406,0-.75-.33594-.75-.75,0-1.24023,1.00977-2.25,2.25-2.25.41406,0,.75.33594.75.75s-.33594.75-.75.75c-.41309,0-.75.33691-.75.75,0,.41406-.33594.75-.75.75Z"/><path d="m13,3.5h-2c-.41406,0-.75-.33594-.75-.75s.33594-.75.75-.75h2c.41406,0,.75.33594.75.75s-.33594.75-.75.75Z"/><path d="m13,14h-2c-.41406,0-.75-.33594-.75-.75s.33594-.75.75-.75h2c.41406,0,.75.33594.75.75s-.33594.75-.75.75Z"/><path d="m15.75,14c-.41406,0-.75-.33594-.75-.75s.33594-.75.75-.75c.41309,0,.75-.33691.75-.75,0-.41406.33594-.75.75-.75s.75.33594.75.75c0,1.24023-1.00977,2.25-2.25,2.25Z"/><path d="m17.25,5c-.41406,0-.75-.33594-.75-.75,0-.41309-.33691-.75-.75-.75-.41406,0-.75-.33594-.75-.75s.33594-.75.75-.75c1.24023,0,2.25,1.00977,2.25,2.25,0,.41406-.33594.75-.75.75Z"/><path d="m17.25,9.75c-.41406,0-.75-.33594-.75-.75v-2c0-.41406.33594-.75.75-.75s.75.33594.75.75v2c0,.41406-.33594.75-.75.75Z"/><path d="m6.75,9.75c-.41406,0-.75-.33594-.75-.75v-2c0-.41406.33594-.75.75-.75s.75.33594.75.75v2c0,.41406-.33594.75-.75.75Z"/><path d="m8.25,14c-1.24023,0-2.25-1.00977-2.25-2.25,0-.41406.33594-.75.75-.75s.75.33594.75.75c0,.41309.33691.75.75.75.41406,0,.75.33594.75.75s-.33594.75-.75.75Z"/>';
+  const CHECK_ICON =
+    '<path d="M7.86426,15.73438c-.22266,0-.43359-.09863-.57617-.26953l-3.74707-4.49805c-.26562-.31836-.22168-.79199.0957-1.05664.31738-.26562.79004-.22363,1.05664.0957l3.15332,3.78613,7.43945-9.46875c.25586-.32617.72852-.38184,1.05273-.12695.32617.25586.38281.72754.12695,1.05273l-8.01172,10.19824c-.13965.17871-.35254.28418-.5791.28711h-.01074Z"/>';
+
+  function icon(paths) {
+    return (
+      '<svg class="spectrum-Icon spectrum-Icon--sizeS spectrum-ActionButton-icon" ' +
+      'width="20" height="20" viewBox="0 0 20 20" focusable="false" aria-hidden="true">' +
+      paths +
+      "</svg>"
+    );
+  }
+
+  function addCopyButtons() {
+    const blocks = document.querySelectorAll("article pre");
+
+    blocks.forEach((pre) => {
+      const code = pre.querySelector("code");
+      if (!code || pre.parentElement.classList.contains("code-block")) return;
+
+      // Wrap each <pre> so the button can sit outside the scrollable region.
+      const wrapper = document.createElement("div");
+      wrapper.className = "code-block";
+      pre.parentNode.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className =
+        "spectrum-ActionButton spectrum-ActionButton--sizeS spectrum-ActionButton--quiet code-block-copy";
+      button.setAttribute("aria-label", "Copy code to clipboard");
+      button.innerHTML = icon(COPY_ICON);
+      wrapper.appendChild(button);
+
+      let resetTimer;
+      button.addEventListener("click", () => {
+        window.clearTimeout(resetTimer);
+
+        const showCopied = () => {
+          button.innerHTML = icon(CHECK_ICON);
+          button.classList.add("is-copied");
+          button.setAttribute("aria-label", "Copied");
+          resetTimer = window.setTimeout(() => {
+            button.innerHTML = icon(COPY_ICON);
+            button.classList.remove("is-copied");
+            button.setAttribute("aria-label", "Copy code to clipboard");
+          }, 2000);
+        };
+
+        navigator.clipboard.writeText(code.textContent).then(showCopied, () => {
+          button.setAttribute("aria-label", "Copy failed \u2014 press \u2318C");
+          resetTimer = window.setTimeout(
+            () => button.setAttribute("aria-label", "Copy code to clipboard"),
+            2000,
+          );
+        });
+      });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", addCopyButtons);
+  } else {
+    addCopyButtons();
+  }
+})();

--- a/docs/site/src/layouts/base.liquid
+++ b/docs/site/src/layouts/base.liquid
@@ -22,5 +22,6 @@
       {% render "includes/layout/footer.liquid" %}
     </main>
   </div>
+  <script src="/assets/js/copy-code.js" defer></script>
 </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,12 @@ importers:
       "@11ty/eleventy-plugin-syntaxhighlight":
         specifier: ^5.0.2
         version: 5.0.2
+      "@spectrum-css/actionbutton":
+        specifier: ^7.2.0
+        version: 7.2.0(@spectrum-css/icon@9.2.0(@spectrum-css/tokens@16.0.2))(@spectrum-css/tokens@16.0.2)
+      "@spectrum-css/icon":
+        specifier: ^9.2.0
+        version: 9.2.0(@spectrum-css/tokens@16.0.2)
       "@spectrum-css/link":
         specifier: ^7.1.0
         version: 7.2.0(@spectrum-css/tokens@16.0.2)
@@ -2185,6 +2191,20 @@ packages:
         integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==,
       }
     engines: { node: ">=12" }
+
+  "@spectrum-css/actionbutton@7.2.0":
+    resolution:
+      {
+        integrity: sha512-uz6/TTQS05ZHwvKSKUE21WBLKcsl3JvVPTGEnwrNm88DO6ZFXwNyAK770oKWlCv1HHB/M0q0F0sKhXKA18mJFA==,
+      }
+    peerDependencies:
+      "@spectrum-css/icon": ">=9.0.0 <10.0.0"
+      "@spectrum-css/tokens": ">=16.0.0 <17.0.0"
+    peerDependenciesMeta:
+      "@spectrum-css/icon":
+        optional: true
+      "@spectrum-css/tokens":
+        optional: true
 
   "@spectrum-css/icon@9.2.0":
     resolution:
@@ -10489,6 +10509,11 @@ snapshots:
   "@sindresorhus/transliterate@1.6.0":
     dependencies:
       escape-string-regexp: 5.0.0
+
+  "@spectrum-css/actionbutton@7.2.0(@spectrum-css/icon@9.2.0(@spectrum-css/tokens@16.0.2))(@spectrum-css/tokens@16.0.2)":
+    optionalDependencies:
+      "@spectrum-css/icon": 9.2.0(@spectrum-css/tokens@16.0.2)
+      "@spectrum-css/tokens": 16.0.2
 
   "@spectrum-css/icon@9.2.0(@spectrum-css/tokens@16.0.2)":
     optionalDependencies:


### PR DESCRIPTION
## Description

Adds a copy-to-clipboard button to every code block on the docs site, built as a real Spectrum CSS quiet ActionButton with a Spectrum 2 workflow icon.

- `assets/js/copy-code.js`: a small (~2 KB, no-dependency) script wraps each `<article pre>` and injects a `spectrum-ActionButton--quiet` button containing the S2 **Copy** workflow icon. On click it copies the code via the Clipboard API and swaps to a green **Checkmark** icon, with `aria-label` feedback ("Copied") and a graceful fallback if the clipboard call is blocked.
- `eleventy.config.js`: passthrough copy of `src/assets/js` to `assets/js`.
- `layouts/base.liquid`: loads the deferred `copy-code.js`.
- `global.css`: imports `@spectrum-css/icon` and `@spectrum-css/actionbutton`.
- `components/code.css`: positions and hover/focus-reveals the button (always visible on touch), tints the checkmark with the Spectrum positive color, and lifts the global `reset.css` `max-inline-size: 100%` cap on svg for the icon (the cap collapsed the icon-only ActionButton's icon to ~4px).
- `package.json` / `pnpm-lock.yaml`: add `@spectrum-css/actionbutton` and `@spectrum-css/icon`.

## Related Issue

<!--- No tracking issue; incremental docs-site polish, follow-up to #1090. -->

## Motivation and Context

The styled code blocks added in #1090 had no quick way to copy their contents. This brings the docs site to parity with the React Spectrum and Spectrum Web Components docs, which both offer a copy button — implemented here with on-spec Spectrum components rather than a hand-rolled button.

A copy button requires JavaScript (the Clipboard API only runs from a user-gesture handler), so this is a deliberate, minimal exception to the site's otherwise zero-JS approach: one small vanilla script, no framework.

## How Has This Been Tested?

- `pnpm --filter site build` completes with no warnings.
- `pnpm install --frozen-lockfile` confirms the lockfile is up to date (only the two new packages added; no reformatting noise).
- In a browser: one quiet ActionButton renders per code block, the Copy icon sizes correctly (16x16 in a 24x24 button), and a click swaps to a green Checkmark, sets `aria-label="Copied"`, and writes to the clipboard. (Clipboard writes work on a real user gesture on localhost/HTTPS; the fallback path handles blocked contexts.)

## Screenshots (if appropriate):

Quiet ActionButton with the S2 Copy icon in the top-right of each code panel, swapping to a green checkmark on copy (verified locally).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
