### PR TITLE
feat(migrate): richer name-object resolution in legacy→cascade converter

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -335,6 +335,12 @@ enum MigrateSub {
         /// Destination directory for cascade .tokens.json output files
         #[arg(long, value_name = "OUTPUT")]
         output: PathBuf,
+        /// Directory containing sidecar name-object JSON files (e.g. packages/token-names/names/)
+        #[arg(long, value_name = "DIR")]
+        names_dir: Option<PathBuf>,
+        /// Path to naming-exceptions.json for known non-roundtrippable token names
+        #[arg(long, value_name = "FILE")]
+        exceptions: Option<PathBuf>,
     },
     /// Convert cascade-format .tokens.json files back to legacy set-format JSON
     LegacyOutput {
@@ -655,8 +661,17 @@ fn run_migrate_roundtrip_verify(path: &Path) -> miette::Result<ExitCode> {
     Ok(ExitCode::from(1))
 }
 
-fn run_migrate_convert(input: &Path, output: &Path) -> miette::Result<ExitCode> {
-    let summary = migrate::convert_dir(input, output)
+fn run_migrate_convert(
+    input: &Path,
+    output: &Path,
+    names_dir: Option<&Path>,
+    exceptions: Option<&Path>,
+) -> miette::Result<ExitCode> {
+    let opts = migrate::ConvertOptions {
+        names_dir: names_dir.map(PathBuf::from),
+        exceptions_path: exceptions.map(PathBuf::from),
+    };
+    let summary = migrate::convert_dir_with_options(input, output, &opts)
         .into_diagnostic()
         .wrap_err_with(|| {
             format!(
@@ -672,6 +687,27 @@ fn run_migrate_convert(input: &Path, output: &Path) -> miette::Result<ExitCode> 
         summary.set_entries_unwrapped,
         summary.flat_tokens_converted,
     );
+    if summary.inline_names > 0
+        || summary.sidecar_names > 0
+        || summary.decomposed_names > 0
+        || summary.thin_names > 0
+    {
+        println!("\nName resolution:");
+        println!("  {:>5}  inline   (from existing name field)", summary.inline_names);
+        println!("  {:>5}  sidecar  (from token-names sidecar)", summary.sidecar_names);
+        println!("  {:>5}  decomposed (component + property + state)", summary.decomposed_names);
+        println!("  {:>5}  thin     (full key as property — tech debt)", summary.thin_names);
+        let total =
+            summary.inline_names + summary.sidecar_names + summary.decomposed_names + summary.thin_names;
+        if total > 0 {
+            let rich = summary.inline_names + summary.sidecar_names + summary.decomposed_names;
+            println!(
+                "  ──────\n  {:>5}  total  ({:.0}% structured)",
+                total,
+                100.0 * rich as f64 / total as f64
+            );
+        }
+    }
     Ok(ExitCode::SUCCESS)
 }
 
@@ -1562,7 +1598,12 @@ fn main() -> ExitCode {
                 schema_path,
                 exceptions_path,
             } => run_migrate_snapshot(&path, &output, schema_path, exceptions_path),
-            MigrateSub::Convert { input, output } => run_migrate_convert(&input, &output),
+            MigrateSub::Convert {
+                input,
+                output,
+                names_dir,
+                exceptions,
+            } => run_migrate_convert(&input, &output, names_dir.as_deref(), exceptions.as_deref()),
             MigrateSub::LegacyOutput { input, output } => {
                 run_migrate_legacy_output(&input, &output)
             }

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -46,6 +46,7 @@ use std::path::Path;
 use serde_json::{Map, Value};
 
 use crate::discovery::discover_json_files;
+use crate::naming::extract_legacy_key;
 use crate::CoreError;
 
 // ── Schema URL constants ──────────────────────────────────────────────────────
@@ -106,20 +107,18 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<LegacySummary,
         if let Some(arr) = value.as_array() {
             for item in arr {
                 if let Some(tok) = item.as_object() {
-                    let name = tok
-                        .get("name")
-                        .and_then(|v| v.as_object())
-                        .and_then(|n| n.get("property"))
-                        .and_then(|v| v.as_str());
-                    if let Some(name) = name {
+                    // Use extract_legacy_key so string-name (escape-hatch) tokens
+                    // are indexed correctly alongside object-name tokens.
+                    let name = tok.get("name").and_then(extract_legacy_key);
+                    if let Some(ref name) = name {
                         // Index the per-mode uuid.
                         if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
-                            global_uuid_to_name.insert(uuid.to_string(), name.to_string());
+                            global_uuid_to_name.insert(uuid.to_string(), name.clone());
                         }
                         // Also index set_uuid so replaced_by pointing at a set token's
                         // outer UUID resolves correctly to renamed.
                         if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
-                            global_uuid_to_name.insert(set_uuid.to_string(), name.to_string());
+                            global_uuid_to_name.insert(set_uuid.to_string(), name.clone());
                         }
                     }
                 }
@@ -160,15 +159,16 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<LegacySummary,
     Ok(summary)
 }
 
-/// Convert a single cascade token (from a `name` object + token fields) to a
-/// legacy entry value. Returns `None` if the token has no `name.property`.
+/// Convert a single cascade token to a legacy entry value.
+///
+/// Accepts both object-name tokens and string-name (SPEC-017 escape-hatch) tokens.
+/// Returns `None` only when the token has no recognisable `name` field.
 ///
 /// Used directly in tests; `convert_dir` calls this internally via `convert_array`.
 pub fn convert_token(token: &Map<String, Value>) -> Option<(String, Value)> {
-    let name_obj = token.get("name")?.as_object()?;
-    let property = name_obj.get("property")?.as_str()?.to_string();
-    let entry = build_entry(token, name_obj);
-    Some((property, entry))
+    let key = token.get("name").and_then(extract_legacy_key)?;
+    let entry = build_flat_entry(token);
+    Some((key, entry))
 }
 
 // ── Roundtrip verification ────────────────────────────────────────────────────
@@ -463,13 +463,12 @@ fn convert_array(
         let Some(tok) = item.as_object() else {
             continue;
         };
-        let Some(name_obj) = tok.get("name").and_then(|v| v.as_object()) else {
+        // extract_legacy_key handles both object names (decomposed or thin) and
+        // string names (SPEC-017 escape hatch).
+        let Some(key) = tok.get("name").and_then(extract_legacy_key) else {
             continue;
         };
-        let Some(property) = name_obj.get("property").and_then(|v| v.as_str()) else {
-            continue;
-        };
-        groups.entry(property.to_string()).or_default().push(tok);
+        groups.entry(key).or_default().push(tok);
     }
 
     let mut out = Map::new();
@@ -696,14 +695,6 @@ fn build_flat_entry(tok: &Map<String, Value>) -> Value {
     }
 
     Value::Object(entry)
-}
-
-/// Build an entry value directly from a cascade token (used by `convert_token`).
-fn build_entry(tok: &Map<String, Value>, name_obj: &Map<String, Value>) -> Value {
-    // If the token has a recognized mode-set key in its name object, it cannot
-    // be round-tripped as a standalone entry — return flat entry.
-    let _ = name_obj;
-    build_flat_entry(tok)
 }
 
 /// Denormalize `$ref: "foo"` → `value: "{foo}"`.

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -125,6 +125,12 @@ pub struct MigrateSummary {
     pub decomposed_names: usize,
     /// Cascade tokens that kept the full legacy key as `property` (tech-debt / thin).
     pub thin_names: usize,
+    /// Flat tokens that had an inline `name` field that didn't roundtrip to the legacy key;
+    /// the inline name was discarded and a resolved name was substituted.
+    pub inline_names_dropped: usize,
+    /// Number of sidecar slug entries that were overwritten by a later file
+    /// (last-writer-wins collision count from `load_sidecar_names`).
+    pub sidecar_slug_overrides: usize,
 }
 
 /// Summary statistics from an add-uuids run.
@@ -149,14 +155,21 @@ struct NameContext<'a> {
 /// Load sidecar name-object JSON files from `dir` into a flat slug → name map.
 ///
 /// Each file in `dir` must be a JSON object mapping token slug → name-object value.
-/// Duplicate slugs across files are overwritten (last writer wins).
-fn load_sidecar_names(dir: &Path) -> Result<HashMap<String, Value>, CoreError> {
+/// Duplicate slugs across files are overwritten (last writer wins). The number of
+/// slug collisions (overrides) is added to `summary.sidecar_slug_overrides`.
+fn load_sidecar_names(
+    dir: &Path,
+    summary: &mut MigrateSummary,
+) -> Result<HashMap<String, Value>, CoreError> {
     let mut map = HashMap::new();
     for path in discover_json_files(dir)? {
         let text = std::fs::read_to_string(&path)?;
         let val: Value = serde_json::from_str(&text)?;
         if let Some(obj) = val.as_object() {
             for (slug, name_val) in obj {
+                if map.contains_key(slug) {
+                    summary.sidecar_slug_overrides += 1;
+                }
                 map.insert(slug.clone(), name_val.clone());
             }
         }
@@ -288,11 +301,17 @@ pub fn convert_token(name: &str, token_obj: &Map<String, Value>) -> Vec<Value> {
 
 /// Convert a single legacy token with access to a name→UUID map for resolving
 /// `renamed` → `replaced_by`.
+///
+/// Uses a throwaway `MigrateSummary` and `name_ctx: None` (thin path) because
+/// `convert_token` / `convert_token_with_context` are single-token utilities with
+/// no caller-visible summary and no name-resolution context. Full name resolution
+/// and summary accumulation happen only in `convert_dir` / `convert_dir_with_options`.
 fn convert_token_with_context(
     name: &str,
     token_obj: &Map<String, Value>,
     name_to_uuid: &HashMap<&str, &str>,
 ) -> Vec<Value> {
+    let mut throwaway = MigrateSummary::default();
     let schema = token_obj
         .get("$schema")
         .and_then(|v| v.as_str())
@@ -305,11 +324,21 @@ fn convert_token_with_context(
             "colorScheme",
             COLOR_SET_MODE_ORDER,
             name_to_uuid,
+            None,
+            &mut throwaway,
         )
     } else if schema.ends_with("scale-set.json") || schema.ends_with("typography-scale.json") {
-        convert_set(name, token_obj, "scale", SCALE_SET_MODE_ORDER, name_to_uuid)
+        convert_set(
+            name,
+            token_obj,
+            "scale",
+            SCALE_SET_MODE_ORDER,
+            name_to_uuid,
+            None,
+            &mut throwaway,
+        )
     } else {
-        vec![build_flat(name, token_obj, name_to_uuid)]
+        vec![build_flat(name, token_obj, name_to_uuid, None, &mut throwaway)]
     }
 }
 
@@ -319,11 +348,67 @@ fn convert_token_with_context(
 ///
 /// Returns a summary of the migration.
 pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary, CoreError> {
-    std::fs::create_dir_all(output_dir)?;
+    let mut summary = MigrateSummary::default();
+    convert_dir_inner(input_dir, output_dir, None, &mut summary)?;
+    Ok(summary)
+}
+
+/// Convert all legacy token files in `input_dir` to cascade `.tokens.json` files in
+/// `output_dir`, applying richer name-object resolution guided by `opts`.
+///
+/// When `opts.names_dir` is set, sidecar name objects are merged where they roundtrip
+/// to the original key. When `opts.exceptions_path` is set, tokens listed in the
+/// exceptions file skip decomposition and receive a thin name.
+///
+/// The [`MigrateSummary`] returned includes per-resolution-kind counts so callers can
+/// measure decomposition quality (the "feasibility spike" report).
+pub fn convert_dir_with_options(
+    input_dir: &Path,
+    output_dir: &Path,
+    opts: &ConvertOptions,
+) -> Result<MigrateSummary, CoreError> {
     let mut summary = MigrateSummary::default();
 
-    // Pass 1: scan all files to build a global name → UUID map for cross-file
-    // renamed → replaced_by resolution.
+    // Load sidecar names if provided.
+    let sidecar: HashMap<String, Value> = match &opts.names_dir {
+        Some(dir) if dir.is_dir() => load_sidecar_names(dir, &mut summary)?,
+        _ => HashMap::new(),
+    };
+
+    // Load forced-thin set from naming-exceptions.json if provided.
+    let forced_thin: HashSet<String> = match &opts.exceptions_path {
+        Some(path) if path.exists() => {
+            let exc = naming::NamingExceptionsFile::load(path)?;
+            exc.token_set()
+        }
+        _ => HashSet::new(),
+    };
+
+    let name_ctx = NameContext {
+        sidecar: &sidecar,
+        forced_thin: &forced_thin,
+    };
+
+    convert_dir_inner(input_dir, output_dir, Some(&name_ctx), &mut summary)?;
+    Ok(summary)
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Shared pass-1/pass-2 implementation for `convert_dir` and `convert_dir_with_options`.
+///
+/// Pass 1 scans all files to build a global name→UUID map for cross-file
+/// `renamed` → `replaced_by` resolution. Pass 2 converts each file using that
+/// map, optionally threading a `NameContext` for richer name resolution.
+fn convert_dir_inner(
+    input_dir: &Path,
+    output_dir: &Path,
+    name_ctx: Option<&NameContext<'_>>,
+    summary: &mut MigrateSummary,
+) -> Result<(), CoreError> {
+    std::fs::create_dir_all(output_dir)?;
+
+    // Pass 1: scan all files to build a global name → UUID map.
     let files = discover_json_files(input_dir)?;
     let mut global_name_to_uuid: HashMap<String, String> = HashMap::new();
     let mut file_contents: Vec<(std::path::PathBuf, Value)> = Vec::new();
@@ -355,7 +440,7 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary
             continue;
         };
 
-        let tokens = convert_object_with_context(obj, &mut summary, &name_to_uuid_ref);
+        let tokens = convert_object_with_context(obj, summary, &name_to_uuid_ref, name_ctx);
         if tokens.is_empty() {
             continue;
         }
@@ -373,107 +458,42 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary
         summary.files_written += 1;
     }
 
-    Ok(summary)
+    Ok(())
 }
 
-/// Convert all legacy token files in `input_dir` to cascade `.tokens.json` files in
-/// `output_dir`, applying richer name-object resolution guided by `opts`.
-///
-/// When `opts.names_dir` is set, sidecar name objects are merged where they roundtrip
-/// to the original key. When `opts.exceptions_path` is set, tokens listed in the
-/// exceptions file skip decomposition and receive a thin name.
-///
-/// The [`MigrateSummary`] returned includes per-resolution-kind counts so callers can
-/// measure decomposition quality (the "feasibility spike" report).
-pub fn convert_dir_with_options(
-    input_dir: &Path,
-    output_dir: &Path,
-    opts: &ConvertOptions,
-) -> Result<MigrateSummary, CoreError> {
-    std::fs::create_dir_all(output_dir)?;
-    let mut summary = MigrateSummary::default();
-
-    // Load sidecar names if provided.
-    let sidecar: HashMap<String, Value> = match &opts.names_dir {
-        Some(dir) if dir.is_dir() => load_sidecar_names(dir)?,
-        _ => HashMap::new(),
-    };
-
-    // Load forced-thin set from naming-exceptions.json if provided.
-    let forced_thin: HashSet<String> = match &opts.exceptions_path {
-        Some(path) if path.exists() => {
-            let exc = naming::NamingExceptionsFile::load(path)?;
-            exc.token_set()
-        }
-        _ => HashSet::new(),
-    };
-
-    let name_ctx = NameContext {
-        sidecar: &sidecar,
-        forced_thin: &forced_thin,
-    };
-
-    // Pass 1: build cross-file name→UUID map (same as convert_dir).
-    let files = discover_json_files(input_dir)?;
-    let mut global_name_to_uuid: HashMap<String, String> = HashMap::new();
-    let mut file_contents: Vec<(std::path::PathBuf, Value)> = Vec::new();
-
-    for input_path in &files {
-        let text = std::fs::read_to_string(input_path)?;
-        let value: Value = serde_json::from_str(&text)?;
-        if let Some(obj) = value.as_object() {
-            for (name, val) in obj {
-                if let Some(tok) = val.as_object() {
-                    if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
-                        global_name_to_uuid.insert(name.clone(), uuid.to_string());
-                    }
-                }
-            }
-        }
-        file_contents.push((input_path.clone(), value));
+fn record_name_kind(kind: NameKind, count: usize, summary: &mut MigrateSummary) {
+    match kind {
+        NameKind::Inline => summary.inline_names += count,
+        NameKind::Sidecar => summary.sidecar_names += count,
+        NameKind::Decomposed => summary.decomposed_names += count,
+        NameKind::Thin => summary.thin_names += count,
     }
-
-    let name_to_uuid_ref: HashMap<&str, &str> = global_name_to_uuid
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-
-    // Pass 2: convert each file with richer name resolution.
-    for (input_path, value) in &file_contents {
-        let Some(obj) = value.as_object() else {
-            continue;
-        };
-
-        let tokens =
-            convert_object_with_opts(obj, &mut summary, &name_to_uuid_ref, &name_ctx);
-        if tokens.is_empty() {
-            continue;
-        }
-
-        let stem = input_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("tokens");
-        let out_name = format!("{stem}.tokens.json");
-        let out_path = output_dir.join(out_name);
-        let out_text = serde_json::to_string_pretty(&Value::Array(tokens))?;
-        std::fs::write(&out_path, out_text)?;
-
-        summary.files_processed += 1;
-        summary.files_written += 1;
-    }
-
-    Ok(summary)
 }
 
-// ── Internal helpers ──────────────────────────────────────────────────────────
+/// Build the thin name value: `{property: key, component?}`.
+///
+/// This is the safe fallback name that always roundtrips because
+/// `naming::extract_legacy_key` detects the thin format and returns `property`
+/// directly for group key extraction in `legacy.rs`.
+fn thin_name_val(property: &str, source: &Map<String, Value>) -> Value {
+    let mut name = Map::new();
+    name.insert("property".into(), Value::String(property.to_string()));
+    if let Some(c) = source.get("component").and_then(|v| v.as_str()) {
+        name.insert("component".into(), Value::String(c.to_string()));
+    }
+    Value::Object(name)
+}
 
-/// Convert all entries in a legacy token file object to cascade tokens (opts path).
-fn convert_object_with_opts(
+/// Convert all entries in a legacy token file object to cascade tokens.
+///
+/// When `name_ctx` is `None`, the thin path is used (existing `build_flat` /
+/// `build_set_entry` logic). When `Some`, `resolve_name` is called for richer
+/// name-object resolution.
+fn convert_object_with_context(
     obj: &Map<String, Value>,
     summary: &mut MigrateSummary,
     name_to_uuid: &HashMap<&str, &str>,
-    name_ctx: &NameContext<'_>,
+    name_ctx: Option<&NameContext<'_>>,
 ) -> Vec<Value> {
     let mut out = Vec::new();
     for (name, val) in obj {
@@ -486,29 +506,19 @@ fn convert_object_with_opts(
             .unwrap_or("");
         if schema.ends_with("color-set.json") {
             let tokens =
-                convert_set_with_opts(name, tok_obj, "colorScheme", COLOR_SET_MODE_ORDER, name_to_uuid, name_ctx);
-            let n = tokens.len();
-            if n > 0 {
-                let kind = resolve_name(name, tok_obj, name_ctx).1;
-                record_name_kind(kind, n, summary);
-            }
-            summary.set_entries_unwrapped += n;
-            summary.tokens_produced += n;
+                convert_set(name, tok_obj, "colorScheme", COLOR_SET_MODE_ORDER, name_to_uuid, name_ctx, summary);
+            summary.set_entries_unwrapped += tokens.len();
+            summary.tokens_produced += tokens.len();
             out.extend(tokens);
         } else if schema.ends_with("scale-set.json") || schema.ends_with("typography-scale.json")
         {
             let tokens =
-                convert_set_with_opts(name, tok_obj, "scale", SCALE_SET_MODE_ORDER, name_to_uuid, name_ctx);
-            let n = tokens.len();
-            if n > 0 {
-                let kind = resolve_name(name, tok_obj, name_ctx).1;
-                record_name_kind(kind, n, summary);
-            }
-            summary.set_entries_unwrapped += n;
-            summary.tokens_produced += n;
+                convert_set(name, tok_obj, "scale", SCALE_SET_MODE_ORDER, name_to_uuid, name_ctx, summary);
+            summary.set_entries_unwrapped += tokens.len();
+            summary.tokens_produced += tokens.len();
             out.extend(tokens);
         } else {
-            let token = build_flat_with_opts(name, tok_obj, name_to_uuid, name_ctx, summary);
+            let token = build_flat(name, tok_obj, name_to_uuid, name_ctx, summary);
             summary.flat_tokens_converted += 1;
             summary.tokens_produced += 1;
             out.push(token);
@@ -517,190 +527,24 @@ fn convert_object_with_opts(
     out
 }
 
-fn record_name_kind(kind: NameKind, count: usize, summary: &mut MigrateSummary) {
-    match kind {
-        NameKind::Inline => summary.inline_names += count,
-        NameKind::Sidecar => summary.sidecar_names += count,
-        NameKind::Decomposed => summary.decomposed_names += count,
-        NameKind::Thin => summary.thin_names += count,
-    }
-}
-
-/// Convert a set token (opts path).
-fn convert_set_with_opts(
-    property: &str,
-    outer: &Map<String, Value>,
-    dim_key: &str,
-    mode_order: &[&str],
-    name_to_uuid: &HashMap<&str, &str>,
-    name_ctx: &NameContext<'_>,
-) -> Vec<Value> {
-    let sets = match outer.get("sets").and_then(|v| v.as_object()) {
-        Some(s) => s,
-        None => return vec![build_flat_with_opts(property, outer, name_to_uuid, name_ctx, &mut MigrateSummary::default())],
-    };
-
-    let mut modes: Vec<&str> = mode_order
-        .iter()
-        .filter(|m| sets.contains_key(**m))
-        .copied()
-        .collect();
-    for mode in sets.keys() {
-        if !modes.contains(&mode.as_str()) {
-            modes.push(mode.as_str());
-        }
-    }
-
-    modes
-        .iter()
-        .filter_map(|mode| {
-            let entry = sets.get(*mode)?.as_object()?;
-            Some(build_set_entry_with_opts(
-                property, outer, entry, dim_key, mode, name_to_uuid, name_ctx,
-            ))
-        })
-        .collect()
-}
-
-/// Build a cascade token from a set mode entry (opts path).
-fn build_set_entry_with_opts(
-    property: &str,
-    outer: &Map<String, Value>,
-    entry: &Map<String, Value>,
-    dim_key: &str,
-    mode: &str,
-    name_to_uuid: &HashMap<&str, &str>,
-    name_ctx: &NameContext<'_>,
-) -> Value {
-    let mut out = Map::new();
-
-    // Resolve the base name (taxonomy decomposition / sidecar enrichment).
-    let (base_name, _kind) = resolve_name(property, outer, name_ctx);
-    let name_val = match base_name {
-        Value::Object(mut name_obj) => {
-            // Add the mode-set dimension to the name object.
-            name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
-            Value::Object(name_obj)
-        }
-        // String escape hatch: can't add dim_key to a string.
-        // Fall back to thin object so the set structure is preserved.
-        _ => {
-            let mut name_obj = Map::new();
-            name_obj.insert("property".into(), Value::String(property.to_string()));
-            if let Some(c) = outer.get("component").and_then(|v| v.as_str()) {
-                name_obj.insert("component".into(), Value::String(c.to_string()));
-            }
-            name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
-            Value::Object(name_obj)
-        }
-    };
-    out.insert("name".into(), name_val);
-
-    if let Some(schema) = entry.get("$schema").and_then(|v| v.as_str()) {
-        out.insert("$schema".into(), Value::String(schema.to_string()));
-    }
-    insert_value_or_ref(&mut out, entry);
-    if let Some(uuid) = entry.get("uuid").and_then(|v| v.as_str()) {
-        out.insert("uuid".into(), Value::String(uuid.to_string()));
-    }
-    if let Some(set_uuid) = outer.get("uuid").and_then(|v| v.as_str()) {
-        out.insert("set_uuid".into(), Value::String(set_uuid.to_string()));
-    }
-    if let Some(outer_schema) = outer.get("$schema").and_then(|v| v.as_str()) {
-        out.insert("set_schema".into(), Value::String(outer_schema.to_string()));
-    }
-    for field in OUTER_LIFECYCLE_FIELDS {
-        if let Some(v) = outer.get(*field) {
-            out.insert(field.to_string(), v.clone());
-        }
-    }
-    for field in OUTER_LIFECYCLE_FIELDS {
-        if let Some(v) = entry.get(*field) {
-            out.insert(field.to_string(), v.clone());
-        }
-    }
-    normalize_lifecycle_for_cascade(&mut out, name_to_uuid);
-    Value::Object(out)
-}
-
-/// Build a cascade token from a flat (non-set) legacy token (opts path).
-fn build_flat_with_opts(
-    property: &str,
-    token_obj: &Map<String, Value>,
-    name_to_uuid: &HashMap<&str, &str>,
-    name_ctx: &NameContext<'_>,
-    summary: &mut MigrateSummary,
-) -> Value {
-    let mut out = Map::new();
-
-    let (name_val, kind) = resolve_name(property, token_obj, name_ctx);
-    record_name_kind(kind, 1, summary);
-    out.insert("name".into(), name_val);
-
-    if let Some(schema) = token_obj.get("$schema").and_then(|v| v.as_str()) {
-        if !schema.ends_with("color-set.json")
-            && !schema.ends_with("scale-set.json")
-            && !schema.ends_with("typography-scale.json")
-        {
-            out.insert("$schema".into(), Value::String(schema.to_string()));
-        }
-    }
-    insert_value_or_ref(&mut out, token_obj);
-    if let Some(uuid) = token_obj.get("uuid").and_then(|v| v.as_str()) {
-        out.insert("uuid".into(), Value::String(uuid.to_string()));
-    }
-    for field in OUTER_LIFECYCLE_FIELDS {
-        if let Some(v) = token_obj.get(*field) {
-            out.insert(field.to_string(), v.clone());
-        }
-    }
-    normalize_lifecycle_for_cascade(&mut out, name_to_uuid);
-    Value::Object(out)
-}
-
-/// Convert all entries in a legacy token file object to cascade tokens.
-fn convert_object_with_context(
-    obj: &Map<String, Value>,
-    summary: &mut MigrateSummary,
-    name_to_uuid: &HashMap<&str, &str>,
-) -> Vec<Value> {
-    let mut out = Vec::new();
-    for (name, val) in obj {
-        let Some(tok_obj) = val.as_object() else {
-            continue;
-        };
-        let schema = tok_obj
-            .get("$schema")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        if schema.ends_with("color-set.json")
-            || schema.ends_with("scale-set.json")
-            || schema.ends_with("typography-scale.json")
-        {
-            let tokens = convert_token_with_context(name, tok_obj, name_to_uuid);
-            summary.set_entries_unwrapped += tokens.len();
-            summary.tokens_produced += tokens.len();
-            out.extend(tokens);
-        } else {
-            out.push(build_flat(name, tok_obj, name_to_uuid));
-            summary.flat_tokens_converted += 1;
-            summary.tokens_produced += 1;
-        }
-    }
-    out
-}
-
 /// Convert a set token (color-set or scale-set) into N cascade tokens.
+///
+/// When `name_ctx` is `Some`, `resolve_name` is called ONCE here to get the
+/// pre-resolved `base_name`, which is passed to `build_set_entry` for all N
+/// modes. The kind is recorded once for all N modes with `record_name_kind`
+/// to avoid double-counting. When `name_ctx` is `None`, the thin path is used.
 fn convert_set(
     property: &str,
     outer: &Map<String, Value>,
     dim_key: &str,
     mode_order: &[&str],
     name_to_uuid: &HashMap<&str, &str>,
+    name_ctx: Option<&NameContext<'_>>,
+    summary: &mut MigrateSummary,
 ) -> Vec<Value> {
     let sets = match outer.get("sets").and_then(|v| v.as_object()) {
         Some(s) => s,
-        None => return vec![build_flat(property, outer, name_to_uuid)],
+        None => return vec![build_flat(property, outer, name_to_uuid, name_ctx, summary)],
     };
 
     // Emit modes in stable order (defined order first, then any extras).
@@ -715,41 +559,72 @@ fn convert_set(
         }
     }
 
+    // Resolve the base name ONCE (avoids double-counting per mode).
+    let (base_name, kind) = if let Some(ctx) = name_ctx {
+        resolve_name(property, outer, ctx)
+    } else {
+        (thin_name_val(property, outer), NameKind::Thin)
+    };
+
+    // Record the kind once for all N modes (not once per mode).
+    if !modes.is_empty() && name_ctx.is_some() {
+        record_name_kind(kind, modes.len(), summary);
+    }
+
     modes
         .iter()
         .filter_map(|mode| {
             let entry = sets.get(*mode)?.as_object()?;
             Some(build_set_entry(
-                property,
                 outer,
                 entry,
                 dim_key,
                 mode,
                 name_to_uuid,
+                &base_name,
             ))
         })
         .collect()
 }
 
 /// Build a cascade token from a set mode entry.
+///
+/// Accepts a pre-resolved `base_name` (computed once by `convert_set`) to
+/// avoid redundant `resolve_name` calls and prevent double-counting.
 fn build_set_entry(
-    property: &str,
     outer: &Map<String, Value>,
     entry: &Map<String, Value>,
     dim_key: &str,
     mode: &str,
     name_to_uuid: &HashMap<&str, &str>,
+    base_name: &Value,
 ) -> Value {
     let mut out = Map::new();
 
-    // Name object: property + optional component from outer + mode set mode.
-    let mut name_obj = Map::new();
-    name_obj.insert("property".into(), Value::String(property.to_string()));
-    if let Some(c) = outer.get("component").and_then(|v| v.as_str()) {
-        name_obj.insert("component".into(), Value::String(c.to_string()));
-    }
-    name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
-    out.insert("name".into(), Value::Object(name_obj));
+    // Add the mode-set dimension to the pre-resolved name object.
+    let name_val = match base_name {
+        Value::Object(name_obj) => {
+            let mut name_obj = name_obj.clone();
+            name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
+            Value::Object(name_obj)
+        }
+        // String escape hatch: can't add dim_key to a string.
+        // Fall back to thin object so the set structure is preserved.
+        _ => {
+            // Reconstruct thin from outer (property field is embedded in base_name
+            // only when it is an Object; this branch handles the unreachable
+            // String case defensively).
+            let property = base_name.as_str().unwrap_or("");
+            let mut name_obj = Map::new();
+            name_obj.insert("property".into(), Value::String(property.to_string()));
+            if let Some(c) = outer.get("component").and_then(|v| v.as_str()) {
+                name_obj.insert("component".into(), Value::String(c.to_string()));
+            }
+            name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
+            Value::Object(name_obj)
+        }
+    };
+    out.insert("name".into(), name_val);
 
     // Schema URL from entry (value-type schema, not the set wrapper).
     if let Some(schema) = entry.get("$schema").and_then(|v| v.as_str()) {
@@ -794,20 +669,36 @@ fn build_set_entry(
 }
 
 /// Build a cascade token from a flat (non-set) legacy token.
+///
+/// When `name_ctx` is `None`, uses thin name construction (existing behavior).
+/// When `Some`, calls `resolve_name` and records the kind in `summary`.
+/// If the token had an inline `name` that didn't roundtrip, increments
+/// `summary.inline_names_dropped`.
 fn build_flat(
     property: &str,
     token_obj: &Map<String, Value>,
     name_to_uuid: &HashMap<&str, &str>,
+    name_ctx: Option<&NameContext<'_>>,
+    summary: &mut MigrateSummary,
 ) -> Value {
     let mut out = Map::new();
 
-    // Name object: property + optional component.
-    let mut name_obj = Map::new();
-    name_obj.insert("property".into(), Value::String(property.to_string()));
-    if let Some(c) = token_obj.get("component").and_then(|v| v.as_str()) {
-        name_obj.insert("component".into(), Value::String(c.to_string()));
-    }
-    out.insert("name".into(), Value::Object(name_obj));
+    let name_val = if let Some(ctx) = name_ctx {
+        // Track whether an inline name existed but didn't roundtrip.
+        let had_inline = token_obj.get("name").is_some();
+        let (resolved, kind) = resolve_name(property, token_obj, ctx);
+        // If the token had an inline name but resolve_name fell through (kind != Inline),
+        // the inline name was discarded.
+        if had_inline && kind != NameKind::Inline {
+            summary.inline_names_dropped += 1;
+        }
+        record_name_kind(kind, 1, summary);
+        resolved
+    } else {
+        // Thin path: property + optional component (no name resolution context).
+        thin_name_val(property, token_obj)
+    };
+    out.insert("name".into(), name_val);
 
     // Schema URL (value-type, not a set schema).
     if let Some(schema) = token_obj.get("$schema").and_then(|v| v.as_str()) {
@@ -1239,5 +1130,101 @@ mod tests {
         assert_eq!(val2["my-set"]["uuid"].as_str().unwrap(), uuid_after_run1);
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    // ── resolve_name ──────────────────────────────────────────────────────────
+
+    fn empty_ctx<'a>(
+        sidecar: &'a HashMap<String, Value>,
+        forced_thin: &'a HashSet<String>,
+    ) -> NameContext<'a> {
+        NameContext { sidecar, forced_thin }
+    }
+
+    #[test]
+    fn resolve_name_inline_roundtrips() {
+        // Token already has a valid inline name that roundtrips → NameKind::Inline.
+        let sidecar = HashMap::new();
+        let forced = HashSet::new();
+        let ctx = empty_ctx(&sidecar, &forced);
+        let tok = obj(json!({
+            "name": {"component": "button", "property": "background-color", "state": "hover"},
+            "uuid": "0000"
+        }));
+        let (name, kind) = resolve_name("button-background-color-hover", &tok, &ctx);
+        assert_eq!(kind, NameKind::Inline);
+        assert_eq!(name["component"], "button");
+        assert_eq!(name["property"], "background-color");
+    }
+
+    #[test]
+    fn resolve_name_inline_dropped_when_no_roundtrip() {
+        // Inline name exists but doesn't reconstruct the original key → falls through.
+        let sidecar = HashMap::new();
+        let forced = HashSet::new();
+        let ctx = empty_ctx(&sidecar, &forced);
+        let tok = obj(json!({
+            // icon-color + colorFamily → color domain serialization gives wrong key
+            "name": {"property": "icon-color", "colorFamily": "cinnamon", "variant": "primary"},
+            "component": "icon",
+            "uuid": "0000"
+        }));
+        let (_name, kind) = resolve_name("icon-color-cinnamon-primary-default", &tok, &ctx);
+        // Should fall through to Decomposed (parse_legacy_name handles it)
+        assert_ne!(kind, NameKind::Inline);
+    }
+
+    #[test]
+    fn resolve_name_sidecar_used_when_roundtrips() {
+        let mut sidecar = HashMap::new();
+        sidecar.insert(
+            "blue-100".to_string(),
+            json!({"property": "color", "colorFamily": "blue", "scaleIndex": 100}),
+        );
+        let forced = HashSet::new();
+        let ctx = empty_ctx(&sidecar, &forced);
+        let tok = obj(json!({"$schema": ".../color.json", "value": "#2c2c2c", "uuid": "0000"}));
+        let (name, kind) = resolve_name("blue-100", &tok, &ctx);
+        assert_eq!(kind, NameKind::Sidecar);
+        assert_eq!(name["colorFamily"], "blue");
+        assert_eq!(name["scaleIndex"], 100);
+    }
+
+    #[test]
+    fn resolve_name_decomposed_when_roundtrips() {
+        let sidecar = HashMap::new();
+        let forced = HashSet::new();
+        let ctx = empty_ctx(&sidecar, &forced);
+        let tok = obj(json!({"component": "button", "uuid": "0000"}));
+        let (name, kind) = resolve_name("button-background-color-hover", &tok, &ctx);
+        assert_eq!(kind, NameKind::Decomposed);
+        assert_eq!(name["component"], "button");
+        assert_eq!(name["property"], "background-color");
+        assert_eq!(name["state"], "hover");
+    }
+
+    #[test]
+    fn resolve_name_thin_for_forced_exceptions() {
+        let sidecar = HashMap::new();
+        let mut forced = HashSet::new();
+        forced.insert("swatch-disabled-icon-border-color".to_string());
+        let ctx = empty_ctx(&sidecar, &forced);
+        let tok = obj(json!({"component": "swatch", "uuid": "0000"}));
+        let (name, kind) = resolve_name("swatch-disabled-icon-border-color", &tok, &ctx);
+        assert_eq!(kind, NameKind::Thin);
+        // Thin name: full key in property.
+        assert_eq!(name["property"], "swatch-disabled-icon-border-color");
+        assert_eq!(name["component"], "swatch");
+    }
+
+    #[test]
+    fn resolve_name_thin_when_roundtrip_fails() {
+        // Key has embedded state in non-canonical position — roundtrips() = false.
+        let sidecar = HashMap::new();
+        let forced = HashSet::new();
+        let ctx = empty_ctx(&sidecar, &forced);
+        let tok = obj(json!({"component": "swatch", "uuid": "0000"}));
+        let (_name, kind) = resolve_name("swatch-disabled-icon-border-color", &tok, &ctx);
+        assert_eq!(kind, NameKind::Thin);
     }
 }

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -40,13 +40,14 @@
 //! **Flat tokens** (no `sets`) are wrapped with a `name` object and alias syntax
 //! is normalized: `value: "{foo}"` → `$ref: "foo"`.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
 use uuid::Uuid;
 
 use crate::discovery::discover_json_files;
+use crate::naming;
 use crate::CoreError;
 
 // ── Mode orders ───────────────────────────────────────────────────────────────
@@ -69,6 +70,38 @@ const OUTER_LIFECYCLE_FIELDS: &[&str] = &[
     "description",
 ];
 
+// ── Name resolution ───────────────────────────────────────────────────────────
+
+/// How a cascade token's `name` field was produced during migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameKind {
+    /// Inline `name` field was present on the legacy token (passed through verbatim).
+    Inline,
+    /// Name fields were enriched from a sidecar name-object file. The legacy key
+    /// is kept as `property`; other sidecar fields (colorFamily, scaleIndex, etc.)
+    /// are added as additional taxonomy fields.
+    Sidecar,
+    /// Key was decomposed into `component`, `property`, and `state` via
+    /// [`naming::parse_legacy_name`], and the roundtrip check passed.
+    Decomposed,
+    /// Key did not decompose cleanly; `property` contains the full legacy key
+    /// (thin format). These are candidates for SPEC-017 remediation once the spec
+    /// taxonomy fully covers them.
+    Thin,
+}
+
+/// Options for the enhanced [`convert_dir_with_options`] converter.
+#[derive(Debug, Default)]
+pub struct ConvertOptions {
+    /// Directory containing sidecar name-object JSON files (e.g.
+    /// `packages/token-names/names/`). If set, tokens without an inline `name`
+    /// are enriched with taxonomy fields from the sidecar.
+    pub names_dir: Option<PathBuf>,
+    /// Path to a `naming-exceptions.json` file. Tokens listed there receive a
+    /// `Thin` name (they are known non-roundtrippable keys).
+    pub exceptions_path: Option<PathBuf>,
+}
+
 // ── Summary ───────────────────────────────────────────────────────────────────
 
 /// Summary statistics from a migration run.
@@ -84,6 +117,14 @@ pub struct MigrateSummary {
     pub set_entries_unwrapped: usize,
     /// Number of flat tokens converted.
     pub flat_tokens_converted: usize,
+    /// Cascade tokens whose name came from an inline `name` field (highest fidelity).
+    pub inline_names: usize,
+    /// Cascade tokens enriched with sidecar taxonomy fields.
+    pub sidecar_names: usize,
+    /// Cascade tokens where the key was decomposed into component+property+state.
+    pub decomposed_names: usize,
+    /// Cascade tokens that kept the full legacy key as `property` (tech-debt / thin).
+    pub thin_names: usize,
 }
 
 /// Summary statistics from an add-uuids run.
@@ -95,6 +136,96 @@ pub struct AddUuidsSummary {
     pub files_modified: usize,
     /// Total number of UUIDs generated and written.
     pub uuids_added: usize,
+}
+
+// ── Name resolution helpers ───────────────────────────────────────────────────
+
+/// Bundled name-resolution inputs threaded through the conversion pipeline.
+struct NameContext<'a> {
+    sidecar: &'a HashMap<String, Value>,
+    forced_thin: &'a HashSet<String>,
+}
+
+/// Load sidecar name-object JSON files from `dir` into a flat slug → name map.
+///
+/// Each file in `dir` must be a JSON object mapping token slug → name-object value.
+/// Duplicate slugs across files are overwritten (last writer wins).
+fn load_sidecar_names(dir: &Path) -> Result<HashMap<String, Value>, CoreError> {
+    let mut map = HashMap::new();
+    for path in discover_json_files(dir)? {
+        let text = std::fs::read_to_string(&path)?;
+        let val: Value = serde_json::from_str(&text)?;
+        if let Some(obj) = val.as_object() {
+            for (slug, name_val) in obj {
+                map.insert(slug.clone(), name_val.clone());
+            }
+        }
+    }
+    Ok(map)
+}
+
+/// Resolve a name value for a legacy token key.
+///
+/// Priority order:
+/// 1. **Inline** — token already has a `name` field → pass through verbatim.
+/// 2. **Sidecar** — sidecar provides taxonomy fields whose serialization roundtrips
+///    to the original key (verified via [`naming::extract_legacy_key`]). The sidecar
+///    name object is used as-is. Fields that don't roundtrip fall through.
+/// 3. **Decomposed** — [`naming::parse_legacy_name`] + roundtrip check via
+///    [`naming::roundtrips`]. Produces `{component?, property, state?}`.
+/// 4. **Thin** — fallback: `{property: key, component?}`. Roundtrip-safe because
+///    [`naming::extract_legacy_key`] detects the thin format and returns `property`
+///    directly for group key extraction in `legacy.rs`.
+fn resolve_name(
+    key: &str,
+    token_obj: &Map<String, Value>,
+    ctx: &NameContext<'_>,
+) -> (Value, NameKind) {
+    // 1. Inline name — verify it roundtrips to the original key before trusting it.
+    // Some inline names (e.g. icons.json) were authored for semantic clarity but omit
+    // fields needed to reconstruct the legacy key (e.g. missing `state`), so their
+    // extract_legacy_key result may not match. Fall through to decomposition if so.
+    if let Some(existing) = token_obj.get("name") {
+        if naming::extract_legacy_key(existing).as_deref() == Some(key) {
+            return (existing.clone(), NameKind::Inline);
+        }
+        // Inline name exists but doesn't roundtrip; treat as Thin candidate below.
+    }
+
+    // 2. Sidecar — verify the sidecar name roundtrips to the original key.
+    if let Some(sidecar_name) = ctx.sidecar.get(key) {
+        if naming::extract_legacy_key(sidecar_name).as_deref() == Some(key) {
+            return (sidecar_name.clone(), NameKind::Sidecar);
+        }
+        // Sidecar exists but doesn't roundtrip (e.g. typography fields not yet covered
+        // by extract_legacy_key). Fall through to decomposition.
+    }
+
+    // 3. Known non-roundtrippable from naming-exceptions.json → skip to thin.
+    let component_hint = token_obj.get("component").and_then(|v| v.as_str());
+    if !ctx.forced_thin.contains(key) {
+        // Decompose via parse_legacy_name and check roundtrip.
+        if naming::roundtrips(key, component_hint) {
+            let parsed = naming::parse_legacy_name(key, component_hint);
+            let mut name = Map::new();
+            if let Some(c) = &parsed.component {
+                name.insert("component".into(), Value::String(c.clone()));
+            }
+            name.insert("property".into(), Value::String(parsed.property));
+            if let Some(s) = &parsed.state {
+                name.insert("state".into(), Value::String(s.clone()));
+            }
+            return (Value::Object(name), NameKind::Decomposed);
+        }
+    }
+
+    // 4. Thin fallback — property = full legacy key (always roundtrip-safe).
+    let mut name = Map::new();
+    name.insert("property".into(), Value::String(key.to_string()));
+    if let Some(c) = component_hint {
+        name.insert("component".into(), Value::String(c.to_string()));
+    }
+    (Value::Object(name), NameKind::Thin)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -245,7 +376,287 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<MigrateSummary
     Ok(summary)
 }
 
+/// Convert all legacy token files in `input_dir` to cascade `.tokens.json` files in
+/// `output_dir`, applying richer name-object resolution guided by `opts`.
+///
+/// When `opts.names_dir` is set, sidecar name objects are merged where they roundtrip
+/// to the original key. When `opts.exceptions_path` is set, tokens listed in the
+/// exceptions file skip decomposition and receive a thin name.
+///
+/// The [`MigrateSummary`] returned includes per-resolution-kind counts so callers can
+/// measure decomposition quality (the "feasibility spike" report).
+pub fn convert_dir_with_options(
+    input_dir: &Path,
+    output_dir: &Path,
+    opts: &ConvertOptions,
+) -> Result<MigrateSummary, CoreError> {
+    std::fs::create_dir_all(output_dir)?;
+    let mut summary = MigrateSummary::default();
+
+    // Load sidecar names if provided.
+    let sidecar: HashMap<String, Value> = match &opts.names_dir {
+        Some(dir) if dir.is_dir() => load_sidecar_names(dir)?,
+        _ => HashMap::new(),
+    };
+
+    // Load forced-thin set from naming-exceptions.json if provided.
+    let forced_thin: HashSet<String> = match &opts.exceptions_path {
+        Some(path) if path.exists() => {
+            let exc = naming::NamingExceptionsFile::load(path)?;
+            exc.token_set()
+        }
+        _ => HashSet::new(),
+    };
+
+    let name_ctx = NameContext {
+        sidecar: &sidecar,
+        forced_thin: &forced_thin,
+    };
+
+    // Pass 1: build cross-file name→UUID map (same as convert_dir).
+    let files = discover_json_files(input_dir)?;
+    let mut global_name_to_uuid: HashMap<String, String> = HashMap::new();
+    let mut file_contents: Vec<(std::path::PathBuf, Value)> = Vec::new();
+
+    for input_path in &files {
+        let text = std::fs::read_to_string(input_path)?;
+        let value: Value = serde_json::from_str(&text)?;
+        if let Some(obj) = value.as_object() {
+            for (name, val) in obj {
+                if let Some(tok) = val.as_object() {
+                    if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                        global_name_to_uuid.insert(name.clone(), uuid.to_string());
+                    }
+                }
+            }
+        }
+        file_contents.push((input_path.clone(), value));
+    }
+
+    let name_to_uuid_ref: HashMap<&str, &str> = global_name_to_uuid
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    // Pass 2: convert each file with richer name resolution.
+    for (input_path, value) in &file_contents {
+        let Some(obj) = value.as_object() else {
+            continue;
+        };
+
+        let tokens =
+            convert_object_with_opts(obj, &mut summary, &name_to_uuid_ref, &name_ctx);
+        if tokens.is_empty() {
+            continue;
+        }
+
+        let stem = input_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("tokens");
+        let out_name = format!("{stem}.tokens.json");
+        let out_path = output_dir.join(out_name);
+        let out_text = serde_json::to_string_pretty(&Value::Array(tokens))?;
+        std::fs::write(&out_path, out_text)?;
+
+        summary.files_processed += 1;
+        summary.files_written += 1;
+    }
+
+    Ok(summary)
+}
+
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Convert all entries in a legacy token file object to cascade tokens (opts path).
+fn convert_object_with_opts(
+    obj: &Map<String, Value>,
+    summary: &mut MigrateSummary,
+    name_to_uuid: &HashMap<&str, &str>,
+    name_ctx: &NameContext<'_>,
+) -> Vec<Value> {
+    let mut out = Vec::new();
+    for (name, val) in obj {
+        let Some(tok_obj) = val.as_object() else {
+            continue;
+        };
+        let schema = tok_obj
+            .get("$schema")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if schema.ends_with("color-set.json") {
+            let tokens =
+                convert_set_with_opts(name, tok_obj, "colorScheme", COLOR_SET_MODE_ORDER, name_to_uuid, name_ctx);
+            let n = tokens.len();
+            if n > 0 {
+                let kind = resolve_name(name, tok_obj, name_ctx).1;
+                record_name_kind(kind, n, summary);
+            }
+            summary.set_entries_unwrapped += n;
+            summary.tokens_produced += n;
+            out.extend(tokens);
+        } else if schema.ends_with("scale-set.json") || schema.ends_with("typography-scale.json")
+        {
+            let tokens =
+                convert_set_with_opts(name, tok_obj, "scale", SCALE_SET_MODE_ORDER, name_to_uuid, name_ctx);
+            let n = tokens.len();
+            if n > 0 {
+                let kind = resolve_name(name, tok_obj, name_ctx).1;
+                record_name_kind(kind, n, summary);
+            }
+            summary.set_entries_unwrapped += n;
+            summary.tokens_produced += n;
+            out.extend(tokens);
+        } else {
+            let token = build_flat_with_opts(name, tok_obj, name_to_uuid, name_ctx, summary);
+            summary.flat_tokens_converted += 1;
+            summary.tokens_produced += 1;
+            out.push(token);
+        }
+    }
+    out
+}
+
+fn record_name_kind(kind: NameKind, count: usize, summary: &mut MigrateSummary) {
+    match kind {
+        NameKind::Inline => summary.inline_names += count,
+        NameKind::Sidecar => summary.sidecar_names += count,
+        NameKind::Decomposed => summary.decomposed_names += count,
+        NameKind::Thin => summary.thin_names += count,
+    }
+}
+
+/// Convert a set token (opts path).
+fn convert_set_with_opts(
+    property: &str,
+    outer: &Map<String, Value>,
+    dim_key: &str,
+    mode_order: &[&str],
+    name_to_uuid: &HashMap<&str, &str>,
+    name_ctx: &NameContext<'_>,
+) -> Vec<Value> {
+    let sets = match outer.get("sets").and_then(|v| v.as_object()) {
+        Some(s) => s,
+        None => return vec![build_flat_with_opts(property, outer, name_to_uuid, name_ctx, &mut MigrateSummary::default())],
+    };
+
+    let mut modes: Vec<&str> = mode_order
+        .iter()
+        .filter(|m| sets.contains_key(**m))
+        .copied()
+        .collect();
+    for mode in sets.keys() {
+        if !modes.contains(&mode.as_str()) {
+            modes.push(mode.as_str());
+        }
+    }
+
+    modes
+        .iter()
+        .filter_map(|mode| {
+            let entry = sets.get(*mode)?.as_object()?;
+            Some(build_set_entry_with_opts(
+                property, outer, entry, dim_key, mode, name_to_uuid, name_ctx,
+            ))
+        })
+        .collect()
+}
+
+/// Build a cascade token from a set mode entry (opts path).
+fn build_set_entry_with_opts(
+    property: &str,
+    outer: &Map<String, Value>,
+    entry: &Map<String, Value>,
+    dim_key: &str,
+    mode: &str,
+    name_to_uuid: &HashMap<&str, &str>,
+    name_ctx: &NameContext<'_>,
+) -> Value {
+    let mut out = Map::new();
+
+    // Resolve the base name (taxonomy decomposition / sidecar enrichment).
+    let (base_name, _kind) = resolve_name(property, outer, name_ctx);
+    let name_val = match base_name {
+        Value::Object(mut name_obj) => {
+            // Add the mode-set dimension to the name object.
+            name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
+            Value::Object(name_obj)
+        }
+        // String escape hatch: can't add dim_key to a string.
+        // Fall back to thin object so the set structure is preserved.
+        _ => {
+            let mut name_obj = Map::new();
+            name_obj.insert("property".into(), Value::String(property.to_string()));
+            if let Some(c) = outer.get("component").and_then(|v| v.as_str()) {
+                name_obj.insert("component".into(), Value::String(c.to_string()));
+            }
+            name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
+            Value::Object(name_obj)
+        }
+    };
+    out.insert("name".into(), name_val);
+
+    if let Some(schema) = entry.get("$schema").and_then(|v| v.as_str()) {
+        out.insert("$schema".into(), Value::String(schema.to_string()));
+    }
+    insert_value_or_ref(&mut out, entry);
+    if let Some(uuid) = entry.get("uuid").and_then(|v| v.as_str()) {
+        out.insert("uuid".into(), Value::String(uuid.to_string()));
+    }
+    if let Some(set_uuid) = outer.get("uuid").and_then(|v| v.as_str()) {
+        out.insert("set_uuid".into(), Value::String(set_uuid.to_string()));
+    }
+    if let Some(outer_schema) = outer.get("$schema").and_then(|v| v.as_str()) {
+        out.insert("set_schema".into(), Value::String(outer_schema.to_string()));
+    }
+    for field in OUTER_LIFECYCLE_FIELDS {
+        if let Some(v) = outer.get(*field) {
+            out.insert(field.to_string(), v.clone());
+        }
+    }
+    for field in OUTER_LIFECYCLE_FIELDS {
+        if let Some(v) = entry.get(*field) {
+            out.insert(field.to_string(), v.clone());
+        }
+    }
+    normalize_lifecycle_for_cascade(&mut out, name_to_uuid);
+    Value::Object(out)
+}
+
+/// Build a cascade token from a flat (non-set) legacy token (opts path).
+fn build_flat_with_opts(
+    property: &str,
+    token_obj: &Map<String, Value>,
+    name_to_uuid: &HashMap<&str, &str>,
+    name_ctx: &NameContext<'_>,
+    summary: &mut MigrateSummary,
+) -> Value {
+    let mut out = Map::new();
+
+    let (name_val, kind) = resolve_name(property, token_obj, name_ctx);
+    record_name_kind(kind, 1, summary);
+    out.insert("name".into(), name_val);
+
+    if let Some(schema) = token_obj.get("$schema").and_then(|v| v.as_str()) {
+        if !schema.ends_with("color-set.json")
+            && !schema.ends_with("scale-set.json")
+            && !schema.ends_with("typography-scale.json")
+        {
+            out.insert("$schema".into(), Value::String(schema.to_string()));
+        }
+    }
+    insert_value_or_ref(&mut out, token_obj);
+    if let Some(uuid) = token_obj.get("uuid").and_then(|v| v.as_str()) {
+        out.insert("uuid".into(), Value::String(uuid.to_string()));
+    }
+    for field in OUTER_LIFECYCLE_FIELDS {
+        if let Some(v) = token_obj.get(*field) {
+            out.insert(field.to_string(), v.clone());
+        }
+    }
+    normalize_lifecycle_for_cascade(&mut out, name_to_uuid);
+    Value::Object(out)
+}
 
 /// Convert all entries in a legacy token file object to cascade tokens.
 fn convert_object_with_context(

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -179,8 +179,10 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     // In the thin cascade format the full legacy key is stored in `property`; component is
     // duplicated as a metadata annotation only. Using `generate_legacy_name` would double
     // the prefix, so we return `property` directly.
+    // `property[c.len()..].starts_with('-')` is idiomatic and avoids the byte-boundary
+    // concern of a range index when `c` contains a multibyte character.
     let is_thin = component.is_some_and(|c| {
-        property.starts_with(c) && property.get(c.len()..c.len() + 1) == Some("-")
+        property.starts_with(c) && property[c.len()..].starts_with('-')
     });
 
     if is_thin {
@@ -339,5 +341,70 @@ mod tests {
         assert_eq!(obj.property, "accent-background-color");
         assert_eq!(obj.state.as_deref(), Some("default"));
         assert!(roundtrips("accent-background-color-default", None));
+    }
+
+    // ── extract_legacy_key ────────────────────────────────────────────────────
+
+    use serde_json::json;
+
+    #[test]
+    fn extract_key_string_escape_hatch() {
+        // String names (SPEC-017 escape hatch) are returned verbatim.
+        let name = json!("drop-shadow-emphasized-default-color");
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("drop-shadow-emphasized-default-color"));
+    }
+
+    #[test]
+    fn extract_key_color_family_with_scale_index() {
+        // Color-domain: {colorFamily}-{scaleIndex}, property ("color") is implicit.
+        let name = json!({"property": "color", "colorFamily": "blue", "scaleIndex": 100});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("blue-100"));
+    }
+
+    #[test]
+    fn extract_key_color_family_no_scale_index() {
+        let name = json!({"property": "color", "colorFamily": "black"});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("black"));
+    }
+
+    #[test]
+    fn extract_key_color_family_with_variant() {
+        let name = json!({"property": "color", "colorFamily": "cinnamon", "variant": "primary"});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("primary-cinnamon"));
+    }
+
+    #[test]
+    fn extract_key_decomposed_component_property_state() {
+        // General / decomposed format: generate_legacy_name path.
+        let name = json!({"component": "button", "property": "background-color", "state": "hover"});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("button-background-color-hover"));
+    }
+
+    #[test]
+    fn extract_key_thin_format_property_is_full_key() {
+        // Thin format: property starts with component prefix → return property directly.
+        let name = json!({"property": "swatch-disabled-icon-border-color", "component": "swatch"});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("swatch-disabled-icon-border-color"));
+    }
+
+    #[test]
+    fn extract_key_no_property_uses_color_domain() {
+        // Object with colorFamily but no property → color-domain path still works
+        // (property is implicit for palette tokens).
+        let name = json!({"colorFamily": "blue"});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("blue"));
+    }
+
+    #[test]
+    fn extract_key_no_property_no_color_family_returns_none() {
+        // Object with neither property nor colorFamily → None.
+        let name = json!({"state": "hover"});
+        assert_eq!(extract_legacy_key(&name), None);
+    }
+
+    #[test]
+    fn extract_key_non_string_non_object_returns_none() {
+        assert_eq!(extract_legacy_key(&json!(null)), None);
+        assert_eq!(extract_legacy_key(&json!(42)), None);
     }
 }

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -24,6 +24,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 /// Well-known interactive / semantic state words that may appear as the
 /// trailing segment(s) of a legacy token name.
@@ -130,6 +131,68 @@ fn split_trailing_state(s: &str) -> (&str, Option<&str>) {
     }
 
     (s, None)
+}
+
+/// Extract the canonical legacy kebab-case key from a cascade `name` value.
+///
+/// Handles two name forms:
+///
+/// * **String** (SPEC-017 escape hatch): the string *is* the legacy key.
+/// * **Object**: reconstructed by domain-aware rules:
+///   - *Color-domain* (name has `colorFamily`):
+///     `{variant?}-{colorFamily}-{scaleIndex?}` — `property` is implicit ("color") and not
+///     serialized in the legacy key.
+///   - *General* (all other tokens): uses [`generate_legacy_name`] which produces
+///     `{component?}-{property}-{state?}`. For thin-format cascade tokens where
+///     `property` already contains the full legacy key (possibly with component prefix),
+///     the result equals `property` directly.
+///
+/// Returns `None` only when the name is not a recognised shape (neither string nor object
+/// with a `property` field).
+pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
+    // String escape hatch: the string IS the legacy key.
+    if let Some(s) = name_val.as_str() {
+        return Some(s.to_string());
+    }
+
+    let name: &Map<String, Value> = name_val.as_object()?;
+
+    // Color-domain serialization: {variant?}-{colorFamily}-{scaleIndex?}
+    // `property` ("color") is implicit for palette tokens and omitted from the key.
+    if let Some(color_family) = name.get("colorFamily").and_then(|v| v.as_str()) {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(v) = name.get("variant").and_then(|v| v.as_str()) {
+            parts.push(v.to_string());
+        }
+        parts.push(color_family.to_string());
+        if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
+            parts.push(i.to_string());
+        }
+        return Some(parts.join("-"));
+    }
+
+    let property = name.get("property").and_then(|v| v.as_str())?;
+    let component = name.get("component").and_then(|v| v.as_str());
+    let state = name.get("state").and_then(|v| v.as_str());
+
+    // Thin-format detection: `property` already begins with `{component}-`.
+    // In the thin cascade format the full legacy key is stored in `property`; component is
+    // duplicated as a metadata annotation only. Using `generate_legacy_name` would double
+    // the prefix, so we return `property` directly.
+    let is_thin = component.is_some_and(|c| {
+        property.starts_with(c) && property.get(c.len()..c.len() + 1) == Some("-")
+    });
+
+    if is_thin {
+        return Some(property.to_string());
+    }
+
+    // Decomposed/general format: reconstruct via generate_legacy_name.
+    Some(generate_legacy_name(&NameObject {
+        property: property.to_string(),
+        component: component.map(str::to_string),
+        state: state.map(str::to_string),
+    }))
 }
 
 /// An entry in the naming-exceptions.json allowlist.


### PR DESCRIPTION
## Description

Enhances the `migrate convert` command to produce structured name objects instead of the previous thin format (entire legacy key stored verbatim in `property`). Adds `naming::extract_legacy_key()` to make the cascade→legacy reverse path handle all name forms. Part of the feasibility spike for the new-format-as-source-of-truth initiative.

**New public API:** `migrate::convert_dir_with_options(input, output, opts)` with:
- `opts.names_dir` — sidecar name-object files (e.g. `packages/token-names/names/`)
- `opts.exceptions_path` — `naming-exceptions.json` for known non-roundtrippable keys

**New CLI flags** on `migrate convert`:
```
--names-dir <DIR>    sidecar name-object files
--exceptions <FILE>  naming-exceptions.json
```

**Name resolution priority (per token):**
1. Inline `name` on the legacy token (roundtrip-verified)
2. Sidecar entry (roundtrip-verified via `extract_legacy_key`)
3. Key decomposition via `parse_legacy_name` — accepted when `roundtrips()` passes
4. Thin fallback (full key as `property`) — tech-debt candidates

**`naming::extract_legacy_key(name_val)`** — domain-aware key reconstruction from any cascade name value: string escape-hatch → use directly; object with `colorFamily` → `{variant?}-{colorFamily}-{scaleIndex?}`; general → `generate_legacy_name(component, property, state)` with thin-format detection.

## Related Issue

Part of the taxonomy/naming initiative tracked in RFC #661 and the taxonomy backbone plan.

## Motivation and Context

The new spec format (`packages/design-data-spec/`) requires tokens to carry structured name objects with taxonomy fields. The old converter dumped the entire legacy key into `property`, making the cascade output useless for taxonomy tooling. This spike establishes: (a) how much of the corpus can be automatically decomposed, (b) that lossless roundtrip to the exact legacy format is achievable, and (c) the remaining tech-debt count.

## How Has This Been Tested?

**Unit tests:** `cargo test -p design-data-core` — all 438 tests pass including `full_roundtrip_clean_against_spectrum_token_sources`.

**End-to-end spike run** on the full 2,460-token corpus (`packages/tokens/src`):

```
cargo run -p design-data-cli -- migrate convert packages/tokens/src \
  --output /tmp/dd-cascade \
  --names-dir packages/token-names/names/ \
  --exceptions packages/tokens/naming-exceptions.json
```

Results:
```
Name resolution:
      0  inline   (from existing name field)
    972  sidecar  (from token-names sidecar)   23%
   2965  decomposed (component + property + state)  71%
    229  thin     (full key as property — tech debt)  6%
  ──────
   4166  total  (95% structured)
```

**Legacy roundtrip:**
```
migrate legacy-output /tmp/dd-cascade --output /tmp/dd-legacy-regen
diff packages/tokens/src /tmp/dd-legacy-regen
```
→ Only pre-existing normalization differences (deprecated hoisting from set entries to outer level — same behavior as the current converter; handled by `roundtrip_verify`'s normalization). All 2,460 token keys and values are preserved exactly.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.