### PR TITLE
feat(design-data): add cascade-format token package as new source of truth

### DIFF
--- a/.changeset/add-spectrum-design-data-package.md
+++ b/.changeset/add-spectrum-design-data-package.md
@@ -1,0 +1,7 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Initial release of `@adobe/spectrum-design-data` — Spectrum design tokens in cascade format.
+
+This package is the new canonical source of truth for `@adobe/spectrum-tokens`. It holds 4 166 cascade tokens (8 files) with structured name objects derived from the full token taxonomy. `packages/tokens/src/` is regenerated from this package via `moon run design-data:legacy-output`.

--- a/.changeset/add-spectrum-design-data-package.md
+++ b/.changeset/add-spectrum-design-data-package.md
@@ -4,4 +4,6 @@
 
 Initial release of `@adobe/spectrum-design-data` — Spectrum design tokens in cascade format.
 
-This package is the new canonical source of truth for `@adobe/spectrum-tokens`. It holds 4 166 cascade tokens (8 files) with structured name objects derived from the full token taxonomy. `packages/tokens/src/` is regenerated from this package via `moon run design-data:legacy-output`.
+New canonical source of truth for `@adobe/spectrum-tokens`: 4 166 cascade tokens
+(8 files) with structured name objects from the full token taxonomy.
+`packages/tokens/src/` is regenerated via `moon run design-data:legacy-output`.

--- a/packages/design-data/README.md
+++ b/packages/design-data/README.md
@@ -1,0 +1,75 @@
+# [**@adobe/spectrum-design-data**](https://github.com/adobe/spectrum-design-data)
+
+Spectrum design tokens in **cascade format** — the canonical source of truth
+for [`@adobe/spectrum-tokens`](../tokens).
+
+## What is the cascade format?
+
+Each `.tokens.json` file in `tokens/` is a JSON array of spec-compliant token
+objects. Each token carries a structured `name` object with taxonomy fields
+(`component`, `property`, `state`, `colorFamily`, `scaleIndex`, etc.) instead
+of a flat kebab-case string. The format is defined in
+[`packages/design-data-spec`](../design-data-spec).
+
+```jsonc
+// tokens/color-palette.tokens.json (excerpt)
+[
+  {
+    "name": { "property": "color", "colorFamily": "blue", "scaleIndex": 100 },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "#E9F4FF",
+    "uuid": "…"
+  }
+]
+```
+
+## Relationship to `@adobe/spectrum-tokens`
+
+`packages/tokens/src/` (the legacy flat-object format consumed by Style
+Dictionary and downstream tooling) is **generated** from this package. Do not
+edit `packages/tokens/src/` directly — changes will be overwritten.
+
+To regenerate the legacy package after editing tokens here:
+
+```bash
+moon run design-data:legacy-output
+```
+
+## Token corpus
+
+8 files, 4 166 cascade tokens (from 2 460 legacy entries):
+
+| File                          | Description                         |
+| ----------------------------- | ----------------------------------- |
+| `color-palette.json`          | Global color scale (blues, reds, …) |
+| `color-component.json`        | Component-scoped color tokens       |
+| `color-aliases.json`          | Semantic color aliases              |
+| `semantic-color-palette.json` | Semantic/contextual palette         |
+| `typography.json`             | Font sizes, weights, families       |
+| `layout.json`                 | Global spacing and sizing           |
+| `layout-component.json`       | Component-scoped layout tokens      |
+| `icons.json`                  | Icon sizing tokens                  |
+
+## Name-object quality
+
+95% of tokens carry structured name objects:
+
+* **23%** enriched from sidecar name metadata (`colorFamily`, `scaleIndex`, `variant`, …)
+* **71%** decomposed from the legacy key (`component` + `property` + `state`)
+* **6%** thin (full legacy key stored in `property`) — tracked as SPEC-017 tech debt
+
+## moon tasks
+
+| Task                     | Command                                       | Purpose                                               |
+| ------------------------ | --------------------------------------------- | ----------------------------------------------------- |
+| `validate`               | `moon run design-data:validate`               | Validate cascade files against spec rules             |
+| `legacy-output`          | `moon run design-data:legacy-output`          | Regenerate `packages/tokens/src/`                     |
+| `roundtrip-verify`       | `moon run design-data:roundtrip-verify`       | CI guard: fail if cascade and legacy diverge          |
+| `regenerate-from-legacy` | `moon run design-data:regenerate-from-legacy` | Re-sync cascade from legacy (one-time / escape hatch) |
+
+## Consuming the cascade format
+
+```js
+import colorPalette from "@adobe/spectrum-design-data/tokens/color-palette";
+// colorPalette is an array of cascade token objects
+```

--- a/packages/design-data/moon.yml
+++ b/packages/design-data/moon.yml
@@ -15,6 +15,8 @@ fileGroups:
 
 tasks:
   # Validate the cascade token files against the design-data spec rules.
+  # Note: `validate` uses --exceptions-path; `migrate convert` uses --exceptions.
+  # These are different subcommands with different flag names.
   validate:
     command: ../../sdk/target/debug/design-data
     args:
@@ -48,11 +50,30 @@ tasks:
     outputs:
       - "../tokens/src/**/*.json"
 
-  # Regenerate the cascade token files from the legacy source.
-  # Used to re-sync this package after upstream legacy changes.
-  # Under normal operation, edits should be made here (cascade) not in
-  # packages/tokens/src (legacy).
-  generate:
+  # CI guard: verify that packages/tokens/src/ is in sync with the cascade
+  # source. Fails if a PR updates cascade tokens without re-running legacy-output.
+  roundtrip-verify:
+    command: ../../sdk/target/debug/design-data
+    args:
+      - migrate
+      - roundtrip-verify
+      - ../tokens/src
+    platform: system
+    deps:
+      - sdk:build
+    inputs:
+      - "@globs(tokens)"
+      - "../tokens/src/**/*.json"
+
+  # ONE-TIME / ESCAPE HATCH — Re-sync cascade files from the legacy package.
+  # Use this only when upstream legacy changes need to be pulled into cascade
+  # before the full migration is complete. Under normal operation, all edits
+  # go into tokens/*.tokens.json (cascade), not packages/tokens/src/ (legacy).
+  #
+  # WARNING: this task OVERWRITES the cascade token files. Do not run it
+  # routinely — doing so would discard any hand-authored taxonomy improvements
+  # in the cascade source.
+  regenerate-from-legacy:
     command: ../../sdk/target/debug/design-data
     args:
       - migrate
@@ -71,5 +92,5 @@ tasks:
       - "../tokens/src/**/*.json"
       - "../token-names/names/**/*.json"
       - "../tokens/naming-exceptions.json"
-    outputs:
-      - "@globs(tokens)"
+    # No `outputs:` — prevents moon from auto-running this task as part of
+    # dependency graphs and silently clobbering hand-edited cascade tokens.

--- a/packages/design-data/moon.yml
+++ b/packages/design-data/moon.yml
@@ -1,0 +1,75 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+$schema: "https://moonrepo.dev/schemas/project.json"
+layer: library
+fileGroups:
+  tokens:
+    - "tokens/**/*.tokens.json"
+
+tasks:
+  # Validate the cascade token files against the design-data spec rules.
+  validate:
+    command: ../../sdk/target/debug/design-data
+    args:
+      - validate
+      - ./tokens
+      - --exceptions-path
+      - ../tokens/naming-exceptions.json
+    platform: system
+    deps:
+      - sdk:build
+    inputs:
+      - "@globs(tokens)"
+      - "../tokens/naming-exceptions.json"
+
+  # Regenerate packages/tokens/src/ from the cascade source of truth.
+  # Run this after editing any tokens/*.tokens.json file to keep the
+  # legacy package in sync for downstream consumers.
+  legacy-output:
+    command: ../../sdk/target/debug/design-data
+    args:
+      - migrate
+      - legacy-output
+      - ./tokens
+      - --output
+      - ../tokens/src
+    platform: system
+    deps:
+      - sdk:build
+    inputs:
+      - "@globs(tokens)"
+    outputs:
+      - "../tokens/src/**/*.json"
+
+  # Regenerate the cascade token files from the legacy source.
+  # Used to re-sync this package after upstream legacy changes.
+  # Under normal operation, edits should be made here (cascade) not in
+  # packages/tokens/src (legacy).
+  generate:
+    command: ../../sdk/target/debug/design-data
+    args:
+      - migrate
+      - convert
+      - ../tokens/src
+      - --output
+      - ./tokens
+      - --names-dir
+      - ../token-names/names
+      - --exceptions
+      - ../tokens/naming-exceptions.json
+    platform: system
+    deps:
+      - sdk:build
+    inputs:
+      - "../tokens/src/**/*.json"
+      - "../token-names/names/**/*.json"
+      - "../tokens/naming-exceptions.json"
+    outputs:
+      - "@globs(tokens)"

--- a/packages/design-data/package.json
+++ b/packages/design-data/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@adobe/spectrum-design-data",
+  "version": "1.0.0",
+  "description": "Spectrum design tokens in cascade format — the canonical source of truth for @adobe/spectrum-tokens",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adobe/spectrum-design-data.git"
+  },
+  "author": "Garth Braithwaite <garthdb@gmail.com> (http://garthdb.com/)",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/adobe/spectrum-design-data/issues"
+  },
+  "publishConfig": {
+    "provenance": true
+  },
+  "homepage": "https://github.com/adobe/spectrum-design-data/tree/main/packages/design-data#readme",
+  "exports": {
+    "./tokens/*": "./tokens/*.tokens.json"
+  },
+  "files": [
+    "tokens/"
+  ],
+  "scripts": {}
+}

--- a/packages/design-data/package.json
+++ b/packages/design-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/spectrum-design-data",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Spectrum design tokens in cascade format — the canonical source of truth for @adobe/spectrum-tokens",
   "type": "module",
   "repository": {

--- a/packages/design-data/package.json
+++ b/packages/design-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/spectrum-design-data",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Spectrum design tokens in cascade format — the canonical source of truth for @adobe/spectrum-tokens",
   "type": "module",
   "repository": {
@@ -20,7 +20,8 @@
     "./tokens/*": "./tokens/*.tokens.json"
   },
   "files": [
-    "tokens/"
+    "tokens/",
+    "README.md"
   ],
   "scripts": {}
 }

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1,0 +1,4124 @@
+[
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-900",
+    "uuid": "d9d8488d-9b38-47e0-9660-dcad040f3ca8",
+    "set_uuid": "e05251ac-d64a-4157-9b20-224f0392269e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-800",
+    "uuid": "f24eb871-6419-4cef-88a2-cca8548ae31e",
+    "set_uuid": "e05251ac-d64a-4157-9b20-224f0392269e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-900",
+    "uuid": "1f4f6c48-633c-4eb5-b7d6-bf5a9a7fde18",
+    "set_uuid": "e05251ac-d64a-4157-9b20-224f0392269e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "026b1d5e-7cbc-4ee9-91e8-19766b9ac541",
+    "set_uuid": "1cc745b9-a6a8-4252-b7ea-84998a5654e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-700",
+    "uuid": "e2c0de7e-d271-4b2c-9393-d864a95732e6",
+    "set_uuid": "1cc745b9-a6a8-4252-b7ea-84998a5654e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "a5201034-a592-47c6-be78-050ae951043e",
+    "set_uuid": "1cc745b9-a6a8-4252-b7ea-84998a5654e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "9651d413-47dc-4b55-976f-91e5c6c91fb5",
+    "set_uuid": "ce776087-ee7b-4696-87b8-1520a0da8ecd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-700",
+    "uuid": "9e140a94-c11f-470b-b7af-49880e58d4ce",
+    "set_uuid": "ce776087-ee7b-4696-87b8-1520a0da8ecd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "a4fb3dc6-b724-4e5d-bbc4-c4d985e85975",
+    "set_uuid": "ce776087-ee7b-4696-87b8-1520a0da8ecd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "key-focus",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "43ca5f34-decc-4de8-9413-74ce57802b65",
+    "set_uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "key-focus",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-700",
+    "uuid": "af809118-7a97-409c-925f-8d7636a791c8",
+    "set_uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-background-color",
+      "state": "key-focus",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "afb8dd77-7de2-4749-a594-1ff68b2fcd67",
+    "set_uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-content-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-900",
+    "uuid": "b14c876e-2930-413b-8688-1e0cf2358185"
+  },
+  {
+    "name": {
+      "property": "accent-content-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "25d3b2d2-e7d5-4686-95ff-bfaaddc14ff1"
+  },
+  {
+    "name": {
+      "property": "accent-content-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "d6cd141c-d7a4-457f-bed5-9a725ca7a0fe"
+  },
+  {
+    "name": {
+      "property": "accent-content-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-1000",
+    "uuid": "71dcd137-f767-4d2c-b6ac-942b99ac8621"
+  },
+  {
+    "name": {
+      "property": "accent-content-color",
+      "state": "selected"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-content-color-down",
+    "uuid": "9cfbf8bc-e4f3-4658-922e-9421e2ed126b"
+  },
+  {
+    "name": {
+      "property": "accent-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-800",
+    "uuid": "dbcb4372-f250-42bd-a5bc-b9d48cfb9322",
+    "set_uuid": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-900",
+    "uuid": "8ccd197f-fc8e-4d31-866c-2b96049eea89",
+    "set_uuid": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-800",
+    "uuid": "6e12afb7-c76e-4a83-acc2-f891953d5190",
+    "set_uuid": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-base-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "e0d8739d-18dd-44bc-92ea-e443882a780b"
+  },
+  {
+    "name": {
+      "property": "background-elevated-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "2275e0fa-69a3-4542-9ec6-919e44035118",
+    "set_uuid": "68fc2ac3-45b4-4067-a238-45a930ae9485",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-elevated-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-75",
+    "uuid": "4c19885d-0411-43dc-8f4a-db81905728e6",
+    "set_uuid": "68fc2ac3-45b4-4067-a238-45a930ae9485",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-elevated-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "644ca621-9138-44e3-bdd7-123a9fccd9a6",
+    "set_uuid": "68fc2ac3-45b4-4067-a238-45a930ae9485",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-layer-1-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-50",
+    "uuid": "7e6678b7-2903-434b-8ee2-06c83815b01d"
+  },
+  {
+    "name": {
+      "property": "background-layer-2-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "b7b2bf98-b96a-40ca-b51e-5876d3418085",
+    "set_uuid": "5b441187-fb00-4d55-8534-9e7e313fed60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-layer-2-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-75",
+    "uuid": "e30b7936-6ae7-4ada-8892-94a1f67d55c9",
+    "set_uuid": "5b441187-fb00-4d55-8534-9e7e313fed60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-layer-2-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "b834a6a5-e582-4450-b87a-57fa23e12179",
+    "set_uuid": "5b441187-fb00-4d55-8534-9e7e313fed60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-opacity",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0",
+    "uuid": "b7b25005-7188-4936-8dbc-e2dd15213f47"
+  },
+  {
+    "name": {
+      "property": "background-opacity",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "0718c9fc-3bb2-4887-97bd-e23b8ad308c5"
+  },
+  {
+    "name": {
+      "property": "background-opacity",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "048c326d-93b1-435f-a9e3-a4cbd3144fdd"
+  },
+  {
+    "name": {
+      "property": "background-opacity",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "a35883a9-43fd-4be5-97ee-62fdf3a33f39"
+  },
+  {
+    "name": {
+      "property": "background-pasteboard-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "4938710b-5a69-49eb-8517-6f5556c23298",
+    "set_uuid": "f8e93285-b100-4dd9-a943-435e173321af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-pasteboard-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "6a7c5092-c262-49b0-b5ec-5b8b4fa66d1e",
+    "set_uuid": "f8e93285-b100-4dd9-a943-435e173321af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "background-pasteboard-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "93e51c98-d83e-4dad-86b7-f060a80a601e",
+    "set_uuid": "f8e93285-b100-4dd9-a943-435e173321af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "c6c435b6-34b3-4fc1-bf96-a56a15e01fe5",
+    "set_uuid": "65651644-f0b3-4464-b656-d3c7896b01c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "83591a94-83e1-4557-8f50-cc1fe9793b76",
+    "set_uuid": "65651644-f0b3-4464-b656-d3c7896b01c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "db8b9268-68dc-46be-aace-1adf8d85061b",
+    "set_uuid": "65651644-f0b3-4464-b656-d3c7896b01c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-200",
+    "uuid": "7d52711e-43fa-4a95-a7b1-3a7367570596",
+    "set_uuid": "f6080c78-c400-40cf-8b83-e81b15bc0373",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-300",
+    "uuid": "7da4709c-caf3-401a-a2ce-07186a7e8e8c",
+    "set_uuid": "f6080c78-c400-40cf-8b83-e81b15bc0373",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-200",
+    "uuid": "93563495-60af-4a84-b811-9672fc46a1cc",
+    "set_uuid": "f6080c78-c400-40cf-8b83-e81b15bc0373",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "b7cca44c-7c7d-4904-8f2c-d5bde4ea42a2",
+    "set_uuid": "3ea5b3ef-e671-444c-a1e9-fbe2566ec771",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "63fe16ed-70fa-4eaf-918c-f642ff69ce05",
+    "set_uuid": "3ea5b3ef-e671-444c-a1e9-fbe2566ec771",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "blue-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "0f058412-085d-4670-8cd5-964ed903a20a",
+    "set_uuid": "3ea5b3ef-e671-444c-a1e9-fbe2566ec771",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-900",
+    "uuid": "168c3534-c54e-415b-a623-27c2a8caea8c",
+    "set_uuid": "428f3605-6727-4b75-900e-76f8f57c2ce3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-800",
+    "uuid": "c6dcdb8e-4966-4de6-a74a-fffa0793d58e",
+    "set_uuid": "428f3605-6727-4b75-900e-76f8f57c2ce3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-900",
+    "uuid": "fbd8df06-a6c9-462b-ad25-a3f77016128e",
+    "set_uuid": "428f3605-6727-4b75-900e-76f8f57c2ce3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-200",
+    "uuid": "4f1f131b-b6d1-401b-82ff-be6fc0cce9f3",
+    "set_uuid": "00aeee53-1402-4410-add3-9f648d68fefd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-300",
+    "uuid": "77b47209-4527-462b-a11f-b3e5f47857ec",
+    "set_uuid": "00aeee53-1402-4410-add3-9f648d68fefd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-200",
+    "uuid": "ac6995d9-8982-4dac-ba85-4c79ec7850a1",
+    "set_uuid": "00aeee53-1402-4410-add3-9f648d68fefd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-800",
+    "uuid": "12fd4bac-b0ef-4285-a0e4-5947526a91a9",
+    "set_uuid": "4e301679-a594-4e25-a26a-030c844f4e74",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-900",
+    "uuid": "a25ac05c-c108-4caf-a77e-79b4fd36ee91",
+    "set_uuid": "4e301679-a594-4e25-a26a-030c844f4e74",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "brown-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-800",
+    "uuid": "349dc3c5-fd57-403c-bc42-2a60b8325bd3",
+    "set_uuid": "4e301679-a594-4e25-a26a-030c844f4e74",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-600",
+    "uuid": "d4fd682d-4bef-4a92-bf14-90ce02b534e6",
+    "set_uuid": "5bd340a5-45fc-4666-82b2-827f9f17d6e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-900",
+    "uuid": "a9ab7a59-9cab-47fb-876d-6f0af93dc5df",
+    "set_uuid": "5bd340a5-45fc-4666-82b2-827f9f17d6e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-600",
+    "uuid": "b6e14409-7a61-46fc-80d0-2b7854baf871",
+    "set_uuid": "5bd340a5-45fc-4666-82b2-827f9f17d6e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-200",
+    "uuid": "cf459b71-0d91-4cb4-96b8-f536e553f66e",
+    "set_uuid": "9a8c68d6-51bb-4c93-afcf-d7c497b51049",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-300",
+    "uuid": "67618d20-60a0-44d9-b98a-a84faf409788",
+    "set_uuid": "9a8c68d6-51bb-4c93-afcf-d7c497b51049",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-200",
+    "uuid": "2182ee3c-55aa-4d07-9cc1-f827c88ce3d6",
+    "set_uuid": "9a8c68d6-51bb-4c93-afcf-d7c497b51049",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-700",
+    "uuid": "8f6f9f6e-1762-4ac3-a9b9-6cacd135dfac",
+    "set_uuid": "bac88d84-8bb8-49eb-82c5-43f8f5cfdc52",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-800",
+    "uuid": "37c1311b-29ed-44ab-b656-a7538726ad77",
+    "set_uuid": "bac88d84-8bb8-49eb-82c5-43f8f5cfdc52",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "celery-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-700",
+    "uuid": "d8adaaf1-b6a3-400a-853b-6ba5a5c873e7",
+    "set_uuid": "bac88d84-8bb8-49eb-82c5-43f8f5cfdc52",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-500",
+    "uuid": "f6e68186-e7fe-4d36-b371-72461a271358",
+    "set_uuid": "4b6aeec7-d8be-41a8-ae4b-b668aa320eb7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-1000",
+    "uuid": "5df9a029-dc91-4078-a198-574486948834",
+    "set_uuid": "4b6aeec7-d8be-41a8-ae4b-b668aa320eb7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-500",
+    "uuid": "67d55f09-a468-4174-9b59-13008b32b44e",
+    "set_uuid": "4b6aeec7-d8be-41a8-ae4b-b668aa320eb7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-200",
+    "uuid": "2dd50902-f9bb-4f79-b31c-3997f4fd2163",
+    "set_uuid": "090131f4-60e4-4e0e-b9cc-84b0116f0c60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-300",
+    "uuid": "b80c47b0-222b-49a2-9012-1465a4575092",
+    "set_uuid": "090131f4-60e4-4e0e-b9cc-84b0116f0c60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-200",
+    "uuid": "ab75a3ba-17ce-4aae-902f-2b3e0233b726",
+    "set_uuid": "090131f4-60e4-4e0e-b9cc-84b0116f0c60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-600",
+    "uuid": "18735078-a942-442b-bc04-1b72bac77c98",
+    "set_uuid": "29c04d77-755d-4d81-bc5b-ab0ab3e6a6ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-900",
+    "uuid": "a46d8e05-4f56-4b46-a279-0164abfa42e8",
+    "set_uuid": "29c04d77-755d-4d81-bc5b-ab0ab3e6a6ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "chartreuse-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-600",
+    "uuid": "a2cc3b6e-014f-4522-8d05-9e9d06464504",
+    "set_uuid": "29c04d77-755d-4d81-bc5b-ab0ab3e6a6ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-900",
+    "uuid": "6dc7df67-2cfb-440f-9b1c-b7262a7cc2d3",
+    "set_uuid": "4db12eba-db54-4121-9968-caccedaa18d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-800",
+    "uuid": "d442e5b5-5083-443d-ba60-12c60406c452",
+    "set_uuid": "4db12eba-db54-4121-9968-caccedaa18d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-900",
+    "uuid": "8e940601-2401-46ff-a5fb-9137d12678b7",
+    "set_uuid": "4db12eba-db54-4121-9968-caccedaa18d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-200",
+    "uuid": "4d114a18-a876-4b01-a356-64b6098496f4",
+    "set_uuid": "820f61ee-85e3-4173-b08b-6196bdc51e8f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-300",
+    "uuid": "68b6af88-a951-48f8-89c3-9d599a05f4dc",
+    "set_uuid": "820f61ee-85e3-4173-b08b-6196bdc51e8f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-200",
+    "uuid": "f326443a-8f5d-4aa2-8bbb-17dc7b0420d6",
+    "set_uuid": "820f61ee-85e3-4173-b08b-6196bdc51e8f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-800",
+    "uuid": "86aa8b9c-b124-45ba-a359-a58295d28509",
+    "set_uuid": "229f3603-edcf-4e55-a5d2-7a805f991ac5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-900",
+    "uuid": "24026c61-470e-41b9-a247-58605b54706d",
+    "set_uuid": "229f3603-edcf-4e55-a5d2-7a805f991ac5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cinnamon-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-800",
+    "uuid": "9022dc27-f9d9-4697-b808-ebe36d216f8b",
+    "set_uuid": "229f3603-edcf-4e55-a5d2-7a805f991ac5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-900",
+    "uuid": "12c060c6-db12-41ca-8b53-f4fc0afd2ed7",
+    "set_uuid": "b21d509c-0067-468f-8ae7-dc38bf67d179",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-800",
+    "uuid": "543af64f-9c28-4e88-8597-3259cd7ebf1f",
+    "set_uuid": "b21d509c-0067-468f-8ae7-dc38bf67d179",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-900",
+    "uuid": "764bb832-de5a-4c21-b429-f911a931ead6",
+    "set_uuid": "b21d509c-0067-468f-8ae7-dc38bf67d179",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-200",
+    "uuid": "084200e3-85bf-496e-b12a-b439e108b9fb",
+    "set_uuid": "0cec96af-08f3-4c3e-b9ed-33b48c47b302",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-300",
+    "uuid": "740e1c42-e68c-4c10-9bcd-30dc0bae6418",
+    "set_uuid": "0cec96af-08f3-4c3e-b9ed-33b48c47b302",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-200",
+    "uuid": "2f72eaf9-547a-436e-86ab-695979db4f93",
+    "set_uuid": "0cec96af-08f3-4c3e-b9ed-33b48c47b302",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-600",
+    "uuid": "c3c126c9-2133-416a-ac0e-4ae00546941b",
+    "set_uuid": "51dff390-8bc1-4652-9fd2-fd079d5795e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-900",
+    "uuid": "091a2073-baa0-4cc6-b943-9dddc285ad62",
+    "set_uuid": "51dff390-8bc1-4652-9fd2-fd079d5795e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "cyan-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-600",
+    "uuid": "ad004c2f-8cab-45d5-8e22-921d3f0332ea",
+    "set_uuid": "51dff390-8bc1-4652-9fd2-fd079d5795e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "disabled-background-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "a46de9d2-5c68-4a1e-97cd-7cbaf4038303"
+  },
+  {
+    "name": {
+      "property": "disabled-border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-300",
+    "uuid": "474ae56c-709a-4f5a-a56b-62d01093f412"
+  },
+  {
+    "name": {
+      "property": "disabled-content-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "8bf69fd3-1462-49b9-a78a-cc2f03380823"
+  },
+  {
+    "name": {
+      "property": "disabled-static-black-background-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-100",
+    "uuid": "579e401c-de49-41af-a8c7-a0a070c31979"
+  },
+  {
+    "name": {
+      "property": "disabled-static-black-border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-300",
+    "uuid": "2df7303f-3c34-47d1-9ec9-b901dfbcf947"
+  },
+  {
+    "name": {
+      "property": "disabled-static-black-content-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-400",
+    "uuid": "e75dbb08-80eb-4de5-afd4-55a532c69c97"
+  },
+  {
+    "name": {
+      "property": "disabled-static-white-background-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-100",
+    "uuid": "fbd40c55-bb12-43ff-9fa6-c93884befc89"
+  },
+  {
+    "name": {
+      "property": "disabled-static-white-border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-300",
+    "uuid": "c0dfeb64-983e-4f4c-a13e-24b5fbd2b791"
+  },
+  {
+    "name": {
+      "property": "disabled-static-white-content-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-400",
+    "uuid": "fe319bca-0413-4ad8-a783-c64563e05816"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-ambient-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.08)",
+    "uuid": "edc729e0-5998-42ac-bf4a-fdc4bfabd771",
+    "set_uuid": "11513da8-ff56-403e-93c8-5935fd8700bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-ambient-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.24)",
+    "uuid": "3dd12e5d-91b3-4466-94db-4c2089238661",
+    "set_uuid": "11513da8-ff56-403e-93c8-5935fd8700bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-ambient-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.08)",
+    "uuid": "df3a555d-3f22-4499-9269-4311c4b657e0",
+    "set_uuid": "11513da8-ff56-403e-93c8-5935fd8700bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-color-100",
+    "uuid": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with drop-shadow-color-100",
+    "replaced_by": "92619056-db5a-45ab-ba0b-50e67cc497f6"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-100",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "5c0f0543-7e9b-43d6-9fea-c771b9b524c6",
+    "set_uuid": "92619056-db5a-45ab-ba0b-50e67cc497f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-100",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.36)",
+    "uuid": "8d7e0eb7-c3c7-485e-896c-d5d5107e3b8f",
+    "set_uuid": "92619056-db5a-45ab-ba0b-50e67cc497f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-100",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "4110e60c-efd6-421d-9c5c-0356cfff8697",
+    "set_uuid": "92619056-db5a-45ab-ba0b-50e67cc497f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-200",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.16)",
+    "uuid": "5945eb42-744c-41df-a4ab-a3d61f8782ee",
+    "set_uuid": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-200",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.48)",
+    "uuid": "c88f7b8e-e5f5-4d0e-a8dd-025f8d274948",
+    "set_uuid": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-200",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.16)",
+    "uuid": "6e379d86-d4cc-48d4-a8a4-8b4be9cfc912",
+    "set_uuid": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-300",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.2)",
+    "uuid": "84ced765-054d-44f4-9dbe-5be607f65a16",
+    "set_uuid": "ebb7effd-f156-41a9-823f-052e5733e53d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-300",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.6)",
+    "uuid": "8fd7fa72-67c3-4004-b8b3-af55a4b9cada",
+    "set_uuid": "ebb7effd-f156-41a9-823f-052e5733e53d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-color-300",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.2)",
+    "uuid": "e91afe82-e2db-4c13-86cd-bcb2e866edf2",
+    "set_uuid": "ebb7effd-f156-41a9-823f-052e5733e53d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
+    "value": [
+      {
+        "x": "0px",
+        "y": "12px",
+        "blur": "16px",
+        "spread": "0px",
+        "color": "{drop-shadow-ambient-color}"
+      },
+      {
+        "x": "0px",
+        "y": "6px",
+        "blur": "8px",
+        "spread": "0px",
+        "color": "{drop-shadow-transition-color}"
+      },
+      {
+        "x": "0px",
+        "y": "0px",
+        "blur": "6px",
+        "spread": "0px",
+        "color": "{drop-shadow-dragged-key-color}"
+      }
+    ],
+    "uuid": "40668dc3-1bc4-4572-8bc8-32818c192a40"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-color-300",
+    "uuid": "83c30113-68b5-475b-ba46-9179c9ff7e8d"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-key-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.16)",
+    "uuid": "5973a140-c745-4835-897c-f6648351f182",
+    "set_uuid": "17849074-a2d3-42a4-9bf7-efaba4c99545",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-key-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.48)",
+    "uuid": "73e17173-3695-4dcd-b37a-1714bb45a696",
+    "set_uuid": "17849074-a2d3-42a4-9bf7-efaba4c99545",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-key-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.16)",
+    "uuid": "0b9777dc-6689-4b97-b7a6-d113272f4576",
+    "set_uuid": "17849074-a2d3-42a4-9bf7-efaba4c99545",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
+    "value": [
+      {
+        "x": "0px",
+        "y": "4px",
+        "blur": "12px",
+        "spread": "0px",
+        "color": "{drop-shadow-ambient-color}"
+      },
+      {
+        "x": "0px",
+        "y": "2px",
+        "blur": "6px",
+        "spread": "0px",
+        "color": "{drop-shadow-transition-color}"
+      },
+      {
+        "x": "0px",
+        "y": "0px",
+        "blur": "2px",
+        "spread": "0px",
+        "color": "{drop-shadow-elevated-key-color}"
+      }
+    ],
+    "uuid": "8ecd414e-72e6-4fac-953d-5a1fbe048835"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-color-200",
+    "uuid": "e475981f-97af-479c-859b-7619dd87c448"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-key-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "6a3837b8-70b6-44b1-a439-551a6e2f75cd",
+    "set_uuid": "e19dd5b0-50c0-4fbe-b8cc-a74a728dbccc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-key-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.36)",
+    "uuid": "e78e9604-1919-4b7d-8338-5900bdbde89f",
+    "set_uuid": "e19dd5b0-50c0-4fbe-b8cc-a74a728dbccc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-key-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "ba2ff175-d2d0-4a53-a070-57c41283cb50",
+    "set_uuid": "e19dd5b0-50c0-4fbe-b8cc-a74a728dbccc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow",
+      "state": "emphasized"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
+    "value": [
+      {
+        "x": "0px",
+        "y": "2px",
+        "blur": "8px",
+        "spread": "0px",
+        "color": "{drop-shadow-ambient-color}"
+      },
+      {
+        "x": "0px",
+        "y": "1px",
+        "blur": "4px",
+        "spread": "0px",
+        "color": "{drop-shadow-transition-color}"
+      },
+      {
+        "x": "0px",
+        "y": "0px",
+        "blur": "1px",
+        "spread": "0px",
+        "color": "{drop-shadow-emphasized-key-color}"
+      }
+    ],
+    "uuid": "71163f17-f6c6-4123-ac65-2fc30271acf1"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-default-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-color-100",
+    "uuid": "af4e0a7a-7c6a-4cf2-a17b-0b07ef365869"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
+    "value": [
+      {
+        "x": "0px",
+        "y": "4px",
+        "blur": "12px",
+        "spread": "0px",
+        "color": "{drop-shadow-ambient-color}"
+      },
+      {
+        "x": "0px",
+        "y": "2px",
+        "blur": "6px",
+        "spread": "0px",
+        "color": "{drop-shadow-transition-color}"
+      },
+      {
+        "x": "0px",
+        "y": "0px",
+        "blur": "2px",
+        "spread": "0px",
+        "color": "{drop-shadow-emphasized-key-color}"
+      }
+    ],
+    "uuid": "35d75867-6bc7-49f2-89d5-e353e1117a94"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-color-200",
+    "uuid": "4c84adb3-9edf-4a5d-b39a-5f31a0d3529c"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-key-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "8acbc847-76d3-4805-a9fd-f68bfe49ddc6",
+    "set_uuid": "d06a4ca8-0355-46d6-a3c4-868c62e6951b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-key-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.36)",
+    "uuid": "e03b0800-c48d-46f0-93b0-5beeb290efe0",
+    "set_uuid": "d06a4ca8-0355-46d6-a3c4-868c62e6951b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-key-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "5a1da245-ffb1-405f-be44-20696c0d5ad4",
+    "set_uuid": "d06a4ca8-0355-46d6-a3c4-868c62e6951b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-key-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.08)",
+    "uuid": "c6fd25ed-1d86-4b7b-aa56-9ac371b2bbe6",
+    "set_uuid": "45922b66-e213-4eff-9611-9de9ab06c2dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-key-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.24)",
+    "uuid": "7a9a257f-538c-4e1b-a3f4-a652e59582c9",
+    "set_uuid": "45922b66-e213-4eff-9611-9de9ab06c2dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-key-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.08)",
+    "uuid": "5e946c9e-6b78-43f7-b8fa-74a3dbd2cc48",
+    "set_uuid": "45922b66-e213-4eff-9611-9de9ab06c2dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-transition-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.04)",
+    "uuid": "0fe5c2a3-3f07-490d-bfe2-95dffa6a11c0",
+    "set_uuid": "3e8eb147-8213-497e-9b51-2a96bf21a7bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-transition-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "aca70da5-3d6d-4d02-b23b-9e2f8374f6e6",
+    "set_uuid": "3e8eb147-8213-497e-9b51-2a96bf21a7bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-transition-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.04)",
+    "uuid": "52d1ce61-a695-439c-80a5-3978505aa04d",
+    "set_uuid": "3e8eb147-8213-497e-9b51-2a96bf21a7bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "focus-indicator-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05"
+  },
+  {
+    "name": {
+      "property": "fuchsia-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-900",
+    "uuid": "5f61f890-93b3-4ab9-bc80-d75198a5bacf",
+    "set_uuid": "807ddfc8-cfad-4221-b956-e5d16e9626ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-800",
+    "uuid": "7b4d71d3-ad78-4e02-a48e-fa79f40854a2",
+    "set_uuid": "807ddfc8-cfad-4221-b956-e5d16e9626ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-900",
+    "uuid": "13e66afc-a9d8-46a9-8b15-310c5b35e52f",
+    "set_uuid": "807ddfc8-cfad-4221-b956-e5d16e9626ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-200",
+    "uuid": "9bb9c1e9-6067-49a4-b4af-13ccd87830d9",
+    "set_uuid": "305b2ff0-425f-4ad1-a27d-00c96d2020ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-300",
+    "uuid": "3e62d682-c770-498d-a25a-5544775aeaa1",
+    "set_uuid": "305b2ff0-425f-4ad1-a27d-00c96d2020ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-200",
+    "uuid": "28ef060d-098c-4388-b600-00f4f8fe49aa",
+    "set_uuid": "305b2ff0-425f-4ad1-a27d-00c96d2020ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-800",
+    "uuid": "36b69bb1-d443-4ec6-807b-ea449a886825",
+    "set_uuid": "e0b357b4-847d-491a-b7b9-7805af3bdf69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-900",
+    "uuid": "38e60263-cb08-4090-a653-5acbd1664ae0",
+    "set_uuid": "e0b357b4-847d-491a-b7b9-7805af3bdf69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "fuchsia-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-800",
+    "uuid": "656af4f3-a545-4445-9d2b-2c4a17ab46db",
+    "set_uuid": "e0b357b4-847d-491a-b7b9-7805af3bdf69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-700",
+    "uuid": "5adeb281-3183-43e0-b20c-bd4e29f4da7e",
+    "set_uuid": "43aadc06-6f34-47a3-9e42-e1a99e3504ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "a3e71134-b44f-4b52-a84d-4841e01505e6",
+    "set_uuid": "43aadc06-6f34-47a3-9e42-e1a99e3504ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-700",
+    "uuid": "385372e9-8b04-45ea-a7a2-f1f62ac68ad6",
+    "set_uuid": "43aadc06-6f34-47a3-9e42-e1a99e3504ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "83fd0c1f-fbf3-4540-b370-6f44a6dbba7e",
+    "set_uuid": "a3c90df5-60df-4936-a1f9-232783790380",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-300",
+    "uuid": "a95998aa-d6ce-4090-9743-614196862acf",
+    "set_uuid": "a3c90df5-60df-4936-a1f9-232783790380",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "6529e76c-0c21-449f-a318-2629cf90a58a",
+    "set_uuid": "a3c90df5-60df-4936-a1f9-232783790380",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "744537db-023b-4833-8262-9c349b0915ee",
+    "set_uuid": "230b364f-f25a-4f55-baa3-56a1d3559b1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-600",
+    "uuid": "0f7a39c2-3ee7-4ff0-873f-334c81054b77",
+    "set_uuid": "230b364f-f25a-4f55-baa3-56a1d3559b1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "gray-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "e8113995-d2ec-4089-a050-9b393eb9e403",
+    "set_uuid": "230b364f-f25a-4f55-baa3-56a1d3559b1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-900",
+    "uuid": "d5cac08e-56e8-4217-a153-33f43c1a2059",
+    "set_uuid": "544da90d-04a9-4753-b77b-9bf71f5b837f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-800",
+    "uuid": "49170573-9c22-42e1-a1ce-cd3d3972ddb7",
+    "set_uuid": "544da90d-04a9-4753-b77b-9bf71f5b837f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-900",
+    "uuid": "f7814be9-b21f-40ff-9d34-8c0a96eea93e",
+    "set_uuid": "544da90d-04a9-4753-b77b-9bf71f5b837f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-200",
+    "uuid": "3b582b64-988e-4b5d-a08d-e04269403536",
+    "set_uuid": "b8fb4556-da03-4096-b180-cb9b915ab3e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-300",
+    "uuid": "e10ef55e-c18d-4b73-97d0-330b480e9aa4",
+    "set_uuid": "b8fb4556-da03-4096-b180-cb9b915ab3e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-200",
+    "uuid": "3911fa84-a5b3-4ea1-b6ad-47f222482ddb",
+    "set_uuid": "b8fb4556-da03-4096-b180-cb9b915ab3e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-700",
+    "uuid": "83f76815-8660-425e-80e6-825a5be0628f",
+    "set_uuid": "f48d1bf4-5604-48c7-976c-0d696156e82b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-800",
+    "uuid": "1219770d-543d-4216-9e87-c158f8a74df6",
+    "set_uuid": "f48d1bf4-5604-48c7-976c-0d696156e82b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "green-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-700",
+    "uuid": "4aba2da7-3eed-4a11-830c-58cc4f6bb6cb",
+    "set_uuid": "f48d1bf4-5604-48c7-976c-0d696156e82b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-900",
+    "uuid": "23859fff-27f5-4576-83c9-0fbc316e880a",
+    "set_uuid": "9def3006-8ddc-4212-a61b-8ccdcf9af786",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-800",
+    "uuid": "b7f5a677-4e89-40e1-8324-7619a628ce8b",
+    "set_uuid": "9def3006-8ddc-4212-a61b-8ccdcf9af786",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-900",
+    "uuid": "dedf817e-2883-4632-936c-207fdafe7469",
+    "set_uuid": "9def3006-8ddc-4212-a61b-8ccdcf9af786",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-200",
+    "uuid": "dda05431-bce9-4686-8738-78fb409ab28f",
+    "set_uuid": "cf1d5f25-cde5-4008-9d81-3fc011266cb6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-300",
+    "uuid": "533023cb-f78a-4f1c-af52-244b3c10a7bb",
+    "set_uuid": "cf1d5f25-cde5-4008-9d81-3fc011266cb6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-200",
+    "uuid": "2110b943-24cf-4afd-81b2-31676f1400f8",
+    "set_uuid": "cf1d5f25-cde5-4008-9d81-3fc011266cb6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-800",
+    "uuid": "cb59d4d5-c17e-428d-a22a-e9a3fc02ac9c",
+    "set_uuid": "7d9c915f-bf12-4971-bd66-d8e629f07c55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-900",
+    "uuid": "584ccbd4-3243-4041-b665-e2342d2b26e8",
+    "set_uuid": "7d9c915f-bf12-4971-bd66-d8e629f07c55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "indigo-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-800",
+    "uuid": "056968e0-d29e-4b1c-a9b1-50853f6d159b",
+    "set_uuid": "7d9c915f-bf12-4971-bd66-d8e629f07c55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-900",
+    "uuid": "3acd52f0-d19c-4174-9ad5-42885ec9d49d",
+    "set_uuid": "6b40c677-e046-4a49-b421-8a4451844512",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-800",
+    "uuid": "da3a7c08-7f54-4486-bb66-146db21f0627",
+    "set_uuid": "6b40c677-e046-4a49-b421-8a4451844512",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-900",
+    "uuid": "02e7121e-71eb-4228-a61a-963d7f2a531b",
+    "set_uuid": "6b40c677-e046-4a49-b421-8a4451844512",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-1000",
+    "uuid": "91f91b8c-0e65-4b7b-8c7b-60d3b6e235d8",
+    "set_uuid": "cbee87ce-48b0-4fd8-8292-61db059dd7f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-700",
+    "uuid": "c9c09cc9-1ebd-4738-9613-6a0a67bea4f9",
+    "set_uuid": "cbee87ce-48b0-4fd8-8292-61db059dd7f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-1000",
+    "uuid": "109c9d4a-a024-4b41-9a99-4c0e671f1011",
+    "set_uuid": "cbee87ce-48b0-4fd8-8292-61db059dd7f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-1000",
+    "uuid": "06dcb775-28b2-454e-89ce-fda34f30c7d7",
+    "set_uuid": "96433130-42c8-4ff5-9f12-fc5a7b45ee87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-700",
+    "uuid": "092415a8-0054-4f6d-9a93-1541c767b2c5",
+    "set_uuid": "96433130-42c8-4ff5-9f12-fc5a7b45ee87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-1000",
+    "uuid": "d0ad5e30-c689-4831-bbd0-2de373aa11b5",
+    "set_uuid": "96433130-42c8-4ff5-9f12-fc5a7b45ee87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "key-focus",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-1000",
+    "uuid": "ea314056-fd9a-4325-b19a-33f56fad2859",
+    "set_uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "key-focus",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-700",
+    "uuid": "e5292c94-ea4a-49ba-8c25-6ab1114e0fe3",
+    "set_uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-background-color",
+      "state": "key-focus",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-1000",
+    "uuid": "5bcac2b7-7ebb-405a-bfe3-1785d4e6fde6",
+    "set_uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-800",
+    "uuid": "cd900a8d-1852-4592-9031-9edab2f9721f",
+    "set_uuid": "60aa72d2-3b00-4eea-973d-265a55d3095a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-900",
+    "uuid": "fd64c9ca-6ad7-415c-b0b8-2579399e33a5",
+    "set_uuid": "60aa72d2-3b00-4eea-973d-265a55d3095a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-800",
+    "uuid": "556d02fd-fecb-4772-92cb-921ac509bcae",
+    "set_uuid": "60aa72d2-3b00-4eea-973d-265a55d3095a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-900",
+    "uuid": "4e02601f-12da-4ce2-b58c-0aa0e309442d",
+    "set_uuid": "3b100044-0453-4f8a-8ad0-83b1d2118d7b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-800",
+    "uuid": "5867d764-d909-4490-b947-533e89997d0a",
+    "set_uuid": "3b100044-0453-4f8a-8ad0-83b1d2118d7b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-900",
+    "uuid": "c7b29eba-f8a3-43f7-b5b9-0c1a7f04bb38",
+    "set_uuid": "3b100044-0453-4f8a-8ad0-83b1d2118d7b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-200",
+    "uuid": "09787c85-44e0-4efe-b427-f6e7dde544a4",
+    "set_uuid": "34b86478-26f1-4b9c-87c5-465e614f5d48",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-300",
+    "uuid": "143b0387-7069-4bef-b852-9c456d692b88",
+    "set_uuid": "34b86478-26f1-4b9c-87c5-465e614f5d48",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-200",
+    "uuid": "b526e518-47b2-4a1c-b54b-42596381b7fd",
+    "set_uuid": "34b86478-26f1-4b9c-87c5-465e614f5d48",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-800",
+    "uuid": "8bc581a9-558c-424d-a72b-f24b48207b82",
+    "set_uuid": "83f51bbb-8dc4-4191-88e0-9391fbc9157c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-900",
+    "uuid": "178e4bc6-6986-4e77-aab0-78dbe66f8e6f",
+    "set_uuid": "83f51bbb-8dc4-4191-88e0-9391fbc9157c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "magenta-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-800",
+    "uuid": "9bf3d052-42d1-454b-8ae6-ee0b40d9a9c8",
+    "set_uuid": "83f51bbb-8dc4-4191-88e0-9391fbc9157c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-900",
+    "uuid": "46204746-7fe7-4f22-887e-2c9b85c3b7bc",
+    "set_uuid": "d0300f1c-9d79-4d73-a83e-915cb6566bf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-800",
+    "uuid": "1117b73b-42e3-4ad6-8b26-af76859a27bb",
+    "set_uuid": "d0300f1c-9d79-4d73-a83e-915cb6566bf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-900",
+    "uuid": "ebadb88b-90a3-492e-ba3c-e9f1232b5ce5",
+    "set_uuid": "d0300f1c-9d79-4d73-a83e-915cb6566bf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "3c2d5afe-fff4-487d-a312-000f738c8704",
+    "set_uuid": "4b0af26c-61ca-4fe6-a792-01f527b4f216",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-700",
+    "uuid": "8565ec8e-2196-47ac-8636-40084acbfd4f",
+    "set_uuid": "4b0af26c-61ca-4fe6-a792-01f527b4f216",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "ce2e6ea6-c692-4cff-a2ac-f0c1c2e054ca",
+    "set_uuid": "4b0af26c-61ca-4fe6-a792-01f527b4f216",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "d2481a50-13a0-4f19-8faa-a1a215fee21d",
+    "set_uuid": "3dc8ef4d-e6c0-4316-9df4-ecd7ffa9207b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-700",
+    "uuid": "648da867-549e-47c3-9312-e9cfda288705",
+    "set_uuid": "3dc8ef4d-e6c0-4316-9df4-ecd7ffa9207b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "b1104fe3-4965-411e-95d3-87f59cdbc756",
+    "set_uuid": "3dc8ef4d-e6c0-4316-9df4-ecd7ffa9207b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "key-focus",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "41a6ee21-8db2-410b-a694-fca1fbf70f2a",
+    "set_uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "key-focus",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-700",
+    "uuid": "f1470931-f4f8-47d9-b118-5b813e4c154a",
+    "set_uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-background-color",
+      "state": "key-focus",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "abcf178e-0e44-4f57-a62c-382cb9478be2",
+    "set_uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-border-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-900",
+    "uuid": "6effed65-3d52-465f-9eb2-7994f1ee90fb"
+  },
+  {
+    "name": {
+      "property": "negative-border-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1100",
+    "uuid": "0c35da5c-cf37-4349-82e4-8739ea94aa65"
+  },
+  {
+    "name": {
+      "property": "negative-border-color",
+      "state": "focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "aae2b3a5-1f68-4832-9539-62227179e69e"
+  },
+  {
+    "name": {
+      "property": "negative-border-color-focus",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-border-color-down",
+    "uuid": "63abd660-13c4-47b8-be9e-61e270b95212"
+  },
+  {
+    "name": {
+      "property": "negative-border-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "496571fc-18ce-44a3-a89e-40ff6397adcd"
+  },
+  {
+    "name": {
+      "property": "negative-border-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "393cb93a-3d0a-4118-a2ee-451fdc871b0f"
+  },
+  {
+    "name": {
+      "property": "negative-content-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-900",
+    "uuid": "2a1b0c71-c3a4-4f4c-a625-346e026853e5"
+  },
+  {
+    "name": {
+      "property": "negative-content-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "f760cc99-ebec-4d34-931e-5621aef995a0"
+  },
+  {
+    "name": {
+      "property": "negative-content-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "ff90152d-86bf-4a34-9a7e-ede61966bda0"
+  },
+  {
+    "name": {
+      "property": "negative-content-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-1000",
+    "uuid": "03a7aa1f-9493-4054-bb21-eb10e593da73"
+  },
+  {
+    "name": {
+      "property": "negative-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-800",
+    "uuid": "d1beeda3-a00d-4f8c-8553-0a0f84093b1f",
+    "set_uuid": "23cea5fe-acb5-4460-add7-3512aaceeb35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-900",
+    "uuid": "70cb0316-5b7a-416c-bf93-7d8885c4fce6",
+    "set_uuid": "23cea5fe-acb5-4460-add7-3512aaceeb35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-800",
+    "uuid": "9211e320-de05-4097-8350-fef2293be6a0",
+    "set_uuid": "23cea5fe-acb5-4460-add7-3512aaceeb35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "95cf1481-f476-47ce-a45a-54da64b44255"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "5a0fdda5-6ac2-4a31-a7b9-6b3a5dd868d6"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "142f9467-e519-4ed7-bd98-69a31e876e70"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "f52c6bfb-2d62-4fc8-a1cd-6c8d7420eeb4"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color-selected",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color-selected",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "966c56d0-4461-45e7-9e20-0277f2111a34"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color-selected",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "1c220122-5f32-42f9-848f-ae10061241e5"
+  },
+  {
+    "name": {
+      "property": "neutral-background-color-selected",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "9b8df7df-3439-4614-b446-97a4de782e27"
+  },
+  {
+    "name": {
+      "property": "neutral-content-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "43ca4c0d-7803-4e8e-b444-26fe70d5304c"
+  },
+  {
+    "name": {
+      "property": "neutral-content-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "cf169d95-e427-4665-a983-c24727dbfa60"
+  },
+  {
+    "name": {
+      "property": "neutral-content-color",
+      "state": "focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-content-color-down",
+    "uuid": "f218dfd0-23be-4f07-becb-6027cc971c8b"
+  },
+  {
+    "name": {
+      "property": "neutral-content-color-focus",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-content-color-down",
+    "uuid": "a370f375-b3b1-4af8-9628-fa901c0252fb"
+  },
+  {
+    "name": {
+      "property": "neutral-content-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "d236bdc5-037b-4838-8401-8a0d5136936c"
+  },
+  {
+    "name": {
+      "property": "neutral-content-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "c2c538e0-6f8d-4586-953a-b98ef40c9eca"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-700",
+    "uuid": "3b09b2fd-cbf9-4933-9655-27a75d984f06",
+    "set_uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "bc9979cb-e7c6-45b2-be4d-0ba3c817e2ef",
+    "set_uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-700",
+    "uuid": "fdcab585-e3a9-4026-bf40-e7fdd01bf05b",
+    "set_uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "300d2800-a6e5-4b78-9b6c-aaf2f4af39c6",
+    "set_uuid": "4ff21423-684b-4c78-b4e8-a5535b6e1cad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "11bf9149-d8df-4f37-ba21-51ff911b0517",
+    "set_uuid": "4ff21423-684b-4c78-b4e8-a5535b6e1cad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "6e62476c-b60b-4d33-97c5-5fdf1f3a7930",
+    "set_uuid": "4ff21423-684b-4c78-b4e8-a5535b6e1cad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "a1ab50d5-1aa1-4198-9510-7ea8458cc62f",
+    "set_uuid": "e05475a2-de73-4ca5-a9c4-ef7e3fcb1b3a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "2d72c9fc-22d0-4e4d-9b00-fae4b30a47b5",
+    "set_uuid": "e05475a2-de73-4ca5-a9c4-ef7e3fcb1b3a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "81fb8734-c8c3-4f6e-8a14-177ce1d7db02",
+    "set_uuid": "e05475a2-de73-4ca5-a9c4-ef7e3fcb1b3a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "key-focus",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "eece165c-743c-4d7a-b770-3ee50e1951cf",
+    "set_uuid": "47944e17-0736-426b-9228-4591966bbc38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "key-focus",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "a1e08db6-3a72-4b8e-9475-b54a7b9be506",
+    "set_uuid": "47944e17-0736-426b-9228-4591966bbc38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-background-color",
+      "state": "key-focus",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "ee7dec87-de8b-4145-9985-f5ba78bc3a3b",
+    "set_uuid": "47944e17-0736-426b-9228-4591966bbc38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-content-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-700",
+    "uuid": "7a058b23-341c-4dd3-83d8-358917277836"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-content-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "8ab4accc-bd95-48e0-ae3a-539740a07cc6"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-content-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "a6d8a177-3e5c-4d28-a675-c21c2695d2f6"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-content-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "4e79877b-254d-4226-a28f-4c80d2d8b2f3"
+  },
+  {
+    "name": {
+      "property": "neutral-subdued-content-color",
+      "state": "selected"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-subdued-content-color-down",
+    "uuid": "ea46f6d3-4261-4482-a70f-2cddd113aa4a"
+  },
+  {
+    "name": {
+      "property": "neutral-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "cc79fbaf-a2e1-4761-82e7-1dbea52acee8",
+    "set_uuid": "38777112-84a2-4a1f-a655-646997469521",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-300",
+    "uuid": "9a9589e8-c08c-486f-a42f-8e139dedaa37",
+    "set_uuid": "38777112-84a2-4a1f-a655-646997469521",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "64b2528e-4c1b-4850-a67f-8bd7bb05d36c",
+    "set_uuid": "38777112-84a2-4a1f-a655-646997469521",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "0dc6ed4d-17d5-4878-8ac3-bd99549b4f42",
+    "set_uuid": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-600",
+    "uuid": "35ef6675-7e66-4ef5-8c8d-e8e70939b224",
+    "set_uuid": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "neutral-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "57233b29-bbc6-4f9e-83c1-9325fd6f964c",
+    "set_uuid": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-600",
+    "uuid": "48f3445a-63d8-4477-a2f5-1fee6a022328",
+    "set_uuid": "f0cabe3c-ee14-4791-96ec-84abcd6867fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-900",
+    "uuid": "323428c1-792d-41b4-8a17-a12f1ac00e2a",
+    "set_uuid": "f0cabe3c-ee14-4791-96ec-84abcd6867fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-600",
+    "uuid": "85515d6c-4674-435f-a2d4-b9bf8311781e",
+    "set_uuid": "f0cabe3c-ee14-4791-96ec-84abcd6867fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-800",
+    "uuid": "b8b38df6-aac5-49fc-99bb-d64a543c5bf8",
+    "set_uuid": "da827479-f058-4117-9cd3-90cbe525d05d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-900",
+    "uuid": "2759c912-6385-40e4-9ed9-ff2e11815b4d",
+    "set_uuid": "da827479-f058-4117-9cd3-90cbe525d05d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-800",
+    "uuid": "e6e779ea-6015-467f-8df7-9027280bdea2",
+    "set_uuid": "da827479-f058-4117-9cd3-90cbe525d05d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "opacity",
+      "state": "disabled"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.3",
+    "uuid": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74"
+  },
+  {
+    "name": {
+      "property": "orange-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-600",
+    "uuid": "981c054e-9db5-4589-b9e7-eed307b115ca",
+    "set_uuid": "b2896323-3d58-4394-ab8e-5c47f3f7c6af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-900",
+    "uuid": "3e9a6c2a-bd09-4d28-a95c-920109c1852f",
+    "set_uuid": "b2896323-3d58-4394-ab8e-5c47f3f7c6af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-600",
+    "uuid": "37c3db03-6dd6-47e5-a03c-25663d116c52",
+    "set_uuid": "b2896323-3d58-4394-ab8e-5c47f3f7c6af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-200",
+    "uuid": "e7e1eb3c-7590-4622-a261-8de879bb1500",
+    "set_uuid": "c023322e-930a-4206-b52a-2c4ee91e7cd3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-300",
+    "uuid": "9b2505cc-2a71-4b1e-804d-3f2ffa69d06c",
+    "set_uuid": "c023322e-930a-4206-b52a-2c4ee91e7cd3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-200",
+    "uuid": "a9671857-3e09-4132-a522-cd8f5b4cf8ff",
+    "set_uuid": "c023322e-930a-4206-b52a-2c4ee91e7cd3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-700",
+    "uuid": "8fdaf9e0-bd3e-4188-84bd-7abf72e50b58",
+    "set_uuid": "434f94da-e44d-486d-bb7b-26a1dfbefc04",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-900",
+    "uuid": "e7bf9977-2edf-48bc-8099-ad95e57b55b1",
+    "set_uuid": "434f94da-e44d-486d-bb7b-26a1dfbefc04",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "orange-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-700",
+    "uuid": "f76b6279-2d64-47fe-a531-1737a834b21a",
+    "set_uuid": "434f94da-e44d-486d-bb7b-26a1dfbefc04",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "overlay-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black",
+    "uuid": "af66daa6-9e52-4e68-a605-86d1de4ee971"
+  },
+  {
+    "name": {
+      "property": "overlay-opacity",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.4",
+    "uuid": "26b9803c-577f-4a29-badd-dfc459e8b73e",
+    "set_uuid": "2f391381-6548-45eb-ac3b-ba0543884212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "overlay-opacity",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.6",
+    "uuid": "31d5b502-6266-4309-8f8a-3892e6e158da",
+    "set_uuid": "2f391381-6548-45eb-ac3b-ba0543884212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "overlay-opacity",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.4",
+    "uuid": "8964a28b-af18-4623-b530-7f4446ee6fa4",
+    "set_uuid": "2f391381-6548-45eb-ac3b-ba0543884212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-900",
+    "uuid": "78fc6322-a961-429a-bd40-3e1c1bf2c4e9",
+    "set_uuid": "dc44bb9a-f9a1-43f2-8d45-d3720d841671",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-800",
+    "uuid": "3a363aa8-cf27-48a1-8c61-b1f1eaff6110",
+    "set_uuid": "dc44bb9a-f9a1-43f2-8d45-d3720d841671",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-900",
+    "uuid": "b60042cd-3ce7-4952-aeae-338d2b5fe98d",
+    "set_uuid": "dc44bb9a-f9a1-43f2-8d45-d3720d841671",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-200",
+    "uuid": "41f3d269-85d6-4c82-9b1c-e40ea508fa78",
+    "set_uuid": "45675d54-a787-43a3-ac45-1b8825939cbc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-300",
+    "uuid": "72400c8f-2e44-4757-8be6-3c1eb28d9606",
+    "set_uuid": "45675d54-a787-43a3-ac45-1b8825939cbc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-200",
+    "uuid": "d726501f-8920-4434-b397-b0974037161a",
+    "set_uuid": "45675d54-a787-43a3-ac45-1b8825939cbc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-800",
+    "uuid": "4be32a08-c731-4c59-b376-ba0ef134e14e",
+    "set_uuid": "8204525c-1b1a-485b-950a-addef9f4db36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-900",
+    "uuid": "496cef67-3a25-4d99-8545-e8aa9a7f0adc",
+    "set_uuid": "8204525c-1b1a-485b-950a-addef9f4db36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "pink-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-800",
+    "uuid": "fcbf8451-ad82-4247-a867-a5d0034667b5",
+    "set_uuid": "8204525c-1b1a-485b-950a-addef9f4db36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-900",
+    "uuid": "d878d795-2292-4d90-a9e2-37af1d97a532",
+    "set_uuid": "9639ac0a-827e-4969-9c2f-bb09420e7881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-800",
+    "uuid": "82b54f71-7c9e-4388-9e3b-4d13f12fad60",
+    "set_uuid": "9639ac0a-827e-4969-9c2f-bb09420e7881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-900",
+    "uuid": "27688f39-6b46-4b40-a3c5-67694a0ff672",
+    "set_uuid": "9639ac0a-827e-4969-9c2f-bb09420e7881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-1000",
+    "uuid": "4096a319-241e-410c-ad51-521d57155004",
+    "set_uuid": "621a6182-5fd5-479d-bd6a-7c739f651058",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-700",
+    "uuid": "58a934d2-a715-4544-aa79-7f94bd493f09",
+    "set_uuid": "621a6182-5fd5-479d-bd6a-7c739f651058",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-1000",
+    "uuid": "45c598af-e0da-4e41-855a-55dfc77f198c",
+    "set_uuid": "621a6182-5fd5-479d-bd6a-7c739f651058",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-1000",
+    "uuid": "d60ab5e9-9ada-4587-a75f-91f2b492800f",
+    "set_uuid": "bf1f2daa-3449-4e3b-978a-e5c2bcbc8218",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-700",
+    "uuid": "2992a78b-9ce0-4b29-a4f6-ddbc51f820f2",
+    "set_uuid": "bf1f2daa-3449-4e3b-978a-e5c2bcbc8218",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-1000",
+    "uuid": "7c4bd8ad-72ce-4518-b91d-a7b7721fe920",
+    "set_uuid": "bf1f2daa-3449-4e3b-978a-e5c2bcbc8218",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "key-focus",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-1000",
+    "uuid": "036525d0-c6c4-478c-9aa3-84242737c6b1",
+    "set_uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "key-focus",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-700",
+    "uuid": "56d371b4-437f-4ca9-854f-ae6daf5dcfce",
+    "set_uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-background-color",
+      "state": "key-focus",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-1000",
+    "uuid": "74eef2ae-5b83-4a25-b882-5960f64ecef0",
+    "set_uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-800",
+    "uuid": "455acfc0-1997-4fee-b1dc-3c91bbd9fca2",
+    "set_uuid": "d439dfad-437a-4929-8d0d-9b9290dcb843",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-900",
+    "uuid": "25e8289f-6c82-4485-8920-a187f790cd47",
+    "set_uuid": "d439dfad-437a-4929-8d0d-9b9290dcb843",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-800",
+    "uuid": "96075e1a-6739-41c8-985b-af30b09be6c3",
+    "set_uuid": "d439dfad-437a-4929-8d0d-9b9290dcb843",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-900",
+    "uuid": "ed07d8f4-390f-4124-a4c4-81b62767c6cd",
+    "set_uuid": "48c3ed16-e6b3-42ad-8806-7f3f78aa94f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-800",
+    "uuid": "e577d521-0271-4226-a094-624b35a05826",
+    "set_uuid": "48c3ed16-e6b3-42ad-8806-7f3f78aa94f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-900",
+    "uuid": "720cfaa3-6bb1-4df1-946f-94fabae54e7b",
+    "set_uuid": "48c3ed16-e6b3-42ad-8806-7f3f78aa94f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-200",
+    "uuid": "a53f9f9a-8fde-4de2-83a3-944e1c4556c1",
+    "set_uuid": "a84ac914-c3f2-4d91-ac68-25433f0976bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-300",
+    "uuid": "896f2a2f-4d02-4104-ac33-a3705a9c61e3",
+    "set_uuid": "a84ac914-c3f2-4d91-ac68-25433f0976bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-200",
+    "uuid": "1d628f99-7c9c-423d-a470-a260d84d0d8d",
+    "set_uuid": "a84ac914-c3f2-4d91-ac68-25433f0976bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-800",
+    "uuid": "681fc141-b235-4cde-9c3a-f0033943d772",
+    "set_uuid": "604bcb2d-f04e-436e-a520-3f58cddd4660",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-900",
+    "uuid": "0ee2957b-c401-4106-8ff3-9de9fa544a03",
+    "set_uuid": "604bcb2d-f04e-436e-a520-3f58cddd4660",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "purple-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-800",
+    "uuid": "ef836f5b-c6b9-4e6b-a671-e979dc53c407",
+    "set_uuid": "604bcb2d-f04e-436e-a520-3f58cddd4660",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-900",
+    "uuid": "8cec4a84-3eea-45d6-ae1b-64907be7da78",
+    "set_uuid": "1bdf8cc5-f046-4054-a321-cafccbfe5d2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-800",
+    "uuid": "ce074ee2-a2a2-4da3-a99e-603524193d46",
+    "set_uuid": "1bdf8cc5-f046-4054-a321-cafccbfe5d2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-900",
+    "uuid": "3fb6aa49-631f-489b-9dab-63a5712d72da",
+    "set_uuid": "1bdf8cc5-f046-4054-a321-cafccbfe5d2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-200",
+    "uuid": "5d7cd7c1-66fa-49d4-923b-8cca2dcb4726",
+    "set_uuid": "c95ee642-363a-430b-909e-b1dc4c345cf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-300",
+    "uuid": "c098c385-7fce-4f16-b1d1-54a86c608e64",
+    "set_uuid": "c95ee642-363a-430b-909e-b1dc4c345cf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-200",
+    "uuid": "8a6b560b-50b2-4dbf-900b-0ed63233df8b",
+    "set_uuid": "c95ee642-363a-430b-909e-b1dc4c345cf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-800",
+    "uuid": "7fe7c804-7e6b-48ac-b1fa-b88874e0a330",
+    "set_uuid": "80de3f87-9fea-40a2-94f6-05b88e4a4e11",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-700",
+    "uuid": "870f90ab-7f3e-41b6-9c11-59e9c4ff82c6",
+    "set_uuid": "80de3f87-9fea-40a2-94f6-05b88e4a4e11",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "red-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-800",
+    "uuid": "834d0a71-9060-4ce0-8e25-8b062ef89b19",
+    "set_uuid": "80de3f87-9fea-40a2-94f6-05b88e4a4e11",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-900",
+    "uuid": "be1d8187-effc-430f-ac31-3904cf83a6d6",
+    "set_uuid": "7c2185c4-323c-4ea7-bcec-d550458f821f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-800",
+    "uuid": "9a727140-328d-430f-9b10-8965eebe77d1",
+    "set_uuid": "7c2185c4-323c-4ea7-bcec-d550458f821f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-900",
+    "uuid": "e2f2ef18-aabf-44fd-b074-d94f75862f3d",
+    "set_uuid": "7c2185c4-323c-4ea7-bcec-d550458f821f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-200",
+    "uuid": "7623166b-5320-40eb-8a5f-2cd12f17bdb2",
+    "set_uuid": "32797d40-d482-4503-9a05-1bcdd58f5aad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-300",
+    "uuid": "73620c8b-3943-46c0-acb8-d517e7e6081e",
+    "set_uuid": "32797d40-d482-4503-9a05-1bcdd58f5aad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-200",
+    "uuid": "0acaf55e-7e99-45f9-b99b-e461fa78a481",
+    "set_uuid": "32797d40-d482-4503-9a05-1bcdd58f5aad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-700",
+    "uuid": "2b0a6584-db41-43b9-ba39-39171548c01a",
+    "set_uuid": "ce6db8f0-4fb9-4a7d-9f4a-1b9244bf1ffc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-800",
+    "uuid": "736e4768-7944-40ec-a412-4cd36299e03d",
+    "set_uuid": "ce6db8f0-4fb9-4a7d-9f4a-1b9244bf1ffc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "seafoam-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-700",
+    "uuid": "15de4533-1a59-4a9f-899f-004a429471c7",
+    "set_uuid": "ce6db8f0-4fb9-4a7d-9f4a-1b9244bf1ffc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-900",
+    "uuid": "13d332e4-45b0-4549-a1a3-a608034960a1",
+    "set_uuid": "0c7a05f8-e309-4f57-bc88-2ecdca589e16",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-800",
+    "uuid": "a6e04390-003e-4565-bf96-e0fb8a791cb9",
+    "set_uuid": "0c7a05f8-e309-4f57-bc88-2ecdca589e16",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-900",
+    "uuid": "e0bb7dad-7f1b-4b6e-b2fe-99f8b14f3240",
+    "set_uuid": "0c7a05f8-e309-4f57-bc88-2ecdca589e16",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-200",
+    "uuid": "c80f665a-801e-45c8-b59b-8b9b47ebb356",
+    "set_uuid": "56878e94-5ba9-4c5b-9f21-9e8200789008",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-300",
+    "uuid": "6f596774-e326-4d80-bf1d-23f7ad1f4ccb",
+    "set_uuid": "56878e94-5ba9-4c5b-9f21-9e8200789008",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-200",
+    "uuid": "ec3dddb5-3944-493c-b5c8-f08c3272dc06",
+    "set_uuid": "56878e94-5ba9-4c5b-9f21-9e8200789008",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-800",
+    "uuid": "35f96ec6-0eae-4c55-aa54-134f03feda7d",
+    "set_uuid": "3f2c02a7-454c-4c72-a35a-16987c8417f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-900",
+    "uuid": "f7d55707-b9db-4711-b93f-dcc03932516c",
+    "set_uuid": "3f2c02a7-454c-4c72-a35a-16987c8417f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "silver-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-800",
+    "uuid": "7e749788-d92d-4ad5-b4d2-446e77c5a041",
+    "set_uuid": "3f2c02a7-454c-4c72-a35a-16987c8417f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "static-black-focus-indicator-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black",
+    "uuid": "c6b8275b-f44e-43b4-b763-82dda94d963c"
+  },
+  {
+    "name": {
+      "property": "static-black-text-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black",
+    "uuid": "9b7919b5-764c-4f93-b4c7-39d8bf7f2b51"
+  },
+  {
+    "name": {
+      "property": "static-black-track-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-300",
+    "uuid": "c6d40ce0-bcee-4b56-9e63-a51ee1579ef0"
+  },
+  {
+    "name": {
+      "property": "static-black-track-indicator-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-900",
+    "uuid": "0599d3b0-4d9e-4a12-ae0e-8f60e3533ab9"
+  },
+  {
+    "name": {
+      "property": "static-white-focus-indicator-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "white",
+    "uuid": "1dd6dc5b-47a2-41eb-80fc-f06293ae8e13"
+  },
+  {
+    "name": {
+      "property": "static-white-text-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "white",
+    "uuid": "13ee65f0-4bb9-4213-905d-92c1b788a702"
+  },
+  {
+    "name": {
+      "property": "static-white-track-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-300",
+    "uuid": "23791534-8963-4ff8-bfb4-15108da47103"
+  },
+  {
+    "name": {
+      "property": "static-white-track-indicator-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-900",
+    "uuid": "a1cbc282-1376-48d1-b8bb-92f10aef7c6f"
+  },
+  {
+    "name": {
+      "property": "title-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "a7e9c20c-ab9b-46de-bf6a-c8fec9a8986b"
+  },
+  {
+    "name": {
+      "property": "track-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-300",
+    "uuid": "6f2bb13a-8579-495c-8fe3-0046b1f99b01"
+  },
+  {
+    "name": {
+      "property": "turquoise-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-900",
+    "uuid": "e763acbc-2c17-46c5-8484-1d8536e7ef10",
+    "set_uuid": "d997ddfd-36d9-4229-b6d1-b6ae8b8b37ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-800",
+    "uuid": "6beacbfc-6d61-4567-86fe-39771550cf20",
+    "set_uuid": "d997ddfd-36d9-4229-b6d1-b6ae8b8b37ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-900",
+    "uuid": "50eb3d20-ab84-4541-8807-551391016b54",
+    "set_uuid": "d997ddfd-36d9-4229-b6d1-b6ae8b8b37ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-200",
+    "uuid": "aa7d44fd-6c77-43dc-8981-4200356fd02a",
+    "set_uuid": "ca18e828-3005-4361-9012-3e9d5c75c00f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-300",
+    "uuid": "5e5d9ba8-df94-43e1-ad40-f78312925ec5",
+    "set_uuid": "ca18e828-3005-4361-9012-3e9d5c75c00f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-200",
+    "uuid": "4e874813-4ebc-4855-bcb3-83024a6d1ba2",
+    "set_uuid": "ca18e828-3005-4361-9012-3e9d5c75c00f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-800",
+    "uuid": "2c31e5bc-cf23-42d6-85e8-9947e305d1ff",
+    "set_uuid": "b36c23ca-94a9-4268-b63b-a40490756bb3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-900",
+    "uuid": "04c6819d-5049-4e18-bb83-95239fa3d8c2",
+    "set_uuid": "b36c23ca-94a9-4268-b63b-a40490756bb3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "turquoise-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-800",
+    "uuid": "bc700351-a33c-4164-9ba7-3f86733ebe54",
+    "set_uuid": "b36c23ca-94a9-4268-b63b-a40490756bb3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-400",
+    "uuid": "f8e435de-1630-4628-8b6d-128987d66ddc",
+    "set_uuid": "04478af1-761c-4f12-b57a-5537d42f3d07",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-1100",
+    "uuid": "61c5e375-bff3-479f-8c32-2d2a5edb906c",
+    "set_uuid": "04478af1-761c-4f12-b57a-5537d42f3d07",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-400",
+    "uuid": "ff49d6b0-4f39-4cbb-a580-db03b0579a71",
+    "set_uuid": "04478af1-761c-4f12-b57a-5537d42f3d07",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-200",
+    "uuid": "5d5cfc7a-e6f4-4d6d-a39b-359350ddd280",
+    "set_uuid": "6d867baa-c461-4ff9-9560-680b42750961",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-300",
+    "uuid": "fcb0fe04-3498-4cfa-964d-5134bbcc74c6",
+    "set_uuid": "6d867baa-c461-4ff9-9560-680b42750961",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-200",
+    "uuid": "a238d434-3d0b-48fe-a413-a07e9229cdda",
+    "set_uuid": "6d867baa-c461-4ff9-9560-680b42750961",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-visual-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-600",
+    "uuid": "73e40884-6d55-4a56-a376-bd788e615754",
+    "set_uuid": "d0362576-7efc-4910-a671-b87695571050",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-visual-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-1100",
+    "uuid": "4a2ebbb5-b8b7-43a0-9d64-4974bb382a8b",
+    "set_uuid": "d0362576-7efc-4910-a671-b87695571050",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "yellow-visual-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-600",
+    "uuid": "c14eedf9-0f34-4a38-9b89-7c9b5f3e0af6",
+    "set_uuid": "d0362576-7efc-4910-a671-b87695571050",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-color-highlight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-background-color-default",
+    "uuid": "beaff99a-634a-4ce8-b2f4-54c63202d45b"
+  }
+]

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -1,0 +1,961 @@
+[
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "border-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-25",
+    "uuid": "166159cc-9353-4d22-90f0-64718533d73a",
+    "set_uuid": "1f180759-7dbe-4ac3-80f6-78433659d52c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "border-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "dac0d761-d8c1-4b1f-bfbe-766651122ecf",
+    "set_uuid": "1f180759-7dbe-4ac3-80f6-78433659d52c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "border-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-25",
+    "uuid": "e242c2e1-54db-40c5-98ee-abebdcd59f4d",
+    "set_uuid": "1f180759-7dbe-4ac3-80f6-78433659d52c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-25",
+    "uuid": "bae79ea7-2b3e-4d43-af42-7deab67acc7c"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "opacity",
+      "state": "disabled"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "opacity-disabled",
+    "uuid": "84d25d1b-f9e4-4a9e-8cd0-92367ff00637"
+  },
+  {
+    "name": {
+      "component": "bar-panel",
+      "property": "gripper-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "5a46c025-32b4-4bda-bab0-5ab0fb69ca8e"
+  },
+  {
+    "name": {
+      "component": "bar-panel",
+      "property": "gripper-color-drag"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "16431c28-23e4-4077-bcfa-138f90583282"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "background-loading-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "6022f845-b182-493f-bdae-f86f6336efaa"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "background-well-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "c9c0e684-6b6c-4314-9b5b-7ba5e3333071"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-600",
+    "uuid": "622c6e86-dea6-416d-9f13-bb6ef112d3cb",
+    "set_uuid": "bcf484d9-dd6c-4dbe-a648-fc54b3cedcd7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-600",
+    "uuid": "81c0608b-c977-490e-b8d7-830d0676fdad",
+    "set_uuid": "bcf484d9-dd6c-4dbe-a648-fc54b3cedcd7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-600",
+    "uuid": "5dd9406f-9b36-43f1-8b35-b1bb7f2a4c8d",
+    "set_uuid": "bcf484d9-dd6c-4dbe-a648-fc54b3cedcd7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-color-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.95",
+    "uuid": "ac039445-0bf8-4821-b02e-e7e06a416576"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "bfd387b8-0ce0-45ff-8d66-fc5de2f4900c"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "pagination-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-600",
+    "uuid": "f8cefe70-db2c-489e-bbbe-964050e96ab6"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-1000",
+    "uuid": "70fc4674-0f09-48f5-8850-48b4b38c2f01"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "fba1851e-0056-4cdf-938d-6d61550bbe3c"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "drop-shadow-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-color",
+    "uuid": "97dfaf7f-ac2d-4517-84cc-6f692f712fc5",
+    "deprecated": "unknown",
+    "deprecated_comment": "Express does not need a separate design for Color loupe and Color handle components",
+    "replaced_by": "be45ace6-9227-41d1-80be-0c58c3f8b3cb"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "inner-border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black",
+    "uuid": "0c93f310-d7c6-474b-8f07-0e8e76e2756e"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "inner-border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.42",
+    "uuid": "72b473c6-ec9b-4830-a0f8-48b80070e7b8"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "outer-border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black",
+    "uuid": "e4733356-090e-4bb7-b32d-ab9df30fb785"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "outer-border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "color-handle-inner-border-opacity",
+    "uuid": "0a0eff89-7e7d-4b7f-bcfa-a85e33e5798a"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "drop-shadow-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-elevated-blur",
+    "uuid": "86caa027-9e9e-4a5f-aa38-058f0a96bc9d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "drop-shadow-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-elevated-color",
+    "uuid": "918b8089-d89f-45d2-8c9c-f3f13f81b0b9",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use `drop-shadow-elevated-color` instead",
+    "replaced_by": "e475981f-97af-479c-859b-7619dd87c448"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "drop-shadow-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-elevated-y",
+    "uuid": "c9af5d60-11b1-4fc3-972e-6a607120657b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "inner-border"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-200",
+    "uuid": "d2c4cb48-8a90-461d-95bc-d882ba01472b"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "outer-border"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "white",
+    "uuid": "4e1d1cc5-736e-4e82-9054-5c1a74ac1aca"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-1000",
+    "uuid": "0c85e7fa-f950-436c-a68a-dd7fb8dfac9e"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "8271b69e-6542-4b17-b0f0-72567e16c41b"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-1000",
+    "uuid": "a60c3946-dff7-4245-bdcd-b61445066e48"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "be8fac27-b644-492e-a89d-6c87cfecb8a1"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "background-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-visual-color",
+    "uuid": "866f3613-c12f-4475-87b1-ad86ef2ce153"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "background-color-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "ee5ed78b-230c-4b37-9d76-1787a975bb63"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "background-color-opacity-filled"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.3",
+    "uuid": "ca70550a-b11a-438f-9c70-ff1eeba532cc"
+  },
+  {
+    "name": {
+      "component": "floating-action-button",
+      "property": "drop-shadow-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-black-300",
+    "uuid": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0"
+  },
+  {
+    "name": {
+      "component": "floating-action-button",
+      "property": "shadow-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "floating-action-button-drop-shadow-color",
+    "uuid": "f843b1b7-4b2f-496e-a679-b0372e49d575",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use `floating-action-button-drop-shadow-color` instead",
+    "replaced_by": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "f4d97d6a-c1f3-4ef5-b7e5-8fbee1365a83",
+    "set_uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "9b9e8b32-46b8-470d-85b9-352c00e90138",
+    "set_uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "ae0fb15e-c8a2-42c4-b973-0fb523003b79",
+    "set_uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "disabled",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "211d6540-cf9d-4d80-815b-885844283fa6",
+    "set_uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "disabled",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "0e2c2900-180c-443a-86ff-49170166e616",
+    "set_uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "disabled",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "5924d0c5-6938-4660-8be3-9374bb3e5b0c",
+    "set_uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "d609bd79-ab48-4a7a-95b1-da5a88ac5338",
+    "set_uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "7ccdd9e8-3677-4de8-b9df-19efa80d88c0",
+    "set_uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "e31108a0-1b8a-4d5e-b579-592a01619bd0",
+    "set_uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "857e82a6-537e-4534-9084-353c5401f567",
+    "set_uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "f68ff159-e886-4519-b95e-e93879a2f535",
+    "set_uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "1329d684-6ac9-4f46-9bbc-046e2de5276e",
+    "set_uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "keyboard-focus",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "dd044387-57b9-4867-90fa-b3c4c4a62e5c",
+    "set_uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "keyboard-focus",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "ae9dc785-2406-407e-ab47-d42d6fbf65f6",
+    "set_uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-color",
+      "state": "keyboard-focus",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "e9b046ee-408e-4781-a2cd-1d321bde4529",
+    "set_uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-dark",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "84a7cd5e-bb2b-4bb5-bb5f-f5839ae3a761",
+    "set_uuid": "bcddb17f-3fbc-40f2-b24e-7673225a2097",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-dark",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "f783b8cb-d31f-46c2-b550-990639752510",
+    "set_uuid": "bcddb17f-3fbc-40f2-b24e-7673225a2097",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-dark",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "35fcf7b1-7140-4522-8410-48547aaf6fd6",
+    "set_uuid": "bcddb17f-3fbc-40f2-b24e-7673225a2097",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "white",
+    "uuid": "c7e50676-3f61-49c3-a35f-2532fdb02360"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "border-color",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "transparent-white-25",
+    "uuid": "66da6f53-5446-43c1-bbe0-73b46763fde1",
+    "set_uuid": "a06ca705-47c8-414b-8768-f49a0b5997c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "border-color",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "825dc035-7b1c-4ddd-b1a9-be1546dae7e3",
+    "set_uuid": "a06ca705-47c8-414b-8768-f49a0b5997c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "border-color",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "92133ef4-9b81-4fbd-9736-8b83078ef053",
+    "set_uuid": "a06ca705-47c8-414b-8768-f49a0b5997c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "border-opacity",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0",
+    "uuid": "05c58363-1d34-4991-a7f7-7be7da4df50a",
+    "set_uuid": "d34281bc-ac57-407a-b8e5-1dbdedd45797",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "border-opacity",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "1.0",
+    "uuid": "fa9feacc-0c82-41a7-badc-5803c45a703b",
+    "set_uuid": "d34281bc-ac57-407a-b8e5-1dbdedd45797",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "border-opacity",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0",
+    "uuid": "55ab7957-997f-41a7-b31d-0994a2f77859",
+    "set_uuid": "d34281bc-ac57-407a-b8e5-1dbdedd45797",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "select-box-selected-border-color",
+      "component": "select-box"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "4bbb81b1-09fb-4ebe-80b5-cebb75c13839"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "background-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "c99360a4-de28-48e6-80ad-93adb714d388"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "background-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "022a6244-ce6c-4c3f-82a1-e2f5118d3c5e"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "background-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "a0251da6-7517-4712-85a1-29ca7f16ef91"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-color-default",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "128c4963-471a-44e3-9fb5-328d92d0266d"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-color-down",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-300",
+    "uuid": "1ad58d16-66da-44ae-829e-9ee1ff56a857"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-color-emphasized",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-background-color-default",
+    "uuid": "95685612-09b7-477f-9c13-06eb58abe5c8"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-color-hover",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "a1bcd6c6-ef3e-42e4-8d88-2fafe2b318da"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-color-key-focus",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-200",
+    "uuid": "93f433f2-2d0b-4225-8b39-b10000808360"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "gripper-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-500",
+    "uuid": "71840c7b-acdd-45b9-a228-5091591f5405"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "gripper-color-drag"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "69e2d0b3-6807-4e46-9f8a-72bf49439f36"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-1000",
+    "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.42",
+    "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5"
+  },
+  {
+    "name": {
+      "property": "swatch-disabled-icon-border-color",
+      "component": "swatch"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black",
+    "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535"
+  },
+  {
+    "name": {
+      "property": "swatch-disabled-icon-border-opacity",
+      "component": "swatch"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.42",
+    "uuid": "cdbba3b6-cb51-4fec-88f0-273d4bb59a18"
+  },
+  {
+    "name": {
+      "component": "swatch-group",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-1000",
+    "uuid": "08b8d06a-5475-47bf-ad2e-9f52ee07345a"
+  },
+  {
+    "name": {
+      "property": "table-row-down-opacity",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "75ae742c-e96e-494f-9880-746bb2849575"
+  },
+  {
+    "name": {
+      "property": "table-row-hover-color",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "44aedb76-5483-4ac3-a6f5-8cf71c2bd376"
+  },
+  {
+    "name": {
+      "property": "table-row-hover-opacity",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.07",
+    "uuid": "e287d553-3712-4d6e-98f0-6075107e85fe"
+  },
+  {
+    "name": {
+      "property": "table-selected-row-background-color",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-background-color-default",
+    "uuid": "b7537f50-bd49-44b6-a171-19943d443d24"
+  },
+  {
+    "name": {
+      "property": "table-selected-row-background-color-non-emphasized",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-background-color-selected-default",
+    "uuid": "8578067a-6ce0-4059-84ad-4688c71df156"
+  },
+  {
+    "name": {
+      "property": "table-selected-row-background-opacity",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "61b3aa04-0e7e-44b8-a4c8-8442a4ebf549"
+  },
+  {
+    "name": {
+      "property": "table-selected-row-background-opacity-hover",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "ce2851bc-8ae1-4b27-8cd6-f191c9cd7fe9"
+  },
+  {
+    "name": {
+      "property": "table-selected-row-background-opacity-non-emphasized",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "1ef41e27-3dea-4589-ad7a-140a03a77384"
+  },
+  {
+    "name": {
+      "property": "table-selected-row-background-opacity-non-emphasized-hover",
+      "component": "table"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "6a093ea1-f07e-4673-b52f-5b28a2e080d0"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "border-color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "5bd226f1-0a6b-42bc-80af-4a9dde99e9e9"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "58bd04e9-5b85-44d8-8474-96e157701070"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "opacity",
+      "state": "disabled"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "opacity-disabled",
+    "uuid": "92418bcd-5f0f-4f26-9a96-51f8c9e871bf"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "row-background",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "39d26185-da40-47b5-b4b3-e47689129256"
+  },
+  {
+    "name": {
+      "property": "tree-view-selected-row-background-color-emphasized",
+      "component": "tree-view"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-background-color-default",
+    "uuid": "65854450-ed1a-49ea-ab29-d257b8a0569e"
+  },
+  {
+    "name": {
+      "property": "tree-view-selected-row-background-default",
+      "component": "tree-view"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "8f19994d-f49a-42ea-97bd-98ab1d76d02d"
+  },
+  {
+    "name": {
+      "property": "tree-view-selected-row-background-hover",
+      "component": "tree-view"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-100",
+    "uuid": "c325ed8f-8248-40c3-a0f0-efba57638f24"
+  }
+]

--- a/packages/design-data/tokens/color-palette.tokens.json
+++ b/packages/design-data/tokens/color-palette.tokens.json
@@ -1,0 +1,13417 @@
+[
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "black"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 0, 0)",
+    "uuid": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(245, 249, 255)",
+    "uuid": "bb610367-a43d-4ba9-b667-84b4d8da69b2",
+    "set_uuid": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(14, 23, 63)",
+    "uuid": "7d56ac58-fd58-41b3-9bbd-448ae0a7dd85",
+    "set_uuid": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "05ffb7a9-8bd9-46cd-bfb0-66217d52ceb1",
+    "set_uuid": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(39, 77, 234)",
+    "uuid": "da15fc4a-a3ce-4cbe-a2d1-bf5a2e77e5c4",
+    "set_uuid": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(105, 149, 254)",
+    "uuid": "147ed079-b4f0-4cd7-89cd-7ec93750d688",
+    "set_uuid": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "a50fef9e-d01f-490c-9baa-8c9672f1ac96",
+    "set_uuid": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(29, 62, 207)",
+    "uuid": "7044000c-09c4-4c12-8b37-94f8601217e2",
+    "set_uuid": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(124, 169, 252)",
+    "uuid": "2a5d2e32-930d-4c50-b1fd-6781a1dc1db5",
+    "set_uuid": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "85683533-e660-4037-ad0a-3d5e7714a757",
+    "set_uuid": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(21, 50, 173)",
+    "uuid": "aae7bf70-35c6-49f9-a6da-ba40ee217c3d",
+    "set_uuid": "5c04481e-664e-4e9a-8da9-841e349167f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(152, 192, 252)",
+    "uuid": "ce7da4ba-77ed-4bdd-a154-90f389af6c2a",
+    "set_uuid": "5c04481e-664e-4e9a-8da9-841e349167f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "ccde5f80-26bb-4de8-9982-0f7fd3a97e7d",
+    "set_uuid": "5c04481e-664e-4e9a-8da9-841e349167f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(16, 40, 140)",
+    "uuid": "c6fce6c2-ca99-4a3d-b2af-d96a35ec70dc",
+    "set_uuid": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(181, 213, 253)",
+    "uuid": "2bc63c0d-691c-4cc4-95b6-b4e530a44978",
+    "set_uuid": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "4dbbc998-deeb-4268-9a6a-c49a57ff0bcc",
+    "set_uuid": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(12, 31, 105)",
+    "uuid": "af563d02-b975-4ba5-82d3-02bcf30f762c",
+    "set_uuid": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(213, 231, 254)",
+    "uuid": "eb86d777-ec23-47e4-adc6-1203709dc00d",
+    "set_uuid": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "0284c8ef-fd73-4c33-8f31-bc9a83a5a84f",
+    "set_uuid": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(14, 24, 67)",
+    "uuid": "a24a53d4-d3c3-4d84-b6eb-048326659524",
+    "set_uuid": "be3d8c39-72f3-4134-b009-4aa30fb01883",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(238, 245, 255)",
+    "uuid": "616c28b4-d9bf-4ff3-9075-6acaad6c112c",
+    "set_uuid": "be3d8c39-72f3-4134-b009-4aa30fb01883",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "07862296-803e-42fc-8ba1-ff8c25e76f66",
+    "set_uuid": "be3d8c39-72f3-4134-b009-4aa30fb01883",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(7, 11, 30)",
+    "uuid": "29610c54-a311-470d-ad77-c28c000730e3",
+    "set_uuid": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "7e8a7cd3-c803-41a9-9178-b43f9eb2e735",
+    "set_uuid": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "9d380e6c-f6e9-433d-a8d8-f2432181736c",
+    "set_uuid": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(229, 240, 254)",
+    "uuid": "989a37a5-66f2-4a84-a118-8d36caee6695",
+    "set_uuid": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(15, 28, 82)",
+    "uuid": "7b7d1fd8-cc1e-4053-b320-e481b8f64c46",
+    "set_uuid": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "1f9bd0a5-d1ed-4d24-b8bf-273f5f22a5f4",
+    "set_uuid": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(203, 226, 254)",
+    "uuid": "58dc7d3a-3a6d-4ee4-ad38-5e01a07335bd",
+    "set_uuid": "d434be86-0614-481b-bf30-6f7494f562d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(12, 33, 117)",
+    "uuid": "d88d1685-29dc-486b-a0b9-9c90f60b8cde",
+    "set_uuid": "d434be86-0614-481b-bf30-6f7494f562d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "94ed3997-5b56-41e8-9746-1d7515244c6e",
+    "set_uuid": "d434be86-0614-481b-bf30-6f7494f562d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(172, 207, 253)",
+    "uuid": "9c39c15f-04ee-4cb3-acf3-04c390f14780",
+    "set_uuid": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 45, 154)",
+    "uuid": "29d339bb-ef80-40f8-a69b-afa778b60805",
+    "set_uuid": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "23852b5e-2d80-4c89-946c-1c8c2fe37b39",
+    "set_uuid": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(142, 185, 252)",
+    "uuid": "ccc5c654-280e-4f46-964e-9d589f571bc6",
+    "set_uuid": "1350b184-da3d-4920-bfa1-b42ba88761b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(26, 58, 195)",
+    "uuid": "a61ed901-7f77-4667-9d19-fff6bab20623",
+    "set_uuid": "1350b184-da3d-4920-bfa1-b42ba88761b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "ca7117db-c105-446f-85e5-72f1191b9cfd",
+    "set_uuid": "1350b184-da3d-4920-bfa1-b42ba88761b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(114, 158, 253)",
+    "uuid": "b781aad3-054c-4e81-a368-a8165e6035fd",
+    "set_uuid": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(37, 73, 229)",
+    "uuid": "7e770996-780a-4494-91ea-08c1ae6cfa80",
+    "set_uuid": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "560dddaa-d4ae-4d84-8750-30eb72f9e33c",
+    "set_uuid": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 137, 255)",
+    "uuid": "1a25f1fe-6d20-49f9-b8f9-d304efc83626",
+    "set_uuid": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 91, 248)",
+    "uuid": "5cc66280-e13a-459d-8529-c3f531aa5e4e",
+    "set_uuid": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "0a50f1d3-8ae9-4955-9b1e-3d18121a3302",
+    "set_uuid": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(75, 117, 255)",
+    "uuid": "5ac73d3a-a6cc-4403-a8d5-46bc262d62e9",
+    "set_uuid": "85be576c-6810-4971-9748-e558384b903d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(64, 105, 253)",
+    "uuid": "cf0bafc5-f5c6-4986-a17a-6660dc542b71",
+    "set_uuid": "85be576c-6810-4971-9748-e558384b903d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "84bc6532-7cb0-47ea-8951-b16bc2a7aab9",
+    "set_uuid": "85be576c-6810-4971-9748-e558384b903d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 99, 251)",
+    "uuid": "3451c170-3e78-449b-86f2-8b7dbea24c1c",
+    "set_uuid": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(86, 129, 255)",
+    "uuid": "82b09b04-6a70-4a95-9eb5-a321a66a6465",
+    "set_uuid": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "blue",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "895407bb-8fda-4857-92a9-bf0cc06f2c3f",
+    "set_uuid": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(252, 247, 242)",
+    "uuid": "aa01448b-bf3b-4da2-b483-127a3ed708f7",
+    "set_uuid": "143930b9-2cfd-4849-94d2-fe5ade2ef5f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(35, 24, 8)",
+    "uuid": "478633c7-4a14-4e39-a05c-bfa07aeb4a85",
+    "set_uuid": "143930b9-2cfd-4849-94d2-fe5ade2ef5f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "3d64c998-df63-4695-a1d1-00d78ed2097b",
+    "set_uuid": "143930b9-2cfd-4849-94d2-fe5ade2ef5f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(119, 91, 50)",
+    "uuid": "0dd635ef-0b0a-4914-8900-999ab7ce436e",
+    "set_uuid": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(181, 147, 98)",
+    "uuid": "6fd7a375-e670-4bde-8061-b1b2ba5116be",
+    "set_uuid": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "a2a5c52d-7381-47b8-9b67-5d3c86e8ff21",
+    "set_uuid": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(103, 76, 35)",
+    "uuid": "d14770ac-d032-4408-b5de-637de47bf151",
+    "set_uuid": "aa6d07ca-147f-49f9-bcad-1e7e3afa4afa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(199, 163, 112)",
+    "uuid": "26df5572-cbdb-4988-8847-672ee1669acd",
+    "set_uuid": "aa6d07ca-147f-49f9-bcad-1e7e3afa4afa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "1c1c2c57-890d-4638-b219-5b5e1953ba57",
+    "set_uuid": "aa6d07ca-147f-49f9-bcad-1e7e3afa4afa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(88, 61, 21)",
+    "uuid": "1a2cfeec-1d02-4225-a2a1-ecad878a0372",
+    "set_uuid": "1090f8d4-7629-4515-aabf-9882237b87a9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(222, 185, 130)",
+    "uuid": "c1965544-ed0e-438f-aed0-b1f31836950c",
+    "set_uuid": "1090f8d4-7629-4515-aabf-9882237b87a9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "df9afc4f-bb87-4dae-b2b6-f7d27a590593",
+    "set_uuid": "1090f8d4-7629-4515-aabf-9882237b87a9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(70, 49, 17)",
+    "uuid": "88621915-f832-4401-b42f-4026cbf6720c",
+    "set_uuid": "683f1d83-e54b-4a14-903e-afd3511748a4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(232, 207, 169)",
+    "uuid": "41d1432f-1b3a-4e93-8b57-2e48d0e66096",
+    "set_uuid": "683f1d83-e54b-4a14-903e-afd3511748a4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "1e9a6104-d427-4197-8e01-25673c917143",
+    "set_uuid": "683f1d83-e54b-4a14-903e-afd3511748a4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 37, 13)",
+    "uuid": "fa6e22f6-adb1-4123-b685-dd6050b0a248",
+    "set_uuid": "f6cb0828-54a1-4b21-9231-bd693efbe3b6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(242, 227, 206)",
+    "uuid": "91db9b52-530b-4147-be4f-c4d73a82eac3",
+    "set_uuid": "f6cb0828-54a1-4b21-9231-bd693efbe3b6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "2ceb2cda-a535-44eb-ae23-b922edcb8bb8",
+    "set_uuid": "f6cb0828-54a1-4b21-9231-bd693efbe3b6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(38, 26, 9)",
+    "uuid": "ddac3cfe-8338-4df5-94c5-baf4e04e6c46",
+    "set_uuid": "dc0ba9bf-3267-48f5-b349-dfc83f07279f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(250, 244, 236)",
+    "uuid": "d4d71d28-ce37-4f3f-8487-807cd1c42b9a",
+    "set_uuid": "dc0ba9bf-3267-48f5-b349-dfc83f07279f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "19c96dc5-7a37-4381-a7e8-ac1c442afda6",
+    "set_uuid": "dc0ba9bf-3267-48f5-b349-dfc83f07279f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(16, 12, 4)",
+    "uuid": "e2753343-f81b-4677-899c-6dfbcc9378fe",
+    "set_uuid": "68d1119b-f487-4802-a74a-7e4a6cd315b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "bca1e3d9-9242-4b81-95ab-08735905047b",
+    "set_uuid": "68d1119b-f487-4802-a74a-7e4a6cd315b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "cb18b0b7-7ad5-419f-863c-fdbb05c624c3",
+    "set_uuid": "68d1119b-f487-4802-a74a-7e4a6cd315b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(247, 238, 225)",
+    "uuid": "1b19a7b6-469e-4f5a-b30b-f3f465021d25",
+    "set_uuid": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(44, 31, 11)",
+    "uuid": "ec81816f-120e-46f9-a5b0-adb94814d1eb",
+    "set_uuid": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "5d0e6309-481d-40f9-81b9-7d0bee9cf794",
+    "set_uuid": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(239, 221, 195)",
+    "uuid": "9f0a77f8-aab8-4942-8119-332b09441939",
+    "set_uuid": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(58, 40, 14)",
+    "uuid": "3c253e65-bd9a-4e52-ad68-83aca3b197e6",
+    "set_uuid": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "e710f0e9-90a7-4ed9-8d2b-6a8c9ed778db",
+    "set_uuid": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(229, 200, 157)",
+    "uuid": "e33616c5-157c-42aa-a349-90d05f50beba",
+    "set_uuid": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(78, 55, 19)",
+    "uuid": "a9daa02d-c0aa-4c05-80ee-2bf55165dd36",
+    "set_uuid": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "7a9223ac-0dee-4dd5-8b11-b04815683c6b",
+    "set_uuid": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(214, 177, 123)",
+    "uuid": "5346904d-2c85-4dd5-815c-ea2708a4d380",
+    "set_uuid": "6b511f8b-4f2e-4734-b659-50cca2ca6dce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(98, 71, 30)",
+    "uuid": "f455957b-e647-44b3-a917-7d6e19807d40",
+    "set_uuid": "6b511f8b-4f2e-4734-b659-50cca2ca6dce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "bca8a6a6-557e-4930-b765-0dcc9867c42a",
+    "set_uuid": "6b511f8b-4f2e-4734-b659-50cca2ca6dce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(190, 155, 104)",
+    "uuid": "970fd8ac-c68b-4789-84a6-1397b2514e2f",
+    "set_uuid": "30176b33-a0e1-447e-bb2b-250f963b2d65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(115, 88, 47)",
+    "uuid": "41f83cff-cdd4-4760-a4bd-0bb1ceb46854",
+    "set_uuid": "30176b33-a0e1-447e-bb2b-250f963b2d65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "ef14139b-0550-4a5a-b2f5-eb787bcf406d",
+    "set_uuid": "30176b33-a0e1-447e-bb2b-250f963b2d65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(171, 138, 90)",
+    "uuid": "621aa30e-95de-4b69-814f-821dfe12b78d",
+    "set_uuid": "6f87ea74-5734-40c1-ab34-b284e0f75b1b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(132, 104, 61)",
+    "uuid": "dc738913-4af6-446e-8a1b-09c84993c8e5",
+    "set_uuid": "6f87ea74-5734-40c1-ab34-b284e0f75b1b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "45f999be-146e-4b0f-97de-ef1f7e82d675",
+    "set_uuid": "6f87ea74-5734-40c1-ab34-b284e0f75b1b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(154, 123, 77)",
+    "uuid": "b15bdc92-c03f-4ad4-a385-110d635e66af",
+    "set_uuid": "bfbde25d-e087-444a-b26f-6568325a7d2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 114, 69)",
+    "uuid": "e21a0edf-a81a-46a0-a849-11111cb89516",
+    "set_uuid": "bfbde25d-e087-444a-b26f-6568325a7d2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "2c0181c8-ef5c-46c8-bc3e-703d08f3692b",
+    "set_uuid": "bfbde25d-e087-444a-b26f-6568325a7d2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(139, 109, 66)",
+    "uuid": "b0445ddb-ec22-4dde-81a1-21ea14ed195a",
+    "set_uuid": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(163, 132, 84)",
+    "uuid": "79d7de9d-7bab-4762-acd9-ecf28556906a",
+    "set_uuid": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "brown",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "6756882c-f521-49fc-b7c9-3dc8f4d39d5a",
+    "set_uuid": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 255, 220)",
+    "uuid": "b4a22d71-d90a-4f6e-8f6d-e4967849376f",
+    "set_uuid": "cfa877de-79f8-493f-898d-ceb70a12f64e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(11, 31, 0)",
+    "uuid": "43feed9a-9a2a-44e0-9506-9bc5eb8eab1d",
+    "set_uuid": "cfa877de-79f8-493f-898d-ceb70a12f64e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "a52ac86a-8627-483b-b747-6e8aa5fa7249",
+    "set_uuid": "cfa877de-79f8-493f-898d-ceb70a12f64e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 109, 12)",
+    "uuid": "3d509755-d653-4a3f-a5a3-fcbed0c2e21c",
+    "set_uuid": "2184d450-2711-4e31-bb52-ee71e4fee3a5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(88, 172, 28)",
+    "uuid": "021a55b8-26ae-4767-82fb-06b20c58762b",
+    "set_uuid": "2184d450-2711-4e31-bb52-ee71e4fee3a5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "085d2bcb-85b1-4b55-842b-9559c457a1a0",
+    "set_uuid": "2184d450-2711-4e31-bb52-ee71e4fee3a5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(44, 92, 9)",
+    "uuid": "ea7327bb-48a8-41dd-b139-c7bda3dedaee",
+    "set_uuid": "bd5d2127-7c7e-428c-bded-4638ab7094a5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(100, 190, 35)",
+    "uuid": "e091babe-6e02-4393-a67e-63222ab860b4",
+    "set_uuid": "bd5d2127-7c7e-428c-bded-4638ab7094a5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "5c9ac732-7e1a-448c-b338-18d3b265d5d1",
+    "set_uuid": "bd5d2127-7c7e-428c-bded-4638ab7094a5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(35, 75, 6)",
+    "uuid": "fc4dedc3-0009-4a5a-8e93-f52ba4155e0a",
+    "set_uuid": "e1f435ac-6232-4289-b5fc-f25b10e882a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(116, 213, 46)",
+    "uuid": "9913e84a-4070-476f-a570-a16781a924cf",
+    "set_uuid": "e1f435ac-6232-4289-b5fc-f25b10e882a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "865fc403-cab2-4e38-a181-e5e10523e04d",
+    "set_uuid": "e1f435ac-6232-4289-b5fc-f25b10e882a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(27, 60, 3)",
+    "uuid": "7a3d9646-272f-4ca1-a4e6-0708eb2cd378",
+    "set_uuid": "dcfba07b-4ed9-4dbd-bf70-f0e7bed21711",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(136, 234, 65)",
+    "uuid": "d2d8dc91-da75-4c56-a0d8-e6e9802434ad",
+    "set_uuid": "dcfba07b-4ed9-4dbd-bf70-f0e7bed21711",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "cc88021a-ce1a-4f69-9208-d1b897a1d71b",
+    "set_uuid": "dcfba07b-4ed9-4dbd-bf70-f0e7bed21711",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(19, 46, 0)",
+    "uuid": "02e66104-cbf7-4e27-89cf-f18b1ef04f2d",
+    "set_uuid": "0b88acb2-45bb-4ef5-b1e5-54027c4cf70e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(170, 251, 112)",
+    "uuid": "c5c3c68c-8293-4ebb-a8d1-9f4af902906e",
+    "set_uuid": "0b88acb2-45bb-4ef5-b1e5-54027c4cf70e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "0fd51556-72b0-48ea-86f2-435bf64de316",
+    "set_uuid": "0b88acb2-45bb-4ef5-b1e5-54027c4cf70e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(12, 33, 0)",
+    "uuid": "ca5c139e-1784-4139-89a3-281a83dbeb99",
+    "set_uuid": "118a3ebb-f3f8-4af6-824d-b1413df5f375",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(222, 255, 198)",
+    "uuid": "ad9c1278-7296-4aef-9e19-6cabc2997bfa",
+    "set_uuid": "118a3ebb-f3f8-4af6-824d-b1413df5f375",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "fe522078-7e21-447e-bd4f-e5f2ea6845d9",
+    "set_uuid": "118a3ebb-f3f8-4af6-824d-b1413df5f375",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(4, 15, 0)",
+    "uuid": "56e0d793-ce33-4da3-8e67-d7df10b2cd89",
+    "set_uuid": "f02a51a1-8528-4a97-bf79-df228b3dbcdd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "f1a7d5b6-4414-493a-a5d8-77d81a0121a2",
+    "set_uuid": "f02a51a1-8528-4a97-bf79-df228b3dbcdd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "99fb92f6-7186-4432-99ec-d5fa5b35c5be",
+    "set_uuid": "f02a51a1-8528-4a97-bf79-df228b3dbcdd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(197, 255, 156)",
+    "uuid": "30941af9-354a-4d61-9462-aca4bcd50093",
+    "set_uuid": "d22658b0-6638-45f9-8567-a2ad056f7c10",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(15, 38, 0)",
+    "uuid": "741a30fb-62a9-4c76-a78e-cc2590af9c7d",
+    "set_uuid": "d22658b0-6638-45f9-8567-a2ad056f7c10",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "a83229ca-de1f-4fdb-a72b-b8a3498a31bb",
+    "set_uuid": "d22658b0-6638-45f9-8567-a2ad056f7c10",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(157, 247, 92)",
+    "uuid": "3562f589-ba34-465e-9549-2600e2527ab8",
+    "set_uuid": "577626d4-7631-4de5-bd71-350b9748a4dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(21, 51, 1)",
+    "uuid": "5eda4487-8f82-48ed-8b22-aa38601bbf88",
+    "set_uuid": "577626d4-7631-4de5-bd71-350b9748a4dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "5b271002-0fe2-4407-be21-7c09646a2303",
+    "set_uuid": "577626d4-7631-4de5-bd71-350b9748a4dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(129, 228, 58)",
+    "uuid": "d86c4477-a2f4-449a-8883-daaf33608fde",
+    "set_uuid": "e8b68c0f-5e9f-47c0-b844-35032c46aeee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(31, 67, 4)",
+    "uuid": "646d80c1-7073-4e13-bbfe-4bd0c2226079",
+    "set_uuid": "e8b68c0f-5e9f-47c0-b844-35032c46aeee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "813b3e86-659b-48ee-b88d-122c13fa96e8",
+    "set_uuid": "e8b68c0f-5e9f-47c0-b844-35032c46aeee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(110, 206, 42)",
+    "uuid": "9c5fc2d5-30cc-4389-b219-2db69f8a86f9",
+    "set_uuid": "b937bc38-d471-47ee-b416-1bbb91c524ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(41, 86, 8)",
+    "uuid": "7d4c282b-78ce-4b2c-ab39-26bf02366e4d",
+    "set_uuid": "b937bc38-d471-47ee-b416-1bbb91c524ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "13e77335-22c0-470a-a5e5-da6363f622e0",
+    "set_uuid": "b937bc38-d471-47ee-b416-1bbb91c524ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 180, 31)",
+    "uuid": "c2cfbc22-b556-4cb5-b5ee-670254d5ecbc",
+    "set_uuid": "b908fb61-f581-4942-9d00-57a828a0660b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(50, 105, 11)",
+    "uuid": "260d8921-3810-4a5d-a20f-cd00170cf951",
+    "set_uuid": "b908fb61-f581-4942-9d00-57a828a0660b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "a52a4fbf-dc30-4c09-b1d8-b25bcead712c",
+    "set_uuid": "b908fb61-f581-4942-9d00-57a828a0660b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(82, 161, 25)",
+    "uuid": "59b03f98-f898-4888-ad71-07a434e2fc7e",
+    "set_uuid": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(60, 122, 15)",
+    "uuid": "7e7e6abb-a2e9-4308-ac8e-e6866ec17c64",
+    "set_uuid": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "3e9a8018-a0bf-4562-867d-555c75c08d9f",
+    "set_uuid": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(72, 144, 20)",
+    "uuid": "41747345-10ab-476a-9d3d-e657f9383e8e",
+    "set_uuid": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(66, 134, 18)",
+    "uuid": "3b130e0d-eb9b-49e6-84db-eda6ee95eee5",
+    "set_uuid": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "7a5096e0-6845-4ae5-bab4-d958c7e3dadb",
+    "set_uuid": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(64, 129, 17)",
+    "uuid": "deec9c21-caeb-4ec4-bca4-a7661a2c5f91",
+    "set_uuid": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(78, 154, 23)",
+    "uuid": "706f3a95-ab27-497f-aab7-f4ed806eef30",
+    "set_uuid": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "celery",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "10c7c9b0-0d15-43ae-bf6f-84384783a9aa",
+    "set_uuid": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 251, 222)",
+    "uuid": "b7cca467-abe9-4632-b01a-dda350c93480",
+    "set_uuid": "dac7cf0c-9994-4bba-9d65-41d71f15c470",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(23, 28, 0)",
+    "uuid": "bdc6a473-3109-44c6-9e2f-198d3224d75f",
+    "set_uuid": "dac7cf0c-9994-4bba-9d65-41d71f15c470",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "cc59e104-9997-4ed2-a29e-0af0b1a04b67",
+    "set_uuid": "dac7cf0c-9994-4bba-9d65-41d71f15c470",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(86, 103, 0)",
+    "uuid": "00100510-9965-4086-ba82-0cb62ffebba1",
+    "set_uuid": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(136, 164, 0)",
+    "uuid": "7dbedc59-e21c-4953-a7af-5e91d170604a",
+    "set_uuid": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "9a6983b0-a2ba-4633-a618-f3b4ac8f05c6",
+    "set_uuid": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(73, 87, 0)",
+    "uuid": "e964b654-261d-44a5-ab0a-78c8137a7783",
+    "set_uuid": "20c271df-6e71-4082-b953-d8bf938ff286",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(151, 181, 0)",
+    "uuid": "90417b40-97dd-47b3-9dbc-4ac45f8e4a5f",
+    "set_uuid": "20c271df-6e71-4082-b953-d8bf938ff286",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "8e44257e-ec8e-4459-863e-0bbbab65f6e0",
+    "set_uuid": "20c271df-6e71-4082-b953-d8bf938ff286",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(60, 71, 0)",
+    "uuid": "6bf184f6-f0e1-41af-94a4-47aa1a37b0aa",
+    "set_uuid": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(169, 203, 0)",
+    "uuid": "e4b04d5d-e99d-41c5-8b24-540d653ef3ff",
+    "set_uuid": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "9af36936-6d05-4ba4-8beb-9b65bafb9277",
+    "set_uuid": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(47, 57, 0)",
+    "uuid": "e320e57d-2794-4c1e-97ef-3a8b04be1328",
+    "set_uuid": "2e179dee-6bf4-431e-9f0d-1d5300bcca5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(187, 225, 0)",
+    "uuid": "615841b9-08b2-4e21-981a-b8f5247e9e89",
+    "set_uuid": "2e179dee-6bf4-431e-9f0d-1d5300bcca5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "acb36528-7ad1-497c-baf7-c53171ce4112",
+    "set_uuid": "2e179dee-6bf4-431e-9f0d-1d5300bcca5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(35, 43, 0)",
+    "uuid": "56b4f40c-d9f2-4360-99eb-7097aafedf94",
+    "set_uuid": "c71243f9-192e-4560-ad45-bcc35d005705",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(219, 240, 117)",
+    "uuid": "a75188c9-02e3-4337-8056-9a6f8f39001f",
+    "set_uuid": "c71243f9-192e-4560-ad45-bcc35d005705",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "485b7081-a921-42ee-b781-8a99bfeb84fa",
+    "set_uuid": "c71243f9-192e-4560-ad45-bcc35d005705",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 30, 0)",
+    "uuid": "63f13dcb-6d61-4ff0-9999-33e16d30e5d6",
+    "set_uuid": "62a1940c-eeca-4182-b854-fe3c0736772e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(242, 249, 206)",
+    "uuid": "d7f569e2-f91c-439e-8e5a-8c8c825367ff",
+    "set_uuid": "62a1940c-eeca-4182-b854-fe3c0736772e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "75e5c281-4c83-4ffe-a1de-aedfa65be894",
+    "set_uuid": "62a1940c-eeca-4182-b854-fe3c0736772e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(11, 14, 0)",
+    "uuid": "01b68e1d-06d7-44a3-91e6-08e17353008c",
+    "set_uuid": "41eb4e4f-3310-469a-b5f5-cb52e4b47d2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "753f7aa2-6c7d-4b43-baf9-c72adbd9279d",
+    "set_uuid": "41eb4e4f-3310-469a-b5f5-cb52e4b47d2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "a8d9965e-14d9-4015-9a6f-421400c6d011",
+    "set_uuid": "41eb4e4f-3310-469a-b5f5-cb52e4b47d2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(234, 246, 173)",
+    "uuid": "c1146153-61bf-4a31-8254-54a1d25a93c5",
+    "set_uuid": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(30, 36, 0)",
+    "uuid": "b18f4550-5bbe-496c-b4a5-13df8fd0c7d7",
+    "set_uuid": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "838a5de8-2ec7-4814-8ba9-eaa4b0ad8e55",
+    "set_uuid": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(208, 236, 70)",
+    "uuid": "f8812b11-742b-44d6-a21a-7fd3db39fe71",
+    "set_uuid": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(39, 47, 0)",
+    "uuid": "b98dec90-df71-4593-946d-91df7918caac",
+    "set_uuid": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "bbb32db5-4835-4520-8bb1-ef2c8916c604",
+    "set_uuid": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(182, 219, 0)",
+    "uuid": "32e471ce-5b0d-40f1-a77a-67feff02775e",
+    "set_uuid": "dba5cb03-a980-48bd-8b35-99dd063763e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(53, 63, 0)",
+    "uuid": "6a974b7d-ccd2-4778-baae-8caf419a529c",
+    "set_uuid": "dba5cb03-a980-48bd-8b35-99dd063763e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "eb857d3b-1956-4870-98cb-eaaffffaed85",
+    "set_uuid": "dba5cb03-a980-48bd-8b35-99dd063763e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(163, 196, 0)",
+    "uuid": "fe3be762-b55e-43cb-9163-68ee7dafc53e",
+    "set_uuid": "b72ad072-4768-463a-b951-00f1cbe4f657",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(68, 82, 0)",
+    "uuid": "46d8fd3b-0e51-4cdd-a33c-de184b82dcc5",
+    "set_uuid": "b72ad072-4768-463a-b951-00f1cbe4f657",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "7bffe928-4940-41b1-a9d4-3cbee27cb472",
+    "set_uuid": "b72ad072-4768-463a-b951-00f1cbe4f657",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 172, 0)",
+    "uuid": "d61e865b-6538-42a8-aba8-0842359b80c2",
+    "set_uuid": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(83, 100, 0)",
+    "uuid": "965174d2-e743-41df-a8e2-570b2ae2f447",
+    "set_uuid": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "788108ff-5238-4a75-8936-092df93a3fd0",
+    "set_uuid": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(128, 153, 0)",
+    "uuid": "3d0fd171-80f3-4f08-9ac0-eb46d0e755f9",
+    "set_uuid": "f50abb60-7047-4e92-a48c-627d98eb85d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(97, 116, 0)",
+    "uuid": "a615bb51-0249-4201-b1c9-1c6269b82ec2",
+    "set_uuid": "f50abb60-7047-4e92-a48c-627d98eb85d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "0386fb0b-3653-4015-a3a1-cbf047435f0f",
+    "set_uuid": "f50abb60-7047-4e92-a48c-627d98eb85d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(114, 137, 0)",
+    "uuid": "9a0701e4-81a0-420b-b751-c6a46670fbf3",
+    "set_uuid": "9131b099-6865-4e54-b364-acb3891737f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(106, 127, 0)",
+    "uuid": "343f1685-2314-4a64-bc7a-5b7b3fd9fdcf",
+    "set_uuid": "9131b099-6865-4e54-b364-acb3891737f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "c8046b7e-506c-47b7-8105-4d7e805f6b92",
+    "set_uuid": "9131b099-6865-4e54-b364-acb3891737f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(102, 122, 0)",
+    "uuid": "7d22a144-0f7c-435e-ad05-b2d7672dff08",
+    "set_uuid": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(122, 147, 0)",
+    "uuid": "1637c50e-88e4-4273-8a75-6e8a233a690c",
+    "set_uuid": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "chartreuse",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "5f1f16c2-d562-4dd8-9b96-9d19b9a88093",
+    "set_uuid": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(253, 247, 243)",
+    "uuid": "27d84774-6d32-4499-8ba9-9d05c8fca55d",
+    "set_uuid": "c5b7d7be-3392-4635-9fd0-63045afa893f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(48, 17, 4)",
+    "uuid": "4d68b861-ba0c-438b-b10b-c209d4943206",
+    "set_uuid": "c5b7d7be-3392-4635-9fd0-63045afa893f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "3c3b2fb7-053d-47ca-86a6-4d1ee07b6f3f",
+    "set_uuid": "c5b7d7be-3392-4635-9fd0-63045afa893f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(147, 77, 43)",
+    "uuid": "b6943b69-7cec-4707-a556-aa350d9d8b89",
+    "set_uuid": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(206, 136, 99)",
+    "uuid": "40d50298-0ea6-4c7f-8349-2e149ca288aa",
+    "set_uuid": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "696315e6-4d82-49a0-8781-853beb0d1f5b",
+    "set_uuid": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(128, 62, 32)",
+    "uuid": "62edca31-5c84-4353-9707-f3648c8e1936",
+    "set_uuid": "f41f4d00-9e57-4f7c-ad3a-3554bb02bcb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(220, 154, 118)",
+    "uuid": "219f9efa-0717-4d41-80ac-695297b92cf8",
+    "set_uuid": "f41f4d00-9e57-4f7c-ad3a-3554bb02bcb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "41f0e438-0ca6-4240-84e7-dedfcff1aa21",
+    "set_uuid": "f41f4d00-9e57-4f7c-ad3a-3554bb02bcb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(110, 48, 21)",
+    "uuid": "e8b6ac17-268d-4ebc-99bc-480d15554356",
+    "set_uuid": "5bc8f9af-1607-466a-8a85-72053519d95f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(232, 179, 149)",
+    "uuid": "a48f0d44-c67a-4e95-b5b9-81379363aebe",
+    "set_uuid": "5bc8f9af-1607-466a-8a85-72053519d95f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "87e41d92-4099-4248-963c-394d43e33657",
+    "set_uuid": "5bc8f9af-1607-466a-8a85-72053519d95f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(92, 35, 11)",
+    "uuid": "4330fb2e-d402-43bc-b7a0-502c7f6d99ea",
+    "set_uuid": "fe8b0be8-2dfd-404b-808e-8d411f1cb168",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(239, 203, 183)",
+    "uuid": "4aae0490-5f12-430c-824f-f7de008a4e15",
+    "set_uuid": "fe8b0be8-2dfd-404b-808e-8d411f1cb168",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "2c86bff2-dddd-4fea-b6da-99873fa74da3",
+    "set_uuid": "fe8b0be8-2dfd-404b-808e-8d411f1cb168",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(72, 25, 6)",
+    "uuid": "6fe88344-7920-46a6-bbe4-be3cfa20298e",
+    "set_uuid": "3e8926d1-6cd5-4b52-a856-cb9d1bcb907d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 225, 214)",
+    "uuid": "1e29a372-600e-4cda-a190-b865c5521aa6",
+    "set_uuid": "3e8926d1-6cd5-4b52-a856-cb9d1bcb907d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "2ec58374-b4c1-4e03-8f3f-57c747a7ed47",
+    "set_uuid": "3e8926d1-6cd5-4b52-a856-cb9d1bcb907d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 18, 4)",
+    "uuid": "fe6e5407-3f9b-4dd0-9589-7029c19f35b5",
+    "set_uuid": "a6ed40d2-aee1-4458-b8ee-abf21d8fc029",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(252, 244, 239)",
+    "uuid": "7b880574-db1b-47ee-8c66-6504ada37f56",
+    "set_uuid": "a6ed40d2-aee1-4458-b8ee-abf21d8fc029",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "1adb9cd6-2ba1-4501-ab9d-f377ae07d399",
+    "set_uuid": "a6ed40d2-aee1-4458-b8ee-abf21d8fc029",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(24, 8, 2)",
+    "uuid": "e3727e22-c955-4116-b5a7-2877df6ef2fe",
+    "set_uuid": "9e233bbb-1685-4fc6-9d27-728d4043387f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "1d04ed6a-8efc-472b-b7c7-0fbc160ce7fd",
+    "set_uuid": "9e233bbb-1685-4fc6-9d27-728d4043387f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "321a9931-be34-4ce9-8180-8e7fd87e30f4",
+    "set_uuid": "9e233bbb-1685-4fc6-9d27-728d4043387f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(249, 236, 229)",
+    "uuid": "a8d1aa1d-f9be-448e-8209-afc6097f38ed",
+    "set_uuid": "322b71ea-2187-4fce-90e7-2db63d037368",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 21, 5)",
+    "uuid": "bd680dfb-0c2f-45e8-b814-627b496a986c",
+    "set_uuid": "322b71ea-2187-4fce-90e7-2db63d037368",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "07d13e6d-0df2-4eee-8550-ef033f954e9e",
+    "set_uuid": "322b71ea-2187-4fce-90e7-2db63d037368",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(244, 218, 203)",
+    "uuid": "56c7eeb3-990f-48e3-b024-56d36b0378f5",
+    "set_uuid": "3527fc94-a410-4933-bbb7-bedecd37e477",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(79, 28, 7)",
+    "uuid": "4d086a5c-1b70-4750-be79-db934e7bc010",
+    "set_uuid": "3527fc94-a410-4933-bbb7-bedecd37e477",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "74d44818-bbbd-44a3-b9f0-7131fb036498",
+    "set_uuid": "3527fc94-a410-4933-bbb7-bedecd37e477",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(237, 196, 172)",
+    "uuid": "d4760c87-d0e2-4c5c-84f3-81e0c4c8fbb3",
+    "set_uuid": "e2246f50-4876-48fe-a56e-e859c9723e89",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(100, 41, 15)",
+    "uuid": "e5ab12a9-84b3-4bfe-94be-f734ae39f10d",
+    "set_uuid": "e2246f50-4876-48fe-a56e-e859c9723e89",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "2a7d78f3-ad8d-4301-96e8-f2a4ed378c00",
+    "set_uuid": "e2246f50-4876-48fe-a56e-e859c9723e89",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(229, 170, 136)",
+    "uuid": "39effb8c-2bba-4018-b6df-2465f2f7e0a0",
+    "set_uuid": "7527ee4f-a4cb-4e10-b0f2-6239bb9eeff3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(122, 57, 28)",
+    "uuid": "641a2424-c699-4920-8a27-68bc1bb178a1",
+    "set_uuid": "7527ee4f-a4cb-4e10-b0f2-6239bb9eeff3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "c607ecc8-35ed-4d47-a683-54d57b816fbd",
+    "set_uuid": "7527ee4f-a4cb-4e10-b0f2-6239bb9eeff3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(212, 145, 108)",
+    "uuid": "7d4de908-322f-4326-b623-a868b454b031",
+    "set_uuid": "51da608c-3871-48de-8b06-615adbc550ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 74, 40)",
+    "uuid": "6ccccd38-af76-4045-8ffb-a70bed76b365",
+    "set_uuid": "51da608c-3871-48de-8b06-615adbc550ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "d46ae80e-04ba-418f-8368-1d8c0633c0d1",
+    "set_uuid": "51da608c-3871-48de-8b06-615adbc550ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(198, 126, 88)",
+    "uuid": "0601d1ba-9a38-4fc9-ac89-ef332e906f3d",
+    "set_uuid": "09b8c3b9-1887-4bb9-a273-dbe1a01446f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(163, 88, 52)",
+    "uuid": "74c0ef96-2f6e-434a-bd89-69c6d9745a45",
+    "set_uuid": "09b8c3b9-1887-4bb9-a273-dbe1a01446f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "71085b67-c49c-4b1e-b708-6b38c16b9d37",
+    "set_uuid": "09b8c3b9-1887-4bb9-a273-dbe1a01446f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(184, 109, 70)",
+    "uuid": "560d578a-4128-40d5-979f-80d3057294a0",
+    "set_uuid": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(176, 98, 59)",
+    "uuid": "58777c5b-8e62-49fe-8e0b-0f8b5127225c",
+    "set_uuid": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "e78bd82d-f4c0-4617-92bb-08a69153bacd",
+    "set_uuid": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(170, 94, 56)",
+    "uuid": "50199dcc-deae-42ba-99e7-cb98346789eb",
+    "set_uuid": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 119, 80)",
+    "uuid": "7b65cc42-f559-42de-8077-d808c9e096b6",
+    "set_uuid": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cinnamon",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "cdaaa5e1-7ca5-43a8-bdb4-3ef8fedbb30d",
+    "set_uuid": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(238, 250, 254)",
+    "uuid": "72bef490-0c3a-4627-9341-fc6627cf3f74",
+    "set_uuid": "ba6486c3-b48d-4d4e-952e-c179db5671df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 29, 39)",
+    "uuid": "24a8bb5a-93c3-4dd1-9ea2-d48c11479fe7",
+    "set_uuid": "ba6486c3-b48d-4d4e-952e-c179db5671df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "28fe7c7b-b43c-4650-9155-5b0f5ec27a09",
+    "set_uuid": "ba6486c3-b48d-4d4e-952e-c179db5671df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(4, 102, 145)",
+    "uuid": "25c689a1-7876-44fa-8849-3a8db03a866c",
+    "set_uuid": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(38, 159, 244)",
+    "uuid": "04f3d463-9118-43d5-973d-8bf94417912d",
+    "set_uuid": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "8dd5e110-aa2f-47b2-aa21-30bc4241db86",
+    "set_uuid": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 87, 121)",
+    "uuid": "57ca59a9-1677-4813-9c0d-28267233ba35",
+    "set_uuid": "6d22fbe4-8c4e-4aff-8cf9-2061feee46f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(63, 177, 255)",
+    "uuid": "62a7ebff-a49b-4e7a-981f-692a506b4146",
+    "set_uuid": "6d22fbe4-8c4e-4aff-8cf9-2061feee46f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "4698ba84-dab0-4b6b-a2b1-e289261aa7b4",
+    "set_uuid": "6d22fbe4-8c4e-4aff-8cf9-2061feee46f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 71, 98)",
+    "uuid": "d6ba8ac5-09d4-44e2-8ade-216c626eb154",
+    "set_uuid": "ff28bc70-c903-4ee0-85b1-8334d2f7263f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(107, 199, 255)",
+    "uuid": "36a2af99-eef4-476b-a3b8-58eade0931b7",
+    "set_uuid": "ff28bc70-c903-4ee0-85b1-8334d2f7263f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "8e12e7fe-546a-4e8c-92eb-56673446b1bb",
+    "set_uuid": "ff28bc70-c903-4ee0-85b1-8334d2f7263f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 57, 78)",
+    "uuid": "1b179218-9e53-457d-977b-902509ef28aa",
+    "set_uuid": "225024f7-20bb-4227-a35f-2cebe558113c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(152, 219, 255)",
+    "uuid": "5f3df12b-1330-4482-ad34-c623bd36253c",
+    "set_uuid": "225024f7-20bb-4227-a35f-2cebe558113c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "958d5c96-6b57-47c2-a9a5-f589c054aa13",
+    "set_uuid": "225024f7-20bb-4227-a35f-2cebe558113c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 43, 59)",
+    "uuid": "3eac8807-136f-4687-8403-203fb49fbd74",
+    "set_uuid": "3409b02f-7492-474b-8d63-f67efb123522",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(195, 236, 252)",
+    "uuid": "fe63b8a3-ebb9-45fe-99c2-e246b53e06a6",
+    "set_uuid": "3409b02f-7492-474b-8d63-f67efb123522",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "8a2d9c8d-a95a-48ac-b6eb-0ca1d5e69bd7",
+    "set_uuid": "3409b02f-7492-474b-8d63-f67efb123522",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 31, 43)",
+    "uuid": "4d029c4c-4658-4207-b43c-d69b138b25a3",
+    "set_uuid": "c417cbf7-e9e6-4142-8392-08b96fe199e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(230, 248, 253)",
+    "uuid": "ce687c28-38ce-4fbe-8181-060e566b4196",
+    "set_uuid": "c417cbf7-e9e6-4142-8392-08b96fe199e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "6aa5f844-ba8d-40a3-86ec-109e9430ace5",
+    "set_uuid": "c417cbf7-e9e6-4142-8392-08b96fe199e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 14, 20)",
+    "uuid": "e6cd6257-d8de-428e-8ebf-c1c812031e5e",
+    "set_uuid": "2702626c-ab55-4b59-b4f0-f964531d11a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "291e6a5c-41b3-4bf1-ad10-38d427e80e48",
+    "set_uuid": "2702626c-ab55-4b59-b4f0-f964531d11a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "9bf84aeb-6822-40c9-b027-8db8a49fd54b",
+    "set_uuid": "2702626c-ab55-4b59-b4f0-f964531d11a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(217, 244, 253)",
+    "uuid": "c2aaf729-7f39-499a-8b67-e23801073b05",
+    "set_uuid": "c7fd6eda-f850-4dec-a883-e970cdfca622",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 36, 49)",
+    "uuid": "3445cf4b-2460-4692-acf2-71844d687da4",
+    "set_uuid": "c7fd6eda-f850-4dec-a883-e970cdfca622",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "b6b314ea-f9ba-4f49-a115-f4177ecb7bbc",
+    "set_uuid": "c7fd6eda-f850-4dec-a883-e970cdfca622",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(183, 231, 252)",
+    "uuid": "b54275ad-3ea6-4e69-aea2-97f488308fcc",
+    "set_uuid": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 48, 65)",
+    "uuid": "e4bcf4fc-aaec-49a5-a2bb-6bb55e7fff47",
+    "set_uuid": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "f7d51b4b-6c95-4271-a51e-4ad5a1660591",
+    "set_uuid": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(138, 213, 255)",
+    "uuid": "a33de292-77a9-40b7-961e-41ebfe331ad0",
+    "set_uuid": "61be07be-d428-4fe9-8e79-96df63980556",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 64, 88)",
+    "uuid": "94a5bd53-d69a-4063-b630-1976230d4f2d",
+    "set_uuid": "61be07be-d428-4fe9-8e79-96df63980556",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "6c2a20c7-e453-4401-a0b4-8e0d1d7edd7e",
+    "set_uuid": "61be07be-d428-4fe9-8e79-96df63980556",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(92, 192, 255)",
+    "uuid": "f3e8ff9f-e60b-4bce-9c39-280aef6fcb08",
+    "set_uuid": "78fb712e-40e4-4026-881a-a71250b35ceb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 82, 113)",
+    "uuid": "909baeef-fd2f-4550-89ea-fb7ac9ea2db5",
+    "set_uuid": "78fb712e-40e4-4026-881a-a71250b35ceb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "39f96e8f-c9c8-4158-8da9-6825cd084fc3",
+    "set_uuid": "78fb712e-40e4-4026-881a-a71250b35ceb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(48, 167, 254)",
+    "uuid": "d65f3e1d-ad9d-4fa7-ac06-37235124e999",
+    "set_uuid": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(3, 99, 140)",
+    "uuid": "d753ef33-bfc0-424b-a2ac-ea87ecbee590",
+    "set_uuid": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "6f67dfce-62d0-4147-aac6-33873a325cd3",
+    "set_uuid": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(29, 149, 231)",
+    "uuid": "08b4548a-618d-4ab5-ae46-2a60c7936f57",
+    "set_uuid": "2f04ecb9-b406-4eeb-ba9d-ea8d6d7d850a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 115, 168)",
+    "uuid": "3cb348d4-14a9-43da-84c4-068cf46c8c6f",
+    "set_uuid": "2f04ecb9-b406-4eeb-ba9d-ea8d6d7d850a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "08173787-f50d-48a7-badc-141a9e7b7981",
+    "set_uuid": "2f04ecb9-b406-4eeb-ba9d-ea8d6d7d850a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 134, 205)",
+    "uuid": "6dbdd00d-3b03-4eab-a77c-3a1f16d5e6ef",
+    "set_uuid": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(13, 125, 186)",
+    "uuid": "ee8673ca-c39c-437e-b3a5-416f4e8664d3",
+    "set_uuid": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "a006424a-ad2b-4091-a38d-b4af80ddc03e",
+    "set_uuid": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(11, 120, 179)",
+    "uuid": "71769f93-467d-497a-b214-45c8753f34f5",
+    "set_uuid": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(24, 142, 220)",
+    "uuid": "9c183829-4858-4908-b1ac-d89f40f2e903",
+    "set_uuid": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "cyan",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "03de1fef-9ae1-457d-917b-6f22fb545d00",
+    "set_uuid": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(254, 246, 255)",
+    "uuid": "2a8743fc-d3b3-444a-b3f1-8ad816945941",
+    "set_uuid": "203daf80-39e9-4362-bff4-6a9cc609a987",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(50, 0, 61)",
+    "uuid": "3a434405-c4b0-40ef-b383-7cb9a9b60cab",
+    "set_uuid": "203daf80-39e9-4362-bff4-6a9cc609a987",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "c826bbb3-badb-48a1-becf-86f5f395eef7",
+    "set_uuid": "203daf80-39e9-4362-bff4-6a9cc609a987",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(156, 40, 175)",
+    "uuid": "fa79840c-fe56-4f21-b9c5-f1e24f89e031",
+    "set_uuid": "0f412425-de6f-48f1-9d0f-0310d933d244",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(232, 91, 253)",
+    "uuid": "a13d5f15-e4cc-4f7c-928f-aaccbf0d590e",
+    "set_uuid": "0f412425-de6f-48f1-9d0f-0310d933d244",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "7606b799-458c-466e-96c6-a0a7e949a83c",
+    "set_uuid": "0f412425-de6f-48f1-9d0f-0310d933d244",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 27, 154)",
+    "uuid": "44aeb8b3-dd63-43a5-adb6-67cca83ca4c5",
+    "set_uuid": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(240, 122, 255)",
+    "uuid": "0a4eb3af-d067-4d9f-af91-66c676e49e26",
+    "set_uuid": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "aa82e21e-e5a2-4bcd-a63d-a2d76c467ac7",
+    "set_uuid": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 15, 131)",
+    "uuid": "fc66406d-0e4c-4f82-9fa6-aec444f04070",
+    "set_uuid": "b66743ea-ab53-4642-b14d-60f61783686e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(245, 159, 255)",
+    "uuid": "0d93ff9f-63e8-4caf-9e7b-714e56d968d4",
+    "set_uuid": "b66743ea-ab53-4642-b14d-60f61783686e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "bdb3a49e-331e-44b9-96e2-4f1dccdae565",
+    "set_uuid": "b66743ea-ab53-4642-b14d-60f61783686e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(92, 4, 109)",
+    "uuid": "00cfb450-b2b1-47ea-aaf2-221827cca75d",
+    "set_uuid": "64e2235c-ef58-4c57-98f7-2092ae60c1bc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(248, 191, 255)",
+    "uuid": "abd44b32-b837-4e11-95c7-4ba1c34db44b",
+    "set_uuid": "64e2235c-ef58-4c57-98f7-2092ae60c1bc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "c53a7f46-12aa-48c9-afdf-20e7a26bbb09",
+    "set_uuid": "64e2235c-ef58-4c57-98f7-2092ae60c1bc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(72, 0, 88)",
+    "uuid": "e5fc57ed-6d37-4496-a89c-db93104cb333",
+    "set_uuid": "63bb89b6-97d3-4b2b-bb18-d5bcb443d7b8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(251, 219, 255)",
+    "uuid": "7c819391-d74c-4326-ae0d-fe3534eb44e3",
+    "set_uuid": "63bb89b6-97d3-4b2b-bb18-d5bcb443d7b8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "ee6b1d77-41ce-4c87-9d95-098f5fc66da9",
+    "set_uuid": "63bb89b6-97d3-4b2b-bb18-d5bcb443d7b8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(54, 0, 66)",
+    "uuid": "afdfcd22-19fd-4306-a069-c8f9cd0d4f2d",
+    "set_uuid": "4f31cd4a-1aa5-4f68-8999-b0dfbb3a1227",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(253, 241, 255)",
+    "uuid": "ff510e34-7c7c-4795-a224-b1e1c5cc25e0",
+    "set_uuid": "4f31cd4a-1aa5-4f68-8999-b0dfbb3a1227",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "a8afc139-5eeb-4b56-9acd-62433f802563",
+    "set_uuid": "4f31cd4a-1aa5-4f68-8999-b0dfbb3a1227",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(29, 0, 35)",
+    "uuid": "38117e2a-efd1-4edd-8284-6fb0bc7482cc",
+    "set_uuid": "7f7a1ea4-5833-48db-8aa5-230808d39cf7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "c06ab95f-6471-4840-99cc-710851d25de4",
+    "set_uuid": "7f7a1ea4-5833-48db-8aa5-230808d39cf7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "cd37d695-d1b0-4322-92f7-9bc0a347aa90",
+    "set_uuid": "7f7a1ea4-5833-48db-8aa5-230808d39cf7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(253, 233, 255)",
+    "uuid": "a304f27a-7a17-4c12-88d1-07171fa3ca75",
+    "set_uuid": "078936af-2556-4ee2-a849-e7f19088b0ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 0, 74)",
+    "uuid": "779ec441-475d-41de-b207-3e139c7c3168",
+    "set_uuid": "078936af-2556-4ee2-a849-e7f19088b0ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "eed8370d-a367-4333-ba69-56843a7657ba",
+    "set_uuid": "078936af-2556-4ee2-a849-e7f19088b0ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(250, 211, 255)",
+    "uuid": "723a23a1-0bb0-4c11-89cf-0eca2a421867",
+    "set_uuid": "09aef364-8827-48fa-9888-b0424ce8981c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(79, 0, 95)",
+    "uuid": "5fa7110f-0c33-4139-8277-eff40921939e",
+    "set_uuid": "09aef364-8827-48fa-9888-b0424ce8981c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "7b52a8c6-67b3-4d8c-b506-aa5eeababdfb",
+    "set_uuid": "09aef364-8827-48fa-9888-b0424ce8981c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(247, 181, 255)",
+    "uuid": "ce8ce579-0dca-462c-a9d3-49e451931812",
+    "set_uuid": "2136078a-adb2-4011-89fc-ef5863f46033",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(102, 9, 120)",
+    "uuid": "a81bfdd6-4b80-4f1a-922d-2f6e04c27e01",
+    "set_uuid": "2136078a-adb2-4011-89fc-ef5863f46033",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "670788fe-2614-4673-bda2-681622680109",
+    "set_uuid": "2136078a-adb2-4011-89fc-ef5863f46033",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(243, 147, 255)",
+    "uuid": "779bda09-25fd-4912-9aa8-8e3a5643d0cb",
+    "set_uuid": "53fc62b5-9f54-45b7-af63-0d14c72d3d8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(127, 23, 146)",
+    "uuid": "7ecdb8fa-7c4b-4392-bca8-a00a9b931cb4",
+    "set_uuid": "53fc62b5-9f54-45b7-af63-0d14c72d3d8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "906889fa-ad69-4129-978c-23ea12d2b362",
+    "set_uuid": "53fc62b5-9f54-45b7-af63-0d14c72d3d8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(236, 105, 255)",
+    "uuid": "bd2db3f8-5eae-4fcb-a1f6-307d3b8e4139",
+    "set_uuid": "44f05566-476f-407f-b6d6-a211b2754fa5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(151, 38, 170)",
+    "uuid": "0fb76488-9965-4cf9-878f-ceed7fc2be43",
+    "set_uuid": "44f05566-476f-407f-b6d6-a211b2754fa5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "0b09ae9a-7aa8-4b63-b6c4-4317b03dc3ff",
+    "set_uuid": "44f05566-476f-407f-b6d6-a211b2754fa5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(223, 77, 245)",
+    "uuid": "42525649-03ba-44f7-bc8c-9a824b898920",
+    "set_uuid": "1149f4f6-5cd0-4792-9dad-189c2a75a542",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(173, 51, 192)",
+    "uuid": "5f971453-aa30-4c1f-8cbc-be45ff042fcd",
+    "set_uuid": "1149f4f6-5cd0-4792-9dad-189c2a75a542",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "02b7bf12-ff14-4829-aa9b-52c3033b0652",
+    "set_uuid": "1149f4f6-5cd0-4792-9dad-189c2a75a542",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(200, 68, 220)",
+    "uuid": "3b2867ea-80f8-44ca-9394-7bb17e8c5a22",
+    "set_uuid": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(186, 60, 206)",
+    "uuid": "5848fed6-5b42-42ef-9800-8f32e42cf6ba",
+    "set_uuid": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "a6344998-b1e8-4651-a4c9-b1b2aa22d48b",
+    "set_uuid": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(181, 57, 200)",
+    "uuid": "5fa3362b-01ee-4861-9a02-6af6da804f61",
+    "set_uuid": "ad5957c2-2829-450e-973c-bf0075e1fa67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(213, 73, 235)",
+    "uuid": "3c6d42c9-4cba-4373-a61c-c8617c509f92",
+    "set_uuid": "ad5957c2-2829-450e-973c-bf0075e1fa67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "fuchsia",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "2a29020c-1524-4b9b-a249-25b9927d4a54",
+    "set_uuid": "ad5957c2-2829-450e-973c-bf0075e1fa67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "gradient-stop-1-avatar"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 0,
+    "uuid": "8d9e0c2d-d692-47a0-86cd-6349649ec6e2",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "gradient-stop-2-avatar"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 0.6666,
+    "uuid": "a7791b29-4e4d-4b9f-ab34-0240ac4d6769",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "gradient-stop-3-avatar"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 1,
+    "uuid": "620ee6f3-eb3d-40ad-854b-9edceb897c7f",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(233, 233, 233)",
+    "uuid": "64e2dbc2-05fa-43d7-80ae-d4d11c55348f",
+    "set_uuid": "16d156d1-4af9-4878-9984-643a2c08aff8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(44, 44, 44)",
+    "uuid": "abd011c4-87a5-4b1f-82e2-e94d118f417f",
+    "set_uuid": "16d156d1-4af9-4878-9984-643a2c08aff8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(228, 234, 249)",
+    "uuid": "3605974e-8f93-4907-81b3-fb6ab55d03f8",
+    "set_uuid": "16d156d1-4af9-4878-9984-643a2c08aff8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 0, 0)",
+    "uuid": "457fbeb8-56cd-4f3c-9950-f5e01f83f07c",
+    "set_uuid": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "5ce8c477-ae6e-427a-ac5c-79d15c8056ab",
+    "set_uuid": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 0, 0)",
+    "uuid": "e804baf9-ae2c-4574-96d9-10cd5253fe47",
+    "set_uuid": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(225, 225, 225)",
+    "uuid": "8de4888d-8da5-45a0-8d5d-64a734993ae4",
+    "set_uuid": "8a182a6b-149b-41a6-b608-fc247bcc298f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(50, 50, 50)",
+    "uuid": "0a676e7a-8a89-4607-a918-3abcfb0234a2",
+    "set_uuid": "8a182a6b-149b-41a6-b608-fc247bcc298f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(214, 224, 246)",
+    "uuid": "eaad36fe-2827-4404-8876-060de75c2b34",
+    "set_uuid": "8a182a6b-149b-41a6-b608-fc247bcc298f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 25,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "a8c6363c-5297-41e3-ad76-1b6d0d3a3cc9",
+    "set_uuid": "306be0f2-7644-4480-8c83-3bdb1afed54e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 25,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(17, 17, 17)",
+    "uuid": "ac61b090-d356-4f7f-ac6d-b4f20617c9e3",
+    "set_uuid": "306be0f2-7644-4480-8c83-3bdb1afed54e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 25,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(254, 254, 255)",
+    "uuid": "0906f3b2-74a9-4012-9e26-4d8f68f0eba9",
+    "set_uuid": "306be0f2-7644-4480-8c83-3bdb1afed54e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(218, 218, 218)",
+    "uuid": "aad52960-a7ec-4f69-85f9-3e1a87975120",
+    "set_uuid": "dac01571-b26a-4aef-ace7-d0e34e917570",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(57, 57, 57)",
+    "uuid": "cc8c4299-c40d-4e93-80b2-c052ee8aaf40",
+    "set_uuid": "dac01571-b26a-4aef-ace7-d0e34e917570",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(207, 219, 245)",
+    "uuid": "57d4b287-c9d9-4c56-894b-2df496d9a3b4",
+    "set_uuid": "dac01571-b26a-4aef-ace7-d0e34e917570",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(198, 198, 198)",
+    "uuid": "9a4b4fc4-25e4-4ca8-b0d1-949c5851b47e",
+    "set_uuid": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(68, 68, 68)",
+    "uuid": "c34dd99f-e576-4c98-a89d-86dd47514c55",
+    "set_uuid": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(180, 199, 239)",
+    "uuid": "4634f126-2240-4de9-b244-ab2b833d70ef",
+    "set_uuid": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 50,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(248, 248, 248)",
+    "uuid": "f6e408a6-81ae-4658-8375-a532f324eba0",
+    "set_uuid": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 50,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(27, 27, 27)",
+    "uuid": "0913be1e-b648-4b80-9976-fd8e5e53f4fc",
+    "set_uuid": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 50,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 253)",
+    "uuid": "16ee1a81-e7d0-46ff-af81-5eca376ce203",
+    "set_uuid": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 143, 143)",
+    "uuid": "7fa86c73-f058-4922-be8d-19902515cf44",
+    "set_uuid": "60077744-c665-4c80-8f88-dff31a10219e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(109, 109, 109)",
+    "uuid": "05808575-f14b-49d1-aefb-e3667ec0f5a4",
+    "set_uuid": "60077744-c665-4c80-8f88-dff31a10219e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(108, 142, 217)",
+    "uuid": "bc09529e-716c-4541-a75a-081ed9fdd860",
+    "set_uuid": "60077744-c665-4c80-8f88-dff31a10219e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 113, 113)",
+    "uuid": "e6a41088-a188-483c-b197-63ed3c70463d",
+    "set_uuid": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(138, 138, 138)",
+    "uuid": "8880b8f1-7850-49ef-a7ab-fd4e16cb37a6",
+    "set_uuid": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(72, 110, 194)",
+    "uuid": "3ab25385-aece-42c4-af86-01ea97ed2455",
+    "set_uuid": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(80, 80, 80)",
+    "uuid": "97111e8e-5823-47f2-af64-c3244b8d3492",
+    "set_uuid": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(175, 175, 175)",
+    "uuid": "3cc563c6-386e-4b08-850d-68d4a292e559",
+    "set_uuid": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(44, 77, 149)",
+    "uuid": "b5201efc-0a69-4a87-8b9b-e869bcf03457",
+    "set_uuid": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 75,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(243, 243, 243)",
+    "uuid": "01cd6c7e-f2eb-4b5d-9e2a-30940e1ab37b",
+    "set_uuid": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 75,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 34, 34)",
+    "uuid": "1666d544-ad1b-445a-9a57-d2277fb752eb",
+    "set_uuid": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 75,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(241, 244, 251)",
+    "uuid": "4b6e738d-ac71-4d34-83eb-cd45e511b144",
+    "set_uuid": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(41, 41, 41)",
+    "uuid": "2caf1f36-80b9-4659-90be-8d89672bb19f",
+    "set_uuid": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(219, 219, 219)",
+    "uuid": "d39fc368-ec71-40cd-85e9-afb07862f2b7",
+    "set_uuid": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 46, 93)",
+    "uuid": "22e79b14-2a60-4721-8e9b-800fa9e7a128",
+    "set_uuid": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(19, 19, 19)",
+    "uuid": "59093f0d-98b7-4659-bea6-3248ad20e96c",
+    "set_uuid": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(242, 242, 242)",
+    "uuid": "90d25d68-afb1-4b2a-9dba-3fe22d44976f",
+    "set_uuid": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "gray",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(10, 19, 39)",
+    "uuid": "93fb6cac-b190-4a5a-951f-f5dc4c0d5978",
+    "set_uuid": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(237, 252, 241)",
+    "uuid": "4428dba5-df85-4125-ba54-1c022b986847",
+    "set_uuid": "7c7c0136-2623-468d-a12f-678d21973613",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 30, 23)",
+    "uuid": "e5a14d4a-47c5-4a53-84c5-589a0749d906",
+    "set_uuid": "7c7c0136-2623-468d-a12f-678d21973613",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "f0702380-ed81-4f16-844c-b4c3b797161c",
+    "set_uuid": "7c7c0136-2623-468d-a12f-678d21973613",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(3, 110, 69)",
+    "uuid": "b0846caa-d394-4614-aaa2-af179de285f4",
+    "set_uuid": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(14, 175, 98)",
+    "uuid": "3d6732a1-a1f9-4e18-927b-93cebaae3895",
+    "set_uuid": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "a1c41ddd-5c54-4dce-bea3-51768998639c",
+    "set_uuid": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(2, 93, 60)",
+    "uuid": "8d0742b8-c334-41e0-a8e1-50fc8ea3b3ef",
+    "set_uuid": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(24, 193, 110)",
+    "uuid": "a2f8f6c6-07b4-43a4-8f59-995ea2bf4e82",
+    "set_uuid": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "7f426d3d-5ff9-4ee2-b0e1-07282fe389df",
+    "set_uuid": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(1, 76, 52)",
+    "uuid": "4ea6f2d0-bc92-44fa-90e9-9618806a19c2",
+    "set_uuid": "365a47c9-43c8-45a4-8cb8-07c552aca28b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(57, 215, 134)",
+    "uuid": "07fa1b72-bf84-4fd5-9565-28373fae6a1f",
+    "set_uuid": "365a47c9-43c8-45a4-8cb8-07c552aca28b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "515298b6-f629-4c08-9e0f-18a5ba8fe20f",
+    "set_uuid": "365a47c9-43c8-45a4-8cb8-07c552aca28b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 61, 44)",
+    "uuid": "569d58d2-c7e4-4a0c-b92a-841e45fcbc09",
+    "set_uuid": "6668c6c5-b66e-4c83-a95a-37fde594296b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(126, 231, 172)",
+    "uuid": "c5ec27ed-3a16-44fe-bb8d-a21edd2f4d73",
+    "set_uuid": "6668c6c5-b66e-4c83-a95a-37fde594296b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "ce02582f-b327-4367-9f66-92dcc67fd072",
+    "set_uuid": "6668c6c5-b66e-4c83-a95a-37fde594296b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 46, 34)",
+    "uuid": "c0711ebf-a91a-4041-8e1a-259ed6c3c54c",
+    "set_uuid": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(189, 241, 208)",
+    "uuid": "df5458e5-891b-4a88-a96c-748a812978a7",
+    "set_uuid": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "51b8502d-e045-4b40-93e1-e2b49f6bf90c",
+    "set_uuid": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 33, 25)",
+    "uuid": "f853b643-e7bf-4af6-81f4-bc6de9007f3c",
+    "set_uuid": "54ef3b06-ac50-4176-af22-86d0c73d5d13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(229, 250, 236)",
+    "uuid": "8efbb45d-4d6d-423e-8a3d-cb7117f9fbf8",
+    "set_uuid": "54ef3b06-ac50-4176-af22-86d0c73d5d13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "490cf084-b56e-4464-8e38-1bb15458213e",
+    "set_uuid": "54ef3b06-ac50-4176-af22-86d0c73d5d13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 15, 12)",
+    "uuid": "2b4c3a1a-8ea4-4149-862d-801b559e4f65",
+    "set_uuid": "2d45aad7-eb31-46f9-a73f-69498e466a29",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "ce6f19ce-d3fe-4bad-a4fc-7863ea9fd186",
+    "set_uuid": "2d45aad7-eb31-46f9-a73f-69498e466a29",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "96e3e83b-1878-460e-9bc2-aa25a36ff887",
+    "set_uuid": "2d45aad7-eb31-46f9-a73f-69498e466a29",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(215, 247, 225)",
+    "uuid": "9d32cd19-8375-4da3-9324-0e8334c2e714",
+    "set_uuid": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 38, 29)",
+    "uuid": "e8f294f5-cb17-4fdc-b370-ca2e3f95d342",
+    "set_uuid": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "b5d964d5-e68d-44c6-880f-2e23d2bae7ec",
+    "set_uuid": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(173, 238, 197)",
+    "uuid": "88bac762-84e1-4652-8152-384f3b1faf59",
+    "set_uuid": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 51, 38)",
+    "uuid": "cd5e0471-a8c0-46cd-b98c-be3a74c2b6d2",
+    "set_uuid": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "1aaecce9-f58c-44a5-9bb9-f62172ebcd21",
+    "set_uuid": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(107, 227, 162)",
+    "uuid": "5cb02868-9f86-4e20-85e0-e4f5df24853c",
+    "set_uuid": "6673709d-2154-4189-ad4f-e6867ecfe744",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 68, 48)",
+    "uuid": "c5e88879-9773-446c-883e-96531bcb8fad",
+    "set_uuid": "6673709d-2154-4189-ad4f-e6867ecfe744",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "8143aced-4012-4dc3-a132-2b5701e09a52",
+    "set_uuid": "6673709d-2154-4189-ad4f-e6867ecfe744",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(43, 209, 125)",
+    "uuid": "8b315766-4fa0-4acc-a679-89da4162a15c",
+    "set_uuid": "a63a12c8-2526-49b0-a918-543af6deb103",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(2, 87, 58)",
+    "uuid": "27649ccc-69a8-48d6-9d52-6d6e2e28ae17",
+    "set_uuid": "a63a12c8-2526-49b0-a918-543af6deb103",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "9418d6a8-69a1-49a4-ac3d-d81c81a633be",
+    "set_uuid": "a63a12c8-2526-49b0-a918-543af6deb103",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 184, 103)",
+    "uuid": "4c6c7b90-29ac-4186-a991-c298f19aa83d",
+    "set_uuid": "26b0bdde-2ea0-456c-8ade-a521e8799613",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(3, 106, 67)",
+    "uuid": "a0513e49-8483-40f8-8b8f-41fdc222f13d",
+    "set_uuid": "26b0bdde-2ea0-456c-8ade-a521e8799613",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "57d2a064-3028-4225-82c4-e200e4abc6a3",
+    "set_uuid": "26b0bdde-2ea0-456c-8ade-a521e8799613",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(11, 164, 93)",
+    "uuid": "19a07ad0-9e01-4adc-861d-f7634de1f1ab",
+    "set_uuid": "a2d13cc0-1445-46ca-b941-c50f04127376",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(4, 124, 75)",
+    "uuid": "9c24175e-34a5-46c8-b646-f70c08292776",
+    "set_uuid": "a2d13cc0-1445-46ca-b941-c50f04127376",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "fa823d25-6075-455b-a6f4-18de77a01f06",
+    "set_uuid": "a2d13cc0-1445-46ca-b941-c50f04127376",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(7, 147, 85)",
+    "uuid": "1be225f8-3612-422c-923f-b35f1ec4fc00",
+    "set_uuid": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(6, 136, 80)",
+    "uuid": "412da16e-4db2-47d8-84d4-583ae35534f9",
+    "set_uuid": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "12755af6-ac1f-441a-80fb-07c3d61dc6c9",
+    "set_uuid": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(5, 131, 78)",
+    "uuid": "cd39a520-2020-41d0-96d1-3b0fdb453fef",
+    "set_uuid": "c0f6d150-e59f-4ee9-bf85-087c67258767",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(9, 157, 89)",
+    "uuid": "5afee2ee-a5d5-4dcf-a917-11dfdd0c3691",
+    "set_uuid": "c0f6d150-e59f-4ee9-bf85-087c67258767",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "green",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "81174c05-0b05-4030-a8b7-e2fc13533954",
+    "set_uuid": "c0f6d150-e59f-4ee9-bf85-087c67258767",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(247, 248, 255)",
+    "uuid": "04cf76e0-1e7c-479a-9411-0dcad2f6ab25",
+    "set_uuid": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(30, 0, 93)",
+    "uuid": "e60cb247-c265-4009-9f0a-bcbbbb801dd4",
+    "set_uuid": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "37af1036-6ba7-4eac-b1a5-9442ff55036f",
+    "set_uuid": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(99, 56, 238)",
+    "uuid": "9d1a9aa9-a7b3-4254-9e55-a992784bb7b5",
+    "set_uuid": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(139, 141, 254)",
+    "uuid": "0bf6170c-50d7-4600-96fe-2d1af93f173a",
+    "set_uuid": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "ef5ddbb5-3e37-4806-b863-9369294dc07a",
+    "set_uuid": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(84, 36, 219)",
+    "uuid": "2f59721c-2922-4ad3-b50a-37327d592050",
+    "set_uuid": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(153, 161, 255)",
+    "uuid": "c85ea1d9-e28d-46c5-abd0-c053858770e0",
+    "set_uuid": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "f4c7c283-b412-4acc-b2f5-0339f946ff3d",
+    "set_uuid": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(69, 19, 191)",
+    "uuid": "4aaedaea-2d42-4593-84e4-18a12ce5efc2",
+    "set_uuid": "027533ce-0ec5-4f37-ac0e-7ca8aa3ef922",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(176, 186, 255)",
+    "uuid": "91f9622a-03b4-47b0-b380-5f6d64c13b5d",
+    "set_uuid": "027533ce-0ec5-4f37-ac0e-7ca8aa3ef922",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "91d7c77f-6cb0-4f1d-92ea-03965a296cc6",
+    "set_uuid": "027533ce-0ec5-4f37-ac0e-7ca8aa3ef922",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(55, 6, 160)",
+    "uuid": "f8300596-def6-4640-8d9a-c08fea25bfda",
+    "set_uuid": "f48f431b-f811-4f9c-bd10-61c65de8ad40",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(199, 208, 255)",
+    "uuid": "c0bfd081-7859-4ed5-aa4c-c1f547dab8f3",
+    "set_uuid": "f48f431b-f811-4f9c-bd10-61c65de8ad40",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "a274d960-197e-4045-99d3-9919cfa90e6e",
+    "set_uuid": "f48f431b-f811-4f9c-bd10-61c65de8ad40",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 0, 129)",
+    "uuid": "4e8c10e6-0c7e-4f48-91a0-ff460915725d",
+    "set_uuid": "821ebda4-7380-4132-ba50-bddeaaaf1aa0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(223, 228, 255)",
+    "uuid": "080f9ea4-1d87-4691-adb7-3875a7708555",
+    "set_uuid": "821ebda4-7380-4132-ba50-bddeaaaf1aa0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "46fa9ff8-5758-41c3-b0aa-fefd075eb739",
+    "set_uuid": "821ebda4-7380-4132-ba50-bddeaaaf1aa0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(31, 0, 98)",
+    "uuid": "2653368d-d90b-4a5a-97f3-8380fe2e7551",
+    "set_uuid": "ad005eac-7b19-4f23-9f50-514fc1b07f8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(243, 244, 255)",
+    "uuid": "498d2f9c-7304-406d-a3f8-802a2cbd3502",
+    "set_uuid": "ad005eac-7b19-4f23-9f50-514fc1b07f8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "72c07c8d-19f8-44de-8e73-98997502cf86",
+    "set_uuid": "ad005eac-7b19-4f23-9f50-514fc1b07f8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(17, 0, 54)",
+    "uuid": "6a0ad8e2-b574-4148-b151-e0607c4d5317",
+    "set_uuid": "64ef5b19-c162-4283-9f5d-1fe46ccf6dd8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "c498c300-86e8-4c71-bd3e-5a344324b9c1",
+    "set_uuid": "64ef5b19-c162-4283-9f5d-1fe46ccf6dd8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "2f76990f-4bfd-4b4d-b063-aa374ea9df83",
+    "set_uuid": "64ef5b19-c162-4283-9f5d-1fe46ccf6dd8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 238, 255)",
+    "uuid": "ab568cfd-20e5-4e20-a3bf-32292297df8f",
+    "set_uuid": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(35, 0, 110)",
+    "uuid": "56c709dd-b41e-478a-8098-21014e3f9ec8",
+    "set_uuid": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "401d532f-8374-4e5a-99c5-51c4ec9bc344",
+    "set_uuid": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 222, 255)",
+    "uuid": "a220a225-3bb9-446c-8ee3-732a96a150d2",
+    "set_uuid": "571bb191-0f29-4a11-95a2-831a454b4df1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(47, 0, 140)",
+    "uuid": "716f244e-67c5-4566-b824-ed7f2192b585",
+    "set_uuid": "571bb191-0f29-4a11-95a2-831a454b4df1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "fb607a6f-2d62-4163-a6a3-068b80a084da",
+    "set_uuid": "571bb191-0f29-4a11-95a2-831a454b4df1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 201, 255)",
+    "uuid": "891799a7-b51d-4769-abe3-62dd0da6e190",
+    "set_uuid": "17d0ac0b-d180-4027-b424-5325e5954cf0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(62, 12, 174)",
+    "uuid": "c256e06e-07bc-4dcd-9239-48841916c93b",
+    "set_uuid": "17d0ac0b-d180-4027-b424-5325e5954cf0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "5cd6358b-bdc0-488e-a5fe-089a769b6bfb",
+    "set_uuid": "17d0ac0b-d180-4027-b424-5325e5954cf0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(167, 178, 255)",
+    "uuid": "2751b8ae-f347-4a57-938d-98a5ee86071c",
+    "set_uuid": "57800450-9118-40df-aa96-739ef71a0914",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(79, 30, 209)",
+    "uuid": "1ea0564b-6e88-456e-a796-4620d57b8771",
+    "set_uuid": "57800450-9118-40df-aa96-739ef71a0914",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "a9e657da-8f33-425a-b2ab-dca9d1337bf3",
+    "set_uuid": "57800450-9118-40df-aa96-739ef71a0914",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(145, 151, 254)",
+    "uuid": "2d69bbe7-37c1-4302-9fee-39733bb13a86",
+    "set_uuid": "906f3a03-47e3-4763-97e6-376cf4545429",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(95, 52, 235)",
+    "uuid": "df590853-ce16-4ddf-bbe9-a912695eae17",
+    "set_uuid": "906f3a03-47e3-4763-97e6-376cf4545429",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "233a1b84-3ab6-4899-9b41-d9177356c175",
+    "set_uuid": "906f3a03-47e3-4763-97e6-376cf4545429",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(132, 128, 254)",
+    "uuid": "3c57f9f6-e837-450b-9443-a702caa049a4",
+    "set_uuid": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(109, 75, 248)",
+    "uuid": "0ea3a7e0-35c5-46ec-ae9d-500c5ee06a16",
+    "set_uuid": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "feeeaa05-5c75-4a06-b5be-ed8bf3ecd773",
+    "set_uuid": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(122, 106, 253)",
+    "uuid": "f5a317ea-25f2-4193-9305-f20c231e786e",
+    "set_uuid": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(116, 91, 252)",
+    "uuid": "97e84a30-1de4-4e84-8d59-e625f9ec9ab1",
+    "set_uuid": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "63e9a41c-ee85-43c1-b550-3ca8ce7c0986",
+    "set_uuid": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 85, 250)",
+    "uuid": "87b65e85-d767-47bb-8af5-01b85282c663",
+    "set_uuid": "f482731c-c07e-4323-bf79-6e45cdce4052",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(128, 119, 254)",
+    "uuid": "5cb7ff5e-ec53-4df8-b59d-a1419190a6cf",
+    "set_uuid": "f482731c-c07e-4323-bf79-6e45cdce4052",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "indigo",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "39f6823f-ca35-413c-ad64-31529710cf3c",
+    "set_uuid": "f482731c-c07e-4323-bf79-6e45cdce4052",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 245, 248)",
+    "uuid": "06219a66-5150-42ab-a9fd-c743058728af",
+    "set_uuid": "36840c2e-6b57-484b-911a-f915c8a5c086",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 0, 22)",
+    "uuid": "9149371a-1978-4136-a89c-8895edd35e7d",
+    "set_uuid": "36840c2e-6b57-484b-911a-f915c8a5c086",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "3f70bddc-f8e3-41a1-a68e-9500ac9a2474",
+    "set_uuid": "36840c2e-6b57-484b-911a-f915c8a5c086",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(186, 22, 80)",
+    "uuid": "98125f18-a061-4aa7-a0c5-a746d635c4c5",
+    "set_uuid": "66f59c7d-f12b-4b8b-a472-c196deec527c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 96, 149)",
+    "uuid": "bdabbfb5-1ae6-44a7-bc2e-55e11f4e5154",
+    "set_uuid": "66f59c7d-f12b-4b8b-a472-c196deec527c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "8a8e447b-6b31-4758-b59e-51acad7c9210",
+    "set_uuid": "66f59c7d-f12b-4b8b-a472-c196deec527c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(163, 5, 62)",
+    "uuid": "29d203d7-7c2c-4f36-a5f3-d84fab6be9f1",
+    "set_uuid": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 128, 171)",
+    "uuid": "548a74eb-4401-44f4-85b4-921287d84ac9",
+    "set_uuid": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "9784741b-612e-4986-952b-a102c04e2afd",
+    "set_uuid": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(136, 0, 51)",
+    "uuid": "2a9f4ecf-5678-4345-973a-da1e066eaf10",
+    "set_uuid": "b98f20e8-32f0-4ca4-80a3-e8a280060b76",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 163, 194)",
+    "uuid": "9c634688-1ad5-438b-bd44-a92c64ef9934",
+    "set_uuid": "b98f20e8-32f0-4ca4-80a3-e8a280060b76",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "3c632a35-bf86-4182-9475-84854a20f15a",
+    "set_uuid": "b98f20e8-32f0-4ca4-80a3-e8a280060b76",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(111, 0, 40)",
+    "uuid": "0be3f108-028b-4fdd-9a98-8bb24deec2d8",
+    "set_uuid": "1b7b4db7-c2a7-4a3c-a4dc-b7da54eb3dde",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 193, 214)",
+    "uuid": "6c441ca7-0294-462f-ac18-7b28ff20d7ff",
+    "set_uuid": "1b7b4db7-c2a7-4a3c-a4dc-b7da54eb3dde",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "030c6431-3ea5-429b-a492-1a01dd396d44",
+    "set_uuid": "1b7b4db7-c2a7-4a3c-a4dc-b7da54eb3dde",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(86, 0, 30)",
+    "uuid": "40d9a0f7-0085-4001-a22e-3c22d3887846",
+    "set_uuid": "cf007ff4-06dc-434e-95bb-20f941a1fb78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 220, 232)",
+    "uuid": "15f36ded-01af-4c5d-8b11-45523e7d908e",
+    "set_uuid": "cf007ff4-06dc-434e-95bb-20f941a1fb78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "b6dd1b22-5f8f-46d8-924e-4ce02ad5a99f",
+    "set_uuid": "cf007ff4-06dc-434e-95bb-20f941a1fb78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(64, 0, 22)",
+    "uuid": "70dd220b-46cd-4975-ad8b-5ca31f7c33dc",
+    "set_uuid": "72bd2742-4716-42a3-893a-ee7ae83dfa90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 241, 246)",
+    "uuid": "d2814529-9c64-47fd-a317-8669d565cf67",
+    "set_uuid": "72bd2742-4716-42a3-893a-ee7ae83dfa90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "950ba124-e6b5-47b6-b1b8-31960f7cc380",
+    "set_uuid": "72bd2742-4716-42a3-893a-ee7ae83dfa90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(35, 0, 12)",
+    "uuid": "fd25d1ee-438b-49a3-93d8-1d59b2a06f72",
+    "set_uuid": "14b3aac6-cd51-4591-afca-4da472c4bf1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "c24954cd-f17c-47b4-8a3e-8cb019a3e330",
+    "set_uuid": "14b3aac6-cd51-4591-afca-4da472c4bf1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "2fc90f48-a54e-4aae-9b9f-aa3c4d7e55de",
+    "set_uuid": "14b3aac6-cd51-4591-afca-4da472c4bf1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 232, 240)",
+    "uuid": "0a9c01d3-0659-4884-a0e8-7032deeee766",
+    "set_uuid": "f7909075-b049-43d4-bae5-bd74c7827174",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 0, 27)",
+    "uuid": "f5ffc5b3-d3e6-4d7e-b8a8-850324b5d9b8",
+    "set_uuid": "f7909075-b049-43d4-bae5-bd74c7827174",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "074993b8-2652-448c-a6ca-b18a39176ed9",
+    "set_uuid": "f7909075-b049-43d4-bae5-bd74c7827174",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 213, 227)",
+    "uuid": "bfe2436d-c026-4641-8cd7-a9824f6948dd",
+    "set_uuid": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 0, 34)",
+    "uuid": "673ab9b4-e296-4472-b0b5-15adf9f1f762",
+    "set_uuid": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "04b09fbb-08cb-4fe3-a287-d7de2bf39312",
+    "set_uuid": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 185, 208)",
+    "uuid": "4419b5e5-344d-4905-b39d-8935bedf7d6c",
+    "set_uuid": "cd64bdbd-3a45-4643-a3b7-32aa72a10445",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(123, 0, 45)",
+    "uuid": "60560de2-28e6-44b4-bcff-f357fe13a4a7",
+    "set_uuid": "cd64bdbd-3a45-4643-a3b7-32aa72a10445",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "41d578d1-c853-4360-95e9-b94ad61e7786",
+    "set_uuid": "cd64bdbd-3a45-4643-a3b7-32aa72a10445",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 152, 187)",
+    "uuid": "d7c3e696-4ec4-497f-89c5-bad17cb4699a",
+    "set_uuid": "56c78f18-9687-4d7a-8291-22bc12071897",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(152, 7, 60)",
+    "uuid": "830123a6-0e42-4c4f-9b20-2f4204d37af8",
+    "set_uuid": "56c78f18-9687-4d7a-8291-22bc12071897",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "0734c859-3e4c-4974-98e2-700c49c69bcd",
+    "set_uuid": "56c78f18-9687-4d7a-8291-22bc12071897",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 112, 159)",
+    "uuid": "329f4efa-6f0b-4bc1-95f7-1121bda7f421",
+    "set_uuid": "33d7cba7-516c-452d-b359-34827edead60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(181, 19, 76)",
+    "uuid": "e6b14a1d-e26e-41c4-b386-7fb3f95b8c93",
+    "set_uuid": "33d7cba7-516c-452d-b359-34827edead60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "e70126f5-e8d6-47e2-9737-0dbb17655b1f",
+    "set_uuid": "33d7cba7-516c-452d-b359-34827edead60",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 72, 133)",
+    "uuid": "fcacf0f0-c919-4705-b4c2-6edbe2796fb0",
+    "set_uuid": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(207, 31, 92)",
+    "uuid": "11055a6b-7e81-4b59-9feb-8b0b6352be07",
+    "set_uuid": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "e5ffefaa-72d6-444d-8f9f-3fb08a9f2480",
+    "set_uuid": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(240, 45, 110)",
+    "uuid": "21e774f7-89d8-438d-9fc4-aa93261022d1",
+    "set_uuid": "ff51c954-677f-4053-8426-b7fbc3d2d155",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(224, 38, 101)",
+    "uuid": "6676db79-7b7e-4fcf-868b-321f9372517a",
+    "set_uuid": "ff51c954-677f-4053-8426-b7fbc3d2d155",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "6dca10b8-2ed2-463c-82f5-fad66a833675",
+    "set_uuid": "ff51c954-677f-4053-8426-b7fbc3d2d155",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(217, 35, 97)",
+    "uuid": "0166ed9b-52e7-447a-b45d-de29ba85eb0d",
+    "set_uuid": "d8eb420e-b2d5-4bbe-baad-955009069eff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 51, 119)",
+    "uuid": "fa5e523e-7ee3-46d0-971f-4ee95c7222b8",
+    "set_uuid": "d8eb420e-b2d5-4bbe-baad-955009069eff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "magenta",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "991792f1-03ed-494b-ada7-1beb965e39c9",
+    "set_uuid": "d8eb420e-b2d5-4bbe-baad-955009069eff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 246, 231)",
+    "uuid": "8bfd5eff-55b4-4b98-9b2e-2871e4ec6ff6",
+    "set_uuid": "b31d8010-6701-4a59-8f7e-3ae680755c17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(49, 16, 0)",
+    "uuid": "974ab8ec-6691-4696-b38c-77e16fb3df88",
+    "set_uuid": "b31d8010-6701-4a59-8f7e-3ae680755c17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "e4fff178-2055-4ec8-83e8-636a4ea8bb8c",
+    "set_uuid": "b31d8010-6701-4a59-8f7e-3ae680755c17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(167, 62, 0)",
+    "uuid": "7dc902b9-6512-429e-9cb4-c2f97ca08e99",
+    "set_uuid": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(243, 117, 0)",
+    "uuid": "92e06ff6-8347-4320-9a98-3054ba458d0e",
+    "set_uuid": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "bc744bfa-dd64-4660-b67c-105f07e66644",
+    "set_uuid": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(144, 51, 0)",
+    "uuid": "b6c1e499-f043-4b5a-81cf-4224a0f83fce",
+    "set_uuid": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 137, 0)",
+    "uuid": "a571e2cd-2aff-4344-b608-45a48162cb61",
+    "set_uuid": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "7aea0d8d-0fb0-47c1-ae6a-97510159359b",
+    "set_uuid": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(118, 41, 0)",
+    "uuid": "14da1231-c89f-45a1-845e-f3bd902f704b",
+    "set_uuid": "cdffa59a-a440-4e1b-a9f4-c45755f954b8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 173, 45)",
+    "uuid": "8e3fe8e0-2b14-4331-869f-de2680ea60ac",
+    "set_uuid": "cdffa59a-a440-4e1b-a9f4-c45755f954b8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "269da724-5ec7-4ceb-991d-1e83495cfaed",
+    "set_uuid": "cdffa59a-a440-4e1b-a9f4-c45755f954b8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(95, 32, 0)",
+    "uuid": "f650301b-6586-4193-9937-9f12d6c3f99f",
+    "set_uuid": "322a161e-bbda-4369-b4ec-6140ccbb01c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 201, 116)",
+    "uuid": "06afaefe-7e0a-42e2-99b5-e62674e1185d",
+    "set_uuid": "322a161e-bbda-4369-b4ec-6140ccbb01c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "c1389efc-8e68-4e2d-94b1-17e193264be7",
+    "set_uuid": "322a161e-bbda-4369-b4ec-6140ccbb01c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(73, 24, 0)",
+    "uuid": "99a43835-df3a-4447-b91d-9d943659b07f",
+    "set_uuid": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 225, 178)",
+    "uuid": "9f2f551f-b606-48ce-9493-888587d3ccb6",
+    "set_uuid": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "0d6ed0c9-b185-4656-9985-04904a39f5e6",
+    "set_uuid": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 18, 0)",
+    "uuid": "8aa75bbd-fd78-463d-a321-8672e5a537d6",
+    "set_uuid": "dae987e5-c3ee-405b-83a9-3d9e054f95b1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 243, 225)",
+    "uuid": "48b0167c-d675-4fc5-9130-1b36a94fd163",
+    "set_uuid": "dae987e5-c3ee-405b-83a9-3d9e054f95b1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "ea973b33-e10f-44b6-a621-92c752edb8af",
+    "set_uuid": "dae987e5-c3ee-405b-83a9-3d9e054f95b1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 8, 0)",
+    "uuid": "e99566f3-7b29-4c75-a4bd-ce17c0d84c3f",
+    "set_uuid": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "b2f21ea2-e546-4b1a-a72d-e840172857b4",
+    "set_uuid": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "c93608b1-700d-496c-90c4-298870776956",
+    "set_uuid": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 236, 207)",
+    "uuid": "64371717-ac11-4ec3-a0aa-9042cf43fa8f",
+    "set_uuid": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 21, 0)",
+    "uuid": "587d4ce3-4275-4d2a-916c-2b1bf78c38ea",
+    "set_uuid": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "47e53be7-b33b-48e3-abdf-fe48d59f8819",
+    "set_uuid": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 218, 158)",
+    "uuid": "f34f9b32-ef46-4473-bfd6-10b858e53f55",
+    "set_uuid": "ec281039-7256-4db9-8261-d0af048d3e6d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(80, 27, 0)",
+    "uuid": "74f40bbb-5afd-4c88-89d3-e69de9e2b604",
+    "set_uuid": "ec281039-7256-4db9-8261-d0af048d3e6d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "c455298b-cc23-4504-b731-27be6433fbcd",
+    "set_uuid": "ec281039-7256-4db9-8261-d0af048d3e6d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 193, 94)",
+    "uuid": "15bea688-4c32-44c0-9ee3-242bdb50954c",
+    "set_uuid": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(106, 36, 0)",
+    "uuid": "b912089a-b6c9-49ef-8a4b-0a1f6fbbe963",
+    "set_uuid": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "2c08292c-e6cc-4dcb-9046-8a2af09d1e43",
+    "set_uuid": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 162, 19)",
+    "uuid": "33bd4908-1259-4e75-8e96-bd410bebcfd6",
+    "set_uuid": "9e3e4263-9515-4937-b33f-3af341e57073",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 47, 0)",
+    "uuid": "8a56b352-d7d4-45d4-b403-448557656dab",
+    "set_uuid": "9e3e4263-9515-4937-b33f-3af341e57073",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "e6c70e40-f9e7-4975-af39-9458a8325c6f",
+    "set_uuid": "9e3e4263-9515-4937-b33f-3af341e57073",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(252, 125, 0)",
+    "uuid": "eeede364-d711-40e5-9d2a-0255b10d36f2",
+    "set_uuid": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(162, 59, 0)",
+    "uuid": "27b198b5-bf02-476a-a440-84c9a5bd2ce3",
+    "set_uuid": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "8a201cca-353e-4538-a6b5-efbc2fc86186",
+    "set_uuid": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(232, 106, 0)",
+    "uuid": "a4527b6f-e2d4-4a0f-b013-007dc5a2d3ac",
+    "set_uuid": "a43502bd-ffae-4544-a3d0-08288cff141d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(185, 73, 0)",
+    "uuid": "f9e84513-57d6-4786-b8db-c86055cebfc6",
+    "set_uuid": "a43502bd-ffae-4544-a3d0-08288cff141d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "58992b4e-69ab-4919-922a-dd9277cb770e",
+    "set_uuid": "a43502bd-ffae-4544-a3d0-08288cff141d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(212, 91, 0)",
+    "uuid": "437e4f5b-e68c-4491-b26c-a9fa1503561b",
+    "set_uuid": "bed559d1-c097-40ad-8d3a-2866198832c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(199, 82, 0)",
+    "uuid": "5a88ed4e-94f9-4533-ab13-3995b5a60a5a",
+    "set_uuid": "bed559d1-c097-40ad-8d3a-2866198832c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "8f42ee1b-59a5-4759-bef3-614835b348b2",
+    "set_uuid": "bed559d1-c097-40ad-8d3a-2866198832c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(194, 78, 0)",
+    "uuid": "e9df9a43-f509-44f3-89f6-c277f7445651",
+    "set_uuid": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(224, 100, 0)",
+    "uuid": "0fbe4f46-02a8-444d-ace5-c245c6f15112",
+    "set_uuid": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "orange",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "69637678-cb68-46f1-9353-1c7d0f86e51e",
+    "set_uuid": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 246, 252)",
+    "uuid": "89d9aa85-aef2-47fa-8939-e6774f5fa2de",
+    "set_uuid": "d74ec156-cd49-484d-9cf3-aef8707fe0b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(58, 0, 37)",
+    "uuid": "bd616b1d-fe15-498b-b8c3-02b3ec12917c",
+    "set_uuid": "d74ec156-cd49-484d-9cf3-aef8707fe0b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "4c01ddf8-d689-4433-826c-75b33bc2214d",
+    "set_uuid": "d74ec156-cd49-484d-9cf3-aef8707fe0b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(176, 31, 123)",
+    "uuid": "8d8448ee-5b8d-4953-a2f8-ba34a3c7f796",
+    "set_uuid": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(251, 90, 196)",
+    "uuid": "89cc3b46-c438-4e65-bf43-c373cb6af83f",
+    "set_uuid": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "deac6200-0e75-47d5-9073-3aaa390f1cd1",
+    "set_uuid": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(152, 22, 104)",
+    "uuid": "889ea4ff-1362-474e-ab12-15eb08bec89b",
+    "set_uuid": "6e45d7ec-2d6b-4cea-a99e-3e0b60f89579",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 122, 210)",
+    "uuid": "ee41ab95-9c22-4523-94ce-efab466cc261",
+    "set_uuid": "6e45d7ec-2d6b-4cea-a99e-3e0b60f89579",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "b9911ab3-fa6b-42e7-9247-c341b68ee151",
+    "set_uuid": "6e45d7ec-2d6b-4cea-a99e-3e0b60f89579",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(128, 12, 85)",
+    "uuid": "ac7fa4bb-da89-44ef-95d0-5d15fd8df976",
+    "set_uuid": "6d2d02df-d772-42ef-8b7e-a8443c38513b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 159, 223)",
+    "uuid": "670f5ea8-1435-4dd6-9ee9-f1886378b18f",
+    "set_uuid": "6d2d02df-d772-42ef-8b7e-a8443c38513b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "4c73d77d-95e3-4311-b644-2b55ad4552cf",
+    "set_uuid": "6d2d02df-d772-42ef-8b7e-a8443c38513b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(105, 3, 68)",
+    "uuid": "a10ffb76-fc1a-4f2f-ac43-dace44726820",
+    "set_uuid": "be724277-3ab7-4bfa-877d-e58a0c9df662",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 191, 234)",
+    "uuid": "c70eb5b9-80fa-4e03-9589-88001bbed4e2",
+    "set_uuid": "be724277-3ab7-4bfa-877d-e58a0c9df662",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "efa5d789-8e54-493d-9787-8e5dce4180a0",
+    "set_uuid": "be724277-3ab7-4bfa-877d-e58a0c9df662",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(83, 0, 53)",
+    "uuid": "8c14e640-5df8-4753-8a47-295c1aee63c5",
+    "set_uuid": "9ba11179-dde4-478a-8c04-9d7664b9a438",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 219, 243)",
+    "uuid": "bb85af92-a0c8-4b12-b651-a2a084d6d1cc",
+    "set_uuid": "9ba11179-dde4-478a-8c04-9d7664b9a438",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "4d10b352-648d-404a-a863-3fd3308b2696",
+    "set_uuid": "9ba11179-dde4-478a-8c04-9d7664b9a438",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(62, 0, 39)",
+    "uuid": "886065e2-949f-4f4c-9aa9-0a843c3d8cf2",
+    "set_uuid": "e1bc1107-0b97-47ff-a7c5-6c5336764d2d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 241, 250)",
+    "uuid": "0344a02f-ae86-4c77-bb36-480da43b3be1",
+    "set_uuid": "e1bc1107-0b97-47ff-a7c5-6c5336764d2d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "13813529-7eb8-4171-a40b-a719c430299b",
+    "set_uuid": "e1bc1107-0b97-47ff-a7c5-6c5336764d2d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(33, 0, 21)",
+    "uuid": "0612a373-58a7-4393-b789-7dcf8e388b2c",
+    "set_uuid": "6bb71c0d-2f9b-4ab9-9ad7-5930f559e99b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "fd715951-5fb7-433c-8a9d-2d10707893e5",
+    "set_uuid": "6bb71c0d-2f9b-4ab9-9ad7-5930f559e99b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "44800628-6a86-49de-b44f-256ca36c4127",
+    "set_uuid": "6bb71c0d-2f9b-4ab9-9ad7-5930f559e99b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 232, 247)",
+    "uuid": "d80ed3c8-4db1-48e7-bd16-1d34580a3108",
+    "set_uuid": "500888e2-48c7-4962-8323-f160cc7a07d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(71, 0, 44)",
+    "uuid": "b27db3ca-2a1d-40f0-aa6b-d7256262a70c",
+    "set_uuid": "500888e2-48c7-4962-8323-f160cc7a07d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "d4e972fb-fbd5-4b37-bd20-9487ed47d243",
+    "set_uuid": "500888e2-48c7-4962-8323-f160cc7a07d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 211, 240)",
+    "uuid": "3041a3b2-4275-41fb-94ff-607108d94df3",
+    "set_uuid": "7bb48388-b3bc-47eb-a7ab-b15327996714",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(90, 0, 57)",
+    "uuid": "b4a885e9-96d3-498f-b8a9-87c448723198",
+    "set_uuid": "7bb48388-b3bc-47eb-a7ab-b15327996714",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "83e9b8e8-ff2a-49fc-9ac8-349c694c1aec",
+    "set_uuid": "7bb48388-b3bc-47eb-a7ab-b15327996714",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 181, 230)",
+    "uuid": "c86af74f-6fe2-41a1-a934-2589f56fd041",
+    "set_uuid": "7185247f-126a-48ee-9c40-9c5e8bb77838",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(115, 7, 75)",
+    "uuid": "3a4e3a24-0f21-44a4-ad80-f721ad6acb38",
+    "set_uuid": "7185247f-126a-48ee-9c40-9c5e8bb77838",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "ba838eaa-0dc0-4bbd-be25-300e8bd89272",
+    "set_uuid": "7185247f-126a-48ee-9c40-9c5e8bb77838",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 148, 219)",
+    "uuid": "e526f977-736d-473b-b851-475fd08f5276",
+    "set_uuid": "dec3c71f-42c7-4e91-89a7-db4c88366fd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 18, 97)",
+    "uuid": "14b4ffb1-3dcb-4155-b470-1006982eec4c",
+    "set_uuid": "dec3c71f-42c7-4e91-89a7-db4c88366fd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "356a4b99-8ffc-4d11-b56e-a88c5e70194d",
+    "set_uuid": "dec3c71f-42c7-4e91-89a7-db4c88366fd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 103, 204)",
+    "uuid": "d383f12e-48f4-446c-abb4-595a50fd29a2",
+    "set_uuid": "f36f7f59-44b3-48d7-aed5-32996709c9db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(171, 29, 119)",
+    "uuid": "77da83cc-1a57-486b-bb43-e74e6b5ac041",
+    "set_uuid": "f36f7f59-44b3-48d7-aed5-32996709c9db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "527b5dcd-0896-4dbc-82f9-866297227eb0",
+    "set_uuid": "f36f7f59-44b3-48d7-aed5-32996709c9db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(242, 76, 184)",
+    "uuid": "91406d69-6d53-4231-be9e-e90d8ad0cc51",
+    "set_uuid": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(196, 39, 138)",
+    "uuid": "6c1ae7db-8ca1-4dbe-9d1e-2b3f5ab28a5c",
+    "set_uuid": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "873c22cd-488b-45d4-a79d-0473fc4f3c7f",
+    "set_uuid": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(228, 52, 163)",
+    "uuid": "af67d2bf-e92e-42f2-93d6-2f0b45fba0ac",
+    "set_uuid": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(213, 45, 151)",
+    "uuid": "86b686e1-d580-4fc0-9246-8b94ad2fed96",
+    "set_uuid": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "b50fbb92-1897-469d-a867-d9f6e5070c2e",
+    "set_uuid": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(206, 42, 146)",
+    "uuid": "a53ae96d-64bc-4baa-b51f-4490242047df",
+    "set_uuid": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(236, 67, 175)",
+    "uuid": "fb259e11-a051-4116-a7cb-f567cf814df5",
+    "set_uuid": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "pink",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "85c314fe-cdfe-4542-856f-f58acfad1aee",
+    "set_uuid": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(251, 247, 254)",
+    "uuid": "e80b112b-a26d-4392-a431-844b33d8bac8",
+    "set_uuid": "7b8cb760-9a04-4274-98bb-66dd657e814b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(41, 0, 79)",
+    "uuid": "ffc5aa7a-c339-4583-a586-3e8b1329d16d",
+    "set_uuid": "7b8cb760-9a04-4274-98bb-66dd657e814b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "8898f93b-9e3f-4143-bb78-fd0afd4c4ee0",
+    "set_uuid": "7b8cb760-9a04-4274-98bb-66dd657e814b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(134, 40, 217)",
+    "uuid": "163a3d87-cba9-48de-8384-c2820cf03984",
+    "set_uuid": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(186, 127, 237)",
+    "uuid": "e527a3bd-3543-4b40-8a9c-eb465695bdb9",
+    "set_uuid": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "2287f92f-6851-4f5f-b48c-3a43067a7a08",
+    "set_uuid": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(115, 13, 204)",
+    "uuid": "991db22a-d0c2-4f1a-a45b-95aaf13d747d",
+    "set_uuid": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(197, 149, 240)",
+    "uuid": "18265c0a-e466-4575-a364-3dfda9e71bd4",
+    "set_uuid": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "ed68aade-7d0a-4029-bf17-9a3b88f08ceb",
+    "set_uuid": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 0, 177)",
+    "uuid": "b71041e1-ca59-4d0c-87e4-2a8e8821b3ab",
+    "set_uuid": "72a305b3-3696-4d92-8f74-46694168c75b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(212, 176, 244)",
+    "uuid": "ae071768-dcdd-4e30-8f72-d066abac97af",
+    "set_uuid": "72a305b3-3696-4d92-8f74-46694168c75b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "aa502b60-e84f-4a35-910f-de28016d44fc",
+    "set_uuid": "72a305b3-3696-4d92-8f74-46694168c75b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(75, 0, 144)",
+    "uuid": "7a524851-d57b-40f7-930a-f67739c0e138",
+    "set_uuid": "82adc7f4-119c-407c-923f-3496a76b3a6e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(225, 201, 247)",
+    "uuid": "fbaaff02-da93-4f45-830a-5fc449a58f0b",
+    "set_uuid": "82adc7f4-119c-407c-923f-3496a76b3a6e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "eeb7a71b-1a59-4629-a1fd-4fe9bae6d3db",
+    "set_uuid": "82adc7f4-119c-407c-923f-3496a76b3a6e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 0, 111)",
+    "uuid": "e1609d80-a6ba-46b6-bd52-83f32fd009ad",
+    "set_uuid": "3ea73e1d-91ba-4801-837c-ae908fc74465",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(238, 224, 250)",
+    "uuid": "9ae063c9-5817-45b4-9f57-4b2196c845b9",
+    "set_uuid": "3ea73e1d-91ba-4801-837c-ae908fc74465",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "10c0a8e7-8496-4421-bfa0-cc41af6271d7",
+    "set_uuid": "3ea73e1d-91ba-4801-837c-ae908fc74465",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(44, 0, 84)",
+    "uuid": "f43e7a56-8663-41a9-b688-5b6471e3fcff",
+    "set_uuid": "ba35d83a-03b8-4e07-9a85-71e61e472818",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(248, 243, 253)",
+    "uuid": "d96c8fa3-5872-4bd2-81a3-0109ddf0bf18",
+    "set_uuid": "ba35d83a-03b8-4e07-9a85-71e61e472818",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "05c1a879-e716-4f67-97ab-7f524b713815",
+    "set_uuid": "ba35d83a-03b8-4e07-9a85-71e61e472818",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(23, 0, 45)",
+    "uuid": "8adc4493-0971-4b9c-bff7-c5ce8100fc43",
+    "set_uuid": "2eed244c-3803-4922-9d87-8f906a05f619",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "0f10b720-c0f8-46db-9205-fdde265d05f7",
+    "set_uuid": "2eed244c-3803-4922-9d87-8f906a05f619",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "1d742643-035d-4966-aba9-2be2bbfb793e",
+    "set_uuid": "2eed244c-3803-4922-9d87-8f906a05f619",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(244, 235, 252)",
+    "uuid": "65816c3d-544e-4bbd-bf0e-c0981e08a5cb",
+    "set_uuid": "745626e1-7c10-4e35-a99f-03c252bd441d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(50, 0, 96)",
+    "uuid": "2d67627b-372c-46af-b015-6c95bd027664",
+    "set_uuid": "745626e1-7c10-4e35-a99f-03c252bd441d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "0980d65e-bf37-40c7-a59c-5a0c80795211",
+    "set_uuid": "745626e1-7c10-4e35-a99f-03c252bd441d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 218, 249)",
+    "uuid": "bea266d7-8f53-43b7-b7df-0daa5b7e6f89",
+    "set_uuid": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(64, 0, 122)",
+    "uuid": "be628028-f41d-4ace-abf3-f7f38ecb2e01",
+    "set_uuid": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "2f450b24-782a-428f-80ff-9d762e22e44c",
+    "set_uuid": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(221, 193, 246)",
+    "uuid": "b68c2d3d-02e6-4130-9904-d2d32e67d115",
+    "set_uuid": "8b7aba6a-1ab0-46b0-834d-4aab42892a36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(83, 0, 159)",
+    "uuid": "474fed30-921a-4795-8999-2310521c64c5",
+    "set_uuid": "8b7aba6a-1ab0-46b0-834d-4aab42892a36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "7faf15d0-6890-4cde-919e-1b720d5bfc0a",
+    "set_uuid": "8b7aba6a-1ab0-46b0-834d-4aab42892a36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(208, 167, 243)",
+    "uuid": "9625edd4-fcdd-406a-9a66-068dcfeb3bd9",
+    "set_uuid": "e4039631-2769-464d-800c-ad084597761c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(107, 6, 195)",
+    "uuid": "b912e8ba-ed77-4179-9b80-7448f9e37193",
+    "set_uuid": "e4039631-2769-464d-800c-ad084597761c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "2473ee91-ecb3-414d-ac05-8b040aee3283",
+    "set_uuid": "e4039631-2769-464d-800c-ad084597761c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(191, 138, 238)",
+    "uuid": "bfd24d4f-9100-4937-a45d-7614ce0ece74",
+    "set_uuid": "cfc7871e-bb08-4b7e-8fe7-257b9e29c9ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(130, 34, 215)",
+    "uuid": "05638159-aaf7-4f3e-849e-a46e80cd9ee6",
+    "set_uuid": "cfc7871e-bb08-4b7e-8fe7-257b9e29c9ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "78f628a8-2d9f-4532-8502-bf389ec8ae7d",
+    "set_uuid": "cfc7871e-bb08-4b7e-8fe7-257b9e29c9ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(178, 114, 235)",
+    "uuid": "2f218111-4cef-432b-8d69-06492e7c40c1",
+    "set_uuid": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(148, 62, 224)",
+    "uuid": "fb186f5e-72a8-4a27-8ba2-d2fdf53d5a5c",
+    "set_uuid": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "8cdcca2d-71d7-4a08-b7a0-072e954980fe",
+    "set_uuid": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(166, 92, 231)",
+    "uuid": "a6205c53-9e63-475c-85f4-bdd5963e1eb2",
+    "set_uuid": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(157, 78, 228)",
+    "uuid": "30aae683-83e3-47a1-bdcb-ebe658e110a3",
+    "set_uuid": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "32ee4548-9a32-476b-a245-f0af6c701fdb",
+    "set_uuid": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(154, 71, 226)",
+    "uuid": "b72cb9ff-2b75-487c-914f-1c10bff76f75",
+    "set_uuid": "630e0415-8751-4a1c-8f1f-96800ff93802",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(173, 105, 233)",
+    "uuid": "12d86845-fd54-4d30-aac8-bb9451560ba5",
+    "set_uuid": "630e0415-8751-4a1c-8f1f-96800ff93802",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "purple",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "1f898f83-cd72-4bf1-bd66-ee1486a0f70d",
+    "set_uuid": "630e0415-8751-4a1c-8f1f-96800ff93802",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 246, 245)",
+    "uuid": "c9e0870a-8cf0-438e-9395-8141c316ad57",
+    "set_uuid": "921d4bb8-f5b0-4955-a495-294864cf4ca5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(54, 10, 3)",
+    "uuid": "04f6044b-d0fa-4705-858c-2dc5721ec30f",
+    "set_uuid": "921d4bb8-f5b0-4955-a495-294864cf4ca5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "b9752d64-5683-4ddc-ae30-164c475a5d90",
+    "set_uuid": "921d4bb8-f5b0-4955-a495-294864cf4ca5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(183, 40, 24)",
+    "uuid": "4a585714-4331-44b1-b81f-25a8ff1cc8ea",
+    "set_uuid": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 103, 86)",
+    "uuid": "95621c5a-1768-4707-a2ce-bd15c61c89f4",
+    "set_uuid": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "d3c2852d-4d9f-4493-af1a-cba5269baf22",
+    "set_uuid": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(156, 33, 19)",
+    "uuid": "a02ee7fb-b9de-45f1-bee7-8ffe2145cbec",
+    "set_uuid": "5485c698-0ea9-47d7-b81d-43f0647c4078",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 134, 120)",
+    "uuid": "53617d38-1075-4b47-87c7-4695b385a2d7",
+    "set_uuid": "5485c698-0ea9-47d7-b81d-43f0647c4078",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "fb1cf925-d51e-4b6a-9cd1-ee711193a03a",
+    "set_uuid": "5485c698-0ea9-47d7-b81d-43f0647c4078",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(129, 27, 14)",
+    "uuid": "ea79c634-9d94-4012-bae0-903479c34dc5",
+    "set_uuid": "403564fd-fda3-4ef5-a68e-96c6f5a93a93",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 167, 157)",
+    "uuid": "e7820c1c-ff58-431d-b521-b81ee3281db0",
+    "set_uuid": "403564fd-fda3-4ef5-a68e-96c6f5a93a93",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "2caf3838-8be9-41d9-9cb9-fa2e6a2f8373",
+    "set_uuid": "403564fd-fda3-4ef5-a68e-96c6f5a93a93",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(104, 21, 10)",
+    "uuid": "63934482-260f-4c73-a176-cad11427c537",
+    "set_uuid": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 196, 189)",
+    "uuid": "7691bca6-3749-4cb7-a950-a94fe3d2910f",
+    "set_uuid": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "5e630b5e-ff35-4463-8db5-79519a54d64f",
+    "set_uuid": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(80, 16, 6)",
+    "uuid": "1c208bc2-2eca-4727-a195-f80fe0e7ea11",
+    "set_uuid": "590136e1-3127-4540-9689-05b1161bd4c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 222, 219)",
+    "uuid": "aaafa24c-cb3c-48cd-9cb7-e164be140ab5",
+    "set_uuid": "590136e1-3127-4540-9689-05b1161bd4c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "e70a8b5a-06ec-4771-9c16-9e74ae15c9bc",
+    "set_uuid": "590136e1-3127-4540-9689-05b1161bd4c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 11, 4)",
+    "uuid": "45ef3c1f-fb24-4a0e-98c3-69c6027eb709",
+    "set_uuid": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 242, 240)",
+    "uuid": "e99ac2fd-25ab-4202-a279-41808cc8dbc6",
+    "set_uuid": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "421ec0d6-4d71-4c2d-8a39-19e3700451f0",
+    "set_uuid": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(29, 5, 2)",
+    "uuid": "3d8a70af-6e0b-449f-98e3-515498bf00ca",
+    "set_uuid": "e042de3e-9b82-4229-880d-e1e4b1af80b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "685778a4-bc17-4d74-a713-1776fc2516af",
+    "set_uuid": "e042de3e-9b82-4229-880d-e1e4b1af80b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "50807cbc-ade6-4f6d-8711-f569a52adaf8",
+    "set_uuid": "e042de3e-9b82-4229-880d-e1e4b1af80b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 235, 232)",
+    "uuid": "a1f7b6a3-4195-44dc-a772-9a04d3cf859c",
+    "set_uuid": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(68, 13, 5)",
+    "uuid": "b18ca77b-898e-4e09-88e2-8901de3e9172",
+    "set_uuid": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "1d78cfc4-2c54-450e-9c5a-e3d3a40bcf32",
+    "set_uuid": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 214, 209)",
+    "uuid": "3a393af6-c7f2-45bb-a4bc-9b55518c71ac",
+    "set_uuid": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(87, 17, 7)",
+    "uuid": "fcfcf026-be31-4a05-b833-6757cacb8b05",
+    "set_uuid": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "c020ab70-b666-478b-aaf2-8e06c033f307",
+    "set_uuid": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 188, 180)",
+    "uuid": "49e7cf3a-1f2a-4487-a0a9-3869a30593f1",
+    "set_uuid": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(115, 24, 11)",
+    "uuid": "8f9fa135-5aca-4e42-b247-fdfbf74bc07b",
+    "set_uuid": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "4ca331f0-9278-4ad7-9328-766e8a5f83e6",
+    "set_uuid": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 157, 145)",
+    "uuid": "70b11bf5-60c8-48a6-a1d5-2a74bc22e283",
+    "set_uuid": "33e7f73d-be80-4961-bcd7-6088fddadf44",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(147, 31, 17)",
+    "uuid": "ec50a21c-88aa-41a8-b607-c8b1c407ac4f",
+    "set_uuid": "33e7f73d-be80-4961-bcd7-6088fddadf44",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "92784233-e6b0-4de0-8069-f3c037472dec",
+    "set_uuid": "33e7f73d-be80-4961-bcd7-6088fddadf44",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 118, 101)",
+    "uuid": "00d13447-f1f9-4cda-89b4-6a839260e91a",
+    "set_uuid": "2bad908f-065a-45fb-9a75-6f3ae0da19a4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(177, 38, 23)",
+    "uuid": "ff0fa040-17d6-4570-84b5-7a88c5bb9f45",
+    "set_uuid": "2bad908f-065a-45fb-9a75-6f3ae0da19a4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "3fe966a7-eac1-4e06-9652-271182ff332d",
+    "set_uuid": "2bad908f-065a-45fb-9a75-6f3ae0da19a4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 81, 61)",
+    "uuid": "a84b6ffe-5235-4517-9beb-320ed79cf6b0",
+    "set_uuid": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(205, 46, 29)",
+    "uuid": "cb2486de-b2be-45e5-b459-6e371b29d357",
+    "set_uuid": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "fd598b48-a775-4c72-92e5-55f357c33537",
+    "set_uuid": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(240, 56, 35)",
+    "uuid": "6c3daf67-9cdc-4c02-9912-ff0b902c22ed",
+    "set_uuid": "cee84ce0-439b-444c-bb7e-a77777da716d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(223, 52, 34)",
+    "uuid": "9ff36ad0-608e-46a7-ab56-00af3d307d83",
+    "set_uuid": "cee84ce0-439b-444c-bb7e-a77777da716d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "abc67d6b-bd80-4e94-a91b-1f52216a5013",
+    "set_uuid": "cee84ce0-439b-444c-bb7e-a77777da716d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(215, 50, 32)",
+    "uuid": "d5d3bc64-629c-44b0-8ff5-81f260521f5b",
+    "set_uuid": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(252, 67, 46)",
+    "uuid": "ccb79099-59f4-4bf2-b149-0de72f556a45",
+    "set_uuid": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "red",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "f9fbdd87-77f6-4b99-b5f5-357604b57a48",
+    "set_uuid": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 251, 246)",
+    "uuid": "2330ab05-6153-47a1-ab56-18f3cb1c579f",
+    "set_uuid": "68294acd-b557-4990-a326-9b8c724c5d2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 30, 27)",
+    "uuid": "080b56a3-6f95-422a-9f4b-d850966c4984",
+    "set_uuid": "68294acd-b557-4990-a326-9b8c724c5d2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "3c862893-b1e9-45df-99da-33906686d3c1",
+    "set_uuid": "68294acd-b557-4990-a326-9b8c724c5d2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(5, 108, 92)",
+    "uuid": "84e4e598-4fd7-445a-a6cf-2884c0aae4d0",
+    "set_uuid": "487ae86b-24c7-4587-87b0-008fca574e84",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(12, 173, 142)",
+    "uuid": "c416b5c5-0506-419f-88ca-f722f12a9d86",
+    "set_uuid": "487ae86b-24c7-4587-87b0-008fca574e84",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "72873817-3cf5-4a14-aa93-1f86b4c6f7f2",
+    "set_uuid": "487ae86b-24c7-4587-87b0-008fca574e84",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(3, 92, 80)",
+    "uuid": "d1bb038a-f83b-4e97-b95f-b215c7bc2916",
+    "set_uuid": "17f2ffaf-07ad-4cf2-9224-1bee76e4c3ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(14, 190, 156)",
+    "uuid": "4a853bfc-f1b0-4e39-8cd8-da0350c99cd5",
+    "set_uuid": "17f2ffaf-07ad-4cf2-9224-1bee76e4c3ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "fb3f4cf4-e032-4cc1-94b1-d122f0d695ac",
+    "set_uuid": "17f2ffaf-07ad-4cf2-9224-1bee76e4c3ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(1, 75, 67)",
+    "uuid": "0eab9416-b6f5-4d26-bde6-9b8a840f7681",
+    "set_uuid": "50172156-b818-458f-aae6-d24bcd128272",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(29, 214, 176)",
+    "uuid": "8e4c65b7-d819-4ffd-9398-71e9d294ba63",
+    "set_uuid": "50172156-b818-458f-aae6-d24bcd128272",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "8a7fb1d7-90ca-41d1-a04c-84bd1d70d9ec",
+    "set_uuid": "50172156-b818-458f-aae6-d24bcd128272",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 60, 54)",
+    "uuid": "a88e0c6e-dfd5-4a43-8d43-97fa10101165",
+    "set_uuid": "838807a0-fae7-4fe6-be9d-c6c2ad0f751c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(122, 229, 203)",
+    "uuid": "ef35ace8-870d-42e0-8ce6-2df61415431f",
+    "set_uuid": "838807a0-fae7-4fe6-be9d-c6c2ad0f751c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "3e88a833-9ef2-4f37-86a1-041e76850e1e",
+    "set_uuid": "838807a0-fae7-4fe6-be9d-c6c2ad0f751c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 46, 40)",
+    "uuid": "52c9177c-bc81-41b1-ba6d-9b075fbe8541",
+    "set_uuid": "b179c26d-cd65-419e-b4ad-8af2ec3e478f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(186, 241, 222)",
+    "uuid": "9499384b-336c-4a41-af05-645a92ae40d4",
+    "set_uuid": "b179c26d-cd65-419e-b4ad-8af2ec3e478f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "badc0d78-4232-44f0-8911-e9e2f0eab94f",
+    "set_uuid": "b179c26d-cd65-419e-b4ad-8af2ec3e478f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 33, 29)",
+    "uuid": "4cbacecc-89c9-482d-b3f5-7d8f85f0a3f1",
+    "set_uuid": "1e24bea9-ddb5-4da1-96fe-0523053abedd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(229, 249, 243)",
+    "uuid": "6e538a2b-05f7-41f5-af4b-89bc3039c25a",
+    "set_uuid": "1e24bea9-ddb5-4da1-96fe-0523053abedd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "fd0d5cda-892b-4628-a125-353dcd123987",
+    "set_uuid": "1e24bea9-ddb5-4da1-96fe-0523053abedd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 15, 14)",
+    "uuid": "ebbfe9f4-5c24-46b2-983a-98570ed5ec78",
+    "set_uuid": "4afc4f90-8773-436d-b19c-817b2041ff03",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "29aae26e-f4a4-4e5a-acd2-02df01f6cc90",
+    "set_uuid": "4afc4f90-8773-436d-b19c-817b2041ff03",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "6685e580-982d-4f86-800a-19797f1675af",
+    "set_uuid": "4afc4f90-8773-436d-b19c-817b2041ff03",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(211, 246, 234)",
+    "uuid": "870298fd-4e1f-4649-bfbc-5ad5b768c2e3",
+    "set_uuid": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 39, 35)",
+    "uuid": "2876bdd7-af97-4cd6-89cc-bdb9c2110946",
+    "set_uuid": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "4115d94a-b52e-4cc8-8067-cd9184030ffe",
+    "set_uuid": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(169, 237, 216)",
+    "uuid": "1fe5483a-95bd-4597-802a-9e84c1486dbe",
+    "set_uuid": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 50, 44)",
+    "uuid": "d90b7496-0f54-41ce-96eb-c973457661ae",
+    "set_uuid": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "56c4f393-086d-41d9-87d0-babaea86a2a4",
+    "set_uuid": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(92, 225, 194)",
+    "uuid": "e2b4d354-9a1d-4153-b988-4fc24c117252",
+    "set_uuid": "63882463-c739-495b-b164-317ebcf97e35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 67, 59)",
+    "uuid": "ec603c2c-b2b2-4769-a889-ba7c91a458eb",
+    "set_uuid": "63882463-c739-495b-b164-317ebcf97e35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "21467045-093e-461e-86ac-dc65b657bf50",
+    "set_uuid": "63882463-c739-495b-b164-317ebcf97e35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(16, 207, 169)",
+    "uuid": "a1da1af7-df37-455d-8d27-2920b36f209f",
+    "set_uuid": "455bbf75-71fe-470d-80f9-abe5784270c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(2, 86, 75)",
+    "uuid": "c24b866c-5ac0-49de-857b-48c655fa9990",
+    "set_uuid": "455bbf75-71fe-470d-80f9-abe5784270c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "50117040-ca43-4b90-832d-7e4c2d83c31c",
+    "set_uuid": "455bbf75-71fe-470d-80f9-abe5784270c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(13, 181, 149)",
+    "uuid": "cfd8a8b3-d567-4eb4-9b6f-5db352607dab",
+    "set_uuid": "dbb00476-446d-4243-9e80-291c6ee1602d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(4, 105, 89)",
+    "uuid": "73b58f7e-008b-44ae-8969-19d981d444d6",
+    "set_uuid": "dbb00476-446d-4243-9e80-291c6ee1602d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "0a450ad0-dd5e-414c-9b76-dac4ca20a1b8",
+    "set_uuid": "dbb00476-446d-4243-9e80-291c6ee1602d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(11, 162, 134)",
+    "uuid": "a036b309-95ec-45e6-b035-f30f0f922422",
+    "set_uuid": "ad52345b-0360-4819-9fe8-b6e07249810d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(6, 122, 103)",
+    "uuid": "0b8528e6-ceea-47a5-9727-24e97d7bc138",
+    "set_uuid": "ad52345b-0360-4819-9fe8-b6e07249810d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "c26d7e9d-fef9-4aa9-991b-bbac307e3c7a",
+    "set_uuid": "ad52345b-0360-4819-9fe8-b6e07249810d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(9, 144, 120)",
+    "uuid": "ac4f12a3-a3f0-4053-87f4-5fc42b08cf23",
+    "set_uuid": "472d8ac6-f0ae-4a37-9990-28773c10c959",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 134, 112)",
+    "uuid": "df8f47d4-5c3b-4ecb-b9fb-5d2dbd39d696",
+    "set_uuid": "472d8ac6-f0ae-4a37-9990-28773c10c959",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "7a88f0bf-59cb-4af3-9542-f7648fecd50e",
+    "set_uuid": "472d8ac6-f0ae-4a37-9990-28773c10c959",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(7, 129, 109)",
+    "uuid": "74cb44f8-8ab0-4a36-9920-0735756e0ddc",
+    "set_uuid": "de37323c-69e7-476b-a62e-467e104c5d36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(10, 154, 128)",
+    "uuid": "dca23a18-2b19-48bf-9894-2f0948f6c05e",
+    "set_uuid": "de37323c-69e7-476b-a62e-467e104c5d36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "seafoam",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "8e444b02-f977-4948-b862-63275642ad58",
+    "set_uuid": "de37323c-69e7-476b-a62e-467e104c5d36",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(247, 247, 247)",
+    "uuid": "e190b39c-3e1f-4ad7-bc70-0b98c1770f61",
+    "set_uuid": "35feabca-281f-4eab-8f61-8dc672b1f390",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(26, 26, 26)",
+    "uuid": "0c4a28ee-a473-4437-924e-c46a9bc0771b",
+    "set_uuid": "35feabca-281f-4eab-8f61-8dc672b1f390",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "7e0c8012-9ec4-40c3-a572-dd551627e54f",
+    "set_uuid": "35feabca-281f-4eab-8f61-8dc672b1f390",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(96, 96, 96)",
+    "uuid": "943f1415-fc31-4724-8434-9e9cdb51d2b4",
+    "set_uuid": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(152, 152, 152)",
+    "uuid": "ee71e6fd-283f-4ba3-a6a3-b23491ce86d0",
+    "set_uuid": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "28a8b564-c9fb-41ab-b989-47516f9c0135",
+    "set_uuid": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(81, 81, 81)",
+    "uuid": "28748667-93d7-4752-8c75-419af48b4d1d",
+    "set_uuid": "b00f5d31-8cc1-4883-ab5d-8ce078b0b147",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(169, 169, 169)",
+    "uuid": "e1239867-313d-44f8-8ac7-ebdb9f34724e",
+    "set_uuid": "b00f5d31-8cc1-4883-ab5d-8ce078b0b147",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "69a3ff9a-dec9-4a96-b54f-f9ca12568e59",
+    "set_uuid": "b00f5d31-8cc1-4883-ab5d-8ce078b0b147",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(66, 66, 66)",
+    "uuid": "f1033f5b-aa7f-4351-9100-43ce546f6a8d",
+    "set_uuid": "aea2f725-ee6e-4ca7-b272-6090a8c85c17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(190, 190, 190)",
+    "uuid": "5ce07115-c390-4b72-b1ce-4e1f5346ac59",
+    "set_uuid": "aea2f725-ee6e-4ca7-b272-6090a8c85c17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "18013461-754d-434e-8b05-269dd307d45a",
+    "set_uuid": "aea2f725-ee6e-4ca7-b272-6090a8c85c17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 52, 52)",
+    "uuid": "77bcd85e-90f8-47b8-a9a3-ec59cd7ffe14",
+    "set_uuid": "ba7a5494-8be0-43d5-8523-6314167026c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(211, 211, 211)",
+    "uuid": "426823de-8002-4acb-a591-8ace92d1e0cd",
+    "set_uuid": "ba7a5494-8be0-43d5-8523-6314167026c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "8119e422-4eb8-44fc-bf69-b1f76963afca",
+    "set_uuid": "ba7a5494-8be0-43d5-8523-6314167026c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(39, 39, 39)",
+    "uuid": "369bdb1d-bd52-41b4-8512-159cb20c5d64",
+    "set_uuid": "51d48c84-cc9c-4cce-9fa3-84988492b5a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(229, 229, 229)",
+    "uuid": "b4cae4c1-1075-4776-a217-940423c4297c",
+    "set_uuid": "51d48c84-cc9c-4cce-9fa3-84988492b5a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "9313f4d5-1105-4cb0-81f4-a8a5109594a0",
+    "set_uuid": "51d48c84-cc9c-4cce-9fa3-84988492b5a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(28, 28, 28)",
+    "uuid": "b9b53281-a4f9-4073-8552-d3d4cec25271",
+    "set_uuid": "a73d4598-2974-4efd-a6db-34fac3b649d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(244, 244, 244)",
+    "uuid": "196c4205-2175-4317-82e1-c2fdeb990c4b",
+    "set_uuid": "a73d4598-2974-4efd-a6db-34fac3b649d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "dba91bae-1dae-4687-be68-d831a5bd42ba",
+    "set_uuid": "a73d4598-2974-4efd-a6db-34fac3b649d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(12, 12, 12)",
+    "uuid": "fc85bffe-09d4-4fb6-bb7b-5f1053139b97",
+    "set_uuid": "29e4253c-f215-4f5b-aa15-ef8593b70c57",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "8509cb0b-461b-441c-b909-0384737ca553",
+    "set_uuid": "29e4253c-f215-4f5b-aa15-ef8593b70c57",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "cd1b844a-29bf-4643-a246-4f124544e25d",
+    "set_uuid": "29e4253c-f215-4f5b-aa15-ef8593b70c57",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(239, 239, 239)",
+    "uuid": "f0bae14e-1c9a-4a03-9dbf-dcd3213463c1",
+    "set_uuid": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(33, 33, 33)",
+    "uuid": "99b20fba-8fa9-414b-9119-dbaccc5af3c5",
+    "set_uuid": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "240ade94-eb1b-4ddd-b667-7c05af2b196a",
+    "set_uuid": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(223, 223, 223)",
+    "uuid": "41989dfb-ef46-493d-8b50-d9422b221ee8",
+    "set_uuid": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(44, 44, 44)",
+    "uuid": "27ca065d-5baf-470f-b1aa-09e9934055d0",
+    "set_uuid": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "da36dc54-21c0-412f-baa1-ae3a2810b926",
+    "set_uuid": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(204, 204, 204)",
+    "uuid": "4bdcf062-a1b6-4615-ad8e-747082107f44",
+    "set_uuid": "2ac14b55-357e-43a0-85f3-c41a8f3697c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 59, 59)",
+    "uuid": "0c4f7cca-a9fc-40d5-9503-04c505962f33",
+    "set_uuid": "2ac14b55-357e-43a0-85f3-c41a8f3697c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "a52e646b-54c7-419b-850e-1da7abc74dd3",
+    "set_uuid": "2ac14b55-357e-43a0-85f3-c41a8f3697c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(183, 183, 183)",
+    "uuid": "1bd72e90-6ec1-4a55-beb2-04ad5afd03d5",
+    "set_uuid": "83e5106a-8420-4013-bcb3-58ba8a2b5d08",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(76, 76, 76)",
+    "uuid": "98e7bc6e-bfed-47c4-8f6e-ab1e035deef7",
+    "set_uuid": "83e5106a-8420-4013-bcb3-58ba8a2b5d08",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "696e8452-cd1b-4ab8-b9d6-eb2b76bdf020",
+    "set_uuid": "83e5106a-8420-4013-bcb3-58ba8a2b5d08",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(160, 160, 160)",
+    "uuid": "1354b7a3-d0b5-4f48-8631-6b4afd7efe4f",
+    "set_uuid": "d360e142-a676-4474-89de-a6e478860fbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(92, 92, 92)",
+    "uuid": "9e46a3c3-25d1-41f5-b76d-d4d136668589",
+    "set_uuid": "d360e142-a676-4474-89de-a6e478860fbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "b0f8e027-ba0e-4460-8d45-b0ada27327d9",
+    "set_uuid": "d360e142-a676-4474-89de-a6e478860fbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 143, 143)",
+    "uuid": "8c7b40e3-239d-4b57-a846-eb5d9f96615d",
+    "set_uuid": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(108, 108, 108)",
+    "uuid": "d66afc23-a9aa-4a50-a094-3dfebe044a08",
+    "set_uuid": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "907d96cc-375b-49a7-abe0-afb229c98474",
+    "set_uuid": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(128, 128, 128)",
+    "uuid": "bbfb55a6-5bca-424d-8a27-e1e54fff7309",
+    "set_uuid": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(118, 118, 118)",
+    "uuid": "3f481be4-bdd3-45b8-bcfe-c7577cac40d4",
+    "set_uuid": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "8ed554bc-be40-4ebb-9a83-c85c73c0cb3d",
+    "set_uuid": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(114, 114, 114)",
+    "uuid": "39cdbda8-3c8c-4977-a90e-3883647d93a6",
+    "set_uuid": "d522fe05-cad5-4484-89e0-65c524f92e89",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(137, 137, 137)",
+    "uuid": "66efbf5e-008b-41f6-a623-ee3722e41c69",
+    "set_uuid": "d522fe05-cad5-4484-89e0-65c524f92e89",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "silver",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "3f1bbfff-8a14-4984-a725-211aba36fa98",
+    "set_uuid": "d522fe05-cad5-4484-89e0-65c524f92e89",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-blue",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(39, 77, 234)",
+    "uuid": "8402b6ad-f3da-4ea2-8b55-174a9794950d",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-blue",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(59, 99, 251)",
+    "uuid": "e193b8bb-6a0b-4c23-9851-83634f3797f8",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-chartreuse",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(182, 219, 0)",
+    "uuid": "956d3239-08e0-4f24-86ed-f9a3c63407a8",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-chartreuse",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(143, 172, 0)",
+    "uuid": "c1a4bb2c-5823-41fb-abab-02024e601b2e",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-chartreuse",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(114, 137, 0)",
+    "uuid": "5b878f8b-b097-4bcd-aac7-adde5b8b704f",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-cyan",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(138, 213, 255)",
+    "uuid": "c83a7db4-4fbe-467b-a6b7-34e37544c8a4",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-cyan",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(48, 167, 254)",
+    "uuid": "3d8f857c-09fb-4be9-a557-76b5d3f95439",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-cyan",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 134, 205)",
+    "uuid": "341fd624-7f99-4d2e-93b1-5f9b06af6796",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(156, 40, 175)",
+    "uuid": "0aee9ad6-2d79-4479-bdb6-aafa07a98673",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(247, 181, 255)",
+    "uuid": "6bf55034-f65e-4ce5-af39-b36c2ef2af0b",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(236, 105, 255)",
+    "uuid": "47d7dca9-deed-4508-aec4-55713e1548ce",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(200, 68, 220)",
+    "uuid": "d4d44881-8175-414b-b707-e94d3f97a983",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-fuchsia",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(181, 57, 200)",
+    "uuid": "7629af9c-2f91-449e-a82f-c60a771b0e6f",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-green",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(107, 227, 162)",
+    "uuid": "43ad64e7-95b1-4edf-8a25-3ea6e047a549",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-green",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 184, 103)",
+    "uuid": "a8264c36-acc7-4082-8be7-037016b1e79a",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-green",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(7, 147, 85)",
+    "uuid": "16a05db4-e5e1-48ff-92d2-72fc6d3e1ebe",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(99, 56, 238)",
+    "uuid": "fb3003ec-6793-47b0-947d-a89e642652fc",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 201, 255)",
+    "uuid": "61c77769-5598-4509-8ec6-579838e2ca0c",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(145, 151, 254)",
+    "uuid": "def10fcb-9261-4869-b221-48707c4037fb",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(122, 106, 253)",
+    "uuid": "f1fb98f5-401c-40ff-88da-b06c97ef8a39",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-indigo",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 85, 250)",
+    "uuid": "970ddf30-3683-4f48-9ac7-8a9e42902fd3",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(186, 22, 80)",
+    "uuid": "058a8ff9-740d-4e11-bdb6-7473a77f872b",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 185, 208)",
+    "uuid": "d8fc21df-dcf5-4d7e-9366-f1df094c95c2",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 112, 159)",
+    "uuid": "f743ffcd-019e-4f25-b559-5d563a2d8996",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(240, 45, 110)",
+    "uuid": "a6fb2dc7-d4b9-497d-af1a-863217a84b2a",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-magenta",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(217, 35, 97)",
+    "uuid": "5b34bb1d-a23e-4799-ad59-8fa8f51d3726",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-orange",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 193, 94)",
+    "uuid": "333615da-5ca1-44be-9407-4613fba38999",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-orange",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(252, 125, 0)",
+    "uuid": "fa30a6d2-df6f-40b0-8877-f826f5f62adb",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-orange",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(212, 91, 0)",
+    "uuid": "77e8a380-26f9-4b61-8131-421b8ccf2212",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-purple",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(221, 193, 246)",
+    "uuid": "40c4db9a-eaea-4266-b00f-5793afc95422",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-purple",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(191, 138, 238)",
+    "uuid": "c1cc646a-21a9-4c3b-bcda-be77e4b2d735",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-purple",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(166, 92, 231)",
+    "uuid": "a6bfb1a2-9fd6-4247-b615-af1d4fc4c476",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(183, 40, 24)",
+    "uuid": "3a65213c-4d36-48ec-8bf9-1b163a81299d",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 188, 180)",
+    "uuid": "59ce78e2-3fbb-4e2a-be17-07afce5ca987",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 118, 101)",
+    "uuid": "865349c3-a5e0-4940-b404-918616390195",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(240, 56, 35)",
+    "uuid": "341e5068-62cb-4e3f-a0a1-54c107db50cc",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-red",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(215, 50, 32)",
+    "uuid": "d31011ef-7270-4c83-802d-05701ae9a3c8",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-turquoise",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(111, 221, 228)",
+    "uuid": "86ef11d6-aacd-470b-9d61-ffd7c5c09b45",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-turquoise",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(15, 177, 192)",
+    "uuid": "60816b84-ee3f-4b17-9bcb-fd26f194dd32",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "static-turquoise",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(10, 141, 153)",
+    "uuid": "94f1f308-c049-4b5e-ae02-2d609c114e83",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 100
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.09)",
+    "uuid": "7565eb32-d745-4fc3-8779-a717f8ba910a",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 0, 0)",
+    "uuid": "098f2f56-e52f-47b1-943a-d1d7218de484",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 200
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.12)",
+    "uuid": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 25
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0)",
+    "uuid": "d0867b86-6245-4c02-8617-ea7fd5c80288",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 300
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.15)",
+    "uuid": "16a871e1-d9df-42bb-8889-99059d70e82e",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.22)",
+    "uuid": "b769453b-586c-4dd2-b3a1-ddf5964160bc",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 50
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.03)",
+    "uuid": "d6aa176c-30bd-423f-b05f-4360672bd87e",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 500
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.44)",
+    "uuid": "cebedd9f-9e4b-47cf-addb-45d8ff9c9179",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.56)",
+    "uuid": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 700
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.69)",
+    "uuid": "56da822f-98ea-4ad1-b993-3f052de45f36",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 75
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.05)",
+    "uuid": "d33a66ea-ca60-416f-9e92-967dbbb1e983",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.84)",
+    "uuid": "3e89f180-b0f0-4de0-904b-c80f0210a361",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-black",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(0, 0, 0, 0.93)",
+    "uuid": "c0a331f9-53e3-4c72-b5e3-139d730a1752",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 100
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.11)",
+    "uuid": "a1b64a62-7c78-415e-a9be-c86acbf361ca",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 1000
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "1409a50a-9a9d-463d-957f-fa2e4f98a0cd",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 200
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.14)",
+    "uuid": "936db837-bc5a-40b0-a0e8-8e39b9fc62cb",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 25
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0)",
+    "uuid": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 300
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.17)",
+    "uuid": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 400
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.21)",
+    "uuid": "12e610d4-e3dc-4e86-9c09-09d86915b6f1",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 50
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.04)",
+    "uuid": "db1dbf26-fa48-42e1-b724-7953b0a6a543",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 500
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.39)",
+    "uuid": "89c1380f-3e8e-4895-b025-027cee7ecd5b",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 600
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.51)",
+    "uuid": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 700
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.66)",
+    "uuid": "3ecc14ec-a21e-47ba-8225-915509a532af",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 75
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.07)",
+    "uuid": "28d11d38-570d-4d99-b581-855781b972c5",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 800
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.85)",
+    "uuid": "b85836bf-af47-412a-900a-4ec5ad0733b2",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "transparent-white",
+      "scaleIndex": 900
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgba(255, 255, 255, 0.94)",
+    "uuid": "c5c823c6-1911-4e0e-ba2f-5105f467e108",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(238, 251, 251)",
+    "uuid": "8e69d558-2c95-496f-8244-56c1abecef5f",
+    "set_uuid": "32dac6f5-6603-4f0a-b85e-1177e1ce23a1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 30, 33)",
+    "uuid": "7be82e76-2525-4496-9425-c180746f12df",
+    "set_uuid": "32dac6f5-6603-4f0a-b85e-1177e1ce23a1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "094b2708-cb1f-4936-96ee-503cf113ab7a",
+    "set_uuid": "32dac6f5-6603-4f0a-b85e-1177e1ce23a1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(5, 107, 116)",
+    "uuid": "f46bb42a-00fe-44ae-8421-16fbdbe1a9e3",
+    "set_uuid": "eba4bafc-0f66-4dd1-8007-d25121e79a4b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(13, 168, 182)",
+    "uuid": "89d12308-9718-40d6-a089-73b9fcf1185b",
+    "set_uuid": "eba4bafc-0f66-4dd1-8007-d25121e79a4b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "7c82b1ca-e445-45a0-b7b2-5ed3030e92e7",
+    "set_uuid": "eba4bafc-0f66-4dd1-8007-d25121e79a4b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(3, 90, 98)",
+    "uuid": "7c957f48-f033-4814-a4e0-127e67169771",
+    "set_uuid": "b179a56d-ff8b-4540-94fa-6ddd415b5841",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(16, 186, 202)",
+    "uuid": "7f0dafc6-6863-4542-b58c-610bd97f79fa",
+    "set_uuid": "b179a56d-ff8b-4540-94fa-6ddd415b5841",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "e3e88d56-d236-41f7-8eaa-3804576b6161",
+    "set_uuid": "b179a56d-ff8b-4540-94fa-6ddd415b5841",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(1, 74, 81)",
+    "uuid": "d85163b6-fbaf-4c49-b61b-f0b7b9529ff7",
+    "set_uuid": "25950327-72b2-4f1d-97df-b8411e03abcb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(64, 208, 220)",
+    "uuid": "70ca07eb-a370-4059-9d5a-b55f6a9c9f31",
+    "set_uuid": "25950327-72b2-4f1d-97df-b8411e03abcb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "1ca86f12-0424-40b5-a606-912e2fcc5cc1",
+    "set_uuid": "25950327-72b2-4f1d-97df-b8411e03abcb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 59, 65)",
+    "uuid": "c9ab3575-f393-45db-a92b-07eccd4696bb",
+    "set_uuid": "12ccafd6-dd63-4829-b3b4-9d015b9dc0c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(128, 225, 231)",
+    "uuid": "c1f51874-6699-4250-bcd3-9d15add56a86",
+    "set_uuid": "12ccafd6-dd63-4829-b3b4-9d015b9dc0c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "07b5d5b0-8952-4901-a0e5-227fa3e1aacf",
+    "set_uuid": "12ccafd6-dd63-4829-b3b4-9d015b9dc0c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 44, 49)",
+    "uuid": "6ee374d9-95c4-4e5d-8f4d-fa1912cf6514",
+    "set_uuid": "f2fec1aa-b46a-4046-8c5a-ce7360b37f0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(183, 240, 240)",
+    "uuid": "f2f63354-d6fb-4687-abf8-554c4ab95fbf",
+    "set_uuid": "f2fec1aa-b46a-4046-8c5a-ce7360b37f0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "81180029-eec8-4d26-9fe0-3966aa372151",
+    "set_uuid": "f2fec1aa-b46a-4046-8c5a-ce7360b37f0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 32, 35)",
+    "uuid": "d3e919d4-3777-4dca-93f9-0e04ab00d0dd",
+    "set_uuid": "796df5b7-982f-409a-892f-791eaee4d9f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(228, 249, 249)",
+    "uuid": "d4b79c34-286d-40f0-87ce-bbfb6b217dba",
+    "set_uuid": "796df5b7-982f-409a-892f-791eaee4d9f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "1162302d-4bcf-478a-a95e-660785220434",
+    "set_uuid": "796df5b7-982f-409a-892f-791eaee4d9f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 15, 17)",
+    "uuid": "6af4ec29-d7c5-4562-be2c-a838aa919aed",
+    "set_uuid": "b248731f-de4c-4526-983c-cee0ac10b20f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "4ae14c01-10b1-4daf-a064-dab9f6fdea9d",
+    "set_uuid": "b248731f-de4c-4526-983c-cee0ac10b20f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "21be860b-80bb-40a1-9aaf-20a97b2ddc77",
+    "set_uuid": "b248731f-de4c-4526-983c-cee0ac10b20f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(209, 245, 245)",
+    "uuid": "2dd6c94d-b55e-491e-91a9-bf9b4e3ceb54",
+    "set_uuid": "7720aa32-deea-454b-a593-f1234e638565",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 37, 41)",
+    "uuid": "f70fdb17-da0b-4163-8af6-2daa65327e3a",
+    "set_uuid": "7720aa32-deea-454b-a593-f1234e638565",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "e5a0aca5-4d22-4d1a-9732-6e0e2c98e72d",
+    "set_uuid": "7720aa32-deea-454b-a593-f1234e638565",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(169, 236, 237)",
+    "uuid": "7eda1d2a-4c4a-495c-8b2f-c663be8c22f8",
+    "set_uuid": "47de7f9a-3e02-4824-b667-ad499729c9ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 49, 54)",
+    "uuid": "eb6f8d2a-1a82-42ef-b668-0aac077d4053",
+    "set_uuid": "47de7f9a-3e02-4824-b667-ad499729c9ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "c4877ffd-985b-4260-b1c3-3ac37392315a",
+    "set_uuid": "47de7f9a-3e02-4824-b667-ad499729c9ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(111, 221, 228)",
+    "uuid": "7a80623f-07eb-426a-9a64-ced6e3d09df1",
+    "set_uuid": "1327ec82-3f65-4706-a664-11e46294ffd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(0, 66, 72)",
+    "uuid": "e354eda3-17c2-4f07-b64b-3620692a12f3",
+    "set_uuid": "1327ec82-3f65-4706-a664-11e46294ffd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "f136369b-3ac7-4041-871e-90c90f3da3a9",
+    "set_uuid": "1327ec82-3f65-4706-a664-11e46294ffd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(39, 202, 216)",
+    "uuid": "1fae7edd-0b41-4ae6-a436-c1e5ecda3e3a",
+    "set_uuid": "02f0b460-1456-4c41-bea1-d2bf70eeab5d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(3, 84, 92)",
+    "uuid": "de4d07fb-1d63-44cc-a9bf-1cd2e2ed4e59",
+    "set_uuid": "02f0b460-1456-4c41-bea1-d2bf70eeab5d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "4320a8e7-3509-45c6-b133-02bf0e779a42",
+    "set_uuid": "02f0b460-1456-4c41-bea1-d2bf70eeab5d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(15, 177, 192)",
+    "uuid": "be19fd97-84da-40ed-82a2-1afa75b6f405",
+    "set_uuid": "4d12dcd0-e3ff-43ef-a742-5a9c74848e04",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(5, 103, 112)",
+    "uuid": "ae1d9dc7-e778-4c78-b12d-ab187cc3c254",
+    "set_uuid": "4d12dcd0-e3ff-43ef-a742-5a9c74848e04",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "1ce42e96-435f-4895-896d-268dcdf16b21",
+    "set_uuid": "4d12dcd0-e3ff-43ef-a742-5a9c74848e04",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(12, 158, 171)",
+    "uuid": "0a313605-1db7-4801-afac-28aeb30aa005",
+    "set_uuid": "3cf57594-3174-4192-ab62-b854b1562748",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(7, 120, 131)",
+    "uuid": "08f4307e-74f1-446d-9051-8a4c11546289",
+    "set_uuid": "3cf57594-3174-4192-ab62-b854b1562748",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "9ffcdab9-e422-4ece-b292-6b8ce227bef8",
+    "set_uuid": "3cf57594-3174-4192-ab62-b854b1562748",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(10, 141, 153)",
+    "uuid": "cb62cb21-ce76-4f47-a88d-14682eb6e06d",
+    "set_uuid": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(9, 131, 142)",
+    "uuid": "69ae2217-ba32-41ca-a38f-8f19dcc5cf76",
+    "set_uuid": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "a6548e62-22e6-4089-b098-0a8bb60676ec",
+    "set_uuid": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 126, 137)",
+    "uuid": "b1e2b910-c19d-4b83-9f49-f9e858ab58b9",
+    "set_uuid": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(11, 151, 164)",
+    "uuid": "2ce15c64-8c38-4935-bc65-7580df395231",
+    "set_uuid": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "turquoise",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "2084f7e5-221c-4a4e-96e0-fa0ff2fa40f1",
+    "set_uuid": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "white"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "9b799da8-2130-417e-b7ee-5e1154a89837",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 248, 204)",
+    "uuid": "910d2e36-245f-4df6-a99c-92a5bb4d4cce",
+    "set_uuid": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(37, 23, 0)",
+    "uuid": "7bef094a-1523-4392-a0ca-59c48409f17a",
+    "set_uuid": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(246, 248, 252)",
+    "uuid": "be46f4fb-64d6-4e04-abd1-1f87c634d272",
+    "set_uuid": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1000,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(134, 85, 0)",
+    "uuid": "a9d84db4-e9db-45a8-9010-4e64822f0408",
+    "set_uuid": "92f600a8-beb5-427b-990d-f9f486a7f3ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1000,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(203, 141, 0)",
+    "uuid": "4cf4a500-37a2-4dd8-a243-14f6c012b53c",
+    "set_uuid": "92f600a8-beb5-427b-990d-f9f486a7f3ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1000,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 94, 165)",
+    "uuid": "7e7a2c49-bf61-4402-b85b-bf4df9ca8ff0",
+    "set_uuid": "92f600a8-beb5-427b-990d-f9f486a7f3ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1100,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(114, 72, 0)",
+    "uuid": "b6001568-2f26-4722-85e2-e6a3a8ad0ec8",
+    "set_uuid": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1100,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(218, 159, 0)",
+    "uuid": "4eee9daf-e19d-4e0b-b12d-4fdcc4852956",
+    "set_uuid": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1100,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(52, 79, 140)",
+    "uuid": "b54bc7bb-2347-4265-ba88-8af7fa420bdf",
+    "set_uuid": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 59, 0)",
+    "uuid": "7be15b50-51c6-4d0c-9ec8-89b4ac170a5a",
+    "set_uuid": "af877bd7-9943-454e-b83e-5597e381190a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 183, 0)",
+    "uuid": "69059dfa-e2e1-4f8d-b06b-058a8724e071",
+    "set_uuid": "af877bd7-9943-454e-b83e-5597e381190a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(42, 65, 114)",
+    "uuid": "2e92e2de-12fa-45d3-be1d-5d875311bf1e",
+    "set_uuid": "af877bd7-9943-454e-b83e-5597e381190a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(75, 47, 0)",
+    "uuid": "b5808c39-38db-4378-96db-1f6d44ce5172",
+    "set_uuid": "b2558f6d-b45c-4662-a4a9-e34acd060c1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(249, 206, 0)",
+    "uuid": "b2a1039c-cbfe-44bf-a0fe-822c5f576f52",
+    "set_uuid": "b2558f6d-b45c-4662-a4a9-e34acd060c1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(34, 51, 91)",
+    "uuid": "21c27c6d-f054-48b4-abb8-5b0907e238e2",
+    "set_uuid": "b2558f6d-b45c-4662-a4a9-e34acd060c1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(56, 35, 0)",
+    "uuid": "65ad1c10-fb0d-4dd2-a9f5-66ab34dcc86b",
+    "set_uuid": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 230, 86)",
+    "uuid": "dfd355e7-82fd-4fdb-96bd-b584d7268ee9",
+    "set_uuid": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(25, 39, 69)",
+    "uuid": "e0d95ec7-193d-40d1-9bd9-e68ff27c0275",
+    "set_uuid": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(40, 25, 0)",
+    "uuid": "d8eebb60-7b0c-496e-ae04-1f1fc61f3013",
+    "set_uuid": "20f1c823-6340-45db-afa9-f666bdf65f78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 246, 195)",
+    "uuid": "166ee2cc-b727-4f3c-9c08-5c586a0f6c11",
+    "set_uuid": "20f1c823-6340-45db-afa9-f666bdf65f78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 27, 48)",
+    "uuid": "8be0ad1a-0cdf-409d-953f-0a203282e1d9",
+    "set_uuid": "20f1c823-6340-45db-afa9-f666bdf65f78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(18, 11, 0)",
+    "uuid": "ada313e4-768c-4fd0-b93c-b6f6d2a50f68",
+    "set_uuid": "edc119b5-088e-4099-aa53-da1a8bdd7ba8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 255, 255)",
+    "uuid": "3df0b31f-656a-4400-99c4-d559da586714",
+    "set_uuid": "edc119b5-088e-4099-aa53-da1a8bdd7ba8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 1600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(8, 12, 22)",
+    "uuid": "15f47c52-fa9c-4982-ad9c-684024a9a667",
+    "set_uuid": "edc119b5-088e-4099-aa53-da1a8bdd7ba8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 200,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 241, 151)",
+    "uuid": "0ebcaa53-4d19-4eed-99d1-4477f4358a58",
+    "set_uuid": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 200,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(47, 29, 0)",
+    "uuid": "f4fdc925-63b3-4670-9f2b-a057c27c834a",
+    "set_uuid": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 200,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(235, 239, 248)",
+    "uuid": "2e4d1e66-b660-4e99-8f01-ff9964aa19d8",
+    "set_uuid": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 300,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(255, 222, 44)",
+    "uuid": "97ea0771-52c6-48f0-8725-dc514b0738d4",
+    "set_uuid": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 300,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(61, 39, 0)",
+    "uuid": "238147c6-0302-4d43-b3a3-42df832c7857",
+    "set_uuid": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 300,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(216, 224, 242)",
+    "uuid": "6547eb52-a3a5-4004-8125-df92fed7a062",
+    "set_uuid": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 400,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(245, 199, 0)",
+    "uuid": "8ffb47cc-cc5c-4179-807e-4a1cb45c6496",
+    "set_uuid": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 400,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(83, 52, 0)",
+    "uuid": "62ab6892-66ea-4b55-8c1a-fcc191d29717",
+    "set_uuid": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 400,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(192, 205, 234)",
+    "uuid": "2c6515da-f97b-4961-93cf-5b6c668fc0fc",
+    "set_uuid": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 500,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(230, 175, 0)",
+    "uuid": "68a43979-6dee-45b9-963d-3e827b2554f4",
+    "set_uuid": "8f90e008-a466-4477-ab93-1a55a644f52e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 500,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(107, 67, 0)",
+    "uuid": "efa1fdd8-4478-411a-892c-0ecf23939489",
+    "set_uuid": "8f90e008-a466-4477-ab93-1a55a644f52e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 500,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 183, 225)",
+    "uuid": "8e450204-2aa5-4cb2-959b-8fc28f7f55bf",
+    "set_uuid": "8f90e008-a466-4477-ab93-1a55a644f52e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 600,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(210, 149, 0)",
+    "uuid": "8c86293e-334b-49ed-a7aa-eb4fe987002f",
+    "set_uuid": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 600,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(130, 82, 0)",
+    "uuid": "8ae3c5ec-aabe-47a0-b822-ba0907e67ed4",
+    "set_uuid": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 600,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(135, 160, 215)",
+    "uuid": "dfdf38c7-1e23-44a8-8a62-a5f6c3a341bf",
+    "set_uuid": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 700,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(193, 131, 0)",
+    "uuid": "881b7389-0c65-46e6-a391-d1d5800c535c",
+    "set_uuid": "56ec10af-38c5-46f8-8fcf-634546c1bcc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 700,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(151, 97, 0)",
+    "uuid": "ac3e5d40-51eb-45aa-b4e0-87d3f6e8e359",
+    "set_uuid": "56ec10af-38c5-46f8-8fcf-634546c1bcc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 700,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(113, 142, 208)",
+    "uuid": "69c7c213-9a1c-4cd2-ac90-2142aa955e00",
+    "set_uuid": "56ec10af-38c5-46f8-8fcf-634546c1bcc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 800,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(175, 116, 0)",
+    "uuid": "b9ee2410-9573-4acd-bff8-ce11bf0f72a0",
+    "set_uuid": "3fa72ad4-4c82-457f-a5f8-eb4593a9701d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 800,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(164, 106, 0)",
+    "uuid": "67e8d9aa-d843-4536-9c97-bd51e62da8ee",
+    "set_uuid": "3fa72ad4-4c82-457f-a5f8-eb4593a9701d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 800,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(93, 127, 201)",
+    "uuid": "9ebe0ca0-5580-4083-899a-ba4a4638254d",
+    "set_uuid": "3fa72ad4-4c82-457f-a5f8-eb4593a9701d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 900,
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(158, 102, 0)",
+    "uuid": "1b030fd3-f5bc-4e84-8efd-33db77bf64b8",
+    "set_uuid": "9c2d18b5-151b-4765-97ea-d1307df3de56",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 900,
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(186, 124, 0)",
+    "uuid": "a12f6cac-7fdc-4fd4-8120-ad957823ff6b",
+    "set_uuid": "9c2d18b5-151b-4765-97ea-d1307df3de56",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  },
+  {
+    "name": {
+      "property": "color",
+      "colorFamily": "yellow",
+      "scaleIndex": 900,
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+    "value": "rgb(74, 111, 195)",
+    "uuid": "a9e4cb0b-80af-417f-b8d5-b1a7aefa15e5",
+    "set_uuid": "9c2d18b5-151b-4765-97ea-d1307df3de56",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "private": true
+  }
+]

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -1,0 +1,2367 @@
+[
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-200",
+    "uuid": "5f164d93-6efe-4abf-8f4c-9cb5f91bf26c",
+    "set_uuid": "ce4c7cf5-e97a-439b-9724-9623a8f6ada3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-300",
+    "uuid": "29c9205e-d39d-419a-b6e1-4e0544a3ca7c",
+    "set_uuid": "ce4c7cf5-e97a-439b-9724-9623a8f6ada3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-200",
+    "uuid": "2bfc538f-30ae-4e45-92ef-bb7ad72f1396",
+    "set_uuid": "ce4c7cf5-e97a-439b-9724-9623a8f6ada3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "f53f030b-755f-46ca-b411-7d62f4eb901e",
+    "set_uuid": "bc640c2f-c039-4aee-b1b6-a0f743364612",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "1bac9a3f-4bc8-4a4d-8dfd-53c542b1d1d8",
+    "set_uuid": "bc640c2f-c039-4aee-b1b6-a0f743364612",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "a306b28e-f698-427d-a576-439b2ab378fc",
+    "set_uuid": "bc640c2f-c039-4aee-b1b6-a0f743364612",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1100",
+    "uuid": "2d2a2756-332e-4d78-9385-e50fd8b5edcf",
+    "set_uuid": "f76a1c6d-3b8b-4bf5-940e-bd39ad6ef789",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1000",
+    "uuid": "b775d1a5-2951-4d51-9a48-265f46e8edc3",
+    "set_uuid": "f76a1c6d-3b8b-4bf5-940e-bd39ad6ef789",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1100",
+    "uuid": "c32c7711-0889-4f62-afe6-4b744166a66e",
+    "set_uuid": "f76a1c6d-3b8b-4bf5-940e-bd39ad6ef789",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1000",
+    "uuid": "d5f07e5a-b59b-4613-9eab-eae3a74c67f2",
+    "set_uuid": "a63a3883-74a7-4bb0-96fc-2c716548e60d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "17dd2bcd-e66f-4c86-8335-47bd3828a2cf",
+    "set_uuid": "a63a3883-74a7-4bb0-96fc-2c716548e60d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-blue-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1000",
+    "uuid": "95cd46ba-7b1f-4ae4-86c1-1957c007a6a2",
+    "set_uuid": "a63a3883-74a7-4bb0-96fc-2c716548e60d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-200",
+    "uuid": "40166e04-505e-47ed-b039-0a3827895c36",
+    "set_uuid": "d74c00ca-a11f-4e2a-a3a4-71cd9d4d8ba6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-400",
+    "uuid": "8da7787f-2d39-4801-a5ea-1b3e69d505a6",
+    "set_uuid": "d74c00ca-a11f-4e2a-a3a4-71cd9d4d8ba6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-200",
+    "uuid": "2f1fba9a-25b3-4ac7-aaee-7d6da1292da8",
+    "set_uuid": "d74c00ca-a11f-4e2a-a3a4-71cd9d4d8ba6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-800",
+    "uuid": "59038eb6-5b6f-4fa7-8a5d-9bf78db26fa9",
+    "set_uuid": "3e70443e-6765-4ee2-a271-84fb4eba66a6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-700",
+    "uuid": "bd6c966d-0b33-4f68-9b84-9e7ae0082805",
+    "set_uuid": "3e70443e-6765-4ee2-a271-84fb4eba66a6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-800",
+    "uuid": "afdc8658-f6a4-4205-af17-553c04cca24d",
+    "set_uuid": "3e70443e-6765-4ee2-a271-84fb4eba66a6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-1000",
+    "uuid": "16f958d5-8128-4774-b3ec-3ba5dd41f4fa",
+    "set_uuid": "9a01c0c0-e702-4081-ae56-2adbd00bbcf7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-900",
+    "uuid": "ac16c318-bf3a-49f7-a696-a7aaf8eb4335",
+    "set_uuid": "9a01c0c0-e702-4081-ae56-2adbd00bbcf7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-1000",
+    "uuid": "b2474c42-cecc-4f91-b3e9-a0855a79d5ed",
+    "set_uuid": "9a01c0c0-e702-4081-ae56-2adbd00bbcf7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-900",
+    "uuid": "5821a2cf-320d-4947-8289-2537eeef3154",
+    "set_uuid": "aa1651a3-d002-42d0-8d22-8400c02ad368",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-800",
+    "uuid": "00757309-91b4-4a6a-9897-32db62d9e94b",
+    "set_uuid": "aa1651a3-d002-42d0-8d22-8400c02ad368",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-brown-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "brown-900",
+    "uuid": "bffb9e2b-565a-4774-8f57-ef03768b4176",
+    "set_uuid": "aa1651a3-d002-42d0-8d22-8400c02ad368",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-100",
+    "uuid": "a5bfd666-a843-4b14-9b7e-1f392a34c4ba",
+    "set_uuid": "4a588efb-726f-4122-8991-200fdeed9455",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-400",
+    "uuid": "88437eca-ac07-4a83-930a-10861a8ed839",
+    "set_uuid": "4a588efb-726f-4122-8991-200fdeed9455",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-100",
+    "uuid": "2b519299-a5c9-47d9-bf52-51ce26410073",
+    "set_uuid": "4a588efb-726f-4122-8991-200fdeed9455",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-700",
+    "uuid": "347e56ff-3c87-49ca-b5c3-b359f33a0203",
+    "set_uuid": "8d25cc1e-0ce5-42f7-81ad-0f4f968f3d4d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-900",
+    "uuid": "c7a01756-b63e-4f18-b700-26b3f183e2c8",
+    "set_uuid": "8d25cc1e-0ce5-42f7-81ad-0f4f968f3d4d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-700",
+    "uuid": "c3f8622e-4ee4-4a68-be5d-c7b9f583c686",
+    "set_uuid": "8d25cc1e-0ce5-42f7-81ad-0f4f968f3d4d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-900",
+    "uuid": "4d42768e-6c50-4b41-bfa9-f626119d92b0",
+    "set_uuid": "d5688ac1-3726-4b14-8879-01aef1831def",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-1100",
+    "uuid": "a16feeab-27da-4d04-af0b-2a45cc14982c",
+    "set_uuid": "d5688ac1-3726-4b14-8879-01aef1831def",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-900",
+    "uuid": "f9fa057e-58f4-472f-8ab7-6bae7d1d27eb",
+    "set_uuid": "d5688ac1-3726-4b14-8879-01aef1831def",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-800",
+    "uuid": "00213ade-1251-4e7f-9020-08d3f46bb3a6",
+    "set_uuid": "e24e9976-ef3d-4356-8b9c-68fdf3e38d4e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-1000",
+    "uuid": "44a0a5c5-7131-42c4-859d-fa9541dff287",
+    "set_uuid": "e24e9976-ef3d-4356-8b9c-68fdf3e38d4e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-celery-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "celery-800",
+    "uuid": "a32205e0-b208-4539-9fe4-5eb2d7464d91",
+    "set_uuid": "e24e9976-ef3d-4356-8b9c-68fdf3e38d4e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-200",
+    "uuid": "0b1869d0-6aca-4e20-904f-954153bb4b73",
+    "set_uuid": "3ab68956-d853-4296-8db8-b37fa6ec76d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-400",
+    "uuid": "cad79edb-8add-4b83-ad3e-fcbed050e037",
+    "set_uuid": "3ab68956-d853-4296-8db8-b37fa6ec76d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-200",
+    "uuid": "ec1c5d08-dd5e-40f5-adee-06ffecb36ed6",
+    "set_uuid": "3ab68956-d853-4296-8db8-b37fa6ec76d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-600",
+    "uuid": "ded3802a-2b38-405d-a437-193bf1e061a0",
+    "set_uuid": "622815df-4c22-4cf3-8263-177c21df6c24",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-1000",
+    "uuid": "a407df08-a00b-421a-b999-d37097debc26",
+    "set_uuid": "622815df-4c22-4cf3-8263-177c21df6c24",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-600",
+    "uuid": "6bfd7aea-dfd9-47ee-9f18-e4431886e1cf",
+    "set_uuid": "622815df-4c22-4cf3-8263-177c21df6c24",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-800",
+    "uuid": "dc16f7b1-8b33-42d8-a292-f6efbd3d9f43",
+    "set_uuid": "2ac6e8b0-030d-4c4c-b8dc-1daa101789f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-1200",
+    "uuid": "a8dcf645-ae32-4870-90bf-4d802837cf08",
+    "set_uuid": "2ac6e8b0-030d-4c4c-b8dc-1daa101789f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-800",
+    "uuid": "d00300aa-5990-483d-8218-229169e9cd74",
+    "set_uuid": "2ac6e8b0-030d-4c4c-b8dc-1daa101789f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-700",
+    "uuid": "b263dc42-bcc1-4073-a230-81707fe7f388",
+    "set_uuid": "3b0fc446-0362-4856-a4ca-633262498b29",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-1100",
+    "uuid": "a63751a9-4d3d-4dfb-9028-3aaecf11df47",
+    "set_uuid": "3b0fc446-0362-4856-a4ca-633262498b29",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-chartreuse-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "chartreuse-700",
+    "uuid": "6d3438e5-cc32-4c26-960d-434b24dbb1e0",
+    "set_uuid": "3b0fc446-0362-4856-a4ca-633262498b29",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cinnamon-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-200",
+    "uuid": "a522f597-1ed4-445c-94c4-a594bc50f9ce",
+    "set_uuid": "174d3eef-4447-4e96-93a8-c125b455e1dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cinnamon-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-300",
+    "uuid": "cb5eed01-b2f0-4410-8a71-2bf361d61fcc",
+    "set_uuid": "174d3eef-4447-4e96-93a8-c125b455e1dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cinnamon-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-200",
+    "uuid": "61eaba25-d605-412f-ae11-5f36fd0061c8",
+    "set_uuid": "174d3eef-4447-4e96-93a8-c125b455e1dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cinnamon-primary",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-800",
+    "uuid": "fcf4219b-fa42-4693-ba34-fc5f46bfcde8"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cinnamon-primary",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-1000",
+    "uuid": "6cb36abc-7d86-4df0-a96d-36a4308a8ebd"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cinnamon-primary",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cinnamon-900",
+    "uuid": "a91d68ae-30ac-496b-9558-39272e9926c4"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cyan-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-100",
+    "uuid": "ac6d3cc6-dab7-400c-82d4-bd0876d241b2",
+    "set_uuid": "4a867e32-dac2-404e-a80f-2e5595685056",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cyan-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-400",
+    "uuid": "a5fd0ad9-999f-469d-b224-b60e06313cdb",
+    "set_uuid": "4a867e32-dac2-404e-a80f-2e5595685056",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cyan-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-100",
+    "uuid": "b85aef89-a234-4386-9c46-22e2caa3b4f6",
+    "set_uuid": "4a867e32-dac2-404e-a80f-2e5595685056",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cyan-primary",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-800",
+    "uuid": "2855caf0-9b6d-4d45-bdb8-30aab37a237c"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cyan-primary",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-1000",
+    "uuid": "c6ae865c-1938-4eec-b89c-7f793dc3f049"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-cyan-primary",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cyan-900",
+    "uuid": "2f68ac4a-be55-4fc7-b96e-987bdb5956ca"
+  },
+  {
+    "name": {
+      "property": "icon-color-disabled-primary",
+      "component": "icon"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-400",
+    "uuid": "12c9d145-7357-449e-a99a-1154dd5be026"
+  },
+  {
+    "name": {
+      "property": "icon-color-emphasized-background",
+      "component": "icon"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "fa5b0690-6ecd-4a3e-8675-ab6445df8946"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-background"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-200",
+    "uuid": "707601ab-a624-4466-9ce3-b52552b777a2"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-900",
+    "uuid": "0aedb32f-f3d7-4fa9-82d2-aee9ca727cfe",
+    "set_uuid": "299e2985-3d4e-4ced-97d9-7a81bf4ac644",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-700",
+    "uuid": "ec2b1658-d174-49c9-a36a-7f80d97a1ee8",
+    "set_uuid": "299e2985-3d4e-4ced-97d9-7a81bf4ac644",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-900",
+    "uuid": "75b0d002-84b7-4c75-8c74-3b1ff15ff10a",
+    "set_uuid": "299e2985-3d4e-4ced-97d9-7a81bf4ac644",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-1100",
+    "uuid": "0610e1fa-387f-4018-bbb2-bda7b30c74a3",
+    "set_uuid": "f5992aa9-60d7-4e8f-8d53-31d2040e10c7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-900",
+    "uuid": "6964ef24-8178-4513-8d9a-5240973622fb",
+    "set_uuid": "f5992aa9-60d7-4e8f-8d53-31d2040e10c7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-1100",
+    "uuid": "625728db-30ec-41d7-9f6f-0ce9c0201c66",
+    "set_uuid": "f5992aa9-60d7-4e8f-8d53-31d2040e10c7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-1000",
+    "uuid": "fd2f3488-d5bb-4f36-8799-a0168ae8ca5c",
+    "set_uuid": "8a42d5e3-9a1d-4f97-af00-72e6cb127d84",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-800",
+    "uuid": "0a66c0d9-0a0a-4f0d-9bb3-cbdb2bc12842",
+    "set_uuid": "8a42d5e3-9a1d-4f97-af00-72e6cb127d84",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-fuchsia-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "fuchsia-1000",
+    "uuid": "53acea92-bc9f-4c41-93b9-e18cde613305",
+    "set_uuid": "8a42d5e3-9a1d-4f97-af00-72e6cb127d84",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-green-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-100",
+    "uuid": "7941dc68-44bb-49d5-80ca-3c6952d2acb2",
+    "set_uuid": "834b138e-265e-4313-acda-ea005b1836c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-green-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-400",
+    "uuid": "176c986b-8658-4b3e-b559-4080f4fd7834",
+    "set_uuid": "834b138e-265e-4313-acda-ea005b1836c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-green-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-100",
+    "uuid": "3231780c-e233-4a60-b063-1c3a383669a3",
+    "set_uuid": "834b138e-265e-4313-acda-ea005b1836c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-green-primary",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-800",
+    "uuid": "a0717159-cc62-4ba1-b1f1-a69dfb88c6ee"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-green-primary",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1000",
+    "uuid": "c0acc956-e9de-469b-8919-aa0d8b762bb3"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-green-primary",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-900",
+    "uuid": "9a667090-665d-47b2-b000-5a9f4fe26fcf"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-200",
+    "uuid": "1c49aee1-a8a2-41ae-b709-7e2d1fbc2705",
+    "set_uuid": "81f2bf23-d0a9-4c59-b250-706a7aed4158",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-100",
+    "uuid": "85432c93-7c00-435b-8298-2ba817cb58bd",
+    "set_uuid": "81f2bf23-d0a9-4c59-b250-706a7aed4158",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-200",
+    "uuid": "67cfb253-49f0-4a14-a83c-140324ef5bc0",
+    "set_uuid": "81f2bf23-d0a9-4c59-b250-706a7aed4158",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-900",
+    "uuid": "b6c15610-dc9a-4b7c-9391-247a0f4b56ff",
+    "set_uuid": "e1c92878-e06a-4692-b1f3-d0130be745a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-700",
+    "uuid": "2e4457c1-e637-4f22-909d-643dd535b5fd",
+    "set_uuid": "e1c92878-e06a-4692-b1f3-d0130be745a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-900",
+    "uuid": "05f75802-5062-422a-8a39-f7e8f71ce17e",
+    "set_uuid": "e1c92878-e06a-4692-b1f3-d0130be745a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-1100",
+    "uuid": "ff60b02b-f205-48be-80c0-a362f7b72e27",
+    "set_uuid": "0cfba473-9739-40cf-84a2-6fa2e9a82a31",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-900",
+    "uuid": "f21187bf-8dbe-4eee-9ce9-c76d08517a6c",
+    "set_uuid": "0cfba473-9739-40cf-84a2-6fa2e9a82a31",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-1100",
+    "uuid": "1f2e8832-16e1-4030-a5ef-16f5b5c663d0",
+    "set_uuid": "0cfba473-9739-40cf-84a2-6fa2e9a82a31",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-1000",
+    "uuid": "d6a54fc4-c4d9-403a-ba71-f525d36586ec",
+    "set_uuid": "3baf7277-0033-4db2-b125-99be7010048b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-800",
+    "uuid": "fc9ef846-e264-498c-9b7a-be9a9164f3d3",
+    "set_uuid": "3baf7277-0033-4db2-b125-99be7010048b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-indigo-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "indigo-1000",
+    "uuid": "735472d9-0220-4e7e-a06b-9f3504cad201",
+    "set_uuid": "3baf7277-0033-4db2-b125-99be7010048b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-inverse"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-50",
+    "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-inverse-background"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-50",
+    "uuid": "ba10ab97-0c09-4d07-ab7b-050258169d52"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-background"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-200",
+    "uuid": "2cf7dea9-034c-48a8-8946-d059320ced08"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-900",
+    "uuid": "3fb3630d-e7a3-4807-93c1-c5da4a8f642b",
+    "set_uuid": "df96212d-b4bf-4fbc-8599-a5a6096f510d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-700",
+    "uuid": "7b3f5848-6a8c-47fe-aacd-ad2f1af53306",
+    "set_uuid": "df96212d-b4bf-4fbc-8599-a5a6096f510d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-900",
+    "uuid": "d0802b2a-faba-4530-8f50-dc22e6962d44",
+    "set_uuid": "df96212d-b4bf-4fbc-8599-a5a6096f510d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-1100",
+    "uuid": "31aa02cb-2f5f-4803-bf5d-4e97816472be",
+    "set_uuid": "070dba44-39f3-41f0-9b8a-082cc593ebbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-900",
+    "uuid": "042aa474-5cf0-4cdc-a75d-19eac80a0ade",
+    "set_uuid": "070dba44-39f3-41f0-9b8a-082cc593ebbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-1100",
+    "uuid": "ddfb3e51-e724-48b4-aecc-dcfe000eec11",
+    "set_uuid": "070dba44-39f3-41f0-9b8a-082cc593ebbe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-1000",
+    "uuid": "b81fb79d-69dc-4bde-b3d6-661a7719a6e8",
+    "set_uuid": "8f1e3cb4-fcfb-415c-a353-67f3abaf0db9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-800",
+    "uuid": "23dc0d7b-fb23-460a-b9f1-7a9a7496c107",
+    "set_uuid": "8f1e3cb4-fcfb-415c-a353-67f3abaf0db9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-magenta-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "magenta-1000",
+    "uuid": "3e368eed-b2f7-4e9e-9935-421ef0f86f9f",
+    "set_uuid": "8f1e3cb4-fcfb-415c-a353-67f3abaf0db9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-200",
+    "uuid": "3ceff0a2-fca9-4d73-82a8-f5098c511e17",
+    "set_uuid": "90a3c087-153b-4aaf-ad6c-77300d42fde5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-300",
+    "uuid": "73e28358-35bb-4643-a1b8-ae3fd3de206f",
+    "set_uuid": "90a3c087-153b-4aaf-ad6c-77300d42fde5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-200",
+    "uuid": "a6f69b6d-496f-40bb-96a5-f04efa4ce8bc",
+    "set_uuid": "90a3c087-153b-4aaf-ad6c-77300d42fde5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-700",
+    "uuid": "d035f399-5154-4f0e-b5aa-434644e19f4b",
+    "set_uuid": "a7e402be-9ca8-491c-8a37-0d10c36ae45d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-900",
+    "uuid": "1ea9d171-f3ba-40fd-bd0b-1e0ebaf68f01",
+    "set_uuid": "a7e402be-9ca8-491c-8a37-0d10c36ae45d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-700",
+    "uuid": "41b694b3-5805-4ee7-aca0-88527dc6120b",
+    "set_uuid": "a7e402be-9ca8-491c-8a37-0d10c36ae45d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-900",
+    "uuid": "cb36fbb9-e88f-4965-a67d-8a12f10fb445",
+    "set_uuid": "3c418011-0596-4f28-ae20-26ade2e73e95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1100",
+    "uuid": "4534a7d3-b2b0-4e94-8366-030ac144031c",
+    "set_uuid": "3c418011-0596-4f28-ae20-26ade2e73e95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-900",
+    "uuid": "b00737a5-c111-42fe-9378-47a79139e11a",
+    "set_uuid": "3c418011-0596-4f28-ae20-26ade2e73e95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-800",
+    "uuid": "726e95d7-f687-4e9c-b050-2e54cc1b0b77",
+    "set_uuid": "37aee2f6-f672-421f-b92b-b489adb4f3b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1000",
+    "uuid": "d35dd0cd-49b0-4430-9fe6-9dcf0e9e5874",
+    "set_uuid": "37aee2f6-f672-421f-b92b-b489adb4f3b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-orange-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-800",
+    "uuid": "1c3bc51c-edf8-4c2b-af93-44d7ffeb46b2",
+    "set_uuid": "37aee2f6-f672-421f-b92b-b489adb4f3b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-background"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-200",
+    "uuid": "46d11573-718e-4e38-8493-f3a37a5e7d32"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-800",
+    "uuid": "abd32483-3555-4d1e-831b-9799db14d39c",
+    "set_uuid": "7ad2203f-7595-4c14-b634-2bd5afac55f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-700",
+    "uuid": "4a4d6a11-1343-40c7-b7d3-d25d6f1d4ed3",
+    "set_uuid": "7ad2203f-7595-4c14-b634-2bd5afac55f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-800",
+    "uuid": "1e0b6862-10cd-4860-9bf7-9cbce71e7f81",
+    "set_uuid": "7ad2203f-7595-4c14-b634-2bd5afac55f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-1000",
+    "uuid": "f3b7c0ba-eb0f-46af-bf89-9e1f46afa937",
+    "set_uuid": "7044ccda-e69a-4fac-b726-351773fa58f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-900",
+    "uuid": "b4ead77c-aec3-4dc5-85c4-ab0e62231232",
+    "set_uuid": "7044ccda-e69a-4fac-b726-351773fa58f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-1000",
+    "uuid": "c31819e9-6bf1-4048-94bc-ee6f04b82474",
+    "set_uuid": "7044ccda-e69a-4fac-b726-351773fa58f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-900",
+    "uuid": "c516dfa3-8921-47d6-99fe-976e3d93adef",
+    "set_uuid": "daa99344-9af2-4084-a361-6b8aaa85d2f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-800",
+    "uuid": "88bf5d43-7655-43e6-8844-a94f4696bde0",
+    "set_uuid": "daa99344-9af2-4084-a361-6b8aaa85d2f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-pink-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "pink-900",
+    "uuid": "8a64d036-a935-442a-b596-5d4d0fd001a9",
+    "set_uuid": "daa99344-9af2-4084-a361-6b8aaa85d2f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-primary",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-content-color-default",
+    "uuid": "d143f2f2-e0d8-4eb3-b06c-86233321fb61"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-primary",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-content-color-down",
+    "uuid": "83223069-7a05-4b61-b1ec-2af8e712e0a2"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-primary",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-content-color-hover",
+    "uuid": "2a3d8ce3-6294-41b2-ad19-c6b9b6ed7e10"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-background"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-200",
+    "uuid": "5a9cdf9a-09a5-42bc-a0bf-6f187c6832c5"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-900",
+    "uuid": "7543b9c6-aea2-4dc9-ad2d-204d6f1d2185",
+    "set_uuid": "eb6fd090-430f-463d-9371-1c560fb3c2d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-700",
+    "uuid": "50b28c39-4b4e-43dc-b742-e85a892e843a",
+    "set_uuid": "eb6fd090-430f-463d-9371-1c560fb3c2d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-900",
+    "uuid": "1b6ce540-0839-4ba2-bf98-51fb499113a4",
+    "set_uuid": "eb6fd090-430f-463d-9371-1c560fb3c2d5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-1100",
+    "uuid": "fbec43d7-90e6-424d-8f77-5a39ef739d7a",
+    "set_uuid": "1d630c63-d443-4207-8da9-8a4fa27ebc2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-900",
+    "uuid": "0ff09a0f-33db-40ee-9b36-ed7db52aafbd",
+    "set_uuid": "1d630c63-d443-4207-8da9-8a4fa27ebc2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-1100",
+    "uuid": "bf3e3302-4798-4b35-a37b-0d5fcd89b556",
+    "set_uuid": "1d630c63-d443-4207-8da9-8a4fa27ebc2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-1000",
+    "uuid": "740f2726-16e3-4011-8d2c-aaf504be8f14",
+    "set_uuid": "5bb2c6bb-a798-4560-ae51-e229630dbcc1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-800",
+    "uuid": "2e9e7c94-5454-41d9-95e3-8e1e91c41f14",
+    "set_uuid": "5bb2c6bb-a798-4560-ae51-e229630dbcc1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-purple-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "purple-1000",
+    "uuid": "ec923982-6694-44bc-8f75-ebe1c76ba09a",
+    "set_uuid": "5bb2c6bb-a798-4560-ae51-e229630dbcc1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-200",
+    "uuid": "c6872759-ff54-48ef-8513-d752ec12f8ca",
+    "set_uuid": "2406da90-f230-4e70-8acc-22ed8078721d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-300",
+    "uuid": "1fbda732-e276-4dec-8ec7-faeff6cba3a7",
+    "set_uuid": "2406da90-f230-4e70-8acc-22ed8078721d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-200",
+    "uuid": "12859f90-c49c-4508-bc0d-df4d9512c864",
+    "set_uuid": "2406da90-f230-4e70-8acc-22ed8078721d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-900",
+    "uuid": "89656cae-d490-4b9f-93eb-75912b29ecf5",
+    "set_uuid": "f7a6c17f-70c1-401d-99a6-400a720c173b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-700",
+    "uuid": "a60f2744-ad15-4cf7-b9dc-89ca307ed444",
+    "set_uuid": "f7a6c17f-70c1-401d-99a6-400a720c173b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-900",
+    "uuid": "16bbb033-224a-43e6-881c-bd29ffd70d1b",
+    "set_uuid": "f7a6c17f-70c1-401d-99a6-400a720c173b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1100",
+    "uuid": "e92b61d2-7c99-44ba-bc4b-94bf9cff3623",
+    "set_uuid": "2633f970-1550-4389-aa5e-e26bef70a222",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-900",
+    "uuid": "d44cbe6f-b3e1-4048-b26c-c98e9be970f5",
+    "set_uuid": "2633f970-1550-4389-aa5e-e26bef70a222",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1100",
+    "uuid": "02527b17-485a-4a59-b62e-5aa8bfca7df7",
+    "set_uuid": "2633f970-1550-4389-aa5e-e26bef70a222",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1000",
+    "uuid": "5015c992-9d52-4e30-a4cc-e605a0c99545",
+    "set_uuid": "8f3bfc49-c036-4196-9014-2ecee9db1c3f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-800",
+    "uuid": "362d9053-52d9-478a-aec9-b56fd805826a",
+    "set_uuid": "8f3bfc49-c036-4196-9014-2ecee9db1c3f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-red-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1000",
+    "uuid": "ece07052-dff3-483e-a6b8-1d12b0d94d8a",
+    "set_uuid": "8f3bfc49-c036-4196-9014-2ecee9db1c3f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-seafoam-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-200",
+    "uuid": "975fa979-d134-4d4b-8a27-e50307925ec4",
+    "set_uuid": "18971672-bcfa-4a48-afa3-197a50d3ac33",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-seafoam-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-400",
+    "uuid": "39ff1a28-8c57-490f-8cf7-eb63fd3b7ebb",
+    "set_uuid": "18971672-bcfa-4a48-afa3-197a50d3ac33",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-seafoam-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-200",
+    "uuid": "bc3ce9f1-cde9-4609-b4ab-c78a15ac064c",
+    "set_uuid": "18971672-bcfa-4a48-afa3-197a50d3ac33",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-seafoam-primary",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-800",
+    "uuid": "aca36c2e-6dda-4b5e-a6e1-8db1bbb9e448"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-seafoam-primary",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-1000",
+    "uuid": "3d4610d5-0870-4af3-8878-483218d43f92"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-seafoam-primary",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "seafoam-900",
+    "uuid": "cdc09dab-b4cc-4034-843b-98afcc36caf0"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-200",
+    "uuid": "98f6376e-01b0-4646-afe1-b52c33700db9",
+    "set_uuid": "cdd3116b-9441-40be-bb20-368aec509ffd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-400",
+    "uuid": "a2c48afa-59de-43af-8ec4-2c573948ae52",
+    "set_uuid": "cdd3116b-9441-40be-bb20-368aec509ffd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-200",
+    "uuid": "b2e8e8ac-001a-4a4e-bcc9-9508ba954ece",
+    "set_uuid": "cdd3116b-9441-40be-bb20-368aec509ffd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-700",
+    "uuid": "be16b346-ec55-4aa1-9767-0cb139dd361c",
+    "set_uuid": "696a03e3-12c5-4af8-acaf-90246dd7b3df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-800",
+    "uuid": "839005ad-8e22-4e1b-a83b-1fe5be08acb2",
+    "set_uuid": "696a03e3-12c5-4af8-acaf-90246dd7b3df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-700",
+    "uuid": "928c1a80-e248-4e00-aed8-5ddf764a5d22",
+    "set_uuid": "696a03e3-12c5-4af8-acaf-90246dd7b3df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-900",
+    "uuid": "b44c8584-eec0-4cc4-b3d3-62df9b1877d9",
+    "set_uuid": "07de191f-8b9c-40a0-ac40-434a2865702b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-1000",
+    "uuid": "44ddf65f-494c-4329-b17e-c791c7cfe779",
+    "set_uuid": "07de191f-8b9c-40a0-ac40-434a2865702b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-900",
+    "uuid": "dc071b6f-788a-4a83-b1c0-17ae536c01e7",
+    "set_uuid": "07de191f-8b9c-40a0-ac40-434a2865702b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-800",
+    "uuid": "74b17dd6-9b4b-43a9-9c7f-4c8edc72afc9",
+    "set_uuid": "fdaf49d9-5470-44b4-9c5a-0470ff539079",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-900",
+    "uuid": "a6b610b6-915d-4c40-85ee-9b9fee0b5bd3",
+    "set_uuid": "fdaf49d9-5470-44b4-9c5a-0470ff539079",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-silver-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "silver-800",
+    "uuid": "cd0a41af-19ed-48fc-b659-d34cb37d4cef",
+    "set_uuid": "fdaf49d9-5470-44b4-9c5a-0470ff539079",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-200",
+    "uuid": "a6478f6c-3a60-42e3-98f7-5cabf91e09af",
+    "set_uuid": "b7c72978-d28b-4aca-97d6-7897d2dae50e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-400",
+    "uuid": "3d251526-b63d-412c-bb54-712d36c73e8e",
+    "set_uuid": "b7c72978-d28b-4aca-97d6-7897d2dae50e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-200",
+    "uuid": "a5b3d3f5-785b-4969-9389-12c1f7b2f26d",
+    "set_uuid": "b7c72978-d28b-4aca-97d6-7897d2dae50e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-700",
+    "uuid": "9a65bd1c-3ddf-4294-83f4-04967372c3f5",
+    "set_uuid": "eb0405dc-c3c4-42e4-9b05-892a1959a332",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-800",
+    "uuid": "9566904a-3610-4668-9fe4-71ece5a58398",
+    "set_uuid": "eb0405dc-c3c4-42e4-9b05-892a1959a332",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-700",
+    "uuid": "3c39dea2-cdc4-4042-a134-7197a60ba8dd",
+    "set_uuid": "eb0405dc-c3c4-42e4-9b05-892a1959a332",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-900",
+    "uuid": "c87c8466-22c1-40cb-9e5e-d661cd6cdcae",
+    "set_uuid": "1911e604-88a5-4a64-a85c-fbfbabff604f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-1000",
+    "uuid": "1bbe2749-ba61-4e00-871f-cb3c6decd07c",
+    "set_uuid": "1911e604-88a5-4a64-a85c-fbfbabff604f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-900",
+    "uuid": "0c3db762-fa21-497c-9a32-007e41ab24d6",
+    "set_uuid": "1911e604-88a5-4a64-a85c-fbfbabff604f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-800",
+    "uuid": "260edfe7-6958-4d5b-8489-9ab3ab681577",
+    "set_uuid": "aeb90a17-af9e-4bd4-ba02-5147c78465c6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-900",
+    "uuid": "a727a9f5-8f36-4e50-b8a4-3383f309785f",
+    "set_uuid": "aeb90a17-af9e-4bd4-ba02-5147c78465c6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-turquoise-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "turquoise-800",
+    "uuid": "2aca1631-0249-47dc-aa3b-44a51f5ea220",
+    "set_uuid": "aeb90a17-af9e-4bd4-ba02-5147c78465c6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-background",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-100",
+    "uuid": "3cf7a8f4-9238-4f9f-9c85-97dc38de69d1",
+    "set_uuid": "ca1cbd2f-3434-471c-8897-d70f8950795f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-background",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-400",
+    "uuid": "0dd236ab-7af8-418e-88dd-0cb45cf5da13",
+    "set_uuid": "ca1cbd2f-3434-471c-8897-d70f8950795f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-background",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-100",
+    "uuid": "5a5e15ab-e73b-4997-be67-39534d98e823",
+    "set_uuid": "ca1cbd2f-3434-471c-8897-d70f8950795f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-400",
+    "uuid": "59cd6057-b3d8-4bdf-b752-7df17c2c4a95",
+    "set_uuid": "8b1b13d9-4645-4512-a671-e51bd8250978",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-1200",
+    "uuid": "5ebf8291-23f8-4806-865d-4ebab38ff03c",
+    "set_uuid": "8b1b13d9-4645-4512-a671-e51bd8250978",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-400",
+    "uuid": "fc16cbe3-7cf3-4744-a571-5bd2bdcef29e",
+    "set_uuid": "8b1b13d9-4645-4512-a671-e51bd8250978",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "down",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-600",
+    "uuid": "94b9cfb2-1934-4ee5-88c8-0bf75c226dd3",
+    "set_uuid": "8d9c55fd-9bfd-4ae6-b178-95fd648b02a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "down",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-1400",
+    "uuid": "f92ad869-5610-46a4-8314-bee58a039d0d",
+    "set_uuid": "8d9c55fd-9bfd-4ae6-b178-95fd648b02a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "down",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-600",
+    "uuid": "24f49675-e169-4996-9993-c4a8941e8fab",
+    "set_uuid": "8d9c55fd-9bfd-4ae6-b178-95fd648b02a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "hover",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-500",
+    "uuid": "7d52f667-63c9-4ab9-b92c-10f7f6412632",
+    "set_uuid": "5aa44700-fee8-46bc-9ef5-3c751f661479",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "hover",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-1300",
+    "uuid": "4f50d025-f259-4130-bb6c-6fc30474e99d",
+    "set_uuid": "5aa44700-fee8-46bc-9ef5-3c751f661479",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "component": "icon",
+      "property": "color-yellow-primary",
+      "state": "hover",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "yellow-500",
+    "uuid": "f4edf76c-b3f4-4455-b1d5-e222fa79b146",
+    "set_uuid": "5aa44700-fee8-46bc-9ef5-3c751f661479",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  }
+]

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -1,0 +1,20162 @@
+[
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "7a576841-a2a5-4443-9d31-03a12c7a2efd",
+    "set_uuid": "92fef7e7-45bc-4dcd-91c2-c42e696263a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "70e6d9e7-2a8e-4f0d-96d6-aac7cde829bd",
+    "set_uuid": "92fef7e7-45bc-4dcd-91c2-c42e696263a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "40f76138-1a69-45ed-8df5-db8bc9792383",
+    "set_uuid": "21208d7c-2fd2-48d2-afd6-0b50e9f5ea38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "b4f92e98-694f-46cc-91be-8e0e2d5a17a4",
+    "set_uuid": "21208d7c-2fd2-48d2-afd6-0b50e9f5ea38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "c73f4637-7a33-4598-9498-8eb4a9e9e863",
+    "set_uuid": "4e3a7c0a-d52a-43a8-b05f-6c98b7bb4859",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "97b9278a-11d0-4470-99c3-e2d47ca5a714",
+    "set_uuid": "4e3a7c0a-d52a-43a8-b05f-6c98b7bb4859",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "524cb169-a9c1-4d3c-864e-dba03df6eac9",
+    "set_uuid": "c9702adb-1f13-477c-b13c-79c4d8709856",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-compact-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "af95123b-2ab5-49bb-a070-1ca48b498f58",
+    "set_uuid": "c9702adb-1f13-477c-b13c-79c4d8709856",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "47f2bc45-5fa5-439a-a705-ef965c6ea010",
+    "set_uuid": "3f045028-2598-426a-91bd-443549a4c5f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "5ce86cfe-434b-42ab-b334-c574bae01e6f",
+    "set_uuid": "3f045028-2598-426a-91bd-443549a4c5f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "7ec7fa3a-5ab0-41e8-816a-bdd63b7d9d82",
+    "set_uuid": "036e6eac-cf81-4563-b4ea-f9610de674a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "7db5a087-c361-4080-be50-8e4864436108",
+    "set_uuid": "036e6eac-cf81-4563-b4ea-f9610de674a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "c0f14d75-a7a7-4325-b891-76d055e6371f",
+    "set_uuid": "071af591-5387-4a04-b00a-3451bb1f102d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "abbcad5f-be29-4ca4-b48f-6b0eab7f9942",
+    "set_uuid": "071af591-5387-4a04-b00a-3451bb1f102d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-regular-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-bottom-to-text-extra-large",
+    "uuid": "8c199212-a745-414c-8f6b-22d2445ade3c",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-regular-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-bottom-to-text-large",
+    "uuid": "f484838e-1f0c-4125-9298-beb4ddc0fd53",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-regular-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-bottom-to-text-medium",
+    "uuid": "2d6fa243-5f7e-41a8-840b-27a6432f54bc",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-regular-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-bottom-to-text-small",
+    "uuid": "d64620dc-dd4a-447a-8491-d9e144ec8828",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "ee8445cc-82a2-489f-9ff9-ec5d38a8dfd5",
+    "set_uuid": "13a9d984-2e46-4319-a466-d59fce44fef3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "b69abbba-a98c-40f2-8a9a-972710b73149",
+    "set_uuid": "13a9d984-2e46-4319-a466-d59fce44fef3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "3ca8a65d-5561-4d8e-a4f2-0b653b42991b",
+    "set_uuid": "9f4b3199-56cf-4d3f-9185-969001da490c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "ba11dc6e-fbd8-46bc-94fd-b4d02f654d2d",
+    "set_uuid": "9f4b3199-56cf-4d3f-9185-969001da490c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "96acbf76-082b-487c-8c47-f0fa173f54d2",
+    "set_uuid": "1fc7990f-7ae1-4047-9d0d-e4170d41c631",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "2a6fa386-4eba-44d5-b129-c832264fafd9",
+    "set_uuid": "1fc7990f-7ae1-4047-9d0d-e4170d41c631",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "8a3eadad-8b88-4885-b4ca-07360b45d3ba",
+    "set_uuid": "6092119d-924e-4774-a79c-21886bce0b78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "05d8a39d-a0d5-496c-810a-f1244c31b169",
+    "set_uuid": "6092119d-924e-4774-a79c-21886bce0b78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "bdc61836-fdcf-4ca0-a277-dd9cb314563a",
+    "set_uuid": "ab6d93cd-177d-47b0-b521-f8e3e831b7b5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "bottom-to-text-spacious-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "56a65744-b195-4faf-ab5c-69a8424593f9",
+    "set_uuid": "ab6d93cd-177d-47b0-b521-f8e3e831b7b5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-bottom-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "87008eae-491c-4f7d-a13b-83eae517c92f",
+    "set_uuid": "85bd22b3-6be9-4b69-953a-7717b501ea0b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-bottom-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "48383ab9-1e66-47f9-988b-6f59b7349241",
+    "set_uuid": "85bd22b3-6be9-4b69-953a-7717b501ea0b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "c26ba15a-cb44-44b2-8423-baf52b1b42db",
+    "set_uuid": "ed09b2f0-da52-4317-8be2-89ce2508650e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "c9aaff95-a17a-408b-bb55-1c9026314c8b",
+    "set_uuid": "ed09b2f0-da52-4317-8be2-89ce2508650e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead. Major refactor necessary",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "755f796f-bcb6-466c-b4f2-b10b0f819bba",
+    "set_uuid": "2ed28849-15b1-4e23-9a81-e5a75be79bc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead. Major refactor necessary",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "f4d133f7-d444-4ddc-907f-9d75ff621a03",
+    "set_uuid": "2ed28849-15b1-4e23-9a81-e5a75be79bc9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead. Major refactor necessary",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "66fbf171-ff30-4376-9026-686ae3e2fc70",
+    "set_uuid": "67a7388d-91db-4c0d-a32c-0eda0c6705ba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "80419f6a-d93a-4cc0-883a-833e4717e28f",
+    "set_uuid": "67a7388d-91db-4c0d-a32c-0eda0c6705ba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "b7b23a23-abca-4e96-8c6f-d2b5b4c79d99",
+    "set_uuid": "5dd933e8-c1db-43d1-b3ac-67f7df4ce6fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-edge-to-content-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "782d9dfd-413f-4031-8431-be9b638c69b6",
+    "set_uuid": "5dd933e8-c1db-43d1-b3ac-67f7df4ce6fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Major refactor necessary",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-top-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "709082c2-71b9-423a-9c93-3b53a9e18da3",
+    "set_uuid": "3e16490f-8fca-4a5a-ad95-fb1882d367d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "content-area-top-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "9c651dee-7d77-414d-930b-7c6b78cfed1b",
+    "set_uuid": "3e16490f-8fca-4a5a-ad95-fb1882d367d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "27b481a4-0ea9-4e1c-a283-4a799d18d642",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "90fe1ad4-76a8-4b02-a036-af6d4397334e",
+    "set_uuid": "13517d70-4770-469b-8574-fab16c6ebfc5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead. These gap vales don't match with what's in the Figma component. Recommending design update anyhow",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "aafcb612-0828-48c7-af1c-39870aafd44a",
+    "set_uuid": "13517d70-4770-469b-8574-fab16c6ebfc5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead. These gap vales don't match with what's in the Figma component. Recommending design update anyhow",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "802cef85-0ad5-417b-953f-66a812e6637e",
+    "set_uuid": "43049c7d-3f40-41f1-ae4e-d08ab2d6d6ad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Major refactor necessary",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "fae0b204-0198-465a-aa98-c7b4224e4c48",
+    "set_uuid": "43049c7d-3f40-41f1-ae4e-d08ab2d6d6ad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Major refactor necessary",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "e28ca787-7457-4f40-9188-039347047c83",
+    "set_uuid": "63508f68-42cd-46f3-a4f9-88ce0914d2d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead. Major refactor necessary",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "f62edd6d-b833-4aea-8e03-ddd1dfccc464",
+    "set_uuid": "63508f68-42cd-46f3-a4f9-88ce0914d2d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead. Major refactor necessary",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "e6cb7eb7-afa3-441f-9f22-5ca8eec66749",
+    "set_uuid": "8c484a6a-0851-4f12-8a63-afc3a56d9b53",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead. Major refactor necessary",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "disclosure-indicator-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "f009b7a8-95ca-4b39-92c3-f7656cf2e429",
+    "set_uuid": "8c484a6a-0851-4f12-8a63-afc3a56d9b53",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead. Major refactor necessary",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "edge-to-content-area-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "75bc2d16-cf6b-48ef-a2e5-0516835af468",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead. Duplicate token use case. Major refactor necessary",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "edge-to-content-area-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "56633713-ae34-4a8a-8cfd-39508e4c4b0a",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead. Duplicate token use case. Major refactor necessary",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "edge-to-content-area-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "77894e1e-8b67-468d-a3d0-d9a7c87d1a52",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Duplicate token use case. Major refactor necessary",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "edge-to-content-area-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "b594a566-9649-497d-bf8f-289ec3f59689",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead. Duplicate token use case. Major refactor necessary",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "edge-to-disclosure-indicator"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "614e6448-c0a4-4ad1-b125-f362e3001a86",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "edge-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "a9641e89-2c2e-49c3-9662-f530ad23a688",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "accordion-focus-indicator-gap",
+      "component": "accordion"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "318c5cda-be1b-416b-b1b7-b962e5f45c0c",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead.",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "item-to-divider"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "9a2c9dee-7acf-4083-9c66-685454444f8c",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "47ae1059-6b16-4823-866d-11be0c0e0e8a",
+    "set_uuid": "14ac9b12-ce29-4714-baee-084e72e93edd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "250px",
+    "uuid": "ae8169fe-1672-4e95-87a5-344ec4d7f163",
+    "set_uuid": "14ac9b12-ce29-4714-baee-084e72e93edd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "small-top-to-text-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "229fa20e-6d13-40b0-b19f-5cf6386f81ac",
+    "set_uuid": "e96c75c2-f69a-49b5-8309-6490c5b0768c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead",
+    "replaced_by": "264faa19-9174-4d2c-8fb2-16dc0a693abd"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "small-top-to-text-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "bef73b91-db4f-4532-9f4d-f5a81ead625d",
+    "set_uuid": "e96c75c2-f69a-49b5-8309-6490c5b0768c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Introduced as an error. Use accordion-top-to-text-spacious-small instead",
+    "replaced_by": "264faa19-9174-4d2c-8fb2-16dc0a693abd"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "6e08e002-56bf-421e-b9f8-9d37b1e80e6e",
+    "set_uuid": "ac9fa12f-4864-47c2-bd03-bc057a9bedfa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "5ebd5aab-49b3-49d1-be25-8aff15217eda",
+    "set_uuid": "ac9fa12f-4864-47c2-bd03-bc057a9bedfa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "a73cc1b0-e31d-4d42-bb89-2e283fe9c59b",
+    "set_uuid": "b8bef4c7-090d-409d-91ce-398ebf3db5ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "c09ca9bf-1b8b-4ff3-93b7-e9296472dc76",
+    "set_uuid": "b8bef4c7-090d-409d-91ce-398ebf3db5ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "484c9603-07f1-4ba6-b1bf-7cfaec5d1594",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "d6cc404c-af92-43be-88e3-407fdcb6e068",
+    "set_uuid": "287c49e1-860a-4fd3-8024-0fecfbbbff26",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-compact-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "cfc8d280-5ea0-47f2-bdcb-ae5e93627498",
+    "set_uuid": "287c49e1-860a-4fd3-8024-0fecfbbbff26",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Major refactor necessary",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "1a8c45b2-caa4-47b9-b72a-782894168342",
+    "set_uuid": "346cdddd-d063-42bf-960a-c38e5cdcf862",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "d76aaca3-6e02-4f90-b254-debf8d10fc89",
+    "set_uuid": "346cdddd-d063-42bf-960a-c38e5cdcf862",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "b005554a-ac7f-45ff-86a1-d240d1270f40",
+    "set_uuid": "dd578daf-93a2-48f0-9df2-e67095cf5d7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "ebc6e896-6964-4337-b146-468e43d31db3",
+    "set_uuid": "dd578daf-93a2-48f0-9df2-e67095cf5d7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "728ad09d-0820-4c71-9974-57386f3d62d2",
+    "set_uuid": "9a60996d-f55e-47b5-a966-a10e297e4bd7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "2d7e81ba-1390-4607-8ee2-5d322d3e0bae",
+    "set_uuid": "9a60996d-f55e-47b5-a966-a10e297e4bd7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-regular-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-top-to-text-extra-large",
+    "uuid": "9289aae4-ddaa-4a43-8f00-973dea8350f2",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-regular-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-top-to-text-large",
+    "uuid": "2021d787-ddaa-470a-a25d-8a57f67b7359",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-regular-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-top-to-text-medium",
+    "uuid": "48db5aeb-6752-4267-89c7-48ed84692ec8",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-regular-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accordion-top-to-text-small",
+    "uuid": "4f6e49d2-9ab8-4548-aae4-eed45a4003b9",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "efd68835-b6de-479c-9c71-bccbe8e20c21",
+    "set_uuid": "bbaac303-b17e-48d5-8cad-9342c51d5c80",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "0dea279c-62ca-4670-a693-03eaa7ccecb5",
+    "set_uuid": "bbaac303-b17e-48d5-8cad-9342c51d5c80",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Major refactor necessary",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "5d8877e0-076c-4c9f-b2e9-cdde6942ea61",
+    "set_uuid": "1804d0c4-e643-4c87-8c36-4868405d08b4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "bd300d17-3599-4382-8a7d-1b78700d49e9",
+    "set_uuid": "1804d0c4-e643-4c87-8c36-4868405d08b4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-3x-large instead. Major refactor necessary",
+    "replaced_by": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "8e042372-2504-46f2-8486-4d6174293ea2",
+    "set_uuid": "b7fb12b8-5e6d-4d82-99e7-aa961b86c99b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "e90553f0-d71e-44c2-b70a-89110fab7c6a",
+    "set_uuid": "b7fb12b8-5e6d-4d82-99e7-aa961b86c99b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Major refactor necessary",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "19c91104-bdf4-4969-8d92-c9cd47d39d13",
+    "set_uuid": "93e90ef0-28d7-46c1-8e44-1077e64e8d0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "63602a66-5f96-4e6a-8bf0-2ac03321a577",
+    "set_uuid": "93e90ef0-28d7-46c1-8e44-1077e64e8d0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Major refactor necessary",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "696ab6c1-0c23-4868-8d6c-039d6d430d29",
+    "set_uuid": "264faa19-9174-4d2c-8fb2-16dc0a693abd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "accordion",
+      "property": "top-to-text-spacious-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "7bcbaaf1-f1d8-4755-acb2-5f6a45c3b9fe",
+    "set_uuid": "264faa19-9174-4d2c-8fb2-16dc0a693abd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Major refactor necessary",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "bottom-to-content-area"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "3116a00c-0ad3-4ae6-9fbb-f9b5624a2708",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "close-button-to-counter"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "text-to-control-50",
+    "uuid": "bc54e89f-6740-4004-891e-c515f8f79693",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token group-gap-extra-small instead.",
+    "replaced_by": "c3ada312-da94-4779-bbf0-0fde3beb8121"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "counter-font-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "66540ddb-ec74-487f-8e09-a37b436694b5"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "edge-to-content-area"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "a9fc8786-060e-4663-9381-211621240b2f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-horizontal-compact instead.",
+    "replaced_by": "7f237198-3842-49bc-aa79-e723fbe6c78e"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-400",
+    "uuid": "e67822de-d0cd-4b49-8e90-6c43523bb4dd"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "label-to-action-group-area"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "72e276ce-d6ee-4bcf-9955-91c833b8b2cd",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-gap-horizontal instead.",
+    "replaced_by": "c0571c46-5946-4896-bcbf-270560de5385"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "176px",
+    "uuid": "9fb582b4-38e6-43d0-9b94-69964fb24c9f"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "top-to-content-area"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "cfa41a43-8fb2-4c3b-a2df-f8658c87b31b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "action-bar",
+      "property": "top-to-item-counter"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-300",
+    "uuid": "73f82d09-7927-461c-b7d7-ab0bc6b3e3f9",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "1c72a1bf-cfcc-4553-91c6-d7bbcf02cc5a",
+    "set_uuid": "2ab2fb4b-eb8a-4ea7-9fe9-0d60ee52ac73",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-extra-large instead.",
+    "replaced_by": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "b4b4710b-2073-4285-8342-31ae6712671b",
+    "set_uuid": "2ab2fb4b-eb8a-4ea7-9fe9-0d60ee52ac73",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-extra-large instead.",
+    "replaced_by": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "b79597cc-5294-4555-ab78-f4200e480ac3",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-extra-small instead.",
+    "replaced_by": "b4d6b11b-240b-4daf-8c24-3661888730d1"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "dc65074f-a923-4130-84e5-59fa5d5f4121",
+    "set_uuid": "1f708860-2cfd-42c2-8ccb-f3bb954566ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-large instead.",
+    "replaced_by": "31fe1f21-a95a-4354-b6d1-e40dc66990fb"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "86a36757-a2d1-4263-97dc-62cf4543b3f9",
+    "set_uuid": "1f708860-2cfd-42c2-8ccb-f3bb954566ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-large instead.",
+    "replaced_by": "31fe1f21-a95a-4354-b6d1-e40dc66990fb"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "5022d77a-9332-4bb8-bd9f-d353eed2caa3",
+    "set_uuid": "0f14030d-1b31-4157-b834-f02df83b7a17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-medium instead.",
+    "replaced_by": "32bdfee6-cc93-4d53-9d08-2591646d38e9"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "255a24ab-f70d-4698-8d2e-569c37c6c798",
+    "set_uuid": "0f14030d-1b31-4157-b834-f02df83b7a17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-medium instead.",
+    "replaced_by": "32bdfee6-cc93-4d53-9d08-2591646d38e9"
+  },
+  {
+    "name": {
+      "component": "action-button",
+      "property": "edge-to-hold-icon-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "fa106863-0e09-44d4-9465-68cd3254ed2b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-affixed-small instead.",
+    "replaced_by": "7789a1e5-3bc8-494d-91c2-1309b4697da9"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e2f088b2-1ec4-4fc4-aacd-3ded4f0a239e",
+    "set_uuid": "8fd1aabf-b5e5-4f60-bed2-43c3bec97f7e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "4141f697-72cf-4948-acc7-7aa96035fbe8",
+    "set_uuid": "8fd1aabf-b5e5-4f60-bed2-43c3bec97f7e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "6bc4db4c-ab1a-4c68-bc37-2053b289d982",
+    "set_uuid": "ca31ed73-c382-48a5-a6ae-45cb7648ec2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "708bfa69-42fb-41cf-b734-ef3736cafc02",
+    "set_uuid": "ca31ed73-c382-48a5-a6ae-45cb7648ec2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "6f6b3134-6fcc-457d-ae87-43814ccada0f",
+    "set_uuid": "7153703c-7f93-437d-a3fd-19d3712cd008",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "6ac66626-4a7b-4880-ba39-6756b30e0872",
+    "set_uuid": "7153703c-7f93-437d-a3fd-19d3712cd008",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "d754631a-979d-4dec-b42c-f539421d1c86",
+    "set_uuid": "ebe32780-2683-4112-a31d-a96c83c84d1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "d74d9dc5-9c20-4c87-bacc-d8898c805aa0",
+    "set_uuid": "ebe32780-2683-4112-a31d-a96c83c84d1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "1456b16e-09bc-4b63-b3c7-4ecf9a0c3754",
+    "set_uuid": "19aeee29-ee00-483f-9caa-544149aaabae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "add-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "cfa5af27-add5-475d-90e4-2bd4fc14fcf1",
+    "set_uuid": "19aeee29-ee00-483f-9caa-544149aaabae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "bottom-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "e19fdd96-44a4-407b-b2b1-01001684fc84",
+    "set_uuid": "848a9c0d-eba9-4258-83fd-80e114fac05a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "bottom-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "5f2b2bc1-ebb0-46dd-a563-58df6307996d",
+    "set_uuid": "848a9c0d-eba9-4258-83fd-80e114fac05a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "450405f8-4f08-4151-85dd-730b669a7ed0",
+    "set_uuid": "c469d4c8-8d99-46ac-9b95-63a26e023627",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "6d313800-3020-45f8-969d-63e81057ff97",
+    "set_uuid": "c469d4c8-8d99-46ac-9b95-63a26e023627",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "to-bottom-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "alert-banner-bottom-to-text",
+    "uuid": "e2bd6435-6fbd-4030-9ff5-b034438b8d8a",
+    "deprecated": "unknown",
+    "deprecated_comment": "Introduced as an error. Use alert-banner-bottom-to-text instead",
+    "replaced_by": "848a9c0d-eba9-4258-83fd-80e114fac05a"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "to-top-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "alert-banner-top-to-text",
+    "uuid": "8fefedaf-6e95-4a14-a8ba-08381f57bfeb",
+    "deprecated": "unknown",
+    "deprecated_comment": "Introduced as an error. Use alert-banner-top-to-text instead",
+    "replaced_by": "db0461aa-d466-4a49-8f6d-f3b65659abb5"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "to-top-workflow-icon"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "alert-banner-top-to-workflow-icon",
+    "uuid": "42b40d65-eed4-432e-8ede-74d89905d131",
+    "deprecated": "unknown",
+    "deprecated_comment": "Introduced as an error. Use alert-banner-top-to-workflow-icon instead",
+    "replaced_by": "8ab5ed06-52be-4cbc-8922-35483e361488"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "top-to-alert-icon",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "37px",
+    "uuid": "fa14092c-ef3f-4b11-8bc8-968d22bed6e0",
+    "set_uuid": "cee3c085-e5bb-405e-9065-49e43f9113db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "top-to-alert-icon",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "29px",
+    "uuid": "7939208b-2f8c-4569-b7cb-1c1bcfc8705a",
+    "set_uuid": "cee3c085-e5bb-405e-9065-49e43f9113db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "top-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "1d289972-d5ba-41e8-8935-e8c83afb15cf",
+    "set_uuid": "db0461aa-d466-4a49-8f6d-f3b65659abb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "top-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "8db02117-b543-4b3e-b0ff-203e9a821708",
+    "set_uuid": "db0461aa-d466-4a49-8f6d-f3b65659abb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "top-to-workflow-icon",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "fbe047c4-0346-4b81-bdf6-6565cede7a28",
+    "set_uuid": "8ab5ed06-52be-4cbc-8922-35483e361488",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "top-to-workflow-icon",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "402c755b-322c-4ea0-856c-ca209bdaa8ec",
+    "set_uuid": "8ab5ed06-52be-4cbc-8922-35483e361488",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Need to evaluate how token is used in implementation; refactor may be necessary.",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "832px",
+    "uuid": "713e9ae2-e226-45ab-bce9-869533253ee7",
+    "set_uuid": "c0dc5d73-a689-41c1-a99c-ec3ac6c92760",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-banner",
+      "property": "width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "680px",
+    "uuid": "b02e6302-d443-4b94-bda9-f4cc90b3d4ca",
+    "set_uuid": "c0dc5d73-a689-41c1-a99c-ec3ac6c92760",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "description-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-m",
+    "uuid": "eda300de-5f0a-42e9-9880-9244a45d4e7d",
+    "set_uuid": "6c94683e-1c66-4e07-84e4-7a8b6d7b069d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "description-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "e969f730-9eea-4a35-8981-2804d660c23e",
+    "set_uuid": "6c94683e-1c66-4e07-84e4-7a8b6d7b069d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "description-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "alert-dialog-description-font-size",
+    "uuid": "9dc42d1a-b87d-4a5d-a5a3-6afd4d5bd599",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replace with alert-dialog-description-font-size",
+    "replaced_by": "6c94683e-1c66-4e07-84e4-7a8b6d7b069d"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "480px",
+    "uuid": "45258afa-543b-4fbc-a621-677d8081c2f1"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "288px",
+    "uuid": "7d066c2d-ea59-483d-b8a3-6a9b9e35eedd"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xxl",
+    "uuid": "749fa425-de12-464d-a1e2-80eb135d3ea6",
+    "set_uuid": "5b046013-d264-4f71-b609-7dd2057571ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xl",
+    "uuid": "c84328d2-578b-4a36-9065-6c6a9e1d311f",
+    "set_uuid": "5b046013-d264-4f71-b609-7dd2057571ff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "alert-dialog",
+      "property": "title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "alert-dialog-title-font-size",
+    "uuid": "9b7ce1fc-ea8a-4d7b-a926-0accbd6b1197",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replace with alert-dialog-title-font-size",
+    "replaced_by": "5b046013-d264-4f71-b609-7dd2057571ff"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "c22e7427-617d-4f99-bee7-e3fffba07fc2",
+    "set_uuid": "9aa4e6ea-50ee-4a44-b3a5-cab3f7aed7f2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "e9b3eb08-2004-4ad3-bb13-a00a6cb536aa",
+    "set_uuid": "9aa4e6ea-50ee-4a44-b3a5-cab3f7aed7f2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "645d5384-e3a8-4d97-acf6-7cbce00e6537",
+    "set_uuid": "334c967f-5b41-4fd4-bf75-bd9d405de0d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "c7df43e2-7354-4f53-b453-dc9bf9060e64",
+    "set_uuid": "334c967f-5b41-4fd4-bf75-bd9d405de0d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "d0df9084-c6bf-42e5-b830-82906036e397",
+    "set_uuid": "c2eb8a49-f7aa-49d9-9216-4b3292a9fda8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "f6116604-efbe-4c6f-b047-29247d632174",
+    "set_uuid": "c2eb8a49-f7aa-49d9-9216-4b3292a9fda8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "4ced8527-31ad-4e48-9491-806ffc57442a",
+    "set_uuid": "0c807977-8951-4dce-a580-ed4b11045d86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "35f055a9-8a33-42b2-a316-7e2ef0a4b99d",
+    "set_uuid": "0c807977-8951-4dce-a580-ed4b11045d86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "31f09728-964b-4598-99a0-d17bf7256e40",
+    "set_uuid": "e8ae5614-5793-46a3-9d5c-bf04b57ef870",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "dcf16e1a-49ea-4888-85b7-012462a60f40",
+    "set_uuid": "e8ae5614-5793-46a3-9d5c-bf04b57ef870",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "5ffece39-b8fc-4a40-a051-0d6c8e253f8f",
+    "set_uuid": "54adb815-8e74-498f-a4b9-f647de95d3b5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "2f5f49e5-9aba-4ea0-a8d9-0f0e4c086b89",
+    "set_uuid": "54adb815-8e74-498f-a4b9-f647de95d3b5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "b39b3ce3-6a48-4025-96ef-659b0c9ae9e8",
+    "set_uuid": "853a105e-8a45-4588-a173-4a5b8add9730",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "arrow-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "6ff35aff-8a9f-466c-bdd3-dda460ccaee5",
+    "set_uuid": "853a105e-8a45-4588-a173-4a5b8add9730",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "d04b37cc-2c35-49af-9e92-9993264e405a",
+    "set_uuid": "597db14a-a852-40ac-b4d3-80528dda07d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "f6f11ca3-b78b-4207-868f-f834c19e8d3d",
+    "set_uuid": "597db14a-a852-40ac-b4d3-80528dda07d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "49892fb4-a9df-4882-a656-7f9ffb9558bc",
+    "set_uuid": "692207dd-e636-4511-ba54-c24ddf3e4e46",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "3f1b200b-d341-41e4-ae7b-c981ccb492f7",
+    "set_uuid": "692207dd-e636-4511-ba54-c24ddf3e4e46",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "93506e7b-f388-4cf8-bd73-e7d96da935d5",
+    "set_uuid": "69685097-066a-4fec-8440-fb51804c06d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "a1cdad1f-6537-4c35-a87b-45d8e161ee46",
+    "set_uuid": "69685097-066a-4fec-8440-fb51804c06d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "asterisk-icon",
+      "property": "size-75"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "49ea57ee-7b12-4a8b-a9bb-a11cf2c9d72c",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "border-width-100",
+    "uuid": "2d4cd3ad-cc2c-4ad5-9475-c73882c5201e"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-100",
+    "uuid": "1c869018-8c56-4c10-acea-7fc6e838aa09"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-200",
+    "uuid": "590ef940-55ea-4690-a403-e4b47a185a64"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-300",
+    "uuid": "5e60d980-21db-4bbd-b321-a20808571411"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-400",
+    "uuid": "80e446ee-0091-4c6e-9158-e15fbc6207a4"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-50"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-50",
+    "uuid": "d55ab204-ee6c-47e3-a21b-25543c8fc36b"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-500",
+    "uuid": "4bf63b03-931b-47ce-bb1a-4bd4e2cd82c1"
+  },
+  {
+    "name": {
+      "component": "avatar-group",
+      "property": "size-75"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "avatar-size-75",
+    "uuid": "420c8327-fa41-4919-9e01-4d58178d739b"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "f3293ec2-befd-49e8-a280-b5a1827aa40c",
+    "set_uuid": "6f799e9e-1e37-4d9d-b88d-3969ca707213",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "a2833b95-ba74-4caf-89e6-8294465d2780",
+    "set_uuid": "6f799e9e-1e37-4d9d-b88d-3969ca707213",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1000",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "7f677464-22fe-47c5-b4da-e6c60740aafe",
+    "set_uuid": "14e022bd-1525-42ca-a3d1-333f92da11e6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1000",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "72px",
+    "uuid": "c723eb21-c020-40d5-a225-5857c8b4f0c9",
+    "set_uuid": "14e022bd-1525-42ca-a3d1-333f92da11e6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "72px",
+    "uuid": "63e8bd84-a7e2-4aed-9ac8-44ae2fe70424",
+    "set_uuid": "a8ae28c2-1047-45e7-9d21-36d92a6eb58d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "371af425-26e6-4891-a195-b4dbee5e17b9",
+    "set_uuid": "a8ae28c2-1047-45e7-9d21-36d92a6eb58d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "d8af9c52-b267-4c77-8ca2-ffa5dc27a45e",
+    "set_uuid": "b73ade5d-ac65-40f9-a403-8974891e3212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "88px",
+    "uuid": "49075645-054f-4b42-8b8a-7fa4971b2ca9",
+    "set_uuid": "b73ade5d-ac65-40f9-a403-8974891e3212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "88px",
+    "uuid": "77d45064-5013-417e-9663-a91e97e40d01",
+    "set_uuid": "0784e2ac-d40b-4021-9435-08b80a7fe61c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "96px",
+    "uuid": "b8372421-023d-4d86-b792-eb1c9fd8230c",
+    "set_uuid": "0784e2ac-d40b-4021-9435-08b80a7fe61c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "96px",
+    "uuid": "974ccab6-b9d9-4101-ba6c-69dd75b8602f",
+    "set_uuid": "dde08dc2-14a2-4eed-b02d-8ae0dffcb80f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "104px",
+    "uuid": "c46a76c1-77af-4e15-96e1-9e7f16000de5",
+    "set_uuid": "dde08dc2-14a2-4eed-b02d-8ae0dffcb80f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "104px",
+    "uuid": "2ab3cbdf-5791-41ca-b6e3-66d5a4970f32",
+    "set_uuid": "268105fd-2308-4e1e-8f3a-822f32559250",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-1500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "112px",
+    "uuid": "06359a10-02d1-4886-a841-940b5ffbb0f0",
+    "set_uuid": "268105fd-2308-4e1e-8f3a-822f32559250",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "a17f3911-00ad-4d52-a474-dc5d4e3341d1",
+    "set_uuid": "ad82e875-4243-4665-93b9-91aef258b164",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "7bfa97a1-39a8-4a30-af13-31ce1393098a",
+    "set_uuid": "ad82e875-4243-4665-93b9-91aef258b164",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "337f89c8-5b8a-4cd9-a32d-31f2d9804b2e",
+    "set_uuid": "3c458169-051a-473d-9b68-af84803a74e6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "b0bd14f7-9642-4e20-90c4-68f38a53e72c",
+    "set_uuid": "3c458169-051a-473d-9b68-af84803a74e6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "f7ee2f39-d2ea-44ce-a5e6-e9a2bb8af52e",
+    "set_uuid": "f1ebef6a-9cf7-4aa6-9dcf-2bfd6387a97e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "44237baf-1128-445d-8337-a943c6ac0019",
+    "set_uuid": "f1ebef6a-9cf7-4aa6-9dcf-2bfd6387a97e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "60fd0b38-3bad-4a0f-8a69-d4cf79b635ff",
+    "set_uuid": "bf2b8540-8b70-4c36-8e02-7deeb66d532e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "6f6fae3d-eafd-41d7-a863-b2f0b57240ab",
+    "set_uuid": "bf2b8540-8b70-4c36-8e02-7deeb66d532e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "9088ecf5-e278-48fe-a7cc-bdf77d15772f",
+    "set_uuid": "b05bc8a7-3937-4e31-97eb-4514bdb31f9f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "db33d97e-15e4-4248-a8cf-4b69d745a2e0",
+    "set_uuid": "b05bc8a7-3937-4e31-97eb-4514bdb31f9f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "15634a63-05f3-4fb8-989a-cb3ad46b8946",
+    "set_uuid": "5329cf23-d3ec-4513-8aaa-06f36eafd06e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "9ea7c014-2c8d-403f-ad7f-fa3c08a3a46d",
+    "set_uuid": "5329cf23-d3ec-4513-8aaa-06f36eafd06e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-700",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "92260f9e-ad2a-4e46-ad65-d83d99f7e7b7",
+    "set_uuid": "47ef5b99-9965-40ab-98e2-1f188023a5f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-700",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "52px",
+    "uuid": "0bec4f0f-efb2-44f9-a131-28f8fe248c40",
+    "set_uuid": "47ef5b99-9965-40ab-98e2-1f188023a5f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "6aa2d529-0e10-4eaf-8786-f38e04e4d438",
+    "set_uuid": "88990423-8f5c-486b-9c7d-969db3d82cbb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "f23636e9-93e2-444d-a95b-1311a7e074f3",
+    "set_uuid": "88990423-8f5c-486b-9c7d-969db3d82cbb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-800",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "52px",
+    "uuid": "4c3c7ee0-637c-4c0f-b79b-ba8d4f8aaf9d",
+    "set_uuid": "b5158bd5-8349-4330-84f1-7b900119366f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-800",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "99cf09f1-da56-4961-a805-723b68f718c2",
+    "set_uuid": "b5158bd5-8349-4330-84f1-7b900119366f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-900",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "531b56b5-3abd-4bcc-a4fa-9cceb08b0b8d",
+    "set_uuid": "7bdd8cdd-fb68-48de-b5bd-ce1e05cf3403",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "size-900",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "e774036a-23b9-4d74-b878-5d8edf20355f",
+    "set_uuid": "7bdd8cdd-fb68-48de-b5bd-ce1e05cf3403",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-6px",
+    "uuid": "273888c7-abc9-4af8-802a-e8ecf864f2fa",
+    "set_uuid": "782eb521-1666-4b13-a89a-2fa1b5dc8148",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-7px",
+    "uuid": "bacd5b38-1eed-49d6-9513-f363315f2a23",
+    "set_uuid": "782eb521-1666-4b13-a89a-2fa1b5dc8148",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-7px",
+    "uuid": "629d5ce9-487d-4ee9-be0d-5ff24c66d174",
+    "set_uuid": "d3a296c0-137a-4e4b-bb59-507d88059733",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-8px",
+    "uuid": "7815e63c-1d4f-4ee0-a656-a6053595ad59",
+    "set_uuid": "d3a296c0-137a-4e4b-bb59-507d88059733",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-8px",
+    "uuid": "e345324b-640f-4f45-88c6-4765ca97ea22",
+    "set_uuid": "a04102eb-1876-4792-9172-9152c864e025",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-9px",
+    "uuid": "04481b80-1c05-416a-95cf-c0c85147ce2e",
+    "set_uuid": "a04102eb-1876-4792-9172-9152c864e025",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-9px",
+    "uuid": "63c5deff-94da-4981-ba9a-fd46b4372830",
+    "set_uuid": "1ec7c31f-7dd0-407c-975b-e90b63db5622",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-10px",
+    "uuid": "5c733ac6-d7b9-44f0-8827-1d8232ca5332",
+    "set_uuid": "1ec7c31f-7dd0-407c-975b-e90b63db5622",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "4328bc86-01d4-4467-b99a-33099effe781",
+    "set_uuid": "c6effdcb-1b30-4a23-979d-c2378311565c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-5px",
+    "uuid": "b395e912-9061-44bd-ab77-840cde0f3e80",
+    "set_uuid": "c6effdcb-1b30-4a23-979d-c2378311565c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-10px",
+    "uuid": "8b6b74b4-e7c3-4f7c-a2b6-f410fcc17a83",
+    "set_uuid": "13e5ce35-ff33-44e5-be4d-1365cba897d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-3x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-11px",
+    "uuid": "c980c4f4-f2c5-4963-873e-de275f3353d1",
+    "set_uuid": "13e5ce35-ff33-44e5-be4d-1365cba897d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-3x-large instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-5px",
+    "uuid": "4970f7de-506d-4e2c-9412-8ebd268c5da3",
+    "set_uuid": "f7b596a6-5bf0-49f0-9897-4f368a8f4abf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "avatar",
+      "property": "to-avatar-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-6px",
+    "uuid": "889a7ebb-86b7-4615-87ee-e75aa4b48d60",
+    "set_uuid": "f7b596a6-5bf0-49f0-9897-4f368a8f4abf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead. Implementations could negate value eg calc(-1 * token-name)",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "bar-panel",
+      "property": "maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "72px",
+    "uuid": "00c313bf-61be-4f5a-9d26-3e9f1ea0e950"
+  },
+  {
+    "name": {
+      "component": "bar-panel",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "db0862a7-3a92-4c24-a06a-d20acfd94e1b"
+  },
+  {
+    "name": {
+      "component": "bar-panel",
+      "property": "spacing-extra-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "5fbb857b-5703-4e8e-bba4-86720ca261bd",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "bar-panel",
+      "property": "width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "c0e0d08b-e22f-44d3-b547-6bd173d00e1b"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "bottom-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-bottom-to-text-200",
+    "uuid": "f0e6a20d-8c2d-4aa3-9060-b6ca66aa7943",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "bottom-to-text-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-bottom-to-text-100",
+    "uuid": "70a356be-c304-4bb4-a9df-97806931f089",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "bottom-to-text-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "5a78f5a4-ceee-4854-96d4-b61d76cc522b",
+    "set_uuid": "d97a4b26-6b81-4f71-ac02-6e5914391fe7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "bottom-to-text-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "a51a1142-e38e-4055-bd45-ad2bd0045880",
+    "set_uuid": "d97a4b26-6b81-4f71-ac02-6e5914391fe7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "end-edge-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "99ef1a0d-5fe1-4b62-9609-8929e7a3bf9c",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-200",
+    "uuid": "2d39863c-6987-413c-90d8-07fcc506a0d4",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "height-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-100",
+    "uuid": "8393f599-37e8-484a-a1c6-0934ce15a507",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "height-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "72px",
+    "uuid": "237ff958-a86d-4632-aa7d-504a697509c3",
+    "set_uuid": "060266b1-4ac4-4392-8554-fc1304bd3572",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "height-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "90px",
+    "uuid": "5e7426da-1a1e-4d37-8c96-4fdac06bfad5",
+    "set_uuid": "060266b1-4ac4-4392-8554-fc1304bd3572",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "separator-icon-to-bottom-text-multiline"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-separator-to-bottom-text-multiline",
+    "uuid": "56dd2fd0-c7a3-4f2c-bda9-8e6ba6d99e6c",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "separator-to-bottom-text-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "ba160ed7-e66b-4dd1-bef8-e91fe9b05d2c",
+    "set_uuid": "c5749cb5-6950-4aef-80f0-8445451370a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-3x-large instead.",
+    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "separator-to-bottom-text-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "a1c90c6d-851d-495f-99cc-bbeb0c6fdd4f",
+    "set_uuid": "c5749cb5-6950-4aef-80f0-8445451370a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-3x-large instead.",
+    "replaced_by": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-start-edge-to-text-large",
+    "uuid": "a0542dab-98fb-45d8-b4a0-79cfd2cc4f1c",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-start-edge-to-text-large.",
+    "replaced_by": "6833c05d-b5bd-49af-8dc7-8ef2ce52584a"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "04141c6f-50ff-4301-a7b5-315bbd9cac18",
+    "set_uuid": "6833c05d-b5bd-49af-8dc7-8ef2ce52584a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "1d7bd78d-4469-4385-89e7-fcd574cc6368",
+    "set_uuid": "6833c05d-b5bd-49af-8dc7-8ef2ce52584a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "941f9040-ddb7-419c-ac05-dfa24effa055",
+    "set_uuid": "c5f8d9a0-0d8f-4f6c-be31-b120fb25e474",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e87a054b-dceb-4462-a8fc-733700cc0f79",
+    "set_uuid": "c5f8d9a0-0d8f-4f6c-be31-b120fb25e474",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "3dd655e7-f0d4-4fa4-a885-4a7aff9510fd",
+    "set_uuid": "79d6a7a8-44e7-46fd-bf3c-b6999d04ba49",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-text-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "60a75c05-a9cd-4ecf-89e5-0bca9e137e9f",
+    "set_uuid": "79d6a7a8-44e7-46fd-bf3c-b6999d04ba49",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "start-edge-to-truncated-menu"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "b1fba444-c281-4be4-bded-4852b551cfee",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "text-to-separator-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "3e19f21e-0c87-4eca-bc21-d4c13bc984ef",
+    "set_uuid": "01ce78a6-df7d-47fc-a0fb-2d1484d56aa2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "text-to-separator-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "25d8256e-b05f-43e8-bbc3-5b60c24be29c",
+    "set_uuid": "01ce78a6-df7d-47fc-a0fb-2d1484d56aa2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "text-to-separator-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "74d2cda7-385e-4145-8a3e-26065db5e302",
+    "set_uuid": "73709a35-806f-4b34-a31c-ca856425ba0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "text-to-separator-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "bf2e3518-154e-4975-b9fb-acbf60b7e154",
+    "set_uuid": "73709a35-806f-4b34-a31c-ca856425ba0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "text-to-separator-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "0d4dd9ba-5b01-432d-a7b2-d95947cfc43d",
+    "set_uuid": "db6ce612-bbcd-4107-84c0-7175cb728d6c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "text-to-separator-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "fbf763fe-9e35-4cdc-a5ed-9f90e03d23bd",
+    "set_uuid": "db6ce612-bbcd-4107-84c0-7175cb728d6c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-text-to-bottom-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "3a89734d-4fcc-43cf-9b77-b2f6d3732391",
+    "set_uuid": "6b497d21-d4a6-4690-badf-ec273ec5a692",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-medium instead. Difference is due to other values changing, but expected. Requires some refactor.",
+    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-text-to-bottom-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "b93aad22-aff0-46d5-b54e-17891f02124a",
+    "set_uuid": "6b497d21-d4a6-4690-badf-ec273ec5a692",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-medium instead. Difference is due to other values changing, but expected. Requires some refactor.",
+    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-icon"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-top-to-separator-large",
+    "uuid": "15e56281-5fc1-4b59-b815-fc333231e364",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-large.",
+    "replaced_by": "f5a2b688-0ddd-4423-a958-6ef4bad42809"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-icon-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-top-to-separator-medium",
+    "uuid": "a63e8df1-124f-4f3e-9e1b-ba422b8d8257",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-medium.",
+    "replaced_by": "e7f97e3d-129e-4971-bc78-5f184710d716"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-icon-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-top-to-separator-multiline",
+    "uuid": "6b310160-ab2e-40fd-9216-21ddcb36b575",
+    "set_uuid": "3acadfab-ddd5-4eac-85de-b6c573dae071",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-icon-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-separator-icon-to-bottom-text-multiline",
+    "uuid": "eb3b2566-6fc1-4a2c-a8cf-e40af3d34715",
+    "set_uuid": "3acadfab-ddd5-4eac-85de-b6c573dae071",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "2e8091e4-f60b-438c-bcbb-111eb243900d",
+    "set_uuid": "f5a2b688-0ddd-4423-a958-6ef4bad42809",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Require unified UI icon set.",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "2e12202a-8099-4a4d-b06d-703deaf20862",
+    "set_uuid": "f5a2b688-0ddd-4423-a958-6ef4bad42809",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-2x-large instead. Require unified UI icon set.",
+    "replaced_by": "51761a5c-200d-467d-a575-3722f825edb9"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "fdbf3b4b-7d6e-4464-8514-17c1b4790db6",
+    "set_uuid": "e7f97e3d-129e-4971-bc78-5f184710d716",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "fcbd2bcb-7f53-4219-9d6b-89c01fd50da7",
+    "set_uuid": "e7f97e3d-129e-4971-bc78-5f184710d716",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "96d7dff4-4b3d-433a-8f83-8f55a1514812",
+    "set_uuid": "5b042e52-ddce-4e17-84c0-faf86049a945",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-separator-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "4b7eab87-e6a8-40f6-a071-5aff25493f2f",
+    "set_uuid": "5b042e52-ddce-4e17-84c0-faf86049a945",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-200",
+    "uuid": "d084038e-bc31-43be-99ee-13cf727eaf9d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-text-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-100",
+    "uuid": "b19547e2-bd8f-435d-b726-4f2ce6a83984",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-text-multiline",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "138070fe-1f06-48b4-ac49-f8ff117c5f42",
+    "set_uuid": "23002fd3-7ea9-48a6-9364-fc25fb49e3d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-text-multiline",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "ea82fc23-82e7-4116-a8bb-186a253675ad",
+    "set_uuid": "23002fd3-7ea9-48a6-9364-fc25fb49e3d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-truncated-menu"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "751734bd-1c58-4222-bbd8-8b2349f2fbd2",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "top-to-truncated-menu-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-top-to-truncated-menu",
+    "uuid": "e0aba287-799f-4621-97cb-563352002a20",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "truncated-menu-to-bottom-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "2285d870-68ec-469f-a034-2fdeb31e33f0",
+    "set_uuid": "f6a7f9c9-8722-4df3-9c6f-7093cc91a646",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead.",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "truncated-menu-to-bottom-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "154bce30-bfe2-445b-bbdd-69efce5565ae",
+    "set_uuid": "f6a7f9c9-8722-4df3-9c6f-7093cc91a646",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead.",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "truncated-menu-to-separator"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "963bd7ed-cfc9-4a93-a8a6-a2340ec6479f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "breadcrumbs",
+      "property": "truncated-menu-to-separator-icon"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "breadcrumbs-truncated-menu-to-separator",
+    "uuid": "1fe2a3df-3179-4c4a-8d1f-de41297b6d74",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 2.25,
+    "uuid": "68b6ac88-d229-460d-8d59-3f5c141db358"
+  },
+  {
+    "name": {
+      "property": "card-default-width-extra-large",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "400px",
+    "uuid": "7a94daad-ec68-4ef1-9c84-9bf6c9b6b696"
+  },
+  {
+    "name": {
+      "property": "card-default-width-extra-small",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "120px",
+    "uuid": "b99da217-1715-446c-9120-53e435cb0d0a"
+  },
+  {
+    "name": {
+      "property": "card-default-width-large",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "320px",
+    "uuid": "dc3ab4d0-f006-4ade-91da-ef263a676244"
+  },
+  {
+    "name": {
+      "property": "card-default-width-medium",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "5645fd64-11a8-4a0e-95f6-2f0cd89f5852"
+  },
+  {
+    "name": {
+      "property": "card-default-width-small",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "180px",
+    "uuid": "bec36248-9c3d-4ecd-857e-c5c20bdc0e1a"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "description-to-footer"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "248d1f30-c0d3-49bb-a5b7-0860cc75ee85",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-compact-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "a9f253aa-631e-447a-8335-15b4491a8e9d",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-large instead.",
+    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-compact-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "562738ca-ed16-4855-8855-3914b9109408",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-2x-small instead.",
+    "replaced_by": "f0d9117a-5606-4e49-a81f-f89938b34ca4"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-compact-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "0b551228-5a6a-403d-bb92-9800835cb3be",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-compact-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "f3566ff3-2430-4fdd-a48c-e8c0d3c34adc",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead.",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-compact-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "521df9e4-9c61-4a73-9157-d235a4d04090",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead.",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "property": "card-edge-to-content-default-extra-large",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "7acf60d0-7870-403e-94b9-18e84eff861b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "property": "card-edge-to-content-default-extra-small",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "9ecb4a76-013a-4952-9646-a5660005b31e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead.",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "property": "card-edge-to-content-default-large",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "8856270e-65b5-4f81-87c0-5332ffd7459f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-large instead.",
+    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+  },
+  {
+    "name": {
+      "property": "card-edge-to-content-default-medium",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "04ef066b-4733-4d20-9538-7eefd71e7a1e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "property": "card-edge-to-content-default-small",
+      "component": "card"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "569f8d0a-75f3-4743-aa51-9ec6479cdf21",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead.",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-spacious-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "c4ee268c-aca6-488f-90db-d3e51a0c5c89",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-2x-large instead.",
+    "replaced_by": "3801295f-e52b-412a-baf4-0b8e20449333"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-spacious-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "91289dd0-0a27-49ef-96c9-3508edecfa44",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead.",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-spacious-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "73da978a-bede-439e-97cd-afeb32e87780",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-spacious-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "98ef0816-ad83-43ec-b976-1169a7ce8540",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-large instead.",
+    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "edge-to-content-spacious-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "8ec39e04-de4f-48cf-9c8b-7bb7f76730a0",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "header-to-description"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "e874d2cd-6ad6-4d1c-8103-789945f10294",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-medium instead. May require refactor",
+    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+  },
+  {
+    "name": {
+      "component": "card-horizontal",
+      "property": "edge-to-content-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "fd732759-52ab-45b7-9949-9d9352091efe",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead.",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "card-horizontal",
+      "property": "edge-to-content",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "45af5962-8d41-476d-a92d-befa408b47b7",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "card-horizontal",
+      "property": "edge-to-content-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "104c7b60-387b-4550-b0eb-573915d28f42",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-large instead.",
+    "replaced_by": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "maximum-width-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "460px",
+    "uuid": "6f924664-b056-4fdb-a6ab-c5609e3e9316"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "maximum-width-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "140px",
+    "uuid": "9b2b13ac-1728-49f5-8e15-6eeed2e7f855"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "maximum-width-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "370px",
+    "uuid": "2e85d49c-4002-4beb-9173-f4b2ab78d043"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "maximum-width-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "280px",
+    "uuid": "ccfe1006-0ddd-4203-b0e0-4c92a090c376"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "maximum-width-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "210px",
+    "uuid": "42b0d345-b069-48b6-be41-6ed9047097d4"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-height-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "300px",
+    "uuid": "ef218a9a-900a-4454-840c-2380020bcbf3"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-height-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "90px",
+    "uuid": "f4492a8a-8cb4-481f-a2e4-73da516023be"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-height-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "2047247e-07d1-4b9b-b184-c173e6421daf"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "180px",
+    "uuid": "a29c460d-3496-49e9-8996-f4b42b9fbce7"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-height-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "135px",
+    "uuid": "862e84ab-4efa-4c8e-a0e0-5ed158dadbcb"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "card-minimum-width-default",
+    "uuid": "55db9f3d-621d-4d23-b3d0-c0f2b0f3f9b0",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use card-minimum-width-default instead.",
+    "replaced_by": "3a11949c-f1ac-490b-8416-f4883402d105"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "100px",
+    "uuid": "3a11949c-f1ac-490b-8416-f4883402d105"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "340px",
+    "uuid": "7a98c2aa-404f-4fba-a20d-f5b73919b13e"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "100px",
+    "uuid": "dad01ae6-b161-4d09-8296-33c6ee7d8ca1"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "270px",
+    "uuid": "549fbfad-78b7-430d-8fac-7d23084f2bea"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "813d9d3b-8e02-44d9-a898-3045947edc08"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "minimum-width-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "150px",
+    "uuid": "6d94093e-daba-4312-b083-61f44d027737"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "preview-minimum-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "130px",
+    "uuid": "58eb5be8-644f-448e-99b9-94d1fbb93240"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "496fd060-70a9-48d0-948f-593b81847199"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-size-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "89dca1bf-84e5-436e-9e86-35f37f739812"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-size-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "f8e58ca1-5087-4c4a-95dc-2f145f63fbc5"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-size-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "d169a0a3-9bda-41b4-9e58-897652c95627"
+  },
+  {
+    "name": {
+      "component": "card",
+      "property": "selection-background-size-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "b9268c45-50c7-4209-9f73-99293e15b7fd"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "4ba47ba1-c9bd-447e-8948-009d5b424e0d",
+    "set_uuid": "05686950-e677-4bc0-90c2-0addbe401d17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "13093f8b-e38e-449f-a982-7f960bb84dfa",
+    "set_uuid": "05686950-e677-4bc0-90c2-0addbe401d17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "839a52bc-b9ee-473f-acde-0799b4f55ded",
+    "set_uuid": "71f3577d-e685-41e9-9443-c498fd0125ba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "b4367578-989e-438d-9a3e-7cb077f2f7c9",
+    "set_uuid": "71f3577d-e685-41e9-9443-c498fd0125ba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "86288454-7192-4e4c-b55f-fc509fc58c01",
+    "set_uuid": "04a220ef-907c-433a-b040-fe421cdaf930",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "00fee3f7-a743-45d6-a2b6-028d5d96964a",
+    "set_uuid": "04a220ef-907c-433a-b040-fe421cdaf930",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "460e8170-de69-4f8e-8420-6c87a1f6f5cd",
+    "set_uuid": "39090c90-aa5a-448f-8dd5-01e0c0a5fa2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "control-size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "af31c1a5-ffce-4a54-8862-3e711ca53d25",
+    "set_uuid": "39090c90-aa5a-448f-8dd5-01e0c0a5fa2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "3c4217bb-91f2-4347-9f65-a0528992f600",
+    "set_uuid": "068911fa-495d-43d0-a1bd-c35de883bc47",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires other design enhancements to this component",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "b3be5ac8-2415-4490-8b4a-c08661ec84d1",
+    "set_uuid": "068911fa-495d-43d0-a1bd-c35de883bc47",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires other design enhancements to this component",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "93edae08-5320-4e7e-a006-a9af1d3665ad",
+    "set_uuid": "af3f2878-5437-4b37-a399-508a3bf038fa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires other design enhancements to this component",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "d040d2f4-9bb4-4d27-adac-40fef079d958",
+    "set_uuid": "af3f2878-5437-4b37-a399-508a3bf038fa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires other design enhancements to this component",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "dcde5d2d-60f8-4d56-bfb1-bba44a087515",
+    "set_uuid": "6ed456cf-9c7d-40d1-99b9-0bd4e0e8dc22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires other design enhancements to this component",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e3751526-2db9-421c-85f9-d60071aac49b",
+    "set_uuid": "6ed456cf-9c7d-40d1-99b9-0bd4e0e8dc22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires other design enhancements to this component",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "20518175-5bc7-4659-8007-e74339c39433",
+    "set_uuid": "417a665d-fbe5-4756-ba30-0e8b79c0bee0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires other design enhancements to this component",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "checkbox",
+      "property": "top-to-control-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "f254146e-f469-44b1-b0c9-1ac72e88f9e3",
+    "set_uuid": "417a665d-fbe5-4756-ba30-0e8b79c0bee0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires other design enhancements to this component",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "9227a279-09f4-457a-b5b3-894f0d6a00df",
+    "set_uuid": "7dca1bf5-71bc-406d-8df8-98c9e3c443d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "23247915-3cc0-4fdf-b21a-85b97019a219",
+    "set_uuid": "7dca1bf5-71bc-406d-8df8-98c9e3c443d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "342a360b-d58c-4d7a-9a9d-893600b90785",
+    "set_uuid": "51745ca2-1ea0-4648-8b90-26021d8cb24c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "d4e3f5ff-91d6-499e-b79e-b1d85c0c597b",
+    "set_uuid": "51745ca2-1ea0-4648-8b90-26021d8cb24c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "b5eff9b7-6987-47a1-a673-c47b7e806370",
+    "set_uuid": "ccb1a2b3-4661-4bda-9ccc-aa737e6c3ae1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "d9b251b2-aa8a-46dc-9a2a-0eb46afea241",
+    "set_uuid": "ccb1a2b3-4661-4bda-9ccc-aa737e6c3ae1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "1a043355-03e6-4322-a462-7d628c23fd06",
+    "set_uuid": "43c66b3c-ee3d-42dc-94b3-b4e8f24d9a0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "c044459e-12a3-4cdd-9f22-db1d14f34164",
+    "set_uuid": "43c66b3c-ee3d-42dc-94b3-b4e8f24d9a0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "6335cb3a-6ceb-40e7-b241-ff9b36f1277c",
+    "set_uuid": "4a56fa39-3250-45ee-a13e-885aa51e05d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "ee52f114-1ab6-430b-bd54-62a82bf3600e",
+    "set_uuid": "4a56fa39-3250-45ee-a13e-885aa51e05d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "0bf97a2b-5fe6-46ca-8175-8457e8e37d36",
+    "set_uuid": "e58cc203-6a8d-46a6-a8c6-eeaefbd4a50e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "29f107aa-b8a8-4a09-bf55-9c903c1005ed",
+    "set_uuid": "e58cc203-6a8d-46a6-a8c6-eeaefbd4a50e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "4bacaeea-2d60-46d2-8c98-288b45a79aaf",
+    "set_uuid": "af33c41e-0824-45bf-a6de-f960deacef46",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "b52f4e53-06c2-4746-8063-e2bd99361174",
+    "set_uuid": "af33c41e-0824-45bf-a6de-f960deacef46",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "0545a68c-f273-4348-84cd-9cd365bdb474",
+    "set_uuid": "66be8a28-4c91-4418-9589-f9a3114f361b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "checkmark-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "99224b4e-751a-49ec-8db4-41c8cc4c7bf5",
+    "set_uuid": "66be8a28-4c91-4418-9589-f9a3114f361b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "fdd4f0b4-3284-4734-b158-ecd5da36d586",
+    "set_uuid": "dea35658-0356-4578-b3b0-f538449ee8f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "c4d6bea8-61b0-45a4-81e0-1e5dd7429463",
+    "set_uuid": "dea35658-0356-4578-b3b0-f538449ee8f6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "2df0f6e0-5821-4f70-9aa9-1cc61f860b53",
+    "set_uuid": "6a8b4db6-5057-4aac-a548-88b365f8a491",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "08bbd8dd-bb02-43b9-8e25-7709aee5ff52",
+    "set_uuid": "6a8b4db6-5057-4aac-a548-88b365f8a491",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "087dcfa2-5bfd-47a4-a67c-dca50e086e7a",
+    "set_uuid": "dc5f5463-25e5-4dd6-a019-422dff279d7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "e6fdcac2-9916-45e2-a479-e87d17ece1f9",
+    "set_uuid": "dc5f5463-25e5-4dd6-a019-422dff279d7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "7fc3ab50-4856-442b-85f7-7f0e5ab3304a",
+    "set_uuid": "f683fc1b-4d90-4165-8f00-59a7be264f3b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "ee913eaa-bdaf-44c0-a139-17c5d94b1d4a",
+    "set_uuid": "f683fc1b-4d90-4165-8f00-59a7be264f3b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "785a9152-a69b-4164-a8e2-cc201c1f8063",
+    "set_uuid": "ddd17061-8664-4dd4-8b21-45354cd37467",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "6d8ce7eb-a2a2-496c-9ce7-847f4da5fc0c",
+    "set_uuid": "ddd17061-8664-4dd4-8b21-45354cd37467",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2891d3c7-1178-4901-9be9-75efada4a9e7",
+    "set_uuid": "41f34810-35b7-4179-b997-d01fabf70599",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "95400787-7abb-4cad-830b-8a4042831860",
+    "set_uuid": "41f34810-35b7-4179-b997-d01fabf70599",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "c1de2d7d-ef83-4a3f-9407-2f512127244f",
+    "set_uuid": "95d55e28-01ee-40df-8a67-a30ccea2d809",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "350b77ab-6440-49c1-9b1c-a31c5c4f2f5f",
+    "set_uuid": "95d55e28-01ee-40df-8a67-a30ccea2d809",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "43ef1792-b182-419d-966c-a8a2d77dbe03",
+    "set_uuid": "1ccb5e05-1156-46a9-b2b3-14cc5d815aa5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "chevron-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "74dbb8c0-2e65-413d-8b52-7215993b5696",
+    "set_uuid": "1ccb5e05-1156-46a9-b2b3-14cc5d815aa5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "collapsed-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "adb8eace-decc-4bef-93e9-ff2cb27e9ce6",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead.",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "collapsed-ring-rounding-increment"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "252dc667-b847-4295-8669-3e2f4d408f51"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "collapsed-ring-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "fff486aa-26a4-4b41-91a7-762f8b29d47a"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "expanded-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "b25c696f-c6c3-45af-bdc9-fe3a046067f3",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "expanded-ring-rounding-increment"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "770aa608-80a3-4715-894b-c1d85a1b0c5e"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "expanded-ring-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "09c84cdf-0c82-4201-8203-9eb05d8b9486"
+  },
+  {
+    "name": {
+      "component": "coach-indicator",
+      "property": "opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.2",
+    "uuid": "6fa9bbc8-4c96-45a4-b133-bb2556a003de"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "body-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-m",
+    "uuid": "4b88a0d5-2d07-4e63-afa6-cdd611f0a8c1",
+    "set_uuid": "f4f305ae-e0da-48ec-9dab-c33cdd11b80f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "body-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "73959c3d-afc2-4f6e-bd34-0399bf3b5b73",
+    "set_uuid": "f4f305ae-e0da-48ec-9dab-c33cdd11b80f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "body-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "coach-mark-body-font-size",
+    "uuid": "eba9f466-deda-48d5-a120-14419d5a670f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replace with coach-mark-body-font-size",
+    "replaced_by": "f4f305ae-e0da-48ec-9dab-c33cdd11b80f"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "edge-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-400",
+    "uuid": "d5a3e2c7-f717-4436-91a3-3ab34aebd48e",
+    "set_uuid": "aba07ab5-e655-4a1c-9704-7850bafefae8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "edge-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "11fb0ab2-d6a0-4da8-9c83-c1f6b918406a",
+    "set_uuid": "aba07ab5-e655-4a1c-9704-7850bafefae8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "maximum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "380px",
+    "uuid": "07cdeb95-d368-4ed1-ba29-6b9ddeae1396",
+    "set_uuid": "6ba9d196-81bc-4580-a7e2-b6436c1602bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "maximum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "248px",
+    "uuid": "7f8346b2-f8bf-441d-8412-2a2a28cf4b90",
+    "set_uuid": "6ba9d196-81bc-4580-a7e2-b6436c1602bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "media-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "222px",
+    "uuid": "f6381a33-ac4e-4ff9-86a3-183c857772ad",
+    "set_uuid": "5aac121b-ffcd-4a05-85ff-89c5e3a46e1b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "media-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "162px",
+    "uuid": "45b31e46-b878-40a2-a28a-91c480f45253",
+    "set_uuid": "5aac121b-ffcd-4a05-85ff-89c5e3a46e1b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "media-minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "166px",
+    "uuid": "e62c5a76-685c-4b48-98bb-746d6dd4b10e",
+    "set_uuid": "f26ffd88-afb8-4235-8738-fbe17e6a3416",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "media-minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "121px",
+    "uuid": "53703e12-f837-4573-bd44-e4727ed2aeaa",
+    "set_uuid": "f26ffd88-afb8-4235-8738-fbe17e6a3416",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "296px",
+    "uuid": "9f413341-5ed5-4cd0-8348-1c7141dcab8d",
+    "set_uuid": "e47ef136-eb89-4ca6-97ef-257e9452691c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "216px",
+    "uuid": "9004d69e-5726-42f5-a4d0-de09db2de784",
+    "set_uuid": "e47ef136-eb89-4ca6-97ef-257e9452691c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "pagination-body-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "06ae2458-8490-4741-8a02-97f60cc01592",
+    "set_uuid": "b8a50488-10c4-4b9e-8e3f-7cfdaea6b4a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "pagination-body-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-xs",
+    "uuid": "4f8c99a5-0942-41b0-ac41-923ea9ca2bf2",
+    "set_uuid": "b8a50488-10c4-4b9e-8e3f-7cfdaea6b4a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "pagination-body-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "coach-mark-pagination-body-font-size",
+    "uuid": "df8bc8ae-b6fa-4414-93b7-c89d8097fe11",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replace with coach-mark-pagination-body-font-size",
+    "replaced_by": "b8a50488-10c4-4b9e-8e3f-7cfdaea6b4a8"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "pagination-text-to-bottom-edge",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "33px",
+    "uuid": "d2ff2d4f-058e-412b-9e16-1725d6d29e25",
+    "set_uuid": "b99f2904-e6e6-4ad2-b8d7-02d7ca334932",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead. Refactor may be required",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "pagination-text-to-bottom-edge",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "cd48e6b7-a4d8-4a22-8d65-531d770a9898",
+    "set_uuid": "b99f2904-e6e6-4ad2-b8d7-02d7ca334932",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead. Refactor may be required",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-m",
+    "uuid": "5b132698-4ee2-40e4-83c0-9ad80f36f5fd",
+    "set_uuid": "5ede1ea6-2643-489b-bd30-7165f5afe323",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-s",
+    "uuid": "45855bc5-3b86-49a9-b443-7be9aa763c4e",
+    "set_uuid": "5ede1ea6-2643-489b-bd30-7165f5afe323",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "coach-mark-title-font-size",
+    "uuid": "331604db-3f28-472e-810d-9010ed2c8e33",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replace with coach-mark-title-font-size",
+    "replaced_by": "5ede1ea6-2643-489b-bd30-7165f5afe323"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "296px",
+    "uuid": "49d1e2be-3aa2-4515-ba54-7f6cf3ab007c",
+    "set_uuid": "f8383184-47bf-4ff9-af46-cf7739c37780",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "coach-mark",
+      "property": "width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "216px",
+    "uuid": "b3f14387-44fd-43d3-a152-c8e691ef87df",
+    "set_uuid": "f8383184-47bf-4ff9-af46-cf7739c37780",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "code-size-l",
+    "uuid": "15e8593b-1b86-40e0-ae88-fcc587e24373"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "code-size-m",
+    "uuid": "69436fba-18a7-4a28-b6c5-683a8838917c"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "code-size-s",
+    "uuid": "80c3d9ab-39d1-4329-a88f-bb84c3afd17f"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "code-size-xl",
+    "uuid": "a2e258a0-21f6-44d7-9bfe-0052620e5ac2"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "code-size-xs",
+    "uuid": "6b577e2a-09c0-42bb-8b94-42034df63036"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "249px",
+    "uuid": "6b242eb5-aa73-417c-b786-9047ae7a65ac"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "88px",
+    "uuid": "fabfd445-4c39-4d39-9f7f-1ec531d4eb40"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-hero-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "514px",
+    "uuid": "24d72e3c-ed0d-47d7-85f5-4792fcf87b7f"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-hero-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "168px",
+    "uuid": "dc2f0f1a-609a-448a-833d-ded2580ef737"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-hero-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "414px",
+    "uuid": "d5586b0d-1ff1-4e7e-88ce-75d41aff90d9"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-hero-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "317px",
+    "uuid": "63ecc7ce-8a38-4d18-94ed-d9e6394279ba"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-hero-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "243px",
+    "uuid": "adfc74bd-7520-4bfa-b278-28178007cfbc"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "202px",
+    "uuid": "e5027e50-3a1f-425d-b06b-8e4cf4663c22"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "157px",
+    "uuid": "8422dc66-e17d-4c54-a18b-a997a8e5d7c3"
+  },
+  {
+    "name": {
+      "component": "collection-card",
+      "property": "minimum-height-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "124px",
+    "uuid": "9264b1ff-23ae-4fd5-8863-742c305689e2"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "border-rounding"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-medium-size-small",
+    "uuid": "ab656bf4-8814-42fa-9036-b1e67159e4e1"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "border-width-100",
+    "uuid": "78fff16d-d6fe-4a74-98bc-97c56e352250"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "993f90f6-22a6-49ec-a8e6-7a8b904d42a7",
+    "set_uuid": "4915f362-d8f1-4c87-b45f-f4c99266ba1f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "552a014a-c590-48f8-98dc-26849b62c3ab",
+    "set_uuid": "4915f362-d8f1-4c87-b45f-f4c99266ba1f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "73c558f3-2a1c-4c1d-9b17-cfb49f510070",
+    "set_uuid": "3ecf36e7-fbcd-4f8b-8c8b-ef51c0424cd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "9b84d54e-2b10-4502-b072-ded2a8bf9cb3",
+    "set_uuid": "3ecf36e7-fbcd-4f8b-8c8b-ef51c0424cd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "19ff1ba5-a351-4427-bf2e-4e212dde3d3c",
+    "set_uuid": "28afd99b-0227-41e5-91b6-87da309d7ed7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "126cd0b8-55cc-489c-9582-fddde76b431c",
+    "set_uuid": "28afd99b-0227-41e5-91b6-87da309d7ed7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "8fcf30ee-73e1-4f54-8975-5467dedade29",
+    "set_uuid": "26e77fb6-d62e-492b-b2b6-3fba9fb62fb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-area",
+      "property": "width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "e5daae6b-7040-4e80-a251-db4c8c79e113",
+    "set_uuid": "26e77fb6-d62e-492b-b2b6-3fba9fb62fb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "border-width-200",
+    "uuid": "8ec9adae-0093-42f4-bd1b-6f3b2279996b"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "drop-shadow-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0",
+    "uuid": "29e4a8c8-33ba-44b3-952d-26f3fd6ae4f0"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "drop-shadow-x"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0",
+    "uuid": "49499527-3fdb-4a91-a832-0ae0631ba3bb"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "drop-shadow-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0",
+    "uuid": "05b11927-d0cd-46a6-ae30-6f268f143d4e"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "inner-border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "945e0167-6893-49dd-ab21-886f93f70b92"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "outer-border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "fbf27473-7c97-4d94-968d-c3e68e0cd242"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "7c7fd224-a9d5-4d97-b3de-fd9e4e076444",
+    "set_uuid": "c55cdacd-cc28-4e4f-8974-c44d95317370",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "b81cc6a6-390f-43dc-a6c8-dd335c177da3",
+    "set_uuid": "c55cdacd-cc28-4e4f-8974-c44d95317370",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "size",
+      "state": "key-focus",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "de9cc5ca-81cf-4bde-bd21-be2402e460c5",
+    "set_uuid": "1ff02a51-9266-411d-a8e4-02222f45bac8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-handle",
+      "property": "size",
+      "state": "key-focus",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "feddbfb7-7f1a-4eee-9cbf-b393aafb7385",
+    "set_uuid": "1ff02a51-9266-411d-a8e4-02222f45bac8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "bottom-to-color-handle"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "92beba60-f61d-426a-a864-203dca7244a0"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "0f7e8b9e-99e5-4f5a-ae80-99f65f4c4e51"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "inner-border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "b3900f89-0a7a-4c47-a6d9-ca8aa19b9bfb"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "outer-border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "border-width-200",
+    "uuid": "51cd5039-1319-451a-b13f-bb3a218238a5"
+  },
+  {
+    "name": {
+      "component": "color-loupe",
+      "property": "width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "889e2495-b882-4aa3-8a5b-1a71d44edde4"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "border-rounding"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-medium-size-small",
+    "uuid": "991541a2-df44-4f32-90a5-de698adf5db3"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "2b907cad-7534-411b-b3bf-ab89a3712ad8"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "length",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "11442823-3e61-425a-a24b-a4a0747a06c4",
+    "set_uuid": "eac87a1b-2b93-4501-8d9f-90eae1cce3bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "length",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "c42de1ce-088a-4918-a7dc-36507c8acedf",
+    "set_uuid": "eac87a1b-2b93-4501-8d9f-90eae1cce3bd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "minimum-length",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "54aad7a1-df6a-414a-82b4-7976c912a8e5",
+    "set_uuid": "8b687fbe-e7dd-449a-8356-6bbaf0537d18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-slider",
+      "property": "minimum-length",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "100px",
+    "uuid": "120308f7-4220-420e-b836-20176a8184b7",
+    "set_uuid": "8b687fbe-e7dd-449a-8356-6bbaf0537d18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "color-area-margin"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "4b6bca16-ea29-4d6c-81cf-9005b9a3b5e5"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "175px",
+    "uuid": "647244c3-b071-45c1-94f7-3be32cfebabe",
+    "set_uuid": "8a42148e-0b8f-42cb-9693-e1a2bf42222e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "219px",
+    "uuid": "6733cd28-a949-40f7-bd36-034af9c0261f",
+    "set_uuid": "8a42148e-0b8f-42cb-9693-e1a2bf42222e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "d4cdb77e-54b8-4bcf-97b1-992287af2690",
+    "set_uuid": "f3ef148b-28ca-4bb2-9d13-a525bcbe03dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "color-wheel",
+      "property": "width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "81d866f0-e2a6-4f27-bb22-6675cce4e937",
+    "set_uuid": "f3ef148b-28ca-4bb2-9d13-a525bcbe03dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 2.5,
+    "uuid": "eabcc77a-f263-43ed-9944-9daa78a56b66"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "quiet-minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 2,
+    "uuid": "4798728b-9a97-4ce1-b703-0182b1513e8b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "visual-to-field-button"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "visual-to-field-button-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "combo-box-visual-to-field-button",
+    "uuid": "4a4ee415-1f25-4d36-928c-5ece0ce4abcc",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
+    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "visual-to-field-button-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "combo-box-visual-to-field-button",
+    "uuid": "356c4912-69c7-4a95-956b-c1aa78cb02cb",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
+    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "visual-to-field-button-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "combo-box-visual-to-field-button",
+    "uuid": "c5a4baf2-effe-4d9a-92f3-b4ead5440d36",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
+    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "visual-to-field-button-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "combo-box-visual-to-field-button",
+    "uuid": "292cbbe1-1ba4-4369-9768-2051c07e6406",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
+    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+  },
+  {
+    "name": {
+      "component": "combo-box",
+      "property": "visual-to-field-button-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "combo-box-visual-to-field-button",
+    "uuid": "5d054a3e-e4bb-4ca3-b84a-51b3d7fa2cb8",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
+    "replaced_by": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "body-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "393e9a11-77f6-42a7-973b-34c673ad8afb",
+    "set_uuid": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "body-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-xs",
+    "uuid": "1d817b1e-7916-4443-b04d-aa232b089f67",
+    "set_uuid": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "body-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "contextual-help-body-font-size",
+    "uuid": "e458fa68-ab9c-4441-a7d5-a02f42df1cae",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "268px",
+    "uuid": "83be73fe-50bc-4be8-969c-0361a816225b"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-m",
+    "uuid": "16ee4dfd-afbe-482b-943e-03e2614037dd",
+    "set_uuid": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-s",
+    "uuid": "965f0854-0f3c-4d6e-9e21-54542ecf1a17",
+    "set_uuid": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "contextual-help",
+      "property": "title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "contextual-help-title-font-size",
+    "uuid": "5358fd6c-d9a0-4caa-a85e-af82ed82efaf",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "c9fac273-0c5c-46cd-b774-ad566a540511",
+    "set_uuid": "e8659c2e-f4b7-4732-b23c-16af4a1d79c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "11f924ca-5542-4864-b153-77363a32d690",
+    "set_uuid": "e8659c2e-f4b7-4732-b23c-16af4a1d79c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "5b416331-7910-4d64-9b5f-43fd1832d3a6",
+    "set_uuid": "587977b6-8adf-4b54-b940-6354b0e830fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "11f65b04-c50d-45bb-86bd-34520aa7db61",
+    "set_uuid": "587977b6-8adf-4b54-b940-6354b0e830fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "f0a65c80-55e8-4ad3-b68c-8429c2fefcf5",
+    "set_uuid": "8a4ae475-b40f-49dd-bbcc-bd6bc135b0f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "37867ac1-4101-4553-98e1-c8a94fdd2d66",
+    "set_uuid": "8a4ae475-b40f-49dd-bbcc-bd6bc135b0f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "b7e0939f-45ef-4250-8138-2bee9dcb2be4",
+    "set_uuid": "b490e81d-f2f0-4857-b2f4-cbea8edb8383",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2fed48b7-dd3d-4c3c-9d5c-3046934f5cfd",
+    "set_uuid": "b490e81d-f2f0-4857-b2f4-cbea8edb8383",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "1228762d-8c89-4e04-a097-5001d805877d",
+    "set_uuid": "7029c6a0-dce5-4149-a8fd-c3d28c05d065",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "a865d5f8-4798-4721-ab76-3b51067d6439",
+    "set_uuid": "7029c6a0-dce5-4149-a8fd-c3d28c05d065",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "825c1a0a-e6a3-41dc-81bb-0fb9b74c0ca2",
+    "set_uuid": "96e922f2-8178-4961-99e5-f86e08b947b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "e12ac1ec-08f8-4d8b-8c4b-29b74cafe1a1",
+    "set_uuid": "96e922f2-8178-4961-99e5-f86e08b947b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "8e597833-1025-4de4-b34a-2f34201487c3",
+    "set_uuid": "bd1ab7ff-ab35-401f-8f6e-69d986a457c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "cross-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "622d259d-b52b-409a-bf58-04705d8423f9",
+    "set_uuid": "bd1ab7ff-ab35-401f-8f6e-69d986a457c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "67464126-edf0-49db-a07c-8641d4a24cae",
+    "set_uuid": "01c16d60-dd80-4a7b-a55f-24d68a6e88c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "9dc14737-973d-4f6e-8336-2e119c1f1af7",
+    "set_uuid": "01c16d60-dd80-4a7b-a55f-24d68a6e88c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "220d2f95-067f-4169-bab7-1b4e202bd1a1",
+    "set_uuid": "fafd0a22-6824-43fc-b348-a4cf287ad4a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "98ebf128-02f1-4d4b-a686-af8713a0f24b",
+    "set_uuid": "fafd0a22-6824-43fc-b348-a4cf287ad4a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "84f3da59-4c41-4e4e-925c-5fda4222361d",
+    "set_uuid": "4d434220-41ef-4ab3-8adc-dabb5e0d799c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "ad59353e-3ed1-4e76-af87-020cebfa2664",
+    "set_uuid": "4d434220-41ef-4ab3-8adc-dabb5e0d799c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "17540c3a-2f85-4771-a4f8-834c70872abb",
+    "set_uuid": "85ca8298-e55c-4a58-813a-50419d06a0c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "d2c45711-be18-4c85-8b23-f4d4f3d0b492",
+    "set_uuid": "85ca8298-e55c-4a58-813a-50419d06a0c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "59e5a3f7-c1d0-4b76-bb7e-2bcddddb83da",
+    "set_uuid": "2298f2ce-e1b5-4a77-b1e5-180ed32b9711",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "ea331ff6-aa92-4cb4-936a-554a2404152d",
+    "set_uuid": "2298f2ce-e1b5-4a77-b1e5-180ed32b9711",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "08358bbf-3f8d-48fe-bb48-5dadead4170f",
+    "set_uuid": "59582588-d429-4949-9dfc-d2be3eb1963b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "8d2ad303-095d-4f0c-b0c5-c1ec75b96819",
+    "set_uuid": "59582588-d429-4949-9dfc-d2be3eb1963b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "34316272-7bcd-4b44-af20-07c0e1cb8690",
+    "set_uuid": "002e91f0-f8d7-4c82-983d-9fdeb54c8a27",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "2e81ce48-452d-401f-a44d-10ca427f031e",
+    "set_uuid": "002e91f0-f8d7-4c82-983d-9fdeb54c8a27",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "bfd0ad6e-6656-46d6-aa9f-0940b2c2902a",
+    "set_uuid": "b44a2927-7b2e-494c-9f79-ba7ea5eaabd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "dash-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "1b6d0e50-3ba2-43c9-8b8c-c220364f4434",
+    "set_uuid": "b44a2927-7b2e-494c-9f79-ba7ea5eaabd2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "date-field",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "152px",
+    "uuid": "ebc4d09b-03c8-475a-af01-9bfcd590d92b"
+  },
+  {
+    "name": {
+      "component": "date-field",
+      "property": "text-to-visual"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "4725710f-67b2-4000-b4e8-e67a68cd75f5",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Date and time fields use 20px whereas text field appears to use padding value",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "date-picker",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "152px",
+    "uuid": "69c201ab-f9d3-4a02-8fc9-ff96ff38eed4"
+  },
+  {
+    "name": {
+      "component": "date-picker",
+      "property": "text-to-visual"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "c6c92147-8ee5-408b-9590-adede6abc935",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "date-picker",
+      "property": "visual-to-field-button"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "da7f0c10-fa1b-4700-8acf-01feebdeed7f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "divider",
+      "property": "horizontal-minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "a0093378-0b2c-474b-9fe5-76940fd1398b"
+  },
+  {
+    "name": {
+      "component": "divider",
+      "property": "thickness-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "913cce2a-c928-4803-9bd6-3fb1e0fcbee5"
+  },
+  {
+    "name": {
+      "component": "divider",
+      "property": "thickness-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "3cf3e962-92f3-4334-8b92-9a1da9396c25"
+  },
+  {
+    "name": {
+      "component": "divider",
+      "property": "thickness-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "9dcc27ef-7044-4051-97f3-2fd64a5d0a36"
+  },
+  {
+    "name": {
+      "component": "divider",
+      "property": "vertical-minimum-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "299db7d6-66f6-4fcb-890d-223406c85ae4"
+  },
+  {
+    "name": {
+      "component": "double-calendar",
+      "property": "popover-minimum-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "320px",
+    "uuid": "70cf1c19-7b41-4556-8db2-07fc7ad19666"
+  },
+  {
+    "name": {
+      "component": "double-calendar",
+      "property": "popover-minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "616px",
+    "uuid": "5c1de210-df6c-4a3a-8cc7-b9766a676f2f"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "85273338-00a6-407d-b5f9-803a732b84fa",
+    "set_uuid": "a0334fc6-e127-43e0-be41-7ecb5ef52b22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "f60c626f-f217-46eb-b2ed-5c56c3f87aa4",
+    "set_uuid": "a0334fc6-e127-43e0-be41-7ecb5ef52b22",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "4342319b-d8c4-485b-9b2f-5bd4c702979c",
+    "set_uuid": "79a9ff24-76dd-4d94-aac8-c226e64b88ba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "b8370ec4-5e70-4a53-a98e-a733c86ce065",
+    "set_uuid": "79a9ff24-76dd-4d94-aac8-c226e64b88ba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "91eb8665-5728-468c-a533-1aadf70aeef1",
+    "set_uuid": "42b99d05-5642-4663-8789-c30b9a7439d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "93052ad2-8ada-40d8-a046-16e5a91ae826",
+    "set_uuid": "42b99d05-5642-4663-8789-c30b9a7439d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "c4ae0720-ee2c-41b8-a8ad-a30528a8a967",
+    "set_uuid": "c1efdd8f-29ec-4c77-b750-ca011bd8de1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drag-handle-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "e2615055-159e-4b87-b7ce-1537f25fcdd4",
+    "set_uuid": "c1efdd8f-29ec-4c77-b750-ca011bd8de1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "body-font-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-medium-body-font-size",
+    "uuid": "644593be-82da-4ae4-ae57-fabebd4513ca"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "body-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-zone-body-font-size",
+    "uuid": "bb3fee51-24cc-4643-9f22-fa1592ab2457",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use drop-zone-body-font-size instead",
+    "replaced_by": "644593be-82da-4ae4-ae57-fabebd4513ca"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "border-dash-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "47c15433-53d3-425b-8b87-ea234701f781",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token drop-target-dash-gap instead.",
+    "replaced_by": "5582026a-22e6-4e0e-9a21-2a7a43b026a6"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "border-dash-length"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "a596af57-256f-4445-b91f-36e47bfb2d95",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token drop-target-dash-length instead.",
+    "replaced_by": "24cd8175-3dc5-46ae-b1af-01632787fcd8"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "cjk-title-font-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-medium-cjk-title-font-size",
+    "uuid": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "cjk-title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-zone-cjk-title-font-size",
+    "uuid": "013387e8-8925-4bb4-a8ee-94420141fde9",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use drop-zone-cjk-title-font-size instead",
+    "replaced_by": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "content-maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-maximum-width",
+    "uuid": "b8d0db71-9a25-46fc-b77a-037fcf86be8e",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "title-font-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-medium-title-font-size",
+    "uuid": "07564dd0-3628-42e1-8a29-253448a8c75f"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-zone-title-font-size",
+    "uuid": "edc68bfe-7ad3-4a12-81fa-ded8fb6fc2e3",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use drop-zone-title-font-size instead",
+    "replaced_by": "07564dd0-3628-42e1-8a29-253448a8c75f"
+  },
+  {
+    "name": {
+      "component": "drop-zone",
+      "property": "width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "428px",
+    "uuid": "2097b13e-94b3-4a06-a0af-c7d8420d1273"
+  },
+  {
+    "name": {
+      "property": "field-default-width-extra-large",
+      "component": "field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "23090def-780a-48cb-b644-8edd55189d46",
+    "set_uuid": "5ab58f4b-2493-499a-ab97-f7533de2c5fa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-extra-large",
+      "component": "field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "288px",
+    "uuid": "068a256a-8dfc-4616-bdc1-8895441ba90b",
+    "set_uuid": "5ab58f4b-2493-499a-ab97-f7533de2c5fa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-large",
+      "component": "field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "224px",
+    "uuid": "c6d08f8b-4e8c-478a-8b08-5b69d2da1a5e",
+    "set_uuid": "4b7418ca-2384-4470-bfca-d8f742681740",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-large",
+      "component": "field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "272px",
+    "uuid": "88dfd273-555a-49bc-9271-a63ad45964e2",
+    "set_uuid": "4b7418ca-2384-4470-bfca-d8f742681740",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-medium",
+      "component": "field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "208px",
+    "uuid": "f35ec29c-b8ee-46c9-9c8c-c40171a15920",
+    "set_uuid": "7e5eb477-85b4-46c3-a5eb-ac986b3298e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-medium",
+      "component": "field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "256px",
+    "uuid": "db379ff6-9ef2-44ee-9fce-32f1a53d68da",
+    "set_uuid": "7e5eb477-85b4-46c3-a5eb-ac986b3298e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-small",
+      "component": "field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "39c39c14-0500-4bf6-a542-967697aaff41",
+    "set_uuid": "2fe6f129-a722-46ca-9f87-2cebcd2faa38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "field-default-width-small",
+      "component": "field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "976298d3-326f-43da-aa71-bbd2dc1fad3d",
+    "set_uuid": "2fe6f129-a722-46ca-9f87-2cebcd2faa38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "4140e899-8a28-4627-a91a-e6526da1bdf5",
+    "set_uuid": "b5fb9c25-00db-4bcc-9910-9fa9c0a8e704",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "17ba788d-da38-455d-9322-16e4f05ea923",
+    "set_uuid": "b5fb9c25-00db-4bcc-9910-9fa9c0a8e704",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "997c475e-6ae5-469f-9c8e-9fedafa2b556",
+    "set_uuid": "e96cc084-8713-459c-8912-7cf238446020",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "87149afe-899b-4fb6-bd7c-d2becf8117fc",
+    "set_uuid": "e96cc084-8713-459c-8912-7cf238446020",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "7be280dc-43dc-48c3-bf0c-b53f95e76516",
+    "set_uuid": "95cbc996-ee6b-4f20-88ce-ccca3753ac14",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "2fbc4add-e6b4-4dfa-9a7d-0de628b2f63c",
+    "set_uuid": "95cbc996-ee6b-4f20-88ce-ccca3753ac14",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "4796831f-4d3e-472c-bad8-699d4eb443ea",
+    "set_uuid": "03e228c7-41b9-4f57-b7d9-4b31b881fa35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "text-to-asterisk-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "4271498d-747c-423d-87cc-761b8a181f7c",
+    "set_uuid": "03e228c7-41b9-4f57-b7d9-4b31b881fa35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "4738ec46-a43c-48f9-aeca-87863275dc4d",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-15px",
+    "uuid": "d6c750dc-3117-4c1a-96bf-b94d530e912d",
+    "set_uuid": "af6de4b2-6fee-48fe-9222-c62caa55f212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-19px",
+    "uuid": "e1298748-d7cc-4bff-93bc-745b777fcf9e",
+    "set_uuid": "af6de4b2-6fee-48fe-9222-c62caa55f212",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-12px",
+    "uuid": "be80f1b1-4c08-479f-a39e-28b6a64714f2",
+    "set_uuid": "79363184-cff7-42ae-8087-c68213bfaa8a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-15px",
+    "uuid": "c29cfb87-34e7-4397-bfd8-23378ecbb011",
+    "set_uuid": "79363184-cff7-42ae-8087-c68213bfaa8a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-8px",
+    "uuid": "dc00948e-3c0f-4c6b-8e3e-a7fbf396e059",
+    "set_uuid": "445b1198-2df9-4c34-ae7e-790b846071e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-10px",
+    "uuid": "074489d2-66b0-4198-94fe-9818279bbf0f",
+    "set_uuid": "445b1198-2df9-4c34-ae7e-790b846071e0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-8px",
+    "uuid": "1218beeb-1d74-4e1a-b495-38d5f07afb55",
+    "set_uuid": "e4372c7c-3f59-4b2d-8862-61453adcd800",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "to-component-quiet-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-10px",
+    "uuid": "2d3e67ce-de6d-4e41-bcf8-06b09c0bcce7",
+    "set_uuid": "e4372c7c-3f59-4b2d-8862-61453adcd800",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-margin-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "5c14d528-fe17-4b0b-a123-edbdb93fd173",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-margin-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "f7dd90d8-91e6-4090-a5a9-6b30087860a4",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-margin-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "b5243f56-7985-4686-b41f-9b9b9a18b047",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-margin-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "ab718f97-15c3-4b8b-aee7-b50b09ec0a33",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "e53ea4a5-bde5-4695-9ab8-50c2ce704019",
+    "set_uuid": "2bfd21da-c4db-4837-9404-e02405717b25",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "5227bf07-140a-49c6-88f9-cc454d8a90c1",
+    "set_uuid": "2bfd21da-c4db-4837-9404-e02405717b25",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "60caa810-5335-4c9f-95a7-0e60d49f43fc",
+    "set_uuid": "a06e0c59-60ef-41f4-b471-797687ee76cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "e410a804-2655-4bbc-9b66-53a5facc92ac",
+    "set_uuid": "a06e0c59-60ef-41f4-b471-797687ee76cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "eb2b857d-9482-42fb-82f9-bbe7899a22b9",
+    "set_uuid": "5435348b-4bb7-43b2-910f-31d2ca5873f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "6f65ad1a-4a65-4b83-af44-5bd893f3b40e",
+    "set_uuid": "5435348b-4bb7-43b2-910f-31d2ca5873f9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "7122627b-1906-424d-9cbf-261546ff3774",
+    "set_uuid": "2eda2c97-806e-40fd-8a72-f6542bd4e988",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "field-label",
+      "property": "top-to-asterisk-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "ec0c072f-50fb-4934-99fc-a2576062e7b4",
+    "set_uuid": "2eda2c97-806e-40fd-8a72-f6542bd4e988",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires UI icon to be placed in frame of height workflow-icon-[size], or calculate this token + ( (workflow-icon-[size] - ui-icon-[size]) / 2 )",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "floating-action-button",
+      "property": "drop-shadow-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "82e8cf04-7eda-4f36-8d2c-fda63241c3de"
+  },
+  {
+    "name": {
+      "component": "floating-action-button",
+      "property": "drop-shadow-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "a4ddc1a6-1367-4153-bb7c-c217d16d10f4"
+  },
+  {
+    "name": {
+      "component": "gripper-icon",
+      "property": "size-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "e6f95e88-636d-4d3a-8966-8c811dc697d6",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "help-text",
+      "property": "to-component"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "f99eb317-ebe5-43e7-8066-982fe7a9a8aa",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "help-text",
+      "property": "top-to-workflow-icon-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-workflow-icon-300",
+    "uuid": "bec914a9-5905-40ac-bd61-a727016c1228",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with component-top-to-workflow-icon-300",
+    "replaced_by": "955bbeaf-dc4e-460b-8957-d145d4b6fc3e"
+  },
+  {
+    "name": {
+      "component": "help-text",
+      "property": "top-to-workflow-icon-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-workflow-icon-200",
+    "uuid": "54cae12b-5f21-47b4-a964-6033bd025975",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with component-top-to-workflow-icon-200",
+    "replaced_by": "81bfcc6f-348b-4728-bfdc-10f2f181b041"
+  },
+  {
+    "name": {
+      "component": "help-text",
+      "property": "top-to-workflow-icon-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-workflow-icon-100",
+    "uuid": "d159b313-4def-493a-adcf-398e2d1fce9f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with component-top-to-workflow-icon-100",
+    "replaced_by": "2b17325c-eec1-43e2-9a31-957adf67e44d"
+  },
+  {
+    "name": {
+      "component": "help-text",
+      "property": "top-to-workflow-icon-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-workflow-icon-75",
+    "uuid": "91cb19ef-63fc-4d98-a61e-a5f55951f656",
+    "deprecated": "unknown",
+    "deprecated_comment": "Replaced with component-top-to-workflow-icon-75",
+    "replaced_by": "3b07cd46-add6-4cd9-b3f8-626f113905dd"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "body-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-large-body-font-size",
+    "uuid": "4140710f-ae31-4ae3-b8b6-2d3eb6a1ae78",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use illustrated-message-medium-body-font-size instead",
+    "replaced_by": "22f5b08c-2b86-447d-be0b-ed03841dbcfb"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "cjk-title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-large-cjk-title-font-size",
+    "uuid": "e77279df-bc62-441a-8a30-5faa41d0df10",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use illustrated-message-medium-cjk-title-font-size instead",
+    "replaced_by": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "horizontal-maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "535px",
+    "uuid": "4413ee4d-86b1-4d88-b2ee-64c0939698b9"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "large-body-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "0208e74a-4a86-42e4-a5d0-f931715c293b",
+    "set_uuid": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "large-body-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-xs",
+    "uuid": "f4956b2c-dfda-4449-850b-36cf3a82ea09",
+    "set_uuid": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "large-cjk-title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-cjk-size-xxl",
+    "uuid": "1929c819-5333-43ad-ba6c-fcf236270251",
+    "set_uuid": "44509721-b85a-4c57-8850-d52322e0afef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "large-cjk-title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-cjk-size-xl",
+    "uuid": "e3c5a7ed-94f9-4938-9b92-b411e971af20",
+    "set_uuid": "44509721-b85a-4c57-8850-d52322e0afef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "large-title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xxl",
+    "uuid": "abfe147d-04dd-45bd-8e86-eae6249e1745",
+    "set_uuid": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "large-title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xl",
+    "uuid": "05104cea-7882-4f80-a994-3e072d29eec2",
+    "set_uuid": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-vertical-maximum-width",
+    "uuid": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "medium-body-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "ca0d9e22-35a8-4ae5-99ee-29cce3ffa0bd",
+    "set_uuid": "22f5b08c-2b86-447d-be0b-ed03841dbcfb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "medium-body-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-xs",
+    "uuid": "32b359dc-b489-4476-afbd-1c04e6b0ff0e",
+    "set_uuid": "22f5b08c-2b86-447d-be0b-ed03841dbcfb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "medium-cjk-title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-cjk-size-xl",
+    "uuid": "ee763c7d-b98f-4f2e-9fc4-764cfa2ac53f",
+    "set_uuid": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "medium-cjk-title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-cjk-size-l",
+    "uuid": "1cb0c913-f4ec-478c-b92d-4c9d78875362",
+    "set_uuid": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "medium-title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xl",
+    "uuid": "8e2d1a48-937c-4493-9624-5ca8383f74bd",
+    "set_uuid": "5a575423-6129-4fcf-93f0-d3eb44096dd5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "medium-title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-l",
+    "uuid": "65961091-abdb-4155-9887-4aebe857c4fd",
+    "set_uuid": "5a575423-6129-4fcf-93f0-d3eb44096dd5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "small-body-font-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-xs",
+    "uuid": "fad078e5-1791-4003-994d-3567162d8233"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "small-cjk-title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-cjk-size-m",
+    "uuid": "9a6cf390-ca10-4242-a7d4-da4c9acc4058",
+    "set_uuid": "e5e7d4e3-39c7-4184-b590-cc4abf2f60fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "small-cjk-title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-cjk-size-s",
+    "uuid": "a144455d-6bb3-43d4-828c-6b6f67ae9c51",
+    "set_uuid": "e5e7d4e3-39c7-4184-b590-cc4abf2f60fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "small-title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-m",
+    "uuid": "f21da7b8-ba19-43e0-96e5-f9e60476ef6e",
+    "set_uuid": "2164a3c7-b90d-4072-8f72-f364d07edb38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "small-title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-s",
+    "uuid": "ef8d0abb-9652-4db3-8f1d-506c03e5e115",
+    "set_uuid": "2164a3c7-b90d-4072-8f72-f364d07edb38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "title-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "illustrated-message-large-title-font-size",
+    "uuid": "365ec548-431b-4e1e-9f9d-7b04d337f001",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use illustrated-message-medium-title-font-size instead",
+    "replaced_by": "5a575423-6129-4fcf-93f0-d3eb44096dd5"
+  },
+  {
+    "name": {
+      "component": "illustrated-message",
+      "property": "vertical-maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "380px",
+    "uuid": "95c055b0-f688-4405-8426-1b2302e32ebd"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-disclosure-icon-stacked-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "d563157b-f0d7-407d-aaaf-ae1790c75503",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-disclosure-icon-stacked-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "6a6e5478-b549-4a39-a7f5-5d3c417464ce",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-disclosure-icon-stacked-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "ccb60cfc-86fe-4959-b4a8-1a45835132c8",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-disclosure-icon-stacked-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "8b6a0ab1-4dba-4da2-9c67-3befca0f110e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Requires refactor; prior value is this token + accessory-gap-[size]",
+    "replaced_by": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "5bffe992-2982-49e8-aa3a-e4e93c884f43",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "4b212f73-7a28-4d95-b06b-6d3f0d7e5cf9",
+    "set_uuid": "bb2781a4-0b80-4d3d-9d40-9755833ef217",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead.",
+    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "61cf3878-48bd-4785-ad71-ec35c4f99656",
+    "set_uuid": "bb2781a4-0b80-4d3d-9d40-9755833ef217",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead.",
+    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "44e97486-53ce-4bb0-a778-0f9262dfe27e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-large instead.",
+    "replaced_by": "609e172d-40af-4329-b9d7-32c9158b40bb"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "86f41898-b794-4f7e-ae41-9eb84c2c7a5b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-medium instead.",
+    "replaced_by": "627d972a-4164-4ec6-8c64-0ee97c23fc43"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "0171b422-021a-4f25-bbe3-7d6ca6459166",
+    "set_uuid": "9a3568cf-7ca2-4393-a087-c865ad803e70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-small instead.",
+    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "edge-to-fill-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "a2143caf-07e6-4d45-977c-3d79d69c335e",
+    "set_uuid": "9a3568cf-7ca2-4393-a087-c865ad803e70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-small instead.",
+    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "fill-stacked-inner-border-rounding"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "f8ed9a70-58f1-4f1a-9e87-24bca6d7b4e1"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "inner-edge-to-disclosure-icon-stacked-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large",
+    "uuid": "c47499c1-b89f-49a7-bbb5-17e83e4b306e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "inner-edge-to-disclosure-icon-stacked-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-large",
+    "uuid": "710ebe58-f0d8-4d6b-8974-0be1f2f48dc4",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "inner-edge-to-disclosure-icon-stacked-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-medium",
+    "uuid": "3dd5babb-5026-4f28-89ae-bfe687673f31",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "inner-edge-to-disclosure-icon-stacked-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-small",
+    "uuid": "6c1330a4-1c89-45a7-b2b1-8cbcaf20b9ab",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "outer-edge-to-disclosure-icon-stacked-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "391e1e67-1677-4f60-a09a-3b49bacd01f5",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "outer-edge-to-disclosure-icon-stacked-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "acc9c48a-f461-48ff-9f69-0224c4feabc6",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "outer-edge-to-disclosure-icon-stacked-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "a87d68bb-4249-43cd-947d-bd061baba0ef",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "outer-edge-to-disclosure-icon-stacked-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "9890df35-2d45-4767-9cbe-ee745d09d990",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
+    "replaced_by": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "stacked-inner-edge-to-fill"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "56b54ece-0ff3-4957-9c1c-9e7fb992653c",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "width-stacked-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "5f844b3f-e0d7-40f0-a754-a14bee6a0fb4"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "width-stacked-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "4e103763-4310-4aff-980f-652ad023084f"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "width-stacked-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "bb8c7ce0-1766-47f9-b30e-36b3b57dc2ea"
+  },
+  {
+    "name": {
+      "component": "in-field-button",
+      "property": "width-stacked-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "24125066-c8d1-4c4a-85b3-493d112d3ca0"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "edge-to-fill",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "b49756fe-40d5-439a-ba07-4e5eb07e7cc5",
+    "set_uuid": "b051b8d7-11cd-44e4-9a80-743d551722ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Single pixel value for a specific component: not a token"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "edge-to-fill",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "1263a125-9e9d-4eb4-8b71-024899dcf623",
+    "set_uuid": "b051b8d7-11cd-44e4-9a80-743d551722ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Single pixel value for a specific component: not a token"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "ef5f40e8-d6e9-45a7-b8cf-1689e44e713c",
+    "set_uuid": "f065dfac-d6f2-4b7e-9a3d-b4808cd3ef55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "c522b33c-93b8-491f-b4df-c241f5b5ade8",
+    "set_uuid": "f065dfac-d6f2-4b7e-9a3d-b4808cd3ef55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "86567889-978e-4dfe-8412-42c8f33c3f44",
+    "set_uuid": "444565d9-c91a-40f5-a0a8-0829f29060ad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "85377238-7488-42e0-99ce-f4fd73316d24",
+    "set_uuid": "444565d9-c91a-40f5-a0a8-0829f29060ad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "32d0a47d-c4bb-4955-aef0-28e07f429b92",
+    "set_uuid": "8cb3472c-d320-42bb-b29e-527b6298bb4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "9e740bd1-b98a-416a-be82-20e222cab3b1",
+    "set_uuid": "8cb3472c-d320-42bb-b29e-527b6298bb4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "dbb4f6bf-ddfb-4184-babe-63815cad7202",
+    "set_uuid": "a25ad27d-24c6-4332-838b-5c0605ec38bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-progress-circle",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "c43c89a6-2ae5-4d29-99ab-2c64e153d4e7",
+    "set_uuid": "a25ad27d-24c6-4332-838b-5c0605ec38bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "in-field-stepper",
+      "property": "to-end-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "8e57f77c-2921-44b8-a602-85300639f916",
+    "set_uuid": "e405ccc1-4c8d-4d2e-8bb0-7013733e82c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
+    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+  },
+  {
+    "name": {
+      "component": "in-field-stepper",
+      "property": "to-end-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "fbc42d9d-2f00-42ae-92e9-727cac69404e",
+    "set_uuid": "e405ccc1-4c8d-4d2e-8bb0-7013733e82c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
+    "replaced_by": "ae4398f5-6ead-4928-adf9-f39c0cfcec11"
+  },
+  {
+    "name": {
+      "component": "in-field-stepper",
+      "property": "to-end-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "cb3e458d-7dcd-484d-9028-220d08c9f129",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-large instead. Refactoring required",
+    "replaced_by": "609e172d-40af-4329-b9d7-32c9158b40bb"
+  },
+  {
+    "name": {
+      "component": "in-field-stepper",
+      "property": "to-end-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "fe42bdd0-de02-4814-b498-038b26a3c0e7",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-medium instead. Refactoring required",
+    "replaced_by": "627d972a-4164-4ec6-8c64-0ee97c23fc43"
+  },
+  {
+    "name": {
+      "component": "in-field-stepper",
+      "property": "to-end-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "ec801932-08dc-4697-8725-5bc9d3ee230d",
+    "set_uuid": "bceb3359-ccf7-4f05-9cf5-1fba6b7b9efb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-small instead. Refactoring required",
+    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+  },
+  {
+    "name": {
+      "component": "in-field-stepper",
+      "property": "to-end-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "90669b85-c7e8-4b68-b96d-61a51a2451b3",
+    "set_uuid": "bceb3359-ccf7-4f05-9cf5-1fba6b7b9efb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-gap-small instead. Refactoring required",
+    "replaced_by": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
+  },
+  {
+    "name": {
+      "component": "in-line-alert",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "8007ebd8-fd67-4dc2-8444-9e6a50c88675"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "cc8ad91e-22f2-4f59-ae8c-99d2c1433d6e",
+    "set_uuid": "0722a411-c7c0-4906-8e41-e043b4c245d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "083c11fe-1e10-46f5-9e71-3fcc2567fe2d",
+    "set_uuid": "0722a411-c7c0-4906-8e41-e043b4c245d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "f78418a4-5b55-418b-9c90-7f388d5bb275",
+    "set_uuid": "de0d84cb-14d8-40b3-bae2-8826d4ee03f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "0062482b-0339-4632-9b40-89b5f1a440cf",
+    "set_uuid": "de0d84cb-14d8-40b3-bae2-8826d4ee03f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "66e386cd-e3b5-424b-b89b-27fe9aaf5ad1",
+    "set_uuid": "bc5fab17-8503-442c-a560-fa7a1f8d99c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "a063db0d-81cf-45e0-988e-2224307560ba",
+    "set_uuid": "bc5fab17-8503-442c-a560-fa7a1f8d99c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "54227cbe-b962-46de-b40a-d1ea759425a7",
+    "set_uuid": "43458e95-45f9-4d0b-8383-6da7a6080a58",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "1bcd281a-38b0-4e83-8667-536351dd14ec",
+    "set_uuid": "43458e95-45f9-4d0b-8383-6da7a6080a58",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "1e41d09e-684e-4f87-ae85-4bc95f958c0e",
+    "set_uuid": "981b8bc8-1914-4406-890f-748efaa1c27c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "link-out-icon",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "cb87186b-47aa-4baa-a47d-91b5e9f7965e",
+    "set_uuid": "981b8bc8-1914-4406-890f-748efaa1c27c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "end-edge-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "6dc382ce-8e48-4bd9-8078-1272da767b13",
+    "set_uuid": "4d5193b8-c43e-4bc6-ab23-8d0132ee738e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "end-edge-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "16552174-994e-41c3-9439-32b9876c399d",
+    "set_uuid": "4d5193b8-c43e-4bc6-ab23-8d0132ee738e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "item-bottom-corner-radius"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-medium-default",
+    "uuid": "57821e37-d39e-49d5-b978-4ece3747e531"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "item-top-corner-radius"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-medium-default",
+    "uuid": "6e4611f7-f202-4003-94b4-587d48d07e32"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "fe1dcf27-addf-4aa9-9057-7b98a4dcacdc",
+    "set_uuid": "5dc02446-3f40-4370-b367-5f97b2ad3ca4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "6ca2c317-7e17-41f7-8e2c-20a762fe284d",
+    "set_uuid": "5dc02446-3f40-4370-b367-5f97b2ad3ca4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "82b718ef-6127-472b-b92f-f2f15833c49f",
+    "set_uuid": "378170d5-ffa0-42fe-9f8a-421e539217ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "list-view",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "3f68b526-a22a-4086-a40d-3a875a6324b3",
+    "set_uuid": "378170d5-ffa0-42fe-9f8a-421e539217ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "background-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0",
+    "uuid": "6f464689-0b87-4f38-b9a4-e5015acdd0d7"
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-extra-large",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "45px",
+    "uuid": "2480bdaf-ac18-4f67-9a0b-f92200fb31d7",
+    "set_uuid": "5cfd407f-6acc-4796-b337-e48e46a15ff4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-extra-large",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "54px",
+    "uuid": "3385c12f-199b-4e9d-b2e2-ef6e2658d180",
+    "set_uuid": "5cfd407f-6acc-4796-b337-e48e46a15ff4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-large",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "38px",
+    "uuid": "bc6a7e9d-b84c-4bf3-9a63-a08047deb41c",
+    "set_uuid": "de0aca49-d688-4b7b-85d1-7b1d74ed1098",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-large",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "47px",
+    "uuid": "90385dcc-ea45-466f-ba4d-a1b13f6a079c",
+    "set_uuid": "de0aca49-d688-4b7b-85d1-7b1d74ed1098",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-medium",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "ac4c8abe-abca-4c6f-82e7-ed7fae0c761d",
+    "set_uuid": "68195e44-015b-4611-9557-81fd60ff5965",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-medium",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "42px",
+    "uuid": "5faa4858-5590-40d4-bd12-b4c839908c4c",
+    "set_uuid": "68195e44-015b-4611-9557-81fd60ff5965",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-small",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "033fb47f-30d8-4ff2-9825-a3318ca2118b",
+    "set_uuid": "9e079b05-cb44-4901-945f-35f78b3c5fb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "property": "menu-item-edge-to-content-not-selected-small",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "de2ef572-54a2-46c2-ad1d-60468fbe6090",
+    "set_uuid": "9e079b05-cb44-4901-945f-35f78b3c5fb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This use case should not be a single token but either calculated or structurally determined. Refactor may be required."
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-label-to-description"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "menu-item-label-to-description-medium",
+    "uuid": "628cf42f-eb40-49b0-b110-3340421d4502",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "label-to-description-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "5543ede1-4e55-44f5-920f-288ee96e06ca",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-extra-large instead.",
+    "replaced_by": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "label-to-description-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "4ce8b4db-72f8-411b-baad-8b66c0496182",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-large instead.",
+    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "label-to-description-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "608fd592-fff8-435e-88e2-846bd34cc235",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-medium instead.",
+    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "label-to-description-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "66d57402-d7db-45df-8872-fd362014bcbe",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-small instead.",
+    "replaced_by": "d61248dc-0a2d-469d-a81f-0417e0bb5de2"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-section-divider-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "dac5c077-b948-434b-91bd-0759c2414007"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "63919dd9-0dfa-4e6f-ab89-8a24fc91061b",
+    "set_uuid": "c700c8fe-18e4-49b5-9887-dc65217207f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "77e97b70-ef7e-4228-8d91-0ff9d9d2b063",
+    "set_uuid": "c700c8fe-18e4-49b5-9887-dc65217207f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "bceffb12-72a3-40eb-98a5-3d5fb4d3b627",
+    "set_uuid": "a42d6196-dd09-4731-98fb-6eecf7551f15",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "bda3ee60-8f9a-41b2-a8a2-894aed3b3bed",
+    "set_uuid": "a42d6196-dd09-4731-98fb-6eecf7551f15",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "0ed8f599-b4c1-4ac5-b2b0-60db06a98a88",
+    "set_uuid": "e89563f5-9481-4f60-9af8-d2836ccc4a8d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "e0468683-b2d2-4839-9ad8-46963d7402fc",
+    "set_uuid": "e89563f5-9481-4f60-9af8-d2836ccc4a8d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "8e4b2873-fb57-42d6-8b7b-91fd270c048e",
+    "set_uuid": "108ba016-2e21-4f7b-94a7-3f61c987620b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "item-top-to-disclosure-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "eb9cf950-cba2-4fb8-a115-8a4c0ddb00d0",
+    "set_uuid": "108ba016-2e21-4f7b-94a7-3f61c987620b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-extra-large",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "7be78bf9-a761-45a4-b764-b88e6209440b",
+    "set_uuid": "70bbe380-0356-4d91-98ea-93f40c66638d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-extra-large",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "3ff6cb7a-20cb-4b25-a367-7e4497d0f237",
+    "set_uuid": "70bbe380-0356-4d91-98ea-93f40c66638d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-large",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "ccfed193-e366-4b13-806c-0cc18e2a87b4",
+    "set_uuid": "a3d53327-385a-44c0-a2ee-266cef172810",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-large",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "f84569c5-bb63-4eb1-8193-1130e88e7e5b",
+    "set_uuid": "a3d53327-385a-44c0-a2ee-266cef172810",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-medium",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "8fb8ad12-9bb9-417f-8d0d-7323455cfb7a",
+    "set_uuid": "acef8bbf-016d-44cc-ab9e-59e5b982d38e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-medium",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "61e906e3-6daa-4841-b4f0-54939157a50b",
+    "set_uuid": "acef8bbf-016d-44cc-ab9e-59e5b982d38e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-small",
+      "component": "menu",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "fbe45d1b-f4b9-40d1-965f-38abe057dc69",
+    "set_uuid": "a2e09127-bc4b-4f6f-bff3-b6c1524733e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "menu-item-top-to-selected-icon-small",
+      "component": "menu",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "943a0b43-6c91-40a3-a680-318a934bf6ef",
+    "set_uuid": "a2e09127-bc4b-4f6f-bff3-b6c1524733e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "06a6c13b-2d58-4102-b169-073eed5599e6",
+    "set_uuid": "ea52bf43-3e3b-4559-aec3-4f0a02734a95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "dfeef197-57b9-41a1-b759-3c782a64f2f3",
+    "set_uuid": "ea52bf43-3e3b-4559-aec3-4f0a02734a95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "0d468b92-74df-4044-8af3-c867eebbf370",
+    "set_uuid": "1df536f1-c853-4955-9533-8c9371fc05cc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "64b2f613-35b2-46a8-be7d-c39c314840b9",
+    "set_uuid": "1df536f1-c853-4955-9533-8c9371fc05cc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "f71c4487-3c1e-4204-b631-b0658a6b5e12",
+    "set_uuid": "57fe1e26-77a9-4d8a-ab54-a6f16dc9c5fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "62815f67-4e23-43f9-93d2-f29d1688cddf",
+    "set_uuid": "57fe1e26-77a9-4d8a-ab54-a6f16dc9c5fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "456d5283-eb93-4b8d-b796-7f181ebcec04",
+    "set_uuid": "f81ebf2a-300e-4bc8-89e0-baec8fc07ee4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "menu-item",
+      "property": "top-to-thumbnail-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "af422766-3185-47d6-adba-31b1e97b92d9",
+    "set_uuid": "f81ebf2a-300e-4bc8-89e0-baec8fc07ee4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "section-header-to-description-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "c9e46b75-f1d8-4b19-a258-b8b0a0e66484",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-extra-large instead.",
+    "replaced_by": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "section-header-to-description-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "2899d6e1-acad-453b-ad65-1e6a6e380363",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-large instead.",
+    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "section-header-to-description-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "4211feff-12af-4288-b86d-4c66a5a55b8f",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-medium instead.",
+    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+  },
+  {
+    "name": {
+      "component": "menu",
+      "property": "section-header-to-description-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "ac039575-7c1f-4733-a310-b39cebf83b82",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-small instead.",
+    "replaced_by": "d61248dc-0a2d-469d-a81f-0417e0bb5de2"
+  },
+  {
+    "name": {
+      "property": "meter-default-width",
+      "component": "meter"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "meter-width",
+    "uuid": "2633d29d-8a14-48e8-977c-bdb9a53b3bd5",
+    "deprecated": "unknown",
+    "deprecated_comment": "Token renamed, use `meter-width`",
+    "replaced_by": "986cf4b8-bb3b-4752-83b9-3001d6d6ffac"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "768px",
+    "uuid": "63bfb4da-4aaf-49c6-9328-16c636cf0bf9"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "fd4f6ef0-bab2-4405-9eea-8a9b8a7dd295"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e5ac2b35-da1d-4936-baa8-498705c9529c",
+    "set_uuid": "8f4f9f56-a748-4d92-93ff-7afe0297463a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "272738b2-a274-4e2e-8582-9c2cc7962a85",
+    "set_uuid": "8f4f9f56-a748-4d92-93ff-7afe0297463a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "06751674-2222-433d-9dc6-40f14b2add6c",
+    "set_uuid": "13344afb-aeba-4871-82c6-13275b3aa535",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "c9052808-918e-4368-b113-28f928104eda",
+    "set_uuid": "13344afb-aeba-4871-82c6-13275b3aa535",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "6e404f16-900e-4dd2-8705-3c9077f52240",
+    "set_uuid": "bf21b888-de2b-4e42-9cb2-6a0e10e9d37b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "f9a81245-4bcb-4fca-8a4b-04ac78d9d1ca",
+    "set_uuid": "bf21b888-de2b-4e42-9cb2-6a0e10e9d37b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "0013e354-3f26-41a5-8486-2577045872f6",
+    "set_uuid": "7df8ad06-5524-48ca-946b-0e7a37002422",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "thickness-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "eb9c3cff-5a1a-4832-a623-6ab258b81d37",
+    "set_uuid": "7df8ad06-5524-48ca-946b-0e7a37002422",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "ceeda4da-026b-496c-8abd-7081aceae262",
+    "set_uuid": "986cf4b8-bb3b-4752-83b9-3001d6d6ffac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "meter",
+      "property": "width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "dc5f4966-4ddd-4e9a-a748-370d8eaae568",
+    "set_uuid": "986cf4b8-bb3b-4752-83b9-3001d6d6ffac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1.25,
+    "uuid": "9e24d9b5-1c8b-4693-b10e-8922d519d7e0"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "54f47bf6-78cc-409a-a83e-15f36404d548",
+    "set_uuid": "ebfdcbb4-c3e3-4c68-859e-09b1e01c4005",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead.",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "777f9750-cfea-4eb3-ae08-a18c2fbde315",
+    "set_uuid": "ebfdcbb4-c3e3-4c68-859e-09b1e01c4005",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead.",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "e041ee57-b8be-4c7e-a13d-ec2e2be05504",
+    "set_uuid": "ed452e2a-eded-4035-87fe-d1c120a4de8e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "136a2c42-1868-4343-903d-9e7fbf345d45",
+    "set_uuid": "ed452e2a-eded-4035-87fe-d1c120a4de8e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "2d2b2029-37ff-4563-a404-1347492ca7db",
+    "set_uuid": "fefd5395-dee0-49a6-b5f8-0e2ef2282828",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "83dd3160-a826-4fa2-b643-a6f11533ba45",
+    "set_uuid": "fefd5395-dee0-49a6-b5f8-0e2ef2282828",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "1b494a23-b312-43e2-8148-0d86777c38d4",
+    "set_uuid": "f750781f-5fb2-4578-bf33-95c85bbf469a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "visual-to-in-field-stepper-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "1e55a991-6d8f-4fc1-9dc7-91f86be50e3f",
+    "set_uuid": "f750781f-5fb2-4578-bf33-95c85bbf469a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "168px",
+    "uuid": "c5796762-5837-4600-92e0-5f11364ce471",
+    "set_uuid": "295eaf01-cfae-4514-ae5a-4aafa68555c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "198px",
+    "uuid": "9da98fb6-a90a-4805-8969-88d4a8958157",
+    "set_uuid": "295eaf01-cfae-4514-ae5a-4aafa68555c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "144px",
+    "uuid": "ce84b84a-2036-4041-a121-31f69963bf6c",
+    "set_uuid": "3eca271c-0817-4e00-a826-0f54f467ea05",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "174px",
+    "uuid": "71530ba4-3eb9-4136-b1d2-a28ae5ddf034",
+    "set_uuid": "3eca271c-0817-4e00-a826-0f54f467ea05",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "120px",
+    "uuid": "c7f0b058-d896-4acb-9aac-d073682f8546",
+    "set_uuid": "7978b992-5862-4f9c-b578-b4d2ca6b601a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "150px",
+    "uuid": "4268fc6a-118d-4b3b-a581-b2ab8a503f21",
+    "set_uuid": "7978b992-5862-4f9c-b578-b4d2ca6b601a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "104px",
+    "uuid": "fcd3bdc5-5685-4b14-9ed7-7fd7bb11b584",
+    "set_uuid": "c23d0d28-eda0-43c9-8f48-da9920731e37",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "number-field",
+      "property": "with-stepper-minimum-width-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "126px",
+    "uuid": "08801f40-08ab-47df-82b8-e9cb8a63e3aa",
+    "set_uuid": "c23d0d28-eda0-43c9-8f48-da9920731e37",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "opacity-checkerboard-square-size-medium",
+    "uuid": "9ddf2e73-ad74-46d7-a79d-fe961b06dbbd",
+    "set_uuid": "d847973c-89b2-4454-9dd8-44fb671e9408",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use opacity-checkerboard-square-size-medium instead.",
+    "replaced_by": "a0410857-1be2-4bb8-9b31-a4db7f771485"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "opacity-checkerboard-square-size-medium",
+    "uuid": "879360e9-a7b0-47e0-bc4a-931a12877014",
+    "set_uuid": "d847973c-89b2-4454-9dd8-44fb671e9408",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use opacity-checkerboard-square-size-medium instead.",
+    "replaced_by": "a0410857-1be2-4bb8-9b31-a4db7f771485"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "ead3f34f-55b1-4012-a4af-0f7fbf226020",
+    "set_uuid": "a0410857-1be2-4bb8-9b31-a4db7f771485",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "cc6fdec6-c03a-4691-805f-b60d199bb60d",
+    "set_uuid": "a0410857-1be2-4bb8-9b31-a4db7f771485",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "2537f52b-5cae-4a35-a1f3-b1d4fe89060d",
+    "set_uuid": "8150ac97-2baa-4601-819c-84ab9f6e5cae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "opacity-checkerboard",
+      "property": "square-size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "0916cc84-f46f-45c3-b76d-d7d85d576480",
+    "set_uuid": "8150ac97-2baa-4601-819c-84ab9f6e5cae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "border-width-100",
+    "uuid": "69c28762-f456-4641-b6ce-7cb295e3a27d"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "end-edge-to-disclosure-icon-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "03da68d8-cd87-4e29-9aaf-ab467594ec2b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "end-edge-to-disclousure-icon-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "picker-end-edge-to-disclosure-icon-quiet",
+    "uuid": "c8bd227d-c72b-4f6a-9d93-0b595821dee0",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use `picker-end-edge-to-disclosure-icon-quiet` instead",
+    "replaced_by": "03da68d8-cd87-4e29-9aaf-ab467594ec2b"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 2,
+    "uuid": "67b68a30-ae00-4da2-9730-99196a2eaf96"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "de09427a-eef3-4360-a912-0b0d5602d4a4",
+    "set_uuid": "e23401b3-8651-4e03-8be3-380e09670ccc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "0ac097c8-020e-4a7b-b692-59dfdf07e3f8",
+    "set_uuid": "e23401b3-8651-4e03-8be3-380e09670ccc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "2f22005b-305b-4629-bc03-10d81e36ce78",
+    "set_uuid": "ea7d1bf8-6182-441c-8ffd-046980a2e7b1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "47f5a27f-4039-4668-bb21-aafb9dcb82fb",
+    "set_uuid": "ea7d1bf8-6182-441c-8ffd-046980a2e7b1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "f83b0313-ba78-4c98-be6e-702b58956589",
+    "set_uuid": "bb6e5e38-eb54-464a-a94a-00be04263d2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "c620ab2b-256d-409a-a80c-7d7c2295efc8",
+    "set_uuid": "bb6e5e38-eb54-464a-a94a-00be04263d2a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "4bcebd07-28a8-401d-9072-3b2ac22e8b63",
+    "set_uuid": "6b3db559-9077-45a2-9e7c-993833799c0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "picker",
+      "property": "visual-to-disclosure-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "269725c9-3462-4132-8487-95dd61814448",
+    "set_uuid": "6b3db559-9077-45a2-9e7c-993833799c0a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "edge-to-content-area"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "2a3bd47e-fde5-41d3-a585-f970bdefaf07",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-padding instead.",
+    "replaced_by": "c872da51-317e-44cf-aef8-2f5f9fb77ae8"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "tip-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "5960406b-973d-4e1f-9bb4-2c7a22422c5b"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "tip-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "c4bc3596-1fbc-4b08-85af-6bd8142e499a"
+  },
+  {
+    "name": {
+      "component": "popover",
+      "property": "top-to-content-area"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "popover-edge-to-content-area",
+    "uuid": "f97488e8-b1c1-442e-b98c-0ae6cff0b774",
+    "deprecated": "unknown",
+    "deprecated_comment": "Introduced as an error. Use popover-edge-to-content-area instead",
+    "replaced_by": "2a3bd47e-fde5-41d3-a585-f970bdefaf07"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "768px",
+    "uuid": "7ba00389-a6ba-4d18-9d88-8704427ad784"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "8dfd4f94-93cc-47dd-92d2-87d1696f4ab7"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "71229a29-a2cf-46bc-84d4-d324bffad26b",
+    "set_uuid": "2c15f8e9-7fa5-43d6-9797-d1b3249fea3f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "c15e51b3-4a5e-421e-aa4e-e0a82840f1a2",
+    "set_uuid": "2c15f8e9-7fa5-43d6-9797-d1b3249fea3f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "f8dfa5e7-efb8-409f-8ab3-6bf3adf2199b",
+    "set_uuid": "1254b284-bdec-4235-b13f-9b3eaed7d373",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "4b680695-7e42-493c-889b-c76a60ab1f4f",
+    "set_uuid": "1254b284-bdec-4235-b13f-9b3eaed7d373",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "0d9f1945-262b-48d0-b584-ff78ec28e012",
+    "set_uuid": "95d7924c-dd4e-48ab-9fc5-5895ba316cdd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "d53e3ac6-6091-4c3f-9e1b-b12b716a5f95",
+    "set_uuid": "95d7924c-dd4e-48ab-9fc5-5895ba316cdd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "f8881a13-70fb-4797-a3ec-08c3c8432b5a",
+    "set_uuid": "d45eab8f-f956-46c1-9dd7-bddf5b5dde4c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-bar",
+      "property": "thickness-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "ab98c47f-f2e4-4f74-8008-55c65907b6eb",
+    "set_uuid": "d45eab8f-f956-46c1-9dd7-bddf5b5dde4c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "a91ff845-aeb8-4a1b-9e4a-d34c77bb8253",
+    "set_uuid": "8eb6c228-6374-4243-84c3-5a5d3236268e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "c7719369-7d3d-4446-ade2-08abb472a985",
+    "set_uuid": "8eb6c228-6374-4243-84c3-5a5d3236268e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "2b9efe78-8384-4994-a4ab-82046f109d20",
+    "set_uuid": "f275f342-c396-4781-944e-07cb302f5241",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "c380cf9b-cb59-465c-9b56-41654d3239f1",
+    "set_uuid": "f275f342-c396-4781-944e-07cb302f5241",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2b9f6096-84e7-4430-a3a9-a9daadcd1225",
+    "set_uuid": "ab2492f4-18ef-471b-94f7-9998be139116",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "a7fafd60-dc38-425a-b6b6-952a06d30ab4",
+    "set_uuid": "ab2492f4-18ef-471b-94f7-9998be139116",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "thickness-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "6331ae2c-ddf9-4de4-8df4-82b5581cf2ea",
+    "set_uuid": "aac55ca2-87f0-4a75-a0ab-282c0b1a1419",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "thickness-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "076b031f-5980-4112-bf0b-2cec47f54c6b",
+    "set_uuid": "aac55ca2-87f0-4a75-a0ab-282c0b1a1419",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "thickness-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "a3adff4d-e69e-4aa0-95ec-2019328b7d08",
+    "set_uuid": "27f28f23-f8b4-4c99-a2fc-a7db1606f80c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "thickness-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "aa930d94-7874-44d7-80f1-dc431d40c4a4",
+    "set_uuid": "27f28f23-f8b4-4c99-a2fc-a7db1606f80c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "thickness-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "becddd13-6ef9-4abc-9468-25885b2b4b84",
+    "set_uuid": "5212e366-45e2-41af-9132-926fdbf8b91b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "progress-circle",
+      "property": "thickness-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "a37ef752-662b-4152-b247-0ce9fcd624e4",
+    "set_uuid": "5212e366-45e2-41af-9132-926fdbf8b91b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "f8f1d29b-4093-40ed-b73c-7a27e27a63a4",
+    "set_uuid": "5c7699c2-dc1c-49aa-87ee-55b888c32689",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "cc041f48-aaa4-4c20-8990-599e0c56134e",
+    "set_uuid": "5c7699c2-dc1c-49aa-87ee-55b888c32689",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "cadf4b9e-b4d4-4ff5-808b-557864cf7dc8",
+    "set_uuid": "bfe838ca-b2a9-4b1d-ad1b-a27822a78bda",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "23d0a4aa-693d-4b79-b942-3898f9cf0b80",
+    "set_uuid": "bfe838ca-b2a9-4b1d-ad1b-a27822a78bda",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "9de5b045-532c-48ef-872e-bd3c22f89a41",
+    "set_uuid": "e6de4bc6-29a8-41c8-89d3-05aa7d89e660",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "2eef4003-e666-48e7-b25b-8c50063ce400",
+    "set_uuid": "e6de4bc6-29a8-41c8-89d3-05aa7d89e660",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "407304fc-7c74-4427-9032-b44ab03c07ce",
+    "set_uuid": "e10044fc-687d-4354-afc9-39d9210fc6db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "control-size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "90a2b18a-61c7-40d8-926c-d6b18a641010",
+    "set_uuid": "e10044fc-687d-4354-afc9-39d9210fc6db",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "selection-indicator"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "a7fc6bdb-5b9c-42d4-8f78-d34021ac0708"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "f4620f0a-43ba-4650-8640-9425ed1a1260",
+    "set_uuid": "77bbc887-ee2d-4a6c-8a1b-6a6b9cd6a2fd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "c478710f-1747-455b-998a-6fa837762905",
+    "set_uuid": "77bbc887-ee2d-4a6c-8a1b-6a6b9cd6a2fd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "309c9559-1763-4345-8090-aaa12f570889",
+    "set_uuid": "b99d260c-1bc7-4e0e-96be-bdfe4592829d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "41d0dde7-de34-4e99-96d0-4f727ed71673",
+    "set_uuid": "b99d260c-1bc7-4e0e-96be-bdfe4592829d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "dcc0155a-6bd1-4148-acaf-e255a7f4d22a",
+    "set_uuid": "a7ff453c-7241-406a-a682-c7d841c66134",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "2f805530-cefe-420a-89e6-a6a81c0faea0",
+    "set_uuid": "a7ff453c-7241-406a-a682-c7d841c66134",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "b775d7e9-d182-4818-9ae0-b3765a0ecbf7",
+    "set_uuid": "1f228973-43d9-46f2-a3c6-9d4074d49bb3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "radio-button",
+      "property": "top-to-control-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "02438c4c-161d-45eb-935d-b083ab830876",
+    "set_uuid": "1f228973-43d9-46f2-a3c6-9d4074d49bb3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "bottom-to-content-area-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "897117a7-4e29-4fc2-85b4-1b2aa882ff7b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "bottom-to-content-area-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "360ab235-93bf-482c-9ff1-387d69f018e1",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "edge-to-content-area-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "888c8501-b709-4b72-9d19-504e3b0befb4",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "edge-to-content-area-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "a2ad2062-a115-4abb-859b-f9d307b44744",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-100",
+    "uuid": "d7f24ef9-eb71-45e8-96a1-7e48ddc56964"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "height-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-75",
+    "uuid": "7e0c3f30-31f5-4fa2-b353-a739c904d796"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "indicator-to-icon",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "b132d948-bec9-4a29-b281-e77801ce5a7c",
+    "set_uuid": "56769fc6-5bf3-418e-a424-e3a079e2428b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "indicator-to-icon",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "8e13ea1d-8000-485e-8700-5522cc71b95c",
+    "set_uuid": "56769fc6-5bf3-418e-a424-e3a079e2428b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "indicator-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "f0958cee-9688-43db-9542-1aef164f9dfe",
+    "set_uuid": "2716ef49-9896-4451-a7c2-e0dce18ead18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "indicator-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "dce9ff1e-06d1-49a5-817f-5319f4ab15e2",
+    "set_uuid": "2716ef49-9896-4451-a7c2-e0dce18ead18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "top-to-content-area-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "6b99f788-336d-4159-819e-29050f8b571a",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "top-to-content-area-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "8cf415d3-57f2-41c6-a175-40c75b58a79e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "width-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "128px",
+    "uuid": "91a0e740-8f77-4d4a-b34c-d673afc1093b"
+  },
+  {
+    "name": {
+      "component": "rating",
+      "property": "width-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "104px",
+    "uuid": "b54da2cd-9d1e-498f-a52c-7be5e825c2a2"
+  },
+  {
+    "name": {
+      "component": "search-field",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 4,
+    "uuid": "c4b2177d-4468-4180-be27-69d26a51ba0b"
+  },
+  {
+    "name": {
+      "component": "segmented-control",
+      "property": "item-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-100",
+    "uuid": "4aaef8d2-aa58-46b8-837c-15d794cfcdb5"
+  },
+  {
+    "name": {
+      "component": "segmented-control",
+      "property": "item-maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "265px",
+    "uuid": "efa7a73d-611e-44a1-8ea5-0bad83ef77de"
+  },
+  {
+    "name": {
+      "component": "segmented-control",
+      "property": "selection-border-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "border-width-200",
+    "uuid": "10f93760-7b09-4a4e-8cc2-33783e571926"
+  },
+  {
+    "name": {
+      "component": "segmented-text-field",
+      "property": "gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "9e790995-7d43-4ce2-8ac0-a1c79c607575",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "segmented-text-field",
+      "property": "rounding"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "dc329712-c5ba-45cf-8ae0-8e42aad2fda9"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "edge-to-checkbox"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "70a20970-ebd9-48a7-8324-44d352f79978",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-small instead.",
+    "replaced_by": "9fcd2823-9a13-44c0-a613-7dbe272b99a9"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-end-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "a99ea589-33e4-4196-8c49-77a0d0d522ed",
+    "set_uuid": "26032430-2ed5-430c-aff0-63655b5b82fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-2x-large instead.",
+    "replaced_by": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-end-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "9c78208b-bb4f-4cda-82f0-a38f68d33172",
+    "set_uuid": "26032430-2ed5-430c-aff0-63655b5b82fc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-2x-large instead.",
+    "replaced_by": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-illustration-to-label",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "b98f3e7a-d30a-49f7-80fd-d793554eaf6d",
+    "set_uuid": "e8e1494d-f8da-42f8-a4d7-cb0e4e967982",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-small instead.",
+    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-illustration-to-label",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "6c8580ac-c2c4-4d62-8a9d-b0498dd0b69b",
+    "set_uuid": "e8e1494d-f8da-42f8-a4d7-cb0e4e967982",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-small instead.",
+    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-label-to-description",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "94b742aa-bec9-43bc-81ad-a913191481d1",
+    "set_uuid": "2eec83d8-6239-46b6-9324-2b008aff7133",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-large instead.",
+    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-label-to-description",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "255479ac-24f5-4128-bba0-258ec68026af",
+    "set_uuid": "2eec83d8-6239-46b6-9324-2b008aff7133",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-large instead.",
+    "replaced_by": "52f0ce69-d419-4f27-b1fd-eaad3726017a"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "3d6fc9f4-1f22-4e1d-a602-e00079dd2057",
+    "set_uuid": "dddfd124-708d-4f7a-b9ba-196ba2019c47",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "100px",
+    "uuid": "c731f83e-152b-44ad-818f-460dc1d29228",
+    "set_uuid": "dddfd124-708d-4f7a-b9ba-196ba2019c47",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "188px",
+    "uuid": "b2104b40-4b34-4d98-a564-1688900de75d",
+    "set_uuid": "df8589d3-7c0f-4c4a-9b7a-9fb1b885d98a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "220px",
+    "uuid": "0a6c3623-dd05-40df-a3d8-b724e8a88178",
+    "set_uuid": "df8589d3-7c0f-4c4a-9b7a-9fb1b885d98a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-start-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "9ab0ef93-1293-48e9-911c-2ea32f15b44b",
+    "set_uuid": "e24d7c1a-4fbd-44ac-9660-ff617d011a1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-start-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "009afde4-ea54-4025-aaa0-7df7e5e50229",
+    "set_uuid": "e24d7c1a-4fbd-44ac-9660-ff617d011a1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-top-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "736900ff-ea3c-4c5b-85b6-080524cb78fc",
+    "set_uuid": "560ccf4a-7060-4c66-9d12-03ac082c93c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-top-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "75f16efb-6905-4091-bd87-bd08494a92bf",
+    "set_uuid": "560ccf4a-7060-4c66-9d12-03ac082c93c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-medium instead.",
+    "replaced_by": "81e5f983-4ca0-4d45-89f0-4accd78d7946"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "368px",
+    "uuid": "04fcbf2f-ffe1-4f26-99d1-59a3deb053ed",
+    "set_uuid": "b1e398f1-86a7-4d3d-a424-7164a3f726e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "horizontal-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "460px",
+    "uuid": "d406a096-aea6-4e39-818a-52d82b3c5031",
+    "set_uuid": "b1e398f1-86a7-4d3d-a424-7164a3f726e9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "top-to-checkbox",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "237b6422-31fd-4729-98f1-451b7bd27a4d",
+    "set_uuid": "3a8c21e6-ba80-4ab6-b8e9-d34ac424ced6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead. Should actually be 12 when checkbox component's vertical padding removed as it should be in this scenario",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "top-to-checkbox",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "011f2ccf-b2fb-4da8-94c4-29fc0a5b9a71",
+    "set_uuid": "3a8c21e6-ba80-4ab6-b8e9-d34ac424ced6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-small instead. Should actually be 12 when checkbox component's vertical padding removed as it should be in this scenario",
+    "replaced_by": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "vertical-edge-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "ef9b9dd4-5e45-4c1a-8874-f097fd892352",
+    "set_uuid": "db90cd08-a4fe-46d0-9282-16f6fdfdbd5f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "vertical-edge-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "e807df92-1c13-4394-ace9-cb998ada9395",
+    "set_uuid": "db90cd08-a4fe-46d0-9282-16f6fdfdbd5f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-extra-large instead.",
+    "replaced_by": "2e855806-0f65-4df0-9d8f-74428daa358d"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "vertical-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "170px",
+    "uuid": "fe57d82a-5365-441a-9bd5-8f2c71c2ba83",
+    "set_uuid": "c5d2bdb6-e266-4883-b6e2-e81b88630c67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "vertical-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "212px",
+    "uuid": "2a6a9aef-2c75-43e4-856d-c797900c713f",
+    "set_uuid": "c5d2bdb6-e266-4883-b6e2-e81b88630c67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "vertical-illustration-to-label",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "f6a52618-bf5d-4a9d-ac95-e5a6d002851d",
+    "set_uuid": "30ed63ea-dc66-40b6-8d63-8ef2ec7e5b48",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-small instead.",
+    "replaced_by": "9c79efdc-ab56-4f2e-b44d-5641d2480964"
+  },
+  {
+    "name": {
+      "component": "select-box",
+      "property": "vertical-illustration-to-label",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "8a805540-3b26-4b50-8a0d-0c7beb13885e",
+    "set_uuid": "30ed63ea-dc66-40b6-8d63-8ef2ec7e5b48",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-small instead.",
+    "replaced_by": "9c79efdc-ab56-4f2e-b44d-5641d2480964"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "bottom-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "8751d85d-a325-4e4e-a7b2-0a3ca94b6b6e",
+    "set_uuid": "4647e408-e2c8-417b-94dc-1fe44ef91fe2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "bottom-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e3f49e5e-f9ec-485c-846e-7a8fda08caea",
+    "set_uuid": "4647e408-e2c8-417b-94dc-1fe44ef91fe2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "counter-to-disclosure",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "fe5071ea-bcff-4a7b-ade8-16850426ac30",
+    "set_uuid": "8d6fedf3-e99a-410a-90b4-468c4d7ad275",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "counter-to-disclosure",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "ce76b010-6554-4cfd-993f-9963aa15830e",
+    "set_uuid": "8d6fedf3-e99a-410a-90b4-468c4d7ad275",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "edge-to-indicator",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "cb89bc11-246a-4824-afa3-68076c56f3d9",
+    "set_uuid": "b87a907f-3c16-4f57-9a23-3e38aa8287ae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "edge-to-indicator",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "a1ae3448-227c-4277-9bab-f0147eff02e9",
+    "set_uuid": "b87a907f-3c16-4f57-9a23-3e38aa8287ae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead. Refactor may be needed",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "header-to-item",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "423b5520-bb29-4179-9145-67305ca75b75",
+    "set_uuid": "ea95e13b-1da3-4720-b01b-1e121b6acb59",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "header-to-item",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "ad959938-ad69-4137-91e4-fcf2465b223a",
+    "set_uuid": "ea95e13b-1da3-4720-b01b-1e121b6acb59",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Clean VF update will correct this",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "indicator-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "07262bb6-4b57-4848-b45d-bbf808bdf257",
+    "set_uuid": "ea8b6bf1-d848-42ee-b388-b757ced4e96f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "indicator-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "dfae987d-8f6c-4b2c-a01b-3a010581488d",
+    "set_uuid": "ea8b6bf1-d848-42ee-b388-b757ced4e96f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "indicator-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "6c2264d9-425a-4dec-9071-a47e0d2bfca6"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "indicator-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "436f98c0-ec74-40ab-9a26-a8fe8d139329",
+    "set_uuid": "5bd0f57a-50af-40b4-89f8-43a9678ffa52",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead. If using base padding horizontal, this would be 7",
+    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "indicator-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "37ba411c-9067-46b0-b757-8348f4cf9aab",
+    "set_uuid": "5bd0f57a-50af-40b4-89f8-43a9678ffa52",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead. If using base padding horizontal, this would be 7",
+    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "item-to-header",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "c5de72a2-931a-429d-ba85-5aaf2e30fbc4",
+    "set_uuid": "3aeb1d76-ba81-4f10-b5fe-fc3c8e40145c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
+    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "item-to-header",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "0f3821f1-6f0e-4325-bfa7-e572768fd468",
+    "set_uuid": "3aeb1d76-ba81-4f10-b5fe-fc3c8e40145c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
+    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "item-to-item",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "47e687e4-c458-4e0b-bd02-7698cc14983b",
+    "set_uuid": "43e16db0-e78e-4a13-8b64-92d46ede1a9e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "item-to-item",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "be37c65c-88c5-48cd-9554-8240909db98d",
+    "set_uuid": "43e16db0-e78e-4a13-8b64-92d46ede1a9e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "maximum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "68210b40-f87e-4059-88c1-e66d1c8cbd38",
+    "set_uuid": "771e5a13-6af2-46f9-b850-25e81e2e2c4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "maximum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "300px",
+    "uuid": "bcb163a0-0156-4e2e-abfe-b2ac0158f348",
+    "set_uuid": "771e5a13-6af2-46f9-b850-25e81e2e2c4a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "144px",
+    "uuid": "998bb752-7826-4437-ac18-14e08644e226",
+    "set_uuid": "457ff3f5-031a-4683-9579-aa0da4c49bc2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "180px",
+    "uuid": "ad835d79-64d9-4183-ace0-912c87fc2241",
+    "set_uuid": "457ff3f5-031a-4683-9579-aa0da4c49bc2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-edge-to-indicator",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "e44d5d55-8fc5-4231-ab37-0c06edd06d2c",
+    "set_uuid": "708b50f4-cbb7-4af3-99bc-f2a006422ee2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-edge-to-indicator",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "87377ada-4ebf-4a45-b651-35ee1f94e73b",
+    "set_uuid": "708b50f4-cbb7-4af3-99bc-f2a006422ee2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-edge-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "38px",
+    "uuid": "2e5df819-ac9e-4b09-bdf6-8b1fe751c8fb",
+    "set_uuid": "aedf6dad-a2d8-4c1b-aa3e-51060d22835f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead.",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-edge-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "e77cde34-8f77-4fd1-a1f7-aa6738130902",
+    "set_uuid": "aedf6dad-a2d8-4c1b-aa3e-51060d22835f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead.",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-with-icon-edge-to-indicator",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "c1a8c779-aacf-4b14-8b15-9734deafcc41",
+    "set_uuid": "0e0bc57b-9deb-4e27-aba6-db5dc7bcbb65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-second-level-edge-to-indicator. Refactor may be needed",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-with-icon-edge-to-indicator",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "b76c6a5c-23c1-4cf1-8bbb-baca46b3b497",
+    "set_uuid": "0e0bc57b-9deb-4e27-aba6-db5dc7bcbb65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-second-level-edge-to-indicator. Refactor may be needed",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-with-icon-edge-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "7ba0524c-cfef-47fd-b3df-2c71e5618d20",
+    "set_uuid": "e09f8f4b-9384-49ad-88e9-f8b3fc966b1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "second-level-with-icon-edge-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "34px",
+    "uuid": "17ae8b85-c5d2-47c0-810a-c99c91735d3e",
+    "set_uuid": "e09f8f4b-9384-49ad-88e9-f8b3fc966b1e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-edge-to-indicator",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "aaf6af3d-4d94-4559-880e-c6201a4f72a7",
+    "set_uuid": "5a69662d-fd28-43ac-b3c9-99ae2aad79d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-edge-to-indicator",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "62px",
+    "uuid": "650a896e-c67d-427b-950c-88cfc1099406",
+    "set_uuid": "5a69662d-fd28-43ac-b3c9-99ae2aad79d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-edge-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "adfe198d-a39b-47a1-bfa4-77dd0d139803",
+    "set_uuid": "36b92445-279d-4553-b000-730127f09f3d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead.",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-edge-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "06140452-b779-4527-ae3a-5f0623a6b97c",
+    "set_uuid": "36b92445-279d-4553-b000-730127f09f3d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead.",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-with-icon-edge-to-indicator",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "0c3ad7a1-6e2d-4e34-874e-45a654884650",
+    "set_uuid": "e990d96a-cf34-4e09-bf51-4f8179b18df7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-third-level-edge-to-indicator. Refactor may be needed",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-with-icon-edge-to-indicator",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "42px",
+    "uuid": "2216f8c3-43e1-47ef-aaad-20b0c9bf0f17",
+    "set_uuid": "e990d96a-cf34-4e09-bf51-4f8179b18df7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead. S2 spec file has this named side-navigation-with-icon-third-level-edge-to-indicator. Refactor may be needed",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-with-icon-edge-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "7103cb49-859e-4376-8422-0e2a94b5d2d9",
+    "set_uuid": "50359a00-5714-4f4f-accc-b9debc6de08f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "third-level-with-icon-edge-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "811bd0a1-ed6a-4238-a194-c7709a1691ed",
+    "set_uuid": "50359a00-5714-4f4f-accc-b9debc6de08f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-large instead. Refactor may be needed",
+    "replaced_by": "c5c94124-c16d-46f1-a22a-acf1378846bc"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "trailing-accessory-area-to-edge",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "37969411-2beb-4038-bdee-d2a84398ef19",
+    "set_uuid": "4d352b4a-afeb-4435-a485-0bda4ecd6d1c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Refactor may be needed",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "trailing-accessory-area-to-edge",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "f52fe067-f989-4f43-a762-1ea453fa0dde",
+    "set_uuid": "4d352b4a-afeb-4435-a485-0bda4ecd6d1c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Refactor may be needed",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "d087f995-da55-4c96-89c4-69a9a83e2f05",
+    "set_uuid": "3550c39d-b2c9-434d-bab1-d37c560f5e49",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "3bc5710f-5fd7-4cce-a3c2-f1e45deee2b2",
+    "set_uuid": "3550c39d-b2c9-434d-bab1-d37c560f5e49",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "with-icon-second-level-edge-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "side-navigation-second-level-with-icon-edge-to-text",
+    "uuid": "d254c910-2939-48ce-8547-08cfb346a0db",
+    "set_uuid": "54cd1b31-fdef-4b15-a236-eb18e8468a65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead.",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "with-icon-second-level-edge-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "side-navigation-second-level-with-icon-edge-to-text",
+    "uuid": "7d4cd9bd-bfaf-4ad7-9c3b-19f7913f0825",
+    "set_uuid": "54cd1b31-fdef-4b15-a236-eb18e8468a65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead.",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "with-icon-third-level-edge-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "side-navigation-third-level-with-icon-edge-to-text",
+    "uuid": "f1d90f18-e114-477f-88ca-548c5ddbc287",
+    "set_uuid": "ea2417cb-8f92-44ef-9f0c-00046c43fc69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead.",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "side-navigation",
+      "property": "with-icon-third-level-edge-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "side-navigation-third-level-with-icon-edge-to-text",
+    "uuid": "f82ab001-808a-4528-bf4a-be27645a28fc",
+    "set_uuid": "ea2417cb-8f92-44ef-9f0c-00046c43fc69",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead.",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "single-calendar",
+      "property": "popover-minimum-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "320px",
+    "uuid": "1f0b1cd3-1f15-4a60-a01f-a04f4fb913dd"
+  },
+  {
+    "name": {
+      "component": "single-calendar",
+      "property": "popover-minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "320px",
+    "uuid": "7f880ee3-c074-4370-a132-c22dbe0d5880"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "155b6273-1661-4ef5-85c0-a1688ce1ee72",
+    "set_uuid": "160794db-05e4-4305-a353-326e62f23f9c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "e04d9975-4a54-416b-b5fa-87f3ae930204",
+    "set_uuid": "160794db-05e4-4305-a353-326e62f23f9c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "be9aed61-c7a1-4dce-80a7-07c9ecef1fd9",
+    "set_uuid": "cffd4d17-8e02-43d6-bd96-570af44e198f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "3915ff73-11dd-4389-8d81-2f540ab060f4",
+    "set_uuid": "cffd4d17-8e02-43d6-bd96-570af44e198f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "238ebdc2-e51c-459d-8cc7-abfeafed6451",
+    "set_uuid": "ce8bf0ee-4fa1-4bdc-9b1d-cb9201e7b842",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "5030babb-0017-4784-84ad-d3aaacf6fa05",
+    "set_uuid": "ce8bf0ee-4fa1-4bdc-9b1d-cb9201e7b842",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "bf2e4550-f97e-4bd2-91e8-b0ddb5a8abe2",
+    "set_uuid": "2c1d7793-70e8-4178-9504-a169c2266d7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "bottom-to-handle-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "3b96ab4f-6628-4ebd-aba8-2837fce04709",
+    "set_uuid": "2c1d7793-70e8-4178-9504-a169c2266d7a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "fd74d5a5-b966-4d26-abca-58c7a21f8136",
+    "set_uuid": "c5945975-ac1d-4475-9b95-b69a2dd08082",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "c5d47ebf-c83f-43c3-b2f2-f4d51c40960b",
+    "set_uuid": "c5945975-ac1d-4475-9b95-b69a2dd08082",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "320abda8-9fe8-4f78-87d6-3f1be921e880",
+    "set_uuid": "63f8f04e-7512-4b56-9ac1-9bc8a1240202",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "0926d8f3-bdd6-4dde-89d0-6d5d7ab9f094",
+    "set_uuid": "63f8f04e-7512-4b56-9ac1-9bc8a1240202",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "dd3b649d-12f8-427b-95a6-a4964d92d3b0",
+    "set_uuid": "b4676e41-d9a7-4cf1-bc24-acb21e96f365",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "7306fc00-67fd-4ccd-aec3-7a14e092da5e",
+    "set_uuid": "b4676e41-d9a7-4cf1-bc24-acb21e96f365",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "cf748652-099a-4022-ae68-0e5dcb8eff9b",
+    "set_uuid": "b567a911-c356-4ed3-8d1f-b8698285a8cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-height-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "19adc707-4fc6-40f0-a972-340d6c935908",
+    "set_uuid": "b567a911-c356-4ed3-8d1f-b8698285a8cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-20px",
+    "uuid": "e82d0719-2d65-438f-a9a6-f61c80a80376",
+    "set_uuid": "c94e3a1b-71a8-410c-bf8b-38709189103c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-24px",
+    "uuid": "23f0c597-a889-4653-8870-df86101fe544",
+    "set_uuid": "c94e3a1b-71a8-410c-bf8b-38709189103c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-16px",
+    "uuid": "c849ce3c-0e3a-4882-a061-021eed8d55d8",
+    "set_uuid": "e34d5351-83c3-43b6-b45c-5cef8853b5f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-20px",
+    "uuid": "657325f5-74e4-4d39-8ba4-f480c141da79",
+    "set_uuid": "e34d5351-83c3-43b6-b45c-5cef8853b5f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-12px",
+    "uuid": "4cdfa762-9580-4fff-a396-1538666ef8d7",
+    "set_uuid": "5c9f93bf-bbe2-4e24-af87-52dee0e0949b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-16px",
+    "uuid": "a5326ae9-27b6-450c-b88f-d4b89a06502a",
+    "set_uuid": "5c9f93bf-bbe2-4e24-af87-52dee0e0949b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "882a70c2-afd4-483a-adf5-5437dd34fcba",
+    "set_uuid": "33f78486-04db-4a01-ae1f-29e35cdf83f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-editable-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-8px",
+    "uuid": "5816b3c6-937c-47b8-9bdd-ebc69224831b",
+    "set_uuid": "33f78486-04db-4a01-ae1f-29e35cdf83f0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-20px",
+    "uuid": "309b149c-306a-49ee-b14c-a0eb4826e3b1",
+    "set_uuid": "0e2532f3-c4d2-4001-9c10-9dc706b66273",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-28px",
+    "uuid": "9be47810-7a07-4885-a86d-647f5f36d7e5",
+    "set_uuid": "0e2532f3-c4d2-4001-9c10-9dc706b66273",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-16px",
+    "uuid": "a4be5828-2176-42e7-97de-1f80e7dc08bb",
+    "set_uuid": "9201b712-8203-4653-8f0c-07e489587d35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-20px",
+    "uuid": "f4fc7ec7-cc02-4ff4-bd9a-f05f9bd59c1d",
+    "set_uuid": "9201b712-8203-4653-8f0c-07e489587d35",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-12px",
+    "uuid": "b257bf97-d632-4488-a954-57b16bcf18b9",
+    "set_uuid": "65cf8114-d8a3-4e9b-8a58-082df40c72fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-16px",
+    "uuid": "20a8d579-038e-4432-b271-8e44b83a9aa1",
+    "set_uuid": "65cf8114-d8a3-4e9b-8a58-082df40c72fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "4dc8268e-42c5-4c3c-a17a-fe0f7227facc",
+    "set_uuid": "674b365b-e77b-4c00-ae1a-620725a3d534",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
+    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "19036695-7f27-4c08-babc-45226b7bf920",
+    "set_uuid": "674b365b-e77b-4c00-ae1a-620725a3d534",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
+    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "dff9511c-7b97-4cfb-abff-953be7228e28",
+    "set_uuid": "28d7f1c0-ab0c-40c7-9c50-072187407e14",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-large instead.",
+    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "095779c9-64fc-4a51-8a0a-f8b452fb3650",
+    "set_uuid": "28d7f1c0-ab0c-40c7-9c50-072187407e14",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-large instead.",
+    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "8d294c76-353f-42f0-8aa9-8c489a90ac14",
+    "set_uuid": "4496beb8-be60-4c70-a809-de7b1c9df947",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-medium instead.",
+    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "5d470123-0f06-4319-b299-b8f5d80c7c94",
+    "set_uuid": "4496beb8-be60-4c70-a809-de7b1c9df947",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-medium instead.",
+    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2d3a0c09-3f66-42da-8276-a7dabc6c4cd3",
+    "set_uuid": "9335b6f7-5faa-4f7d-8fc0-3584cc1a1051",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-small instead.",
+    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-side-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "31e670e4-2400-4705-a0e8-cef9cbca9869",
+    "set_uuid": "9335b6f7-5faa-4f7d-8fc0-3584cc1a1051",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-small instead.",
+    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "cbf9c42b-c14e-440d-97ad-3c937c464446",
+    "set_uuid": "d46ed9c3-7ac2-461c-b924-bc7eca3ef7a6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-field-label-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-8px",
+    "uuid": "d20768dd-dbf4-48a9-8cc8-3370fa6ef810",
+    "set_uuid": "d46ed9c3-7ac2-461c-b924-bc7eca3ef7a6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Refactor required; remove padding from label, no negative margins"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "6c592cd0-9d00-478c-a001-b7d4f3e851f9",
+    "set_uuid": "8da44bc9-d615-4788-996e-92b72cbd26d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
+    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "41601fb4-8571-4e7d-91b1-ea7b69ca8a1d",
+    "set_uuid": "8da44bc9-d615-4788-996e-92b72cbd26d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-extra-large instead.",
+    "replaced_by": "c9c7652f-0332-417f-8520-e2202d7a08dc"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "281d3ab8-c760-4240-a349-2b9986eeecfe",
+    "set_uuid": "795d22d2-9adb-4a61-8fc8-42102008c0f2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-large instead.",
+    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "d20985d9-2d46-4744-84a7-21baad0eb8cb",
+    "set_uuid": "795d22d2-9adb-4a61-8fc8-42102008c0f2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-large instead.",
+    "replaced_by": "236385bb-9e50-484c-912d-a71fe33924f4"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "600b162b-5a37-4c01-9fa2-05df934433cc",
+    "set_uuid": "6a333980-ed8f-4a71-9802-92a005dfea15",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-medium instead.",
+    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "a99118fc-9837-4460-b4ae-9c7ffaa20ce0",
+    "set_uuid": "6a333980-ed8f-4a71-9802-92a005dfea15",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-medium instead.",
+    "replaced_by": "06d1563b-7d67-400a-bcfa-bc320c2b7a28"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "52edd5bd-f859-487b-bc89-db09fa523025",
+    "set_uuid": "de83abc9-702d-4d6c-a56b-96195d887f26",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-small instead.",
+    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "control-to-text-field-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "526c8840-b08c-401b-8242-32c1cb574b58",
+    "set_uuid": "de83abc9-702d-4d6c-a56b-96195d887f26",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-small instead.",
+    "replaced_by": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-extra-large",
+      "component": "slider",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "47d025e2-0b26-4ebc-9b46-3cd1e470b9bc",
+    "set_uuid": "00777225-cee5-4b46-97be-5432eda938c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-extra-large",
+      "component": "slider",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "feac9f02-b52a-4694-a5d4-4b1930ab4f07",
+    "set_uuid": "00777225-cee5-4b46-97be-5432eda938c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-large",
+      "component": "slider",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "525e7d74-2bc0-48ac-85ca-b07335819a31",
+    "set_uuid": "7f87b6dc-6864-4086-a3cf-8372ee0659c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-large",
+      "component": "slider",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "3bf8805b-b4f7-4d0d-af85-d227d6380539",
+    "set_uuid": "7f87b6dc-6864-4086-a3cf-8372ee0659c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-medium",
+      "component": "slider",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "63c65cd6-a2c2-4430-a1e9-cf82ae0a3f25",
+    "set_uuid": "8fc235a6-e19a-4463-b097-074f861ce80f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-medium",
+      "component": "slider",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "25959ff8-6c2f-4612-8d69-b95bfe485ce4",
+    "set_uuid": "8fc235a6-e19a-4463-b097-074f861ce80f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-small",
+      "component": "slider",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "c9b7d8d9-c5ba-4d97-a03b-a214104ede23",
+    "set_uuid": "44b4d529-53dd-4013-880e-fd0264644d12",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "slider-handle-border-width-down-small",
+      "component": "slider",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "683fb538-290c-423f-990b-d7134e485f51",
+    "set_uuid": "44b4d529-53dd-4013-880e-fd0264644d12",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "0b83b5fd-117d-4257-bf77-fce39bfa8e3b",
+    "set_uuid": "20b237d5-bc48-444b-af9f-262fca263017",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "caa26be5-d26c-4e5a-aae8-87e0380920da",
+    "set_uuid": "20b237d5-bc48-444b-af9f-262fca263017",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "1a257268-32e9-4c5c-8477-32a724ff1d42",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "1aa8c3a6-29ff-44ec-9b11-51c041ef44f1",
+    "set_uuid": "09bfdc82-d00d-4ccd-aa0e-50165eb25b86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "01ca9561-7b0b-4030-ba1b-85d336537ebc",
+    "set_uuid": "09bfdc82-d00d-4ccd-aa0e-50165eb25b86",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "2305cfb2-f26d-44e0-90ef-3258b8f46e0d",
+    "set_uuid": "ebeccac6-b463-430e-bbdb-35bc6df037c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "5aa8e5c5-2156-49e6-9bb8-ad99b4a1b997",
+    "set_uuid": "ebeccac6-b463-430e-bbdb-35bc6df037c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "0d211640-08bf-4a09-98d8-1398ba70b072",
+    "set_uuid": "cd14d5d1-8002-444b-9f61-8067a8a4bc42",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "18e1a338-5256-41a4-88f7-76b7fb3911c6",
+    "set_uuid": "cd14d5d1-8002-444b-9f61-8067a8a4bc42",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "c2e986a2-2b56-4a82-b4a2-87850ca90d8c",
+    "set_uuid": "6350ac7a-e459-43c7-bc3b-19665cd14dab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-height-precision-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "a93712dc-247e-46f4-bb42-d2d1b8896d7e",
+    "set_uuid": "6350ac7a-e459-43c7-bc3b-19665cd14dab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "920a0f76-d61d-4362-8b50-fb6a98e62229",
+    "set_uuid": "5996b0a0-c3a0-4b3e-9d11-207af0956ce7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "3f14b28b-1289-4a72-89b0-b2fbcf54325e",
+    "set_uuid": "5996b0a0-c3a0-4b3e-9d11-207af0956ce7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "404ce1f8-593c-4738-b9a6-d1969a95b20e",
+    "set_uuid": "33313db4-702e-4730-af46-2c7b419e5b39",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "b17da639-665a-4a4c-8105-f30503b823a0",
+    "set_uuid": "33313db4-702e-4730-af46-2c7b419e5b39",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-precision-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "94045357-9bb7-4d16-b035-342465834a92"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "10ccce0d-5a2c-414e-8055-0be76709c180",
+    "set_uuid": "0d284138-77bb-4395-b9b0-bc332634034b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "413dc697-1f14-47c8-a7f2-e52254513e6e",
+    "set_uuid": "0d284138-77bb-4395-b9b0-bc332634034b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "3df3c866-faf0-43db-8c18-f442e7f94822",
+    "set_uuid": "701777c1-c3b6-4b1b-87ed-be5575beb236",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "2a3fb9b0-d701-4e86-8180-9d81f68e91d5",
+    "set_uuid": "701777c1-c3b6-4b1b-87ed-be5575beb236",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "a8a02181-c797-461d-a666-a63f7535a096",
+    "set_uuid": "b464a520-7d24-4a98-9078-d3ea25b744c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "278fc618-f6c1-4d30-bf85-075654079003",
+    "set_uuid": "b464a520-7d24-4a98-9078-d3ea25b744c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "1384d419-bfad-44d7-847c-a0f2c195fb93",
+    "set_uuid": "5dce7d54-6cc0-4c90-8442-a70fc021d217",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "7feb3d57-59fb-4095-966e-e8ca0e91442f",
+    "set_uuid": "5dce7d54-6cc0-4c90-8442-a70fc021d217",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "688b473d-84bc-4964-b985-63cf5fdbf7d4",
+    "set_uuid": "20a6802a-e741-47a7-9279-4bf7e2f024df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "handle-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "fea1de33-ef0f-4c50-ab19-75542f995d35",
+    "set_uuid": "20a6802a-e741-47a7-9279-4bf7e2f024df",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "track-height-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "211a95ca-f83e-4711-83ed-a723258d8336"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "track-height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "c2eb2949-9471-4dc5-b02b-384627dbdea2"
+  },
+  {
+    "name": {
+      "component": "slider",
+      "property": "track-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "50a71b8b-30fb-40c0-b81e-5ce0dcc8c96b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "action-to-navigation",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "3b41366d-2c29-4477-95fa-528c762b8a3b",
+    "set_uuid": "566ca7d9-87b6-4e9d-be7c-3740c32d5994",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "action-to-navigation",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "cd7df3af-975e-4d8a-addd-92a920173fd6",
+    "set_uuid": "566ca7d9-87b6-4e9d-be7c-3740c32d5994",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "drag-handle-to-control",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "80800e9d-8b0d-4d1b-adfc-f85faee2bc2f",
+    "set_uuid": "35875843-c69e-4c4b-86d7-d4f44e66a9e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead.",
+    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "drag-handle-to-control",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "ed1689ea-2661-419b-ad18-7877712b0dfa",
+    "set_uuid": "35875843-c69e-4c4b-86d7-d4f44e66a9e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-uniform-medium instead.",
+    "replaced_by": "a982f1e2-0545-4ca3-8104-32208ea9e152"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "edge-to-control",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "cb302d23-5dd8-4ca6-b104-3fc5f03f633b",
+    "set_uuid": "12f099d5-f8cf-4251-94a0-0398e6d463a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "edge-to-control",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "ef8dc413-ef24-456c-aa91-6a80d107f6c6",
+    "set_uuid": "12f099d5-f8cf-4251-94a0-0398e6d463a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "edge-to-visual",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "5405f82f-6022-468c-a150-b74210ef52cb",
+    "set_uuid": "1bbe4ff0-1a91-44e3-b992-16c41ad6ef0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "edge-to-visual",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "7e743edb-d49b-4750-88b3-e35b6e534a3b",
+    "set_uuid": "1bbe4ff0-1a91-44e3-b992-16c41ad6ef0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "header-minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "6880260b-1d48-4bfc-9745-3e7c506c40fb",
+    "set_uuid": "1748229e-c8e2-40fb-8932-a8d094cf5689",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "header-minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "e18832ec-c1f5-4cfb-9ac6-111204fc255c",
+    "set_uuid": "1748229e-c8e2-40fb-8932-a8d094cf5689",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "header-to-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "c030a978-cf5b-4ad0-a3c7-dde81f1bf136",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "item-to-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "3862f137-37f5-44c3-a31b-68834d8e1c3c"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "minimum-padding-vertical",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e3175fa6-40b4-4a05-b13c-91886e1ebbc7",
+    "set_uuid": "16494124-d36a-4d46-ba20-633631c181e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "minimum-padding-vertical",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "05109b97-ffa8-4708-93e1-022e52d3e724",
+    "set_uuid": "16494124-d36a-4d46-ba20-633631c181e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-opacity-emphasized",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "d1cd1fc2-5ad1-4a6e-bef8-55a385c1ce29"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-opacity-emphasized-down",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "67946e29-b480-4991-85eb-c57331a509f7"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-opacity-emphasized-hover",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "bb522e19-6bb9-471c-95af-5ab7fa748557"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-opacity-emphasized-key-focus",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "35415d70-944b-4c5a-ae70-4810f991b70d"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-opacity-highlight",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "2e8ef316-9ea1-41f3-bb2e-a9b777466794"
+  },
+  {
+    "name": {
+      "property": "stack-item-selected-background-opacity-highlight-hover",
+      "component": "stack-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "2d07949e-416d-4ab6-b36e-15dde4df78b0"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "start-edge-to-content",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "abc302a3-c0b5-4f93-a141-39988ca3720b",
+    "set_uuid": "745f62b2-d562-4a5a-9a6f-ba01312b29d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "start-edge-to-content",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "799fbc36-ea79-44d2-8e8b-dc3aade544a0",
+    "set_uuid": "745f62b2-d562-4a5a-9a6f-ba01312b29d9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "text-to-control",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e65d0e08-9c29-43f6-b7a2-281865a82b70",
+    "set_uuid": "ad4d04dd-77f1-494b-9825-4d0092c54806",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "stack-item",
+      "property": "text-to-control",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "aaee547c-df72-420e-8d39-3028e79feac1",
+    "set_uuid": "ad4d04dd-77f1-494b-9825-4d0092c54806",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "body-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-m",
+    "uuid": "84aa108a-3c23-494f-b9c0-da64acdbeb79",
+    "set_uuid": "3f6ab646-b255-4e0f-9911-cd2fb41fbaa4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "body-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "body-size-s",
+    "uuid": "f33e2125-0424-4329-bf60-ec42a15c36bc",
+    "set_uuid": "3f6ab646-b255-4e0f-9911-cd2fb41fbaa4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "maximum-width-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "640px",
+    "uuid": "5ec703d4-19d9-4be5-976f-e4c1966c0d3d"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "maximum-width-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "480px",
+    "uuid": "1c886eb9-f651-42ce-baff-9b3996077f92"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "maximum-width-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "400px",
+    "uuid": "c00d9b06-f198-4cd5-9b69-ed3796314dab"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "288px",
+    "uuid": "27f2bc13-53e4-4416-8592-a2a44909d22d"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "title-font-size",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xxl",
+    "uuid": "d4e81ac4-8855-4ac4-b28f-ad054f74e517",
+    "set_uuid": "670ecc3e-b844-4958-ba2f-998b72d39de2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "standard-dialog",
+      "property": "title-font-size",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-xl",
+    "uuid": "02c75ba4-2c9f-45f3-8e74-c9a1065142ac",
+    "set_uuid": "670ecc3e-b844-4958-ba2f-998b72d39de2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "edge-to-close-button-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "6364d657-804c-4753-832d-09bfdf5ad36a",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "edge-to-close-button-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "f2c9847f-2c3f-4e2e-94ed-59b6cc58f34a",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "edge-to-close-button-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "b9c04337-a6f5-42db-9bf9-a761c0d9f876",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "maximum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "400px",
+    "uuid": "11400ef3-c995-41bc-8a9d-eb389d95f360"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "37ab7428-8175-409f-8e74-55e51a962139"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "title-font-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "title-size-s",
+    "uuid": "ce8278ea-da1b-4a42-bf7d-4018c9e9d18e"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "top-to-close-button-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "66f385cd-b60b-42dd-bfdc-aba2db6e35a2",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "top-to-close-button-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "968a056e-4397-4a71-91f1-a0f1ebb6f751",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "top-to-close-button-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "96572147-20a9-4089-9904-0a0efa42a5af",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. RECOMMEND ALTERNATIVE MEASUREMENT (negative offset) so a single token can be reused across all densities",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "standard-panel",
+      "property": "width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "260px",
+    "uuid": "41cd9d92-4d69-4aaa-9c95-e980aa5eb992"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "5e27b361-988c-42ac-8c66-f7d1ba00632d",
+    "set_uuid": "f9e72a05-af00-42b8-a8d8-072e48f1eb76",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "38b8d9c8-d340-4123-88bc-f739cfde91e9",
+    "set_uuid": "f9e72a05-af00-42b8-a8d8-072e48f1eb76",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "45832ec2-5f33-4861-a857-1ca2352213db",
+    "set_uuid": "b9201338-95e8-46d3-a786-7f2a2cca767a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "6554dae9-18b6-4c90-b2f4-8aeaab0724ad",
+    "set_uuid": "b9201338-95e8-46d3-a786-7f2a2cca767a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "ada7bd8c-04c9-4d77-a6e8-072ff86984ae",
+    "set_uuid": "08ed6bf4-5759-4bfb-98fe-1562032b59fe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "a7fc9ca1-ad6d-47cb-8798-4a18ba4acc79",
+    "set_uuid": "08ed6bf4-5759-4bfb-98fe-1562032b59fe",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "04485265-2983-4377-9ec5-f2456863a1df",
+    "set_uuid": "17b26aa3-b67b-45cc-8653-6cf8adc63b45",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "dot-size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "5945e9fe-311a-4d2c-8052-ca4eae4c7c63",
+    "set_uuid": "17b26aa3-b67b-45cc-8653-6cf8adc63b45",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "text-to-visual-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "text-to-visual-100",
+    "uuid": "752a84f5-cbb7-4d18-85ca-fc913a061bb5",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "text-to-visual-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "text-to-visual-200",
+    "uuid": "d3e53f14-b91e-4d10-8508-17360ae5620e",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "text-to-visual-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "text-to-visual-300",
+    "uuid": "ee780be7-b32c-4da8-a6bc-fc0897799537",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "text-to-visual-75"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "text-to-visual-75",
+    "uuid": "ea98b9b0-20b5-4f19-aa4f-375559b1362a",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "899c7b7c-7405-4e29-8d42-edf41ca2943f",
+    "set_uuid": "2173f265-63f5-442a-8795-693e214db315",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires Dot to be placed in frame of height workflow-icon-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "b351cade-6d69-449e-908a-518793fef5b9",
+    "set_uuid": "2173f265-63f5-442a-8795-693e214db315",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires Dot to be placed in frame of height workflow-icon-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "ead22722-10f9-4cfe-a387-65f5d86ca520",
+    "set_uuid": "7d47591a-b1a0-4bc9-b024-3cf78e4cf603",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires Dot to be placed in frame of height workflow-icon-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "8d9d872f-7c55-4a94-a80d-c1f2c8834f5d",
+    "set_uuid": "7d47591a-b1a0-4bc9-b024-3cf78e4cf603",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires Dot to be placed in frame of height workflow-icon-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "e2aa334e-ebb7-4e5f-a735-4f6a43b2d6cf",
+    "set_uuid": "cf3e3e4a-3290-4188-8a43-76331c2d0700",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires Dot to be placed in frame of height workflow-icon-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "321a462b-8811-4264-ac1f-4608df8f8c53",
+    "set_uuid": "cf3e3e4a-3290-4188-8a43-76331c2d0700",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires Dot to be placed in frame of height workflow-icon-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "ddece3b1-7f85-4c08-b783-5bde8e31f480",
+    "set_uuid": "299c2a75-f3d9-4c65-8628-608acbcbdb34",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires Dot to be placed in frame of height workflow-icon-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "status-light",
+      "property": "top-to-dot-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "a4f43adc-1db1-4e2f-a5d1-3ec06c62c9ff",
+    "set_uuid": "299c2a75-f3d9-4c65-8628-608acbcbdb34",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires Dot to be placed in frame of height workflow-icon-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "bottom-to-text"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "a52c893c-8c03-43a5-88ed-3cd230365b84",
+    "deprecated": "unknown",
+    "deprecated_comment": "Even noted in design spec; only needed until VF swap"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-height-extra-large",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "78px",
+    "uuid": "201dc21b-a416-443c-afca-6801cabf31a5"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-height-large",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "912f3b78-d09e-4700-a637-5fefc71960c2"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-height-medium",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "54px",
+    "uuid": "732ea53c-5929-4d31-beef-4ffd60f79c0e"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-height-small",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "46px",
+    "uuid": "205e9849-ecb4-4df6-8f59-a6d9b1458a72"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-width-extra-large",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "78px",
+    "uuid": "0b435546-8368-4fb1-a8a1-c50b14b26ae2"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-width-large",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "f4bae4c5-208e-45d7-94ac-6c9355087224"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-width-medium",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "54px",
+    "uuid": "8606a7f5-fa38-4081-b0a6-4633e7442bd1"
+  },
+  {
+    "name": {
+      "property": "steplist-step-default-width-small",
+      "component": "steplist"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "46px",
+    "uuid": "5fe717d5-b262-46d8-8386-5a94070337c2"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "step-to-track-size-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "bbff5dad-42bf-44f0-a34d-b6733360d28b"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "step-to-track-size-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e8d064e4-3bdb-4fef-97e8-db596d5d2fab"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "step-to-track-size-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "3a6f8cf2-d250-4af6-8641-f0ffd4c789b3"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "step-to-track-size-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "80d29ff2-a2ca-4987-9fa2-6799ba6aa416"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "track-thickness-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "d4db995b-1eff-44cc-8abc-93324a3af119"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "visual-size-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "1b147315-b106-4d2a-80cb-9be0eed84b7e"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "visual-size-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "7f7539e6-5d8f-4f24-99a7-9338a3a3c630"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "visual-size-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "a94843d0-9ef6-423f-b963-7b9ad658ce40"
+  },
+  {
+    "name": {
+      "component": "steplist",
+      "property": "visual-size-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "a65898ec-6a5a-4e4a-8a75-358e78a8345d"
+  },
+  {
+    "name": {
+      "component": "swatch-group",
+      "property": "border-opacity"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.2",
+    "uuid": "19968846-dad0-42eb-b6a8-af65f3a910ff"
+  },
+  {
+    "name": {
+      "component": "swatch-group",
+      "property": "spacing-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "b80ef303-eae7-498f-b172-73a098be0f0b",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-gap-2x-small instead. NOTE: All other swatch gaps need to use these semantics too",
+    "replaced_by": "b83df7f2-8811-4bad-b012-213e430e2aaf"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "rectangle-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 2,
+    "uuid": "b3157e9d-82a0-429e-b987-8c240a669af7"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-extra-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "9fa676c9-ccfb-47db-9ae4-348884b9b120",
+    "set_uuid": "2c8536c7-5a08-4516-b253-e38239923cf2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-extra-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "0d926e1a-080a-41ba-8bb9-ef6d0847cb77",
+    "set_uuid": "2c8536c7-5a08-4516-b253-e38239923cf2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "91e7d7f2-a34d-4d03-831c-75574d1b7bee",
+    "set_uuid": "700b9bd6-a462-4d9d-a573-ac9faafc3c43",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "162c1233-3420-44a2-a270-97d0a7c23df1",
+    "set_uuid": "700b9bd6-a462-4d9d-a573-ac9faafc3c43",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "2e29b29f-b8b7-430a-8720-31422c6ad243",
+    "set_uuid": "daa2f451-5297-4ed2-9926-e1cb25b06b30",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "77be7e79-a589-4f32-9e42-ea45ed7763aa",
+    "set_uuid": "daa2f451-5297-4ed2-9926-e1cb25b06b30",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "33789b22-7d2c-4620-8f45-973e734ef5b6",
+    "set_uuid": "0bf0f836-51dd-455c-a152-e841c4cff582",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "c8d8e379-1e3f-4f5e-bce3-df3fc05ff16e",
+    "set_uuid": "0bf0f836-51dd-455c-a152-e841c4cff582",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "slash-thickness-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "944c49d7-e189-4daa-aca1-b0b590d78875"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "slash-thickness-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "6b1b2709-de8c-450d-9299-49200208599e"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "slash-thickness-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "4e735599-f420-4b51-aa75-607046431c76"
+  },
+  {
+    "name": {
+      "component": "swatch",
+      "property": "slash-thickness-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "f626d145-7840-4958-86be-d2306b5b2233"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "2372d602-78ce-45a7-9dff-152152e55117",
+    "set_uuid": "49d5c54a-8aeb-4cd2-9499-9cb05a3ab599",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "b7ae7b32-b347-4e09-9978-3b0b92a4dbab",
+    "set_uuid": "49d5c54a-8aeb-4cd2-9499-9cb05a3ab599",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "8301bfca-a086-4efd-a22f-1d348cbd6dcf",
+    "set_uuid": "3253cbd9-6ba1-494b-b464-2109db29381a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "91b828ce-8ff9-4d32-958e-a8a23ef9b345",
+    "set_uuid": "3253cbd9-6ba1-494b-b464-2109db29381a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "f97f0f1b-c0c2-410f-b116-86d30f4d52cf",
+    "set_uuid": "db115429-09a3-4a6f-b05c-a89d7349a554",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "0d5f13f2-4d5b-4c30-b3a3-fa4fcc33b928",
+    "set_uuid": "db115429-09a3-4a6f-b05c-a89d7349a554",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "3bf75a24-5e95-4c18-9da2-b7088377fe21",
+    "set_uuid": "d4af5ddb-949f-41c1-87eb-d8298b7b1f74",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-height-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "a1dbcaf0-bbcf-444d-9d22-7f86db20303a",
+    "set_uuid": "d4af5ddb-949f-41c1-87eb-d8298b7b1f74",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "34px",
+    "uuid": "f3102afd-e5df-4912-9203-8226ce37fed5",
+    "set_uuid": "588dd683-2e48-4f76-9e6f-56f266b94e83",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "46px",
+    "uuid": "4e9d9b63-989a-4b63-b74d-22b5188f8df7",
+    "set_uuid": "588dd683-2e48-4f76-9e6f-56f266b94e83",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "cef839a5-2ba7-4e47-9a85-d94260a8ff10",
+    "set_uuid": "96ab7508-15ea-4910-bed7-51d9dc6af3a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "38px",
+    "uuid": "5c7bdcc9-63f8-4c4b-b26f-97b39f53dbea",
+    "set_uuid": "96ab7508-15ea-4910-bed7-51d9dc6af3a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "d329eda6-f13d-4a44-b962-ff06c371ed93",
+    "set_uuid": "fe075ee5-298a-458b-b8fd-0dbb7ef4534b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "34px",
+    "uuid": "ec2f3b6b-80db-4c43-bdd2-caee98796775",
+    "set_uuid": "fe075ee5-298a-458b-b8fd-0dbb7ef4534b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "f4d6fe1a-70bd-473a-9fa5-477865ea898e",
+    "set_uuid": "2451e056-68d0-4cb1-b046-2ccb989f8909",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "control-width-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "ca939c4d-9369-498c-81cb-61df1397f657",
+    "set_uuid": "2451e056-68d0-4cb1-b046-2ccb989f8909",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-extra-large",
+      "component": "switch",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "272949bf-1503-4e7b-80d5-859c1ce57169",
+    "set_uuid": "70965b4b-f180-400e-9057-4535278a4e91",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-extra-large",
+      "component": "switch",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "63c42c0c-3976-4d4e-a86f-0234a3a72243",
+    "set_uuid": "70965b4b-f180-400e-9057-4535278a4e91",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-large",
+      "component": "switch",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "83d7ed85-236a-4266-a57f-d33a5f1785ff",
+    "set_uuid": "1d41ac92-9a33-4a02-9b62-57483d406732",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-large",
+      "component": "switch",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "eadbe025-3d4a-4874-89ad-b6f667a62837",
+    "set_uuid": "1d41ac92-9a33-4a02-9b62-57483d406732",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-medium",
+      "component": "switch",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "29e7e1f1-d789-4d3c-9288-a139c7ae07ad",
+    "set_uuid": "e1c5dba8-cdef-4f72-82f6-46e34c83748a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-medium",
+      "component": "switch",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "12f8e465-8241-4b1a-91f8-27e91e5a01bf",
+    "set_uuid": "e1c5dba8-cdef-4f72-82f6-46e34c83748a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-small",
+      "component": "switch",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "507c0319-747b-448c-8962-5a73097ddfe2",
+    "set_uuid": "ea9efd4a-6c56-4113-9be6-253612442a13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "switch-handle-selected-size-small",
+      "component": "switch",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "14b85a33-6501-4366-90d3-e0c5375c522b",
+    "set_uuid": "ea9efd4a-6c56-4113-9be6-253612442a13",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "cfa167e1-39e9-4d05-b757-bdd616830358",
+    "set_uuid": "64a39d20-3456-42ad-81ee-86d1cb33feb1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "daee9fb3-c94c-4f91-90d5-99e40034c1fd",
+    "set_uuid": "64a39d20-3456-42ad-81ee-86d1cb33feb1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "2216638d-6dc7-4bfa-8364-99fe8eab2b3b",
+    "set_uuid": "c4bde48c-dc55-438e-b3e8-75abc7727133",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "91764817-6e5d-4273-b856-6751e40eb548",
+    "set_uuid": "c4bde48c-dc55-438e-b3e8-75abc7727133",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "6b885dfc-af50-4c44-8ee5-bf6b03624203",
+    "set_uuid": "5110087c-9fa1-4260-9de9-40d0d9af090c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "6263739c-dd33-4670-819a-d3aa0b9056b4",
+    "set_uuid": "5110087c-9fa1-4260-9de9-40d0d9af090c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "459a9b8c-b59b-4c9c-bc2d-c840d463040a",
+    "set_uuid": "d206243f-5d89-4c05-b1bb-60ff1ecacb70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "handle-size-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "8ccf8d0c-13a8-48da-a6dd-790ad728083f",
+    "set_uuid": "d206243f-5d89-4c05-b1bb-60ff1ecacb70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "fbc21571-970f-4bb2-8280-f6262446896b",
+    "set_uuid": "de9a4e67-0d4e-4444-968d-f6d42d93f866",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires switch control to be placed in frame of height workflow-icon-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "7e95ad9a-ca10-4f06-9c19-8dd2270cfdad",
+    "set_uuid": "de9a4e67-0d4e-4444-968d-f6d42d93f866",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires switch control to be placed in frame of height workflow-icon-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "f2c965e6-89fb-4b9d-843d-cfde31b7703d",
+    "set_uuid": "9a52d174-d050-45ee-af46-858738bd8981",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires switch control to be placed in frame of height workflow-icon-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "035e786b-17f2-488e-a049-84b257a3312f",
+    "set_uuid": "9a52d174-d050-45ee-af46-858738bd8981",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires switch control to be placed in frame of height workflow-icon-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "0135b823-5097-43bb-9911-9f731146af3b",
+    "set_uuid": "af618934-f995-4bb4-8014-de8f4663adc3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires switch control to be placed in frame of height workflow-icon-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "68276028-41d8-49e1-b0d4-f70cd27ab149",
+    "set_uuid": "af618934-f995-4bb4-8014-de8f4663adc3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires switch control to be placed in frame of height workflow-icon-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "8a907825-236c-4548-91c4-2123e095726c",
+    "set_uuid": "3434ca1a-5c60-4e2b-83fd-f911b293140b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires switch control to be placed in frame of height workflow-icon-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "switch",
+      "property": "top-to-control-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "f379c453-da21-41f6-92d1-9b6bdb95fd86",
+    "set_uuid": "3434ca1a-5c60-4e2b-83fd-f911b293140b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires switch control to be placed in frame of height workflow-icon-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "7e3a0369-fcc2-45d7-87ab-9053588713ef",
+    "set_uuid": "adc6e66b-3fc9-4fd7-84ec-ef4494c62774",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "3641ac9c-5610-4996-a55d-c2a94b2ff9ea",
+    "set_uuid": "adc6e66b-3fc9-4fd7-84ec-ef4494c62774",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "8e701e0e-4d7c-4d38-ba6b-1fd2ef5978dc",
+    "set_uuid": "c3498128-c005-4ee4-915e-eb287caa1041",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "091144b7-c63b-4827-840d-741cec01432a",
+    "set_uuid": "c3498128-c005-4ee4-915e-eb287caa1041",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "b44bbd5a-ef03-4e83-a9f5-88c896969d4d",
+    "set_uuid": "d4758ee5-0e66-4812-90f3-618775a200e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e69dee42-92da-4ca9-9eb8-97a7860adaba",
+    "set_uuid": "d4758ee5-0e66-4812-90f3-618775a200e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "d87a2ee3-6f7c-4f5e-8191-d35624fc10f1",
+    "set_uuid": "4a7ca31f-9087-4865-9a19-669fec8b1e6d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-compact-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "f453e51e-3d58-430e-8f17-8b95718dbf34",
+    "set_uuid": "4a7ca31f-9087-4865-9a19-669fec8b1e6d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "5840c3b8-3488-417b-8b33-f3fc667ffd7a",
+    "set_uuid": "60b185b4-b257-47e6-9340-7e1a074a40ea",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "25px",
+    "uuid": "c63380d4-cc26-4299-b227-af2faedfdc74",
+    "set_uuid": "60b185b4-b257-47e6-9340-7e1a074a40ea",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "61dd06ac-501e-4725-9d54-cc7a3d9f6586",
+    "set_uuid": "662d4ef9-344e-450f-bd48-0298f111d88a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "31d1b6b6-721f-4474-ba86-795367399e49",
+    "set_uuid": "662d4ef9-344e-450f-bd48-0298f111d88a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "f507e1bd-f08e-42b1-aee6-ea38f9f8a387",
+    "set_uuid": "1cb59572-fa95-4bc4-b3b1-bad21a5bc28d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "691db84a-5336-4e45-bf73-ee617057e718",
+    "set_uuid": "1cb59572-fa95-4bc4-b3b1-bad21a5bc28d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "2d0f71e2-66fc-4f28-bd4b-be41df0948ed",
+    "set_uuid": "cfdfec23-be3a-4327-9067-60ecf3e9bed6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "bottom-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "e0791360-b505-492b-bf71-dfa393abecfa",
+    "set_uuid": "cfdfec23-be3a-4327-9067-60ecf3e9bed6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "compact-height-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-300",
+    "uuid": "49130d66-edfb-48bd-8648-96c47f40a884"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "compact-height-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-200",
+    "uuid": "6d781a0e-e03d-4750-ae4f-67a29d731702"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "compact-height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-100",
+    "uuid": "e8c7c826-548d-4037-b064-3cf699675d35"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "compact-height-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-75",
+    "uuid": "25f7d9a5-9464-4447-97d9-97839b371f96"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-extra-large",
+      "component": "tab-item",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "1f12f9aa-19bd-4f77-93db-d737c0538677",
+    "set_uuid": "efaf1230-6cee-4541-89de-e4ae0879cbdc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-extra-large",
+      "component": "tab-item",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "6c0aad05-5224-4ade-913a-3dc5ebceeb62",
+    "set_uuid": "efaf1230-6cee-4541-89de-e4ae0879cbdc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-large",
+      "component": "tab-item",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "6fd78b93-1356-4eb0-9f70-bed00c3eb2aa",
+    "set_uuid": "c3865c45-3de0-4ab2-bb81-720c5bff2b41",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-large",
+      "component": "tab-item",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "6c4d8c39-9f75-4c75-94e2-274a69a8f556",
+    "set_uuid": "c3865c45-3de0-4ab2-bb81-720c5bff2b41",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-medium",
+      "component": "tab-item",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "cbbaa048-129d-439f-8aae-59153e28216b",
+    "set_uuid": "b84c88e4-e5f2-489b-9564-185e3bd4beda",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-medium",
+      "component": "tab-item",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "09ee234f-a596-47ba-89df-ab9ebc07ded8",
+    "set_uuid": "b84c88e4-e5f2-489b-9564-185e3bd4beda",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-small",
+      "component": "tab-item",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "d23bdd67-d7d0-42df-9575-61502d3692ab",
+    "set_uuid": "352d0f7d-f92e-4ac0-8170-9583107459bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "tab-item-focus-indicator-gap-small",
+      "component": "tab-item",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "5fbc924e-e79e-46c6-8544-c92d7f33bc26",
+    "set_uuid": "352d0f7d-f92e-4ac0-8170-9583107459bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "height-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-500",
+    "uuid": "42ed814c-5044-4c70-b82f-b49f8226241e"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "height-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-400",
+    "uuid": "8abd0b0e-fd6d-4064-9d0e-1ab998fcb0ce"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-300",
+    "uuid": "5d2288f4-f383-47fa-baca-0168cb46750a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "height-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-200",
+    "uuid": "7b31cf38-5bac-4f79-a4f1-172a4ea66e10"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "a480fffb-0a23-4893-87ce-730eb925a7cc",
+    "set_uuid": "b3d0f59e-2e13-4e51-9252-a91a1556de92",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "4e0b2015-06c8-41ab-9e2b-3a332a7625ff",
+    "set_uuid": "b3d0f59e-2e13-4e51-9252-a91a1556de92",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "c3f8f94b-d456-4aeb-8340-bd5643efe8fc",
+    "set_uuid": "d4258a99-f47a-495c-9f24-b63f19c55c71",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "2c85fa9a-e854-46f6-bc6b-547692d08290",
+    "set_uuid": "d4258a99-f47a-495c-9f24-b63f19c55c71",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "4d105a45-7403-47f2-ba50-419d822ff879",
+    "set_uuid": "b3abe910-99fc-4f8b-83af-057fd478c2ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "229477d5-e21a-4f4b-a24d-580f0c60eec5",
+    "set_uuid": "b3abe910-99fc-4f8b-83af-057fd478c2ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "f869f703-a850-4c6c-b518-ec8a1b355046",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "712e62ce-b869-4097-aee1-82e3b7505e14",
+    "set_uuid": "52087c63-410d-455b-8e3b-51ab1bd831c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "start-to-edge-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "8d413f56-6634-49c8-8d6a-53d0f57f1bbc",
+    "set_uuid": "52087c63-410d-455b-8e3b-51ab1bd831c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "c92ec468-0fac-4e12-b1f8-f22d09cb6c1e",
+    "set_uuid": "f1708d11-7b46-45fd-8d39-5c31a65b7e0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-extra-large instead.",
+    "replaced_by": "0c958750-2c96-453b-9464-f041ac126749"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "482ed7f6-ba60-4110-85c8-daf5bf352406",
+    "set_uuid": "f1708d11-7b46-45fd-8d39-5c31a65b7e0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-extra-large instead.",
+    "replaced_by": "0c958750-2c96-453b-9464-f041ac126749"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "1f9460a7-2ec0-4353-875c-ee5a6143d00b",
+    "set_uuid": "3b8da429-2985-480a-b85b-319f0c458bd1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-large instead.",
+    "replaced_by": "8932b4cf-300f-4377-bbda-7fc02011cd37"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "33px",
+    "uuid": "71bdfd06-4672-464f-b787-9a62137b1763",
+    "set_uuid": "3b8da429-2985-480a-b85b-319f0c458bd1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-large instead.",
+    "replaced_by": "8932b4cf-300f-4377-bbda-7fc02011cd37"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "31bea7d1-c8c2-4901-9f18-7a5c936d243f",
+    "set_uuid": "ebae14c7-73ca-4f71-9caa-82fde4816b90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
+    "replaced_by": "7a5f3049-0c20-4ff8-84ea-d161e58546fb"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "885a7cc3-8873-4cb7-99e7-b17f42fb48f1",
+    "set_uuid": "ebae14c7-73ca-4f71-9caa-82fde4816b90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
+    "replaced_by": "7a5f3049-0c20-4ff8-84ea-d161e58546fb"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "79695d07-21cb-4772-b3f7-b2eb56e7ad20",
+    "set_uuid": "038f3637-a968-4ccb-bf7e-6dde89677a8b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-small instead.",
+    "replaced_by": "a41aaa58-77af-476e-9050-4f4864c8c3f9"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-horizontal-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "8b5e1596-f13a-4786-b0c7-f01615423922",
+    "set_uuid": "038f3637-a968-4ccb-bf7e-6dde89677a8b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token tab-gap-horizontal-small instead.",
+    "replaced_by": "a41aaa58-77af-476e-9050-4f4864c8c3f9"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "d74ea722-c146-4ad2-ab20-41c332ae1190",
+    "set_uuid": "5ce7dfa6-aa85-4be6-bd22-10ae28c79f71",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "ea902ec1-25d5-47c3-896a-a95d9ca5bd62",
+    "set_uuid": "5ce7dfa6-aa85-4be6-bd22-10ae28c79f71",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "9846992c-e27b-4760-8808-7c44cca2cc65",
+    "set_uuid": "b0613cb8-b17d-4c5c-bab9-02153144c284",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "c193b2ee-a584-41dc-9ef8-3aebb38fb832",
+    "set_uuid": "b0613cb8-b17d-4c5c-bab9-02153144c284",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "7cd196c1-18b1-4dae-abf7-7ef1b531e0af",
+    "set_uuid": "1579ace5-820f-4b4b-81ed-3b1b8dfc3ae8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "6b6c960f-adcf-48b0-8310-ba12b47f4d9a",
+    "set_uuid": "1579ace5-820f-4b4b-81ed-3b1b8dfc3ae8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "da8211ee-8944-447f-a6df-6a16580e1893",
+    "set_uuid": "877ed7ee-8207-4eb3-8412-de9089cd8eae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "to-tab-item-vertical-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "d51a6c05-67d0-425f-becf-86e783ab3305",
+    "set_uuid": "877ed7ee-8207-4eb3-8412-de9089cd8eae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead.",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "2bdd22cd-93fe-4cf4-a025-e690ecafb50b",
+    "set_uuid": "e5a80358-315d-47b0-ad24-c74d9ad8ac98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "9694ebdc-cc88-4584-89f5-10a2c8de686f",
+    "set_uuid": "e5a80358-315d-47b0-ad24-c74d9ad8ac98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "93af7bac-830c-4460-abe2-0b2d8f786786",
+    "set_uuid": "4506ad0b-71e6-4627-b8e8-d6ff00b14e58",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "fd20b444-38ac-4438-a9ef-32474222e45f",
+    "set_uuid": "4506ad0b-71e6-4627-b8e8-d6ff00b14e58",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "2481e3a1-302b-46b8-98c2-e9461dd47d0c",
+    "set_uuid": "b88d643b-05db-464a-8b71-cd6b682e17e8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "128757b0-d690-4886-95d5-e9df36182a0f",
+    "set_uuid": "b88d643b-05db-464a-8b71-cd6b682e17e8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "bbcf3eda-4add-4d0d-b5ae-c2e7078e85ed",
+    "set_uuid": "1f2a4336-4d5b-4b39-a163-0a78a39c848c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-compact-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "d37488c4-d489-45bd-9086-8157c5204ae4",
+    "set_uuid": "1f2a4336-4d5b-4b39-a163-0a78a39c848c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "f1b6b932-748d-4b26-9c03-2bd9d0a40ac6",
+    "set_uuid": "9a697594-5717-49da-a138-f3c03306082a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "25px",
+    "uuid": "174cc6c8-9c0a-44c0-b6c7-ea6d337c819b",
+    "set_uuid": "9a697594-5717-49da-a138-f3c03306082a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "8b9275f5-3e63-459c-97fc-bc03691aa772",
+    "set_uuid": "1ad119cf-c6ec-458f-b6d6-16c8432b9c28",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "7e3db5ca-cd32-464b-9a23-9d03e83faa9c",
+    "set_uuid": "1ad119cf-c6ec-458f-b6d6-16c8432b9c28",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "e75e4e96-6d1b-4a86-9059-5c1f6f6ab269",
+    "set_uuid": "b66ff2e3-edd1-4e73-9446-85f596b6252e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "a8c455e9-60e5-4838-bc9c-eaf7b39a4bf7",
+    "set_uuid": "b66ff2e3-edd1-4e73-9446-85f596b6252e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "a9a6d785-f06d-4505-89ea-552d47ebe49d",
+    "set_uuid": "1a709fec-7699-4373-83ba-8e8cb6963c5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "3e155b8c-6cea-4b59-817c-cf71a63e00c7",
+    "set_uuid": "1a709fec-7699-4373-83ba-8e8cb6963c5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "dd4769f3-5c7e-491f-9d01-c80af0b561fb",
+    "set_uuid": "863df6bc-a4c3-46f7-80c4-43b3437b37a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "f310e5d7-7435-41a0-b44d-ececff4844f2",
+    "set_uuid": "863df6bc-a4c3-46f7-80c4-43b3437b37a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "fab951e5-1a78-4fb4-8c19-677f5f231189",
+    "set_uuid": "d7b9e286-1b4e-47ef-a0fa-549f26e89848",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "fad964d8-0020-4583-97ab-7d6565d01bdc",
+    "set_uuid": "d7b9e286-1b4e-47ef-a0fa-549f26e89848",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "7788c25c-0ce2-4170-8c5f-2fb1d98d953a",
+    "set_uuid": "ae256abb-27d9-4771-9617-e24c722279ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "4fb0520b-8c74-4fb7-b279-a3586a06a57e",
+    "set_uuid": "ae256abb-27d9-4771-9617-e24c722279ab",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "96c22cdc-aecb-4747-aea9-f140af5ee048",
+    "set_uuid": "04cfef16-7bba-4d8f-9270-6334a2473cff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-compact-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "b79002d2-bcff-4e8d-a406-e512c7e7d0e3",
+    "set_uuid": "04cfef16-7bba-4d8f-9270-6334a2473cff",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "2c869793-c10b-40ef-9545-45a8a6b4cbb5",
+    "set_uuid": "f94bad20-f7c9-4998-822c-b8d20158c4bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "5afa2636-7d4c-4d83-b9fc-3c5a52ee4646",
+    "set_uuid": "f94bad20-f7c9-4998-822c-b8d20158c4bb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "65e1f735-5f46-4bb3-9c7b-d5f5abab91a1",
+    "set_uuid": "8f813787-f636-49e9-94bf-464b291df600",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "23px",
+    "uuid": "4dd99579-949b-4bf9-b022-e8f0c95eae33",
+    "set_uuid": "8f813787-f636-49e9-94bf-464b291df600",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "aec60dda-9e5a-40c8-8e45-5e1662eab6e3",
+    "set_uuid": "5c4ae90f-f4b7-4f50-9e86-b8711c101c9e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "820baccf-af24-42a3-9729-99408bc9322f",
+    "set_uuid": "5c4ae90f-f4b7-4f50-9e86-b8711c101c9e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "7bd7427d-06a8-4194-a9f4-300fd1a4f547",
+    "set_uuid": "906995a7-4f9b-4b37-a90f-7f7712aa6f70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "tab-item",
+      "property": "top-to-workflow-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "923fd09d-8d08-4465-961f-63ac12014206",
+    "set_uuid": "906995a7-4f9b-4b37-a90f-7f7712aa6f70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
+    "replaced_by": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "border-divider-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "b6f2536c-deda-409f-8667-a5a99abdfa46"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "checkbox-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "400553db-907c-43a5-8545-92ba212e12b8",
+    "set_uuid": "da9aa4e5-0430-412e-b735-20cc09d5a740",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Erroneous measurement. It includes the padding of a text cell. Needs to be removed or changed",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "checkbox-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "cb7c89c0-9f31-43c4-8427-2e048f549ff7",
+    "set_uuid": "da9aa4e5-0430-412e-b735-20cc09d5a740",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Erroneous measurement. It includes the padding of a text cell. Needs to be removed or changed",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "0f76ceee-1d19-4c69-9393-09b02e1eede5",
+    "set_uuid": "2e4077b4-2c60-49c6-8b7d-80bb745a01dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "c8bd103d-d952-4649-a7a0-09ae5242ea17",
+    "set_uuid": "2e4077b4-2c60-49c6-8b7d-80bb745a01dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "fc30c9a8-b098-4edf-b3f4-c666c019b3f4",
+    "set_uuid": "b0857d42-73a5-4c93-a831-686a1033cb83",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "e465ee66-392f-469f-a46c-6c98df03b046",
+    "set_uuid": "b0857d42-73a5-4c93-a831-686a1033cb83",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "7357ba3f-c707-4475-b616-4752776c06d1",
+    "set_uuid": "9214054f-3dae-493e-a45d-b2202caae539",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "631d14a5-1d2e-4e4a-90e8-146e8a397530",
+    "set_uuid": "9214054f-3dae-493e-a45d-b2202caae539",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "9388deb6-6a77-49bc-aeb5-9084352c2574",
+    "set_uuid": "889c37a4-4036-4048-a0cf-aaab8df8ef75",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-bottom-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "9cf85eae-ec15-4bb0-ba48-00ec946306a5",
+    "set_uuid": "889c37a4-4036-4048-a0cf-aaab8df8ef75",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "05d4bb65-357a-4561-ab33-ea6de390a304",
+    "set_uuid": "999236d7-31b0-47ab-9b70-62cca87ff4a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "265247a7-bbc3-42b8-910d-946e8d04aee2",
+    "set_uuid": "999236d7-31b0-47ab-9b70-62cca87ff4a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "40b7bc07-3252-492a-9ee1-37aceeca3674",
+    "set_uuid": "cfd7aa7d-ba00-4989-947b-505d17b6c339",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "a02666d8-4ae2-42d2-b48e-419d5070e7ca",
+    "set_uuid": "cfd7aa7d-ba00-4989-947b-505d17b6c339",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "0ec68b5a-4251-4727-a689-b10722ce1a43",
+    "set_uuid": "fcdfa773-b92a-4e33-a98a-13e97dd8a7d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "ff3c5329-ccec-4b94-b200-29a377b34380",
+    "set_uuid": "fcdfa773-b92a-4e33-a98a-13e97dd8a7d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "de67ada3-eeed-45a2-8d03-91a5b09156ec",
+    "set_uuid": "3b59fa13-cd23-460f-94e2-4e91e1d2b791",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "column-header-row-top-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "fdc8b7ae-2356-4d49-ba54-0ea471be2986",
+    "set_uuid": "3b59fa13-cd23-460f-94e2-4e91e1d2b791",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "edge-to-content"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "5e46672f-eab0-4ec3-bd14-68ffa4404ec1",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead.",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "8adf3d5f-1024-4eb8-8515-f3b6fd7cc22c",
+    "set_uuid": "38f190f0-bf31-498c-925e-143c0c5b1af5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "42a78148-e111-4124-a7a6-d9baa2ca963f",
+    "set_uuid": "38f190f0-bf31-498c-925e-143c0c5b1af5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Controls must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "5011ae3c-2e72-4891-926e-8de8847e0a47",
+    "set_uuid": "56e2a957-2163-494f-83c0-c5bb904ffb1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "f6648787-3cf1-4af8-aa4f-15669ea1626d",
+    "set_uuid": "56e2a957-2163-494f-83c0-c5bb904ffb1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Controls must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "578765e6-b2ec-4bfe-ae28-f24cbee15898",
+    "set_uuid": "833adc4a-4868-429c-adff-13f2dc21a2ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "2e168a2b-46aa-453f-9ca1-746485216c84",
+    "set_uuid": "833adc4a-4868-429c-adff-13f2dc21a2ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Controls must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "370e9149-aaf5-43cd-a783-90cfa8d37419",
+    "set_uuid": "3a1f900b-1fc0-4501-b270-aec62b63a0b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "header-row-checkbox-to-top-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "296d445c-243d-454c-9f5a-146c13d0cded",
+    "set_uuid": "3a1f900b-1fc0-4501-b270-aec62b63a0b7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Controls must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "8b969d35-01ab-419f-b391-484aad88fd41",
+    "set_uuid": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "f25c6bfd-0a0d-4fd1-ab7b-9cd1d13053e1",
+    "set_uuid": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-bottom-to-text-300",
+    "uuid": "effa3e3c-eb5b-4c0a-aca9-81331e6a08ac",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-extra-large",
+    "uuid": "d13d2f2e-9425-403d-a95f-889d67f03425",
+    "set_uuid": "72d2def7-a752-4b02-b476-0d58cf74dae3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-extra-large instead.",
+    "replaced_by": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-extra-large",
+    "uuid": "c9ac99be-86c3-4f6c-a2a5-3487041bc95e",
+    "set_uuid": "72d2def7-a752-4b02-b476-0d58cf74dae3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-extra-large instead.",
+    "replaced_by": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "3271ab20-8a93-4b5b-a889-7a07d9f7e6ab",
+    "set_uuid": "285fa517-3947-4641-8480-6fafe084ef37",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-extra-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "06ada9fe-ceef-4fb4-88ee-37c2edee5418",
+    "set_uuid": "285fa517-3947-4641-8480-6fafe084ef37",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "f14b75f3-cb07-48b3-8543-34d80747ff36",
+    "set_uuid": "dfe63537-564b-4f23-ac78-39a08adeaf0b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "0de2f0a5-b32a-4f7b-b46c-1a6c25abc1ec",
+    "set_uuid": "dfe63537-564b-4f23-ac78-39a08adeaf0b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-bottom-to-text-200",
+    "uuid": "15e21448-3174-4565-aed7-ab84aa30d7ac",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-large",
+    "uuid": "775139b2-3fb4-4019-8a3e-2377211ed0ec",
+    "set_uuid": "47db1bbb-aaf2-4d31-bb52-7f260a1a069d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-large instead.",
+    "replaced_by": "dfe63537-564b-4f23-ac78-39a08adeaf0b"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-large",
+    "uuid": "151bf172-2889-4c98-8f15-5b6cdcb30d4b",
+    "set_uuid": "47db1bbb-aaf2-4d31-bb52-7f260a1a069d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-large instead.",
+    "replaced_by": "dfe63537-564b-4f23-ac78-39a08adeaf0b"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "3adc8c4f-32ce-4cd1-8bb1-518b9b267ed2",
+    "set_uuid": "91b5b043-bb34-495b-8cd0-31468dad24b3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "23px",
+    "uuid": "4bc11bec-9c86-4a6c-85d1-382c71c1352d",
+    "set_uuid": "91b5b043-bb34-495b-8cd0-31468dad24b3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "f14087ac-db72-43df-a8fa-9c9b03c6a1c9",
+    "set_uuid": "0a40f436-9f58-4c9d-9a63-77c61adba6e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "6ff9a81f-a2f8-4966-a48b-c8561aa4f833",
+    "set_uuid": "0a40f436-9f58-4c9d-9a63-77c61adba6e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-bottom-to-text-100",
+    "uuid": "d9d8fee2-9e0f-4c2b-8059-f9badb3b6482",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-medium",
+    "uuid": "c66ff3f2-3661-464c-b722-151f72d03f2a",
+    "set_uuid": "18cd494e-f66e-4825-86fb-d35262cf7881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-medium instead.",
+    "replaced_by": "0a40f436-9f58-4c9d-9a63-77c61adba6e2"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-medium",
+    "uuid": "e80339a8-22c4-4b53-9a4a-a4456f6cab3f",
+    "set_uuid": "18cd494e-f66e-4825-86fb-d35262cf7881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-medium instead.",
+    "replaced_by": "0a40f436-9f58-4c9d-9a63-77c61adba6e2"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2cedf119-a2f6-484a-8bdd-83652a8d6d79",
+    "set_uuid": "bc435ab5-6d31-448e-b5de-58b710ab501c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-medium-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "8273e28d-20b4-4575-9449-9178af111e38",
+    "set_uuid": "bc435ab5-6d31-448e-b5de-58b710ab501c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "56b58d2a-01dd-488b-b6e9-ff49555602b4",
+    "set_uuid": "6353bfab-c0fa-4cfd-bf93-11c01df2f236",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "d6100789-7076-403a-b878-7bb204093c52",
+    "set_uuid": "6353bfab-c0fa-4cfd-bf93-11c01df2f236",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-bottom-to-text-75",
+    "uuid": "5eb79adf-f94c-4bf8-9ec9-279f49ce5331",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-small",
+    "uuid": "90ae4c5b-a49d-40ad-8dd8-b25720c13f79",
+    "set_uuid": "539bf649-6bee-4fd1-b0b8-cdcf53ca17c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-small instead.",
+    "replaced_by": "6353bfab-c0fa-4cfd-bf93-11c01df2f236"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-bottom-to-text-small",
+    "uuid": "d3147ee6-dc34-46e2-8379-02d9690ff80a",
+    "set_uuid": "539bf649-6bee-4fd1-b0b8-cdcf53ca17c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-bottom-to-text-small instead.",
+    "replaced_by": "6353bfab-c0fa-4cfd-bf93-11c01df2f236"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "ad51f205-c2e7-4af5-9301-937594c61027",
+    "set_uuid": "df8d5ef4-8eb8-48bd-8283-a82c4da8c40a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-bottom-to-text-small-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "07dd5018-1999-4b95-9a59-fe1c2fcc380f",
+    "set_uuid": "df8d5ef4-8eb8-48bd-8283-a82c4da8c40a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "acd6ad6b-bab0-40fb-afbe-5df7eea7efb3",
+    "set_uuid": "e9908164-5b47-4098-8de3-028cd93eaa0b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "fb02243f-0490-4eb2-aac2-fa364c6eab59",
+    "set_uuid": "e9908164-5b47-4098-8de3-028cd93eaa0b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "a1aa1c65-a1e8-40d6-805f-309d5e43d129",
+    "set_uuid": "c0f93eef-4d3a-4274-92e9-d5b297a4077a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "4069e932-339a-495d-bb36-c89f22af4f96",
+    "set_uuid": "c0f93eef-4d3a-4274-92e9-d5b297a4077a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-extra-large",
+    "uuid": "9b775e1f-9348-431d-9ba8-bffb19bcbf85",
+    "set_uuid": "8819d918-2f76-4980-bf68-4d6b0d12b56a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-extra-large instead.",
+    "replaced_by": "e9908164-5b47-4098-8de3-028cd93eaa0b"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-extra-large",
+    "uuid": "2171aee7-d013-459e-a13f-33075090cbe3",
+    "set_uuid": "8819d918-2f76-4980-bf68-4d6b0d12b56a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-extra-large instead.",
+    "replaced_by": "e9908164-5b47-4098-8de3-028cd93eaa0b"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "23px",
+    "uuid": "568ba981-51b5-4443-a427-0f857ff02572",
+    "set_uuid": "4aecbd35-c2b1-43c0-9e35-0b8b2266481a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-extra-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "31px",
+    "uuid": "683be05e-f8d4-4910-8d07-20515f19fbbd",
+    "set_uuid": "4aecbd35-c2b1-43c0-9e35-0b8b2266481a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "a8c2b073-495b-402b-b1dc-2337b0e42f37",
+    "set_uuid": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "a0fa4e03-c1de-400d-8629-0ae9ffb9b9d8",
+    "set_uuid": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "40acc8c4-81b4-4566-a7ce-7c3d0d8ab5c5",
+    "set_uuid": "e8e48839-029b-4be1-a73a-1bcf1f7281e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "5fde3b28-c553-4124-be3b-212d1407780c",
+    "set_uuid": "e8e48839-029b-4be1-a73a-1bcf1f7281e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-large",
+    "uuid": "559b9fc0-389e-4e2f-985c-8741f218850a",
+    "set_uuid": "b801c82b-6ad6-47aa-a6ee-fae3f07fcc2b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-large instead.",
+    "replaced_by": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-large",
+    "uuid": "2e16e4ef-fec6-41fb-9d96-bc6bb6c88f69",
+    "set_uuid": "b801c82b-6ad6-47aa-a6ee-fae3f07fcc2b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-large instead.",
+    "replaced_by": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "d4b563c8-9234-4eed-a2a3-7e448a174286",
+    "set_uuid": "4a5b7cb8-0546-45ce-a8b3-53e02c0758e1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "cfbd6cb5-c8d3-4908-a77a-7a15cda932fb",
+    "set_uuid": "4a5b7cb8-0546-45ce-a8b3-53e02c0758e1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "be965b15-08f8-43be-9953-52151d8c7670",
+    "set_uuid": "4ca4c4bf-85eb-41f7-9348-6408b408275e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2ae09505-d43f-4e2c-b8a6-014ccfef5c10",
+    "set_uuid": "4ca4c4bf-85eb-41f7-9348-6408b408275e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "0b12ff10-52e2-4084-9f1b-ee7bc0b50576",
+    "set_uuid": "fdee6c12-6083-47fb-9b14-e8ed03a03841",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "84f00d87-c0ea-42fd-8477-9fff028bf79c",
+    "set_uuid": "fdee6c12-6083-47fb-9b14-e8ed03a03841",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-medium",
+    "uuid": "2c8f9b97-f4df-48c2-ab1a-82373d335b83",
+    "set_uuid": "30dfc19e-9751-4dab-a6c3-d3480af57dfc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-medium instead.",
+    "replaced_by": "4ca4c4bf-85eb-41f7-9348-6408b408275e"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-medium",
+    "uuid": "36505a4f-01b6-4b83-adf1-592818eb2c0d",
+    "set_uuid": "30dfc19e-9751-4dab-a6c3-d3480af57dfc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-medium instead.",
+    "replaced_by": "4ca4c4bf-85eb-41f7-9348-6408b408275e"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "c8a04cab-bfad-4b82-94dc-6c2b4160c7cb",
+    "set_uuid": "0bcbc9fa-5512-43ba-acc3-96a584aab30a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-medium-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "a57d2d1a-5e0c-4d4c-84eb-dd2339366aad",
+    "set_uuid": "0bcbc9fa-5512-43ba-acc3-96a584aab30a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "909ebf8a-eebd-41b6-8fac-8fe31d2bac00",
+    "set_uuid": "300645bd-1253-44a2-970e-33a2a028eb4f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "365d9c3f-d287-4feb-b020-89434dd29378",
+    "set_uuid": "300645bd-1253-44a2-970e-33a2a028eb4f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "f5c64a03-3750-4c92-afe2-43575bdb1df9",
+    "set_uuid": "ad134919-4768-4be4-96bd-bc681573ab5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "2444d220-a3d0-4565-a762-02cbc52f828a",
+    "set_uuid": "ad134919-4768-4be4-96bd-bc681573ab5b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-small",
+    "uuid": "4435c143-a75a-47c1-a629-3574b70247a3",
+    "set_uuid": "614a4d4a-48dc-4b3f-8920-e033dc4db28c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-small instead.",
+    "replaced_by": "300645bd-1253-44a2-970e-33a2a028eb4f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-checkbox-to-top-small",
+    "uuid": "a63aa24e-c956-4af5-bf4f-4c5d44bd1e16",
+    "set_uuid": "614a4d4a-48dc-4b3f-8920-e033dc4db28c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-checkbox-to-top-small instead.",
+    "replaced_by": "300645bd-1253-44a2-970e-33a2a028eb4f"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "4637c01d-66cd-451e-8950-9e72700c80d3",
+    "set_uuid": "4b694866-bd3e-4b41-a991-b729b6c7bc1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-checkbox-to-top-small-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "6ccbecd6-a1c4-4fcf-beb5-2b124ac3e75b",
+    "set_uuid": "4b694866-bd3e-4b41-a991-b729b6c7bc1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "d52d3141-27a5-40eb-800f-1a09acd42534",
+    "set_uuid": "34dfc670-7333-40fc-96e0-93a466273634",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "c2e3068b-c0be-4615-bbf7-c65e58ef126b",
+    "set_uuid": "34dfc670-7333-40fc-96e0-93a466273634",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-300",
+    "uuid": "dcc5dd06-bb3d-46d3-adf2-133e5be942b7"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-extra-large",
+    "uuid": "face2717-9c2c-4e18-9632-4e4a595b1fc7",
+    "set_uuid": "e65de693-2b8c-4c70-955d-2e6a64059ca4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-extra-large instead.",
+    "replaced_by": "34dfc670-7333-40fc-96e0-93a466273634"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-extra-large",
+    "uuid": "b7753c9a-8854-4927-89dd-80d47bff5fa5",
+    "set_uuid": "e65de693-2b8c-4c70-955d-2e6a64059ca4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-extra-large instead.",
+    "replaced_by": "34dfc670-7333-40fc-96e0-93a466273634"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "1504ecc5-0bd8-4bf2-ad3c-e073c824cd1a",
+    "set_uuid": "6d69b2dc-16d1-4153-9f57-227f2a0f2c8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-extra-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "6efd745f-2a9a-4eea-a0a3-ebe0d3fbc149",
+    "set_uuid": "6d69b2dc-16d1-4153-9f57-227f2a0f2c8c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "d3d9b523-90dc-4532-9cf7-37b568bd6800",
+    "set_uuid": "9e54ecf6-8a66-468c-8c8c-cd79ae9a6ecd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "60px",
+    "uuid": "ff04cae7-7f96-4db2-bf64-948c22d104ff",
+    "set_uuid": "9e54ecf6-8a66-468c-8c8c-cd79ae9a6ecd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-200",
+    "uuid": "d576b4aa-e3df-4aa9-8260-fecfe6517bde"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-large",
+    "uuid": "3b22a4c7-525c-4482-9e58-19cbe46d318b",
+    "set_uuid": "02c1f806-f32d-4b95-a790-dbc50cd57f0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-large instead.",
+    "replaced_by": "9e54ecf6-8a66-468c-8c8c-cd79ae9a6ecd"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-large",
+    "uuid": "b92bc058-27ea-4e86-a1a2-e5dbae3c2ee8",
+    "set_uuid": "02c1f806-f32d-4b95-a790-dbc50cd57f0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-large instead.",
+    "replaced_by": "9e54ecf6-8a66-468c-8c8c-cd79ae9a6ecd"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "0cd072e1-1757-49b1-a985-09ab65feb672",
+    "set_uuid": "81954a8f-3bd6-43fa-9fba-9cf209435025",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "e377fd73-62ca-481c-93f6-c62eb35ca720",
+    "set_uuid": "81954a8f-3bd6-43fa-9fba-9cf209435025",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "9d6dc5e8-d3f0-4f59-b062-756669ff7217",
+    "set_uuid": "e4365ada-fe16-4c16-af28-eb9bcbb15756",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "2cf7918c-f84a-4903-a6ba-b110807842ba",
+    "set_uuid": "e4365ada-fe16-4c16-af28-eb9bcbb15756",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-100",
+    "uuid": "b4b86a59-041d-451c-a0be-cc82e997a1d2"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-medium",
+    "uuid": "1dc88a25-18bc-491a-ab02-2c1ec36f4c1e",
+    "set_uuid": "6c3fec1e-6a96-400f-8188-cd2fd6f5039a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-medium instead.",
+    "replaced_by": "e4365ada-fe16-4c16-af28-eb9bcbb15756"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-medium",
+    "uuid": "72e6564c-2acf-4f77-80d9-b21d2d55a580",
+    "set_uuid": "6c3fec1e-6a96-400f-8188-cd2fd6f5039a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-medium instead.",
+    "replaced_by": "e4365ada-fe16-4c16-af28-eb9bcbb15756"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "697f4b63-14b9-4d58-9d16-b9dfd72ff391",
+    "set_uuid": "f5f3982f-4902-4a3f-9915-de8e1489bc24",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-medium-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "60px",
+    "uuid": "572d1c5f-62a1-4bfc-a3e0-520a999545fe",
+    "set_uuid": "f5f3982f-4902-4a3f-9915-de8e1489bc24",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "10b892a0-3c97-4af6-8ecc-3359e8cd1302",
+    "set_uuid": "a9bf30e6-0ca8-44af-8f97-149917c9f8c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "77a26f7c-2f71-4021-a1f2-a2af7c69a111",
+    "set_uuid": "a9bf30e6-0ca8-44af-8f97-149917c9f8c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-height-75",
+    "uuid": "a6dfc911-50fe-46dd-a7a3-cec3b115006a"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-small",
+    "uuid": "fd53964b-cf4a-4cdf-b088-418364b1c518",
+    "set_uuid": "f8519e64-027c-4724-b5f3-772ee266ba78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-small instead.",
+    "replaced_by": "a9bf30e6-0ca8-44af-8f97-149917c9f8c2"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-height-small",
+    "uuid": "cdbb999d-c2a9-4325-9689-bede2ad3559a",
+    "set_uuid": "f8519e64-027c-4724-b5f3-772ee266ba78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-height-small instead.",
+    "replaced_by": "a9bf30e6-0ca8-44af-8f97-149917c9f8c2"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "cb6f8879-6d73-40ca-9ea4-7eb05b26385a",
+    "set_uuid": "60852607-b336-4dd8-ae03-db21292a2378",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-height-small-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "ab252e1f-a13a-4630-a6ff-0cfa6e6f0c03",
+    "set_uuid": "60852607-b336-4dd8-ae03-db21292a2378",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "da7274c6-6f45-4087-b42f-dde7d3ac1af7",
+    "set_uuid": "cf9418b9-a5ff-47ee-b19d-b933629f3072",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "40de40fd-4bae-4a49-8aec-38dad2a1c5fb",
+    "set_uuid": "cf9418b9-a5ff-47ee-b19d-b933629f3072",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-300",
+    "uuid": "2e8eff8c-60fa-4e0f-ae40-7b9f9b3679d6",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-extra-large",
+    "uuid": "03555438-78f5-429a-a0dd-c6777dc36372",
+    "set_uuid": "b7562d01-f178-4ab0-bef4-e1f8e5f0f901",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-extra-large instead.",
+    "replaced_by": "cf9418b9-a5ff-47ee-b19d-b933629f3072"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-extra-large",
+    "uuid": "c381a3c4-e0a3-4e86-b279-f51ee6e9e532",
+    "set_uuid": "b7562d01-f178-4ab0-bef4-e1f8e5f0f901",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-extra-large instead.",
+    "replaced_by": "cf9418b9-a5ff-47ee-b19d-b933629f3072"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "7824ab63-198c-4ee3-99d7-9b151898eb40",
+    "set_uuid": "09f3e42a-bc6f-4439-a65a-22fd0ca251ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-extra-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "90c39289-3112-49a3-8e65-d112c97f7479",
+    "set_uuid": "09f3e42a-bc6f-4439-a65a-22fd0ca251ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "0820aecf-0647-4e51-ae40-44130bc86013",
+    "set_uuid": "de73e367-5c1a-4532-bd93-644f066fa2f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "4d55e632-588b-4e82-90c0-4fa434998d15",
+    "set_uuid": "de73e367-5c1a-4532-bd93-644f066fa2f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-200",
+    "uuid": "14437ed2-c60b-40ba-91e6-bed5353fc544",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-large",
+    "uuid": "2ed03fb3-fed4-41d4-8a14-f7446bb76486",
+    "set_uuid": "5be48be9-1157-411c-8357-b48451ee195e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-large instead.",
+    "replaced_by": "de73e367-5c1a-4532-bd93-644f066fa2f3"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-large",
+    "uuid": "0108018e-6146-45c9-b032-e3d44dfb8d84",
+    "set_uuid": "5be48be9-1157-411c-8357-b48451ee195e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-large instead.",
+    "replaced_by": "de73e367-5c1a-4532-bd93-644f066fa2f3"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "a3e22e10-1964-4d4a-8721-2eeddfed6f42",
+    "set_uuid": "afc52caa-98a7-4687-9cbb-3628a5bf2d90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "23px",
+    "uuid": "769d6bbf-64ba-4c08-8a57-580838de1d48",
+    "set_uuid": "afc52caa-98a7-4687-9cbb-3628a5bf2d90",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "ae401c94-c643-446f-a44e-38c9f3104fc6",
+    "set_uuid": "6f81b550-82ce-436f-9e33-93a247eaae54",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "0cd86854-57ca-4023-b544-8a4a76418164",
+    "set_uuid": "6f81b550-82ce-436f-9e33-93a247eaae54",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-100",
+    "uuid": "02c5faff-dbb4-4633-ae57-413b3666dfca",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-medium",
+    "uuid": "8e1448f8-5806-4629-8131-4e8422b26870",
+    "set_uuid": "40e31948-a58c-41f8-968b-2eaf58a1832f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-medium instead.",
+    "replaced_by": "6f81b550-82ce-436f-9e33-93a247eaae54"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-medium",
+    "uuid": "7df1dc32-b96d-41e3-a372-9bcaec7c2ccb",
+    "set_uuid": "40e31948-a58c-41f8-968b-2eaf58a1832f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-medium instead.",
+    "replaced_by": "6f81b550-82ce-436f-9e33-93a247eaae54"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "9893c4bf-aa89-4b46-987f-09432943734a",
+    "set_uuid": "a5705732-efdf-49ee-b292-e3087e6fed9b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-medium-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "cfa36bf7-cce0-4049-970a-8f11c6d60673",
+    "set_uuid": "a5705732-efdf-49ee-b292-e3087e6fed9b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "52fb10e1-a45e-4b21-9563-b72a6cf8c7e0",
+    "set_uuid": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "dfa553a2-b771-4a31-9294-3800d2126952",
+    "set_uuid": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "component-top-to-text-75",
+    "uuid": "b7e7808a-16c6-481a-9257-9c1dc4e13b62",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-small",
+    "uuid": "5e5a6837-34c9-4f01-8769-b66c3f602d1f",
+    "set_uuid": "116a4042-45aa-41d3-8964-b9f9cdfb5e0f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-small instead.",
+    "replaced_by": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-row-top-to-text-small",
+    "uuid": "98014297-14dc-4547-944a-8951c7f6f253",
+    "set_uuid": "116a4042-45aa-41d3-8964-b9f9cdfb5e0f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-row-top-to-text-small instead.",
+    "replaced_by": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "c0f9a500-3259-4888-ab43-c180c694a24e",
+    "set_uuid": "be09a814-07d8-4d09-91f5-45bc397bb1a3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "row-top-to-text-small-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "625733b1-78b3-4dd0-9636-71d59c14e013",
+    "set_uuid": "be09a814-07d8-4d09-91f5-45bc397bb1a3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "34b1c98f-7159-4ae0-b299-bf2fc53035c0",
+    "set_uuid": "7ec12e53-f33b-40ff-a051-cb62f71a376e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "60px",
+    "uuid": "06164331-9a76-4adf-b859-82074df19fbd",
+    "set_uuid": "7ec12e53-f33b-40ff-a051-cb62f71a376e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "553f5ffd-a163-4b33-b96a-5acc08cfb820",
+    "set_uuid": "db3b99d0-492f-4360-8d36-d497e1e00462",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "cc41c4f1-bfc5-4aa5-87af-97f191cc7af3",
+    "set_uuid": "db3b99d0-492f-4360-8d36-d497e1e00462",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "4c9e9bd8-9320-4648-bf2c-bb2db74a63fb",
+    "set_uuid": "9b7fb04a-96c6-4eb2-87ff-e0703b02617b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "07beb872-72a0-400e-b434-dd076c9be0a7",
+    "set_uuid": "9b7fb04a-96c6-4eb2-87ff-e0703b02617b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "89bd3638-bbbb-432d-84eb-e217f9bb0cbf",
+    "set_uuid": "58fd11fd-232a-474b-b53e-3b54a5d96266",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "section-header-row-height-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "2cd8dc05-2f95-45b5-b8a4-0273baf3ba0e",
+    "set_uuid": "58fd11fd-232a-474b-b53e-3b54a5d96266",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "0ae43893-e3ea-461f-a2fe-93239cb3a22a",
+    "set_uuid": "65180f74-078a-48db-aea1-e095d37f9e00",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "17051925-5eda-45a3-8d45-d329e88bf63a",
+    "set_uuid": "65180f74-078a-48db-aea1-e095d37f9e00",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "499530d7-7c3c-4bed-a4a1-d4edc2195afe",
+    "set_uuid": "4ede0b34-d5a0-4670-a9e3-e44e8f07b5c6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "29ee801a-95bd-495c-9905-f2fd00ae0e19",
+    "set_uuid": "4ede0b34-d5a0-4670-a9e3-e44e8f07b5c6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-extra-large",
+    "uuid": "17c4c578-d3e1-44c0-bd21-ee4df5cb2027",
+    "set_uuid": "bfbef5d5-293c-4366-aef3-58e44a06500b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-extra-large instead.",
+    "replaced_by": "65180f74-078a-48db-aea1-e095d37f9e00"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-extra-large",
+    "uuid": "b60c33b8-acc1-4af1-b30f-b467054ee417",
+    "set_uuid": "bfbef5d5-293c-4366-aef3-58e44a06500b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-extra-large instead.",
+    "replaced_by": "65180f74-078a-48db-aea1-e095d37f9e00"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "127b9225-cbab-42c1-8c86-4f425c7c8e27",
+    "set_uuid": "e0ec88e1-fa29-4fbe-9ccf-cc96db4bbbd9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-extra-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "28a5df8a-0fe4-4410-b804-9a6c26de4440",
+    "set_uuid": "e0ec88e1-fa29-4fbe-9ccf-cc96db4bbbd9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "589d6f19-ec7f-4a4f-a622-40d18d7e71f5",
+    "set_uuid": "bea15b38-2401-4051-9c87-c0dc347e7d1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "92ade1a0-ea78-4930-82e7-fedafce42aed",
+    "set_uuid": "bea15b38-2401-4051-9c87-c0dc347e7d1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "9b0e3ebe-59f6-4970-aa47-06b115f5efff",
+    "set_uuid": "36507892-dd39-4c89-8b26-99d04c9d2243",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "891cf7bc-419a-4b78-8c7e-03685fbf36a4",
+    "set_uuid": "36507892-dd39-4c89-8b26-99d04c9d2243",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-large",
+    "uuid": "de6e6ae5-eae6-4f7a-89be-176674176242",
+    "set_uuid": "00499404-08ab-4a8a-9939-035374dfe2f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-large instead.",
+    "replaced_by": "bea15b38-2401-4051-9c87-c0dc347e7d1d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-large",
+    "uuid": "fc7efe7c-ef97-424f-89c2-2211daf44b4a",
+    "set_uuid": "00499404-08ab-4a8a-9939-035374dfe2f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-large instead.",
+    "replaced_by": "bea15b38-2401-4051-9c87-c0dc347e7d1d"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "f1cbc035-b4d0-4593-b563-a107ee2eebb0",
+    "set_uuid": "9682efb2-82ef-46a4-9bd9-221f8018efad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-large-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e6689bf9-6ecc-4900-b8ad-85b103232e3e",
+    "set_uuid": "9682efb2-82ef-46a4-9bd9-221f8018efad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "42914d96-ee9f-4ed9-9c7a-9c8ccca68245",
+    "set_uuid": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "2268750d-4c5f-46f1-bad7-dec21818bfe6",
+    "set_uuid": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "86a1c328-0845-47d8-a189-24a22c1ce053",
+    "set_uuid": "a161ad1c-ff4b-4e73-84a3-0480bc43dd3b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "b546eac7-00ad-4ea2-992d-0c4b8d087679",
+    "set_uuid": "a161ad1c-ff4b-4e73-84a3-0480bc43dd3b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-medium",
+    "uuid": "12a6fd11-d3a5-4d72-9942-89d828d1d256",
+    "set_uuid": "d51b5484-2bae-48f1-890a-fc90198ea480",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-medium instead.",
+    "replaced_by": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-medium",
+    "uuid": "75af7a67-e0ae-4f41-9c70-09babbc587d1",
+    "set_uuid": "d51b5484-2bae-48f1-890a-fc90198ea480",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-medium instead.",
+    "replaced_by": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "1cd90c35-f688-4054-aec4-e1e3b200cfcf",
+    "set_uuid": "8f744293-1acb-4572-8050-cd76740e5557",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-medium-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "0cb1e46b-039b-46d2-a024-b72ddd82d0b4",
+    "set_uuid": "8f744293-1acb-4572-8050-cd76740e5557",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "96d7eb12-7e92-4ee8-988b-8e7e8a7de159",
+    "set_uuid": "6db35635-76fd-4ef3-9a44-c0b6354550ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "43955cdb-afaf-4e59-bb26-3063661141d7",
+    "set_uuid": "6db35635-76fd-4ef3-9a44-c0b6354550ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-regular instead. Refactor may be necessary",
+    "replaced_by": "15ffb38e-341b-4c47-a6b3-c197e05afffe"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small-compact",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "d9cc50d4-6661-4a03-b850-ed0933f2dabb",
+    "set_uuid": "7e65af83-a25c-42dc-8a8c-201e3c8cfa1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small-compact",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "72ebb8a4-9bfb-4ff0-ba3a-232c885931e7",
+    "set_uuid": "7e65af83-a25c-42dc-8a8c-201e3c8cfa1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
+    "replaced_by": "42473d6e-5f40-46c7-9bbc-302e355ae6ae"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small-regular",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-small",
+    "uuid": "db98283d-1f25-4323-9f3a-0555b9670ba6",
+    "set_uuid": "3d54e517-3d92-4adb-83e4-8f1cccc63673",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-small instead.",
+    "replaced_by": "6db35635-76fd-4ef3-9a44-c0b6354550ca"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small-regular",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "table-thumbnail-to-top-minimum-small",
+    "uuid": "e25b14a7-cb9e-406b-bab6-b27575f00a52",
+    "set_uuid": "3d54e517-3d92-4adb-83e4-8f1cccc63673",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use table-thumbnail-to-top-minimum-small instead.",
+    "replaced_by": "6db35635-76fd-4ef3-9a44-c0b6354550ca"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small-spacious",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "9b464ca8-f246-482d-b240-e12e097aaf8b",
+    "set_uuid": "97e074af-13cd-4bbd-a785-b473da69a3cb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "table",
+      "property": "thumbnail-to-top-minimum-small-spacious",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "b6684bce-531d-420a-befc-b4ad884059fc",
+    "set_uuid": "97e074af-13cd-4bbd-a785-b473da69a3cb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token table-item-padding-spacious instead. Refactor may be necessary",
+    "replaced_by": "a775a186-802e-4256-947c-7fda3ac53caa"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "edge-to-clear-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "896b20fc-c13e-4785-a252-00857208d51c",
+    "set_uuid": "4d6e4dec-5d27-4791-b639-5e4a211a21fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "edge-to-clear-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "b046b12c-5c39-4018-8ccc-9a5cb08eb6e5",
+    "set_uuid": "4d6e4dec-5d27-4791-b639-5e4a211a21fb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "edge-to-clear-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "e4e422af-181f-47b5-b165-f514a0a6f41c",
+    "set_uuid": "2d000eb2-5aed-48d3-822e-11522c9c38f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "edge-to-clear-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "a2f75bb4-0ce4-4993-9a43-09cd2b7376bf",
+    "set_uuid": "2d000eb2-5aed-48d3-822e-11522c9c38f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "edge-to-clear-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "a27b0e7c-8840-4d08-8f88-39643589c554",
+    "set_uuid": "58051d9f-6a04-4e64-8a6e-73858a57935c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "edge-to-clear-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "6f913e5f-debc-4b7d-897d-c2704847c2e5",
+    "set_uuid": "58051d9f-6a04-4e64-8a6e-73858a57935c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "property": "tag-field-default-width-large",
+      "component": "tag-field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "288px",
+    "uuid": "ebea4627-12b5-4f51-9bda-be4f9dca213b",
+    "set_uuid": "59ccc726-108b-46ab-8d59-1cf9c16d6972",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "tag-field-default-width-large",
+      "component": "tag-field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "312px",
+    "uuid": "7f4da1db-493c-4965-b89e-3ca585bebd25",
+    "set_uuid": "59ccc726-108b-46ab-8d59-1cf9c16d6972",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "tag-field-default-width-medium",
+      "component": "tag-field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "264px",
+    "uuid": "7afa2c15-4eae-42af-b323-5dfde15a68cc",
+    "set_uuid": "04a7da36-00b6-4f2a-b2f6-92715f134ae0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "tag-field-default-width-medium",
+      "component": "tag-field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "288px",
+    "uuid": "640aa691-c4a4-4cda-9912-2e6c6f9c1ac2",
+    "set_uuid": "04a7da36-00b6-4f2a-b2f6-92715f134ae0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "tag-field-default-width-small",
+      "component": "tag-field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "240px",
+    "uuid": "65194439-66b2-4f47-9096-80e018f2708a",
+    "set_uuid": "05fe2653-edc9-45a6-ace5-e3d1879b79c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "tag-field-default-width-small",
+      "component": "tag-field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "264px",
+    "uuid": "face078a-da74-4dec-9519-ef8a1a8b15cc",
+    "set_uuid": "05fe2653-edc9-45a6-ace5-e3d1879b79c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "edge-to-content-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "03b1351c-1309-4e1a-a18b-bf3a350814c4",
+    "set_uuid": "6e3b375b-5076-4d26-a608-667a98c34f17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "edge-to-content-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "1fda84ab-aa68-46fb-bd0f-d8174a08a41e",
+    "set_uuid": "6e3b375b-5076-4d26-a608-667a98c34f17",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "edge-to-content-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "798ecb75-638c-41dd-81a0-d7ecca9960da",
+    "set_uuid": "a0ca6a64-65d6-4080-baf4-f76fb375383b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "edge-to-content-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "0072dc62-b868-4c4b-afd9-9c52d876c614",
+    "set_uuid": "a0ca6a64-65d6-4080-baf4-f76fb375383b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "edge-to-content-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "b6eebf3a-4733-4177-a235-6eccfacf67cd",
+    "set_uuid": "f8f0b01a-2c63-4d0e-b1e4-506f278040ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "edge-to-content-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "5e448fc3-6c14-4169-84a0-1f70bbc478cb",
+    "set_uuid": "f8f0b01a-2c63-4d0e-b1e4-506f278040ce",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-height-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "68px",
+    "uuid": "09f85b07-baa8-4f51-9067-cf41749e4214",
+    "set_uuid": "513b90e1-d8b9-48bb-9592-bed8a27dfe98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-height-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "82px",
+    "uuid": "b24c4940-bf4a-4c85-8cb8-b613ac9bc7c8",
+    "set_uuid": "513b90e1-d8b9-48bb-9592-bed8a27dfe98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-height-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "12d9d6b6-1621-433a-bc94-4a47843153b9",
+    "set_uuid": "e228d447-a32e-4afb-88a6-2e336d60aa41",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-height-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "68px",
+    "uuid": "163ef7b4-537b-43b7-a543-ebea0153e16b",
+    "set_uuid": "e228d447-a32e-4afb-88a6-2e336d60aa41",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-height-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "b45ded81-85da-4c0d-abfe-3ff51c7e9c70",
+    "set_uuid": "8bd7af69-6696-4b58-9494-13e323598ac1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-height-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "54px",
+    "uuid": "f9f61ca1-b08f-4e8d-89ae-f7f2c5df289d",
+    "set_uuid": "8bd7af69-6696-4b58-9494-13e323598ac1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "180px",
+    "uuid": "be7ccb7a-5eba-4104-91cf-f24121648b76",
+    "set_uuid": "a9c942a5-eff0-4e72-aa32-84075eca856c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag-field",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "c1bf4479-eb9f-45de-b431-57fd892eac6f",
+    "set_uuid": "a9c942a5-eff0-4e72-aa32-84075eca856c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "label-to-clear-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "8533ad58-9e81-4154-8ad1-57213741e814",
+    "set_uuid": "9a8b0028-fefe-41fe-83a9-fed108acb3b3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "label-to-clear-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "7c1375da-c6c7-42b3-b60e-0ef6724c6303",
+    "set_uuid": "9a8b0028-fefe-41fe-83a9-fed108acb3b3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead.",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "label-to-clear-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "c964fe64-fcb6-4417-977d-b15880daf164",
+    "set_uuid": "9136db47-9232-460e-9e57-1143b4ba9e7b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "label-to-clear-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "ff7424ba-5f65-46ff-b408-4ffb2cfc5035",
+    "set_uuid": "9136db47-9232-460e-9e57-1143b4ba9e7b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "label-to-clear-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "bfc9cd19-e115-4ff2-908d-6cd4725f68bc",
+    "set_uuid": "32732b36-a364-4eec-a240-3e8eb538c15d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "label-to-clear-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "2011748e-f950-4c6e-9eee-1c0d77b7ba36",
+    "set_uuid": "32732b36-a364-4eec-a240-3e8eb538c15d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "maximum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 7,
+    "uuid": "8771f506-a491-4222-be86-0e666ea2c711"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "33px",
+    "uuid": "234b3886-77eb-4ad5-9d19-40d801a54617",
+    "set_uuid": "c160e0a6-c19c-4fb5-af16-49ffea4b9b56",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "42px",
+    "uuid": "b2788159-dd2d-4f94-9282-d8cdbba41807",
+    "set_uuid": "c160e0a6-c19c-4fb5-af16-49ffea4b9b56",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "9b373ba1-7381-4360-8730-bd91afacbfa7",
+    "set_uuid": "33cfd1f4-12a3-4cd8-a621-d67868424511",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "34px",
+    "uuid": "40485b19-e1ac-4981-a17c-bb6e264c730d",
+    "set_uuid": "33cfd1f4-12a3-4cd8-a621-d67868424511",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1,
+    "uuid": "837b2ac3-0adc-438c-b249-b96bac07049f",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "d3327dae-cc93-4099-ad75-b5a4193af8e4",
+    "set_uuid": "3d401849-853a-4920-8a94-ac001432d63c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "minimum-width-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "25px",
+    "uuid": "3b9e5d81-e49a-4080-ac53-094e0f7eb151",
+    "set_uuid": "3d401849-853a-4920-8a94-ac001432d63c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-avatar-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "57de6911-6f5f-4a0d-9606-e7584a10d7f4",
+    "set_uuid": "6dc82803-d302-4e3a-9932-3155bdd4a64f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-avatar-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "9881ad7c-e9df-40b1-a368-4f8185042c3f",
+    "set_uuid": "6dc82803-d302-4e3a-9932-3155bdd4a64f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-avatar-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "394343df-fb5d-44be-b6d1-9975ab8a4156",
+    "set_uuid": "1a1233a0-7ad4-4ea9-a453-7dfadd1d6dae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-avatar-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "8dbabe33-52e7-4dc1-b2e3-81c1c62d98cb",
+    "set_uuid": "1a1233a0-7ad4-4ea9-a453-7dfadd1d6dae",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-avatar-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "cf1239b1-495a-482c-8aeb-3b98c6b75583",
+    "set_uuid": "a2f37017-0efa-4706-849a-1808c497e136",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-avatar-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "a2c40238-1fda-4482-a419-b8092a385c9b",
+    "set_uuid": "a2f37017-0efa-4706-849a-1808c497e136",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-cross-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "e335436a-190c-4417-86f4-b7266c093377",
+    "set_uuid": "dfa2b156-7b26-44dd-b2fc-ea33b38192de",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-cross-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "af69e3d1-92b6-4e62-93f2-c1f1f10f0a63",
+    "set_uuid": "dfa2b156-7b26-44dd-b2fc-ea33b38192de",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-cross-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "1bfd3452-93c8-424a-99e4-55e5ecbee90b",
+    "set_uuid": "50b571a8-0931-454b-aa73-88cda1772cb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-cross-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "ac7b17a2-99ef-45b3-ab3b-4d3eeaf99fb9",
+    "set_uuid": "50b571a8-0931-454b-aa73-88cda1772cb0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-cross-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "c9e5e973-4942-414e-b128-5569f62453a2",
+    "set_uuid": "814117c5-90a4-4fad-a66d-68b68a25d8d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "tag",
+      "property": "top-to-cross-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "d93e04b9-1901-4ec4-947a-62c84205e61e",
+    "set_uuid": "814117c5-90a4-4fad-a66d-68b68a25d8d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Edge cases should be ok for edge usage. In principle, it's still padding. In reality, it's vertical not horizontal. But that may be ok",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "component": "takeover-dialog",
+      "property": "height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "100%",
+    "uuid": "be327284-79fe-40b7-b996-8ad176d40d8e"
+  },
+  {
+    "name": {
+      "component": "takeover-dialog",
+      "property": "width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "100%",
+    "uuid": "bb70e39d-c686-4cd2-a991-6b51fa16d9df"
+  },
+  {
+    "name": {
+      "component": "text-area",
+      "property": "minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "71bc5e67-900e-4e32-8109-a4c18da89348",
+    "set_uuid": "17297951-3d82-4fef-95d5-8ca43f644b7f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "text-area",
+      "property": "minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "cb7270a7-8075-435c-81a5-469ef43860c0",
+    "set_uuid": "17297951-3d82-4fef-95d5-8ca43f644b7f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "text-area",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "112px",
+    "uuid": "69694a85-5f31-43b4-8044-c0f08c83d618",
+    "set_uuid": "047fdfe2-3692-4713-93b3-83984ccce345",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "text-area",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "140px",
+    "uuid": "c89bcff3-23ce-405c-a776-3ece7a2ac342",
+    "set_uuid": "047fdfe2-3692-4713-93b3-83984ccce345",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "text-field",
+      "property": "minimum-width-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1.5,
+    "uuid": "875bbeaf-b4b7-41b9-8e6f-d6a57ec03049"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "corner-radius"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-75",
+    "uuid": "13681294-e3c6-4898-a17e-943932a53c08"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "opacity-checkerboard-square-size"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "0322f848-009a-45c4-ad4a-17d8f7e41995"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "46dd2eca-598a-45e3-8c7d-c6cf17e148bf",
+    "set_uuid": "6ccfba1b-2acd-4ea1-a969-af165b1b4803",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "545604c8-484f-4697-907c-31e2b2cb46d0",
+    "set_uuid": "6ccfba1b-2acd-4ea1-a969-af165b1b4803",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-1000",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "48959be8-02f9-45b9-8190-af60c93cbb6c",
+    "set_uuid": "98ec54b1-1ad9-46cd-af5a-0d1247ceb197",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-1000",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "72px",
+    "uuid": "cfbf3ec4-f51d-4a50-b81c-765fff84ce14",
+    "set_uuid": "98ec54b1-1ad9-46cd-af5a-0d1247ceb197",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "ec457831-d272-4809-a84a-f1e9dcaec495",
+    "set_uuid": "788eb0e7-5684-4113-aa58-1b26fa525631",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "0e548378-9633-49d2-90d8-b40e1ba7c98e",
+    "set_uuid": "788eb0e7-5684-4113-aa58-1b26fa525631",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "95c5905f-b209-4e84-881f-13ea85f12d87",
+    "set_uuid": "9a069107-9b74-49a7-b29e-48dc8ffec9ef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "8f4dd02c-d3eb-4654-aea4-b3921048cdbe",
+    "set_uuid": "9a069107-9b74-49a7-b29e-48dc8ffec9ef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "7ee6d5ae-eb01-49e1-93ba-df3e7c25d876",
+    "set_uuid": "ab26b7c6-b002-4494-9cd6-116b53eb6a95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "b0351cf7-f0df-4044-ab26-5b6649ea2e1f",
+    "set_uuid": "ab26b7c6-b002-4494-9cd6-116b53eb6a95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "0578d5e5-9c2d-46f2-9268-85bdf566b3a5",
+    "set_uuid": "3c384b5a-5d50-4178-a24d-e6479b13df5e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "7f33676b-63dd-4d16-b7e1-36520ade716d",
+    "set_uuid": "3c384b5a-5d50-4178-a24d-e6479b13df5e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "87234a25-8f6d-457c-9d3f-363930fec12c",
+    "set_uuid": "bfd1dccd-2166-445f-ac3e-14c78e3e0aa3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "1798b58e-fce4-411d-ba8d-75006fa4f53e",
+    "set_uuid": "bfd1dccd-2166-445f-ac3e-14c78e3e0aa3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "d533a543-9622-4c43-92a6-82dd5eebcc64",
+    "set_uuid": "843927ab-cce4-45e5-a626-0f09dce95c27",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "543dcd25-42cc-4198-b4ba-ba5524b08691",
+    "set_uuid": "843927ab-cce4-45e5-a626-0f09dce95c27",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-700",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "d6aaa2c4-d213-44de-9bae-742d26df8765",
+    "set_uuid": "783c3746-367c-42d9-862e-1eb1ec229b31",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-700",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "52px",
+    "uuid": "5eab16f9-5537-4a14-958d-d96200c5723f",
+    "set_uuid": "783c3746-367c-42d9-862e-1eb1ec229b31",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "20706cc7-9d07-4938-8328-debd3ab8d822",
+    "set_uuid": "389eb221-ff20-43c3-86d6-fefd6d63283c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "852fc55b-beb7-428c-bc0c-452abc204de3",
+    "set_uuid": "389eb221-ff20-43c3-86d6-fefd6d63283c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-800",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "52px",
+    "uuid": "8cee2b4d-48c8-45aa-803b-5d1cd9027fcf",
+    "set_uuid": "644086da-cb67-4cd9-902d-a05f67858932",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-800",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "94ca9817-988a-4e4f-9163-954d29204049",
+    "set_uuid": "644086da-cb67-4cd9-902d-a05f67858932",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-900",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "5b9fb77d-8a2e-4e1c-ba86-475cd66b4202",
+    "set_uuid": "1c2c552a-5d02-42e3-af7c-8fdb7a909e2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "thumbnail",
+      "property": "size-900",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "97f11dd2-0173-464c-9eef-c260c9e8cf22",
+    "set_uuid": "1c2c552a-5d02-42e3-af7c-8fdb7a909e2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "time-field",
+      "property": "minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 2.5,
+    "uuid": "21bb1275-44e7-49be-926a-66966e969a6f",
+    "description": "2.5x height of field"
+  },
+  {
+    "name": {
+      "component": "time-field",
+      "property": "text-to-visual"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "9953fcd9-ac62-49bd-beb2-926dc9fbb8c8",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "title-cjk-emphasized-font-style",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "2be8bfb1-7a0c-452d-9532-ea2eda408b82"
+  },
+  {
+    "name": {
+      "property": "title-cjk-emphasized-font-weight",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "c03b6bc7-76b6-4533-883e-881438de975f"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-font-family",
+    "uuid": "6fa83674-af7c-4656-8b33-d3312534ee53"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "f421339b-fc3b-4d4e-86b4-65a63584131b"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "57a5eaba-935d-47e5-9cc4-cc1da6a330de"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-line-height-100",
+    "uuid": "999ba22a-87b6-45fe-9e89-9911f34ea330"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "2fcf237b-6988-4c31-a806-f4176b94c2a8"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "d1bccaa7-731f-4df2-a4c3-9dbec33145fd"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "a134fab9-7606-453d-a64f-fd2daa989283"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "99472fda-7d17-45d5-b2ba-0c79a45d628f"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-50",
+    "uuid": "f5966933-93a3-4615-a19b-b94d6a0367da"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-xxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "abbc512e-fdce-4025-9d08-5a71692cf523"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-size-xxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-500",
+    "uuid": "223b1966-4dbb-4e89-b508-9191ffedc97c"
+  },
+  {
+    "name": {
+      "property": "title-cjk-strong-emphasized-font-style",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "55c1dcc1-f296-47eb-989b-ae5e22748869"
+  },
+  {
+    "name": {
+      "property": "title-cjk-strong-emphasized-font-weight",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "ba6356fb-cada-4786-9306-71b940e61ca8"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "85e5ba03-3f0a-4245-a26c-ac9c3df23d1b"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "cjk-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "93e5a426-7229-46ee-89f6-a84f7084592b"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "line-height-100",
+    "uuid": "e1397d35-0c23-410c-a213-65db1eb4887f"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "margin-bottom-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.25,
+    "uuid": "73a0bd28-7691-47b0-9e9b-62ec22940e63"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "margin-top-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.88888889,
+    "uuid": "14d9dc6c-28fc-41cf-a1ae-600a150f520a"
+  },
+  {
+    "name": {
+      "property": "title-sans-serif-emphasized-font-style",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "98fd5c98-b53d-49f0-bce1-705b53ae9ae4"
+  },
+  {
+    "name": {
+      "property": "title-sans-serif-emphasized-font-weight",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "4fe9b508-ff74-4819-8188-e080d814d9ef"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "sans-serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "sans-serif-font-family",
+    "uuid": "9a65d2f0-87c0-404b-9965-6e4b00efeda8"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "sans-serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "faa965d6-42c0-40f9-802e-ff0ea69d740d"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "sans-serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "58a27a2e-58c6-42dc-b860-1a8458966da4"
+  },
+  {
+    "name": {
+      "property": "title-sans-serif-strong-emphasized-font-style",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "39c10c1e-56c1-4a94-b5b9-a91a2db92050"
+  },
+  {
+    "name": {
+      "property": "title-sans-serif-strong-emphasized-font-weight",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "ab0482d5-ff9a-4c50-876b-ed5accf067a4"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "sans-serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "871928bc-14ac-465d-b245-c39bcf265a72"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "sans-serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "ace1f3cb-629c-4172-b64f-a8b1f5afbdcc"
+  },
+  {
+    "name": {
+      "property": "title-serif-emphasized-font-style",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "cf6281f7-00ef-437e-b89b-d6d774818f0b"
+  },
+  {
+    "name": {
+      "property": "title-serif-emphasized-font-weight",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "3abd6cd1-42f5-4b4b-9732-bb826fe0a740"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "serif-font-family",
+    "uuid": "b3098f42-d73e-4228-a4f9-9be4b0c46ce8"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "70955f1b-4124-432e-bd9d-c5b42c890195"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "23cf3a6f-911c-4e64-8952-7412bc7f4629"
+  },
+  {
+    "name": {
+      "property": "title-serif-strong-emphasized-font-style",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "6359f577-d462-456b-a748-ceecb893b4a2"
+  },
+  {
+    "name": {
+      "property": "title-serif-strong-emphasized-font-weight",
+      "component": "title"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "c2a2882b-f048-4580-96c8-76556fccc87c"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "6d2f0e78-e527-41c7-8843-af89a9790da6"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "a0367ebf-8cc8-4aa0-80c4-ccf4a03644a3"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "0fb9e5ec-e5b7-41e0-8ef4-db9e4e33e060"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "6d63a369-4261-44a4-bf8d-a567dffa8ef6"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "0babc342-b506-495d-aaf1-20fe9e571e1b"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "b5aaaa50-721b-4b41-ad90-345cd995f69e"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "68dac9e8-9b07-4453-8cb2-24ed349d2134"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-xxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-500",
+    "uuid": "d4c4db99-70f2-4c79-8595-4d23407de068"
+  },
+  {
+    "name": {
+      "component": "title",
+      "property": "size-xxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-600",
+    "uuid": "56152e6a-3058-4467-86a1-34fa2b6f75b2"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "bottom-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "821e8f74-d1de-4507-9ff7-ece44e535e8c",
+    "set_uuid": "ecad3ac8-e45f-460c-a0a9-13f41a3bfdf0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "bottom-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "a790fd9e-4e5f-4f4c-a3ca-832540832580",
+    "set_uuid": "ecad3ac8-e45f-460c-a0a9-13f41a3bfdf0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "52px",
+    "uuid": "a6267318-c8b1-43d4-99b6-ca2a55e9dff4",
+    "set_uuid": "28138e79-4a91-4446-a07e-7c8bac379b18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "60px",
+    "uuid": "12c8ae92-16b9-48ec-801c-bf07785da4b3",
+    "set_uuid": "28138e79-4a91-4446-a07e-7c8bac379b18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "maximum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "336px",
+    "uuid": "9ac252c8-06dd-48a9-a3d3-ca8ccfb355dd",
+    "set_uuid": "e8dc3919-27bb-4fec-9c7c-7842ca1e6946",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "maximum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "420px",
+    "uuid": "a4de5997-1eb1-430f-9a9f-cf2637d02d34",
+    "set_uuid": "e8dc3919-27bb-4fec-9c7c-7842ca1e6946",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "top-to-text",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "be4f24cf-9334-4fc4-aa72-e0347beecda7",
+    "set_uuid": "f2d06ddb-31e5-4da8-9345-47ed975b7d1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "top-to-text",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "9f0688f5-128f-47c3-8585-94d704214881",
+    "set_uuid": "f2d06ddb-31e5-4da8-9345-47ed975b7d1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "top-to-workflow-icon",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "d10d2a55-2b4d-46b1-81e9-521d6c3578e1",
+    "set_uuid": "10da87b7-e0a1-4793-9912-0d43dd15acaf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "toast",
+      "property": "top-to-workflow-icon",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "1f83245b-3d79-4326-b843-df7b6549cade",
+    "set_uuid": "10da87b7-e0a1-4793-9912-0d43dd15acaf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token banner-padding-vertical instead. Refactor may be needed",
+    "replaced_by": "64fa4ab7-be93-4420-8cdc-a6ef91499852"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "maximum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "160px",
+    "uuid": "e5ba234a-afdd-451e-84e7-51314446cdae",
+    "set_uuid": "e606fea0-3540-4461-96b5-c57e9d9b39ef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "maximum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "6d7623e1-65f5-4af5-8c08-b33b093b85ae",
+    "set_uuid": "e606fea0-3540-4461-96b5-c57e9d9b39ef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "tip-corner-radius"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "53fef925-59e3-4df5-9ac2-e2b4d34d9bca"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "tip-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "481757aa-c6b5-4281-9a63-feeb1c88aec6",
+    "set_uuid": "85cce135-1150-4d93-9347-ecf23f8a48e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "tip-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "70c9f65f-1e23-4c47-94dd-0c3ddde15743",
+    "set_uuid": "85cce135-1150-4d93-9347-ecf23f8a48e5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "tip-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "0732bd0e-c5c0-4e58-8fee-2015c1753237",
+    "set_uuid": "0b509ce5-5f52-4cb0-8811-52a1264ff473",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tooltip",
+      "property": "tip-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "ad2c09a6-c42e-4eef-94a3-6c2180c6e2af",
+    "set_uuid": "0b509ce5-5f52-4cb0-8811-52a1264ff473",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tray",
+      "property": "top-to-content-area",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "74787427-ea2f-4b94-99c0-88454e8be6cf",
+    "set_uuid": "ce3f949b-cf92-4fd4-9ca5-a2e843e869ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tray",
+      "property": "top-to-content-area",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "794ad497-1725-4a03-a7c9-425eaee3178e",
+    "set_uuid": "ce3f949b-cf92-4fd4-9ca5-a2e843e869ee",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "bottom-to-label",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "7ab9177a-d035-4e78-b6b9-d80a6470bd7b",
+    "set_uuid": "75396078-60ab-40f8-8783-b1a642e48ea5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Faulty measurement. Combination of two measurements Correcting to text to inner element spacing. Refactor needed",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "bottom-to-label",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "9136f55b-d28b-4802-873c-db6205b8632b",
+    "set_uuid": "75396078-60ab-40f8-8783-b1a642e48ea5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Faulty measurement. Combination of two measurements Correcting to text to inner element spacing. Refactor needed",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "disclosure-indicator-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "f9fcb5e0-d8aa-4077-bb8d-dd487ba9d7de",
+    "set_uuid": "65d6c69e-0d00-4d31-8e18-a27cb4ddd464",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "disclosure-indicator-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "82ac143f-6009-4eaa-a797-c4b17277d416",
+    "set_uuid": "65d6c69e-0d00-4d31-8e18-a27cb4ddd464",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "disclosure-indicator-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "34px",
+    "uuid": "824d592b-c305-4c56-81db-c6566e6ebb2f",
+    "set_uuid": "a9a4a8fe-327f-4c81-9c86-8d824e159de4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "disclosure-indicator-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "42px",
+    "uuid": "e24897f6-7bfb-45c0-ab07-30bc1efc0b59",
+    "set_uuid": "a9a4a8fe-327f-4c81-9c86-8d824e159de4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "drag-handle-to-checkbox",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e8c03b6e-d493-43b6-ae46-a6a92de5c9b8",
+    "set_uuid": "c4cfb591-0aa6-4526-abdc-62377ea96636",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "drag-handle-to-checkbox",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "5a77899c-1547-40da-bce3-d892cfbc0450",
+    "set_uuid": "c4cfb591-0aa6-4526-abdc-62377ea96636",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "edge-to-checkbox",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "2e3817ed-206b-45e5-b55c-6116e9731cd8",
+    "set_uuid": "8799b5e4-5cfc-4f45-bf87-b9ee9942931f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "edge-to-checkbox",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "fba49c63-444e-42fc-b27c-7ce43b8419a7",
+    "set_uuid": "8799b5e4-5cfc-4f45-bf87-b9ee9942931f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead. Refactor or combine list-item-padding-horizontal with base-padding-horizontal-medium",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "edge-to-drag-handle",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "e8127c62-d8fa-405f-a5d5-d4f79bdffa5f",
+    "set_uuid": "745bcb1f-e624-438c-b119-29056c4893e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "edge-to-drag-handle",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "f51d97ac-06c4-45a4-87ff-349b3ffbc36d",
+    "set_uuid": "745bcb1f-e624-438c-b119-29056c4893e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "end-edge-to-action-area",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "91c6c1db-1f68-43b3-80ba-aa3c7ebecaec",
+    "set_uuid": "b44722f5-4b5a-4b9c-879f-565dc850b2c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "end-edge-to-action-area",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "66d490aa-b658-474d-99cf-f18d15cb4098",
+    "set_uuid": "b44722f5-4b5a-4b9c-879f-565dc850b2c5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-horizontal instead.",
+    "replaced_by": "2147f873-8f42-4821-9654-9db2b1adc2f9"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "header-to-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-1px",
+    "uuid": "8f92e6b8-907f-42b2-81d6-83d1786495bf",
+    "deprecated": "unknown",
+    "deprecated_comment": "Should be zero. Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "item-to-header",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "ebf7358c-b691-45d7-a1c4-c346e75e800e",
+    "set_uuid": "07b4d295-fb4e-4c1a-b733-3af00c395a2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead. This gap is not used in design; the header gap is equal to all other list item gaps. Refactor may be necessary",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "item-to-header",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "a06c6929-1acc-4084-a8ee-3d4ad5a0064e",
+    "set_uuid": "07b4d295-fb4e-4c1a-b733-3af00c395a2f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-gap-regular instead. This gap is not used in design; the header gap is equal to all other list item gaps. Refactor may be necessary",
+    "replaced_by": "b7e1af59-753e-4059-8f46-8d862f631ad8"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "item-to-item"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "tree-view-item-to-item-default",
+    "uuid": "9a04f19a-9e2a-43b9-9b1f-3385aef214ac",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use tree-view-item-to-item-default instead.",
+    "replaced_by": "7d44a2b5-0aa6-4770-81da-8dbd87013906"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "item-to-item",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-1px",
+    "uuid": "7d44a2b5-0aa6-4770-81da-8dbd87013906",
+    "deprecated": "unknown",
+    "deprecated_comment": "Should be zero; no token"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "item-to-item-detached"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "c7c837c3-47ad-4ef1-a2eb-e4629628eb44",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-small instead.",
+    "replaced_by": "a8a20ecd-480e-4681-8639-c44d6dcb0658"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "label-to-action-area",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "e5e3b415-97a9-436d-b46d-9bf48d7a2104",
+    "set_uuid": "fcea2a25-e08c-46d2-8e0f-474e89eeb21d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "label-to-action-area",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "096032da-c0b4-4086-82e9-ab80c2b3d90b",
+    "set_uuid": "fcea2a25-e08c-46d2-8e0f-474e89eeb21d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-gap-medium instead.",
+    "replaced_by": "3cd1e483-969b-492c-8d44-d29348c981a5"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "level-increment",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "cf7044fe-e79d-44e4-8ae0-c9c23ac5b9ac",
+    "set_uuid": "33f6922a-9f40-4cee-95c6-dd8f4c7cb259",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead.",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "level-increment",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "038d525f-357a-4441-934e-093d7342eba8",
+    "set_uuid": "33f6922a-9f40-4cee-95c6-dd8f4c7cb259",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-indent-medium instead.",
+    "replaced_by": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "minimum-height",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "de8ed8b3-aee4-4d18-8728-01e6807bec7d",
+    "set_uuid": "b8dc040f-e26d-4d80-b27b-8af4381d24da",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "minimum-height",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "36d1219e-f34a-4ee9-bfa0-a93a42046d94",
+    "set_uuid": "b8dc040f-e26d-4d80-b27b-8af4381d24da",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "minimum-top-to-context-area",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "1569ef2c-0e00-4314-87d0-e8f703b9fee8",
+    "set_uuid": "777bb6b8-4378-426e-a6dc-4411049ea153",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "minimum-top-to-context-area",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "50ce9fc5-eab5-4ab5-8dfa-a22d5b4361e9",
+    "set_uuid": "777bb6b8-4378-426e-a6dc-4411049ea153",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "minimum-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "160px",
+    "uuid": "2ab54eb5-8f32-4a01-b4ff-d5dc7a70f827",
+    "set_uuid": "85b826d7-84dc-4843-9df4-b8385e7ce133",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "minimum-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "200px",
+    "uuid": "06c90c91-1598-4150-a431-e733ba39bec5",
+    "set_uuid": "85b826d7-84dc-4843-9df4-b8385e7ce133",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "tree-view-selected-row-background-opacity-emphasized",
+      "component": "tree-view"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.1",
+    "uuid": "d31772fd-95f3-413d-ab20-826033d71938"
+  },
+  {
+    "name": {
+      "property": "tree-view-selected-row-background-opacity-emphasized-hover",
+      "component": "tree-view"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "value": "0.15",
+    "uuid": "a83e023c-dc92-4b3e-8375-351bbf8ec9bb"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-action-button",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "20a69a94-ddc0-4581-bac9-1d0d2b3e0a48",
+    "set_uuid": "53394c0d-54d2-45cf-a7e1-32875bcea1ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-action-button",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "7bea161d-9ee0-41b0-a31b-162926b28637",
+    "set_uuid": "53394c0d-54d2-45cf-a7e1-32875bcea1ca",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-checkbox",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "6f33e161-86d3-40a4-b631-e7c8b9e9d337",
+    "set_uuid": "7bf6c9ab-4b83-43d4-babc-77dc63542f8d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-checkbox",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "b148e202-b43d-4089-b0d8-885fc99cb983",
+    "set_uuid": "7bf6c9ab-4b83-43d4-babc-77dc63542f8d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead.",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-disclosure-indicator",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "138541e2-022a-4b03-b4d2-c6932ec56ac2",
+    "set_uuid": "a075e8d8-3c95-4d34-a5eb-3499e2aa4cef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Design spec's show different value/measurement than token value",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-disclosure-indicator",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "aae1c8b3-2aa1-4463-ad84-a52f80a6a09b",
+    "set_uuid": "a075e8d8-3c95-4d34-a5eb-3499e2aa4cef",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token list-item-padding-vertical-regular instead. Design spec's show different value/measurement than token value",
+    "replaced_by": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-drag-handle",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "7fc57ed1-9ca8-4b08-b19f-4aa8c49ca6f3",
+    "set_uuid": "61b7a466-eee3-4aa9-9734-d8f739653b0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Drag handle will need to be in a frame with height equal to workflow-icon-size-[size]",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-drag-handle",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "bb805e5e-d65b-4daf-9116-288fa59ddbfd",
+    "set_uuid": "61b7a466-eee3-4aa9-9734-d8f739653b0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Drag handle will need to be in a frame with height equal to workflow-icon-size-[size]",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-label",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "a6a556b7-ff51-41e3-84d0-92fa8ef01ed6",
+    "set_uuid": "8a605bda-4bd2-416d-bfb3-2b9c242eb092",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "tree-view",
+      "property": "top-to-label",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "d2e3ca68-015b-47a4-96ea-0c380e931c09",
+    "set_uuid": "8a605bda-4bd2-416d-bfb3-2b9c242eb092",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "component": "triple-calendar",
+      "property": "popover-minimum-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "320px",
+    "uuid": "19c4d5a5-6ccb-407e-afa7-79f19286837b"
+  },
+  {
+    "name": {
+      "component": "triple-calendar",
+      "property": "popover-minimum-width"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "912px",
+    "uuid": "1ccfcd2c-6de7-4a25-b6b7-0b40acc702c6"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "2x-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "2cc848e3-7990-4235-8cb6-6d246e1bf1df",
+    "set_uuid": "2d1c635e-7273-4a3f-bd23-8a60bcf18cb4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "2x-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "d6ab89f2-4d40-413c-ade4-95fb8a010665",
+    "set_uuid": "2d1c635e-7273-4a3f-bd23-8a60bcf18cb4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "b0281fdc-b044-45e6-af04-e56913432575",
+    "set_uuid": "df73e942-9fb0-4182-a11d-250007ae7f16",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "d7741965-d975-4aee-b0db-93e0d55822fd",
+    "set_uuid": "df73e942-9fb0-4182-a11d-250007ae7f16",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "extra-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "8c4f32d5-746f-4dce-aca3-5e657a03afda",
+    "set_uuid": "c6f1212a-8cee-4174-91ca-499865fc70ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "extra-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "d9e04bc9-d510-4bfb-8193-3269f0ed4e7c",
+    "set_uuid": "c6f1212a-8cee-4174-91ca-499865fc70ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "7f5f9ac3-2029-4cd2-8a4b-e16c58122487",
+    "set_uuid": "d9eb30d2-60ca-4cd2-b72a-983fce263d9a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "9516737f-6855-416e-adc0-f03e08f63259",
+    "set_uuid": "d9eb30d2-60ca-4cd2-b72a-983fce263d9a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "dba2b2d5-43b9-4e2a-9b45-fbc02d16a84d",
+    "set_uuid": "993349fa-e1d0-47c9-a904-4710ee8ce818",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "17cec018-ae0f-4aaf-ad6d-08b758f94c8c",
+    "set_uuid": "993349fa-e1d0-47c9-a904-4710ee8ce818",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "0d252df3-59fc-422e-8f47-d4c894660eb9",
+    "set_uuid": "9f043078-0925-4a0c-be46-a3bda4d80f0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "ui-icon",
+      "property": "small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "2a20e624-976e-4722-bb38-c8d1eeef6e98",
+    "set_uuid": "9f043078-0925-4a0c-be46-a3bda4d80f0e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "236px",
+    "uuid": "9a9f173d-6262-490f-976f-bd9abb9ec355"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "219px",
+    "uuid": "7cf979ef-c47b-41f3-8230-49d67ad47740"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "202px",
+    "uuid": "53c81b30-6d98-4eaa-857f-15707d54a548"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "192px",
+    "uuid": "f646530e-480c-4dbb-85fe-771eb5685966"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-title-below-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "263px",
+    "uuid": "a603a785-8cd8-4caf-a2b4-cfe3371cc10e"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-title-below-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "244px",
+    "uuid": "4cc4f673-912b-4e53-a75e-c8bd4603ab19"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-title-below-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "224px",
+    "uuid": "5f4edfbc-eb2e-4dd5-add1-bf45530b0e61"
+  },
+  {
+    "name": {
+      "component": "user-card",
+      "property": "minimum-height-title-below-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "212px",
+    "uuid": "3373c4d2-d81b-4649-bc24-5251879778c1"
+  }
+]

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -1,0 +1,5906 @@
+[
+  {
+    "name": {
+      "property": "accessory-gap-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "60f6e8c5-35be-4c2f-846d-82ef16550cfb",
+    "description": "Spacing between child elements for accessory elements at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-affixed-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "daa213d5-de2d-4738-b324-be4bdd92d937",
+    "description": "Spacing between child elements for accessory elements at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-affixed-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "5ddb3980-2cbd-41cb-9b60-2139c5ce9544",
+    "description": "Spacing between child elements for accessory elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-affixed-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "b4d6b11b-240b-4daf-8c24-3661888730d1",
+    "description": "Spacing between child elements for accessory elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-affixed-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "31fe1f21-a95a-4354-b6d1-e40dc66990fb",
+    "description": "Spacing between child elements for accessory elements at large size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-affixed-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "32bdfee6-cc93-4d53-9d08-2591646d38e9",
+    "description": "Spacing between child elements for accessory elements at medium size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-affixed-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "7789a1e5-3bc8-494d-91c2-1309b4697da9",
+    "description": "Spacing between child elements for accessory elements at small size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "ae4398f5-6ead-4928-adf9-f39c0cfcec11",
+    "description": "Spacing between child elements for accessory elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "c4071c28-33df-4461-a05c-2a1b1c295d5e",
+    "description": "Spacing between child elements for accessory elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "609e172d-40af-4329-b9d7-32c9158b40bb",
+    "description": "Spacing between child elements for accessory elements at large size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "627d972a-4164-4ec6-8c64-0ee97c23fc43",
+    "description": "Spacing between child elements for accessory elements at medium size"
+  },
+  {
+    "name": {
+      "property": "accessory-gap-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "843d1518-7aa6-4d60-968e-b71ebbfcd88e",
+    "description": "Spacing between child elements for accessory elements at small size"
+  },
+  {
+    "name": {
+      "property": "accessory-item-padding-2x-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "080ab6d2-2967-4a94-946b-d710e84ea656",
+    "description": "Internal spacing for accessory elements items at 2x-small size"
+  },
+  {
+    "name": {
+      "property": "accessory-item-padding-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "f644cf28-8586-43d6-9831-bbf23d4e465a",
+    "description": "Internal spacing for accessory elements items at extra-large size"
+  },
+  {
+    "name": {
+      "property": "accessory-item-padding-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "3db87e61-b057-4e0e-a5f1-78943ed2871e",
+    "description": "Internal spacing for accessory elements items at extra-small size"
+  },
+  {
+    "name": {
+      "property": "accessory-item-padding-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "2a1b4c8d-46ca-4b7c-922f-6f117faba404",
+    "description": "Internal spacing for accessory elements items at large size"
+  },
+  {
+    "name": {
+      "property": "accessory-item-padding-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "c97051d7-eccb-4d55-8487-7ffdec2b1c78",
+    "description": "Internal spacing for accessory elements items at medium size"
+  },
+  {
+    "name": {
+      "property": "accessory-item-padding-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "21bc0c7b-7d9f-4b5e-a954-0b16cfbbb2ca",
+    "description": "Internal spacing for accessory elements items at small size"
+  },
+  {
+    "name": {
+      "property": "android-elevation"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2dp",
+    "uuid": "f9456531-ab61-4c14-b7af-7016ce1c0d3e"
+  },
+  {
+    "name": {
+      "property": "banner-gap-horizontal"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-400",
+    "uuid": "c0571c46-5946-4896-bcbf-270560de5385",
+    "description": "Spacing between child elements for banner components"
+  },
+  {
+    "name": {
+      "property": "banner-gap-vertical"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "312ebac2-32a0-47a8-9c4e-e366b2232228",
+    "description": "Spacing between child elements for banner components"
+  },
+  {
+    "name": {
+      "property": "banner-padding-horizontal"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "eb386242-21c6-437b-8125-e6d4394dd9c5",
+    "description": "Horizontal internal spacing for banner components"
+  },
+  {
+    "name": {
+      "property": "banner-padding-horizontal-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "7f237198-3842-49bc-aa79-e723fbe6c78e",
+    "description": "Horizontal internal spacing for banner components (compact density)"
+  },
+  {
+    "name": {
+      "property": "banner-padding-vertical"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "64fa4ab7-be93-4420-8cdc-a6ef91499852",
+    "description": "Vertical internal spacing for banner components"
+  },
+  {
+    "name": {
+      "property": "base-gap-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "f3078f76-5c45-4b40-8d3c-523afcc4d2af",
+    "description": "Spacing between child elements for base UI elements at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "base-gap-3x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "dae4ef22-9423-4ef2-a0d2-cc08ed9c0cd7",
+    "description": "Spacing between child elements for base UI elements at 3x-large size"
+  },
+  {
+    "name": {
+      "property": "base-gap-4x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "f1af772f-09bb-4b3c-9431-d8db175058fa",
+    "description": "Spacing between child elements for base UI elements at 4x-large size"
+  },
+  {
+    "name": {
+      "property": "base-gap-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd",
+    "description": "Spacing between child elements for base UI elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "base-gap-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "2fca8c2d-dad0-4441-8e52-e623d76ef701",
+    "description": "Spacing between child elements for base UI elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "base-gap-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "2f10fab2-66e0-4007-9c01-9643d472ba3b",
+    "description": "Spacing between child elements for base UI elements at large size"
+  },
+  {
+    "name": {
+      "property": "base-gap-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c",
+    "description": "Spacing between child elements for base UI elements at medium size"
+  },
+  {
+    "name": {
+      "property": "base-gap-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "1247c1ab-9e31-482a-832c-d32911a1e698",
+    "description": "Spacing between child elements for base UI elements at small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "3eb3e963-b4b8-462f-b4e2-a48c657e2fd2",
+    "description": "Horizontal internal spacing for base UI elements at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "26cedd5b-5c67-4da7-974f-806b20064a5b",
+    "description": "Horizontal internal spacing for base UI elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e1030243-729a-4afe-a6d5-47b8e620e2ce",
+    "description": "Horizontal internal spacing for base UI elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "ef179042-3ad8-4db5-8e23-983134f5906c",
+    "description": "Horizontal internal spacing for base UI elements at large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "4043f679-9ec2-4eef-b934-19f60d7e74f5",
+    "description": "Horizontal internal spacing for base UI elements at medium size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "0732ae91-c85b-45ab-8a57-e21622768db3",
+    "description": "Horizontal internal spacing for base UI elements at small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-2x-large",
+    "uuid": "9c571815-ef7f-4baa-9c7f-32a6f89052b7",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-2x-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-2x-small",
+    "uuid": "af1d798e-4235-44a3-a327-1779c134b72b",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-extra-large",
+    "uuid": "54f547dc-cb51-4eb2-91ff-b0f7b383f072",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-extra-small",
+    "uuid": "337ce5da-d735-4930-a9c8-9fecf4dcb9b0",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-large",
+    "uuid": "1006824d-539b-408e-afd6-1e77779b9d21",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-medium",
+    "uuid": "a982f1e2-0545-4ca3-8104-32208ea9e152",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at medium size"
+  },
+  {
+    "name": {
+      "property": "base-padding-horizontal-uniform-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "base-padding-vertical-small",
+    "uuid": "3c42cb65-d84e-4cfd-bf17-e9f21ce17b7e",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "51761a5c-200d-467d-a575-3722f825edb9",
+    "description": "Vertical internal spacing for base UI elements at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-2x-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "c5f12db9-a471-4678-9828-e9b3d80f550d",
+    "description": "Vertical internal spacing for base UI elements at 2x-small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-3x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "3185ad9c-8e5a-4bef-a4db-5ee159ef1b0e",
+    "description": "Vertical internal spacing for base UI elements at 3x-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc",
+    "description": "Vertical internal spacing for base UI elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47",
+    "description": "Vertical internal spacing for base UI elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "cc707192-e70f-4965-8582-55fa97d02184",
+    "description": "Vertical internal spacing for base UI elements at large size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "5741f832-f012-45bc-9e87-6e07ab2cb87f",
+    "description": "Vertical internal spacing for base UI elements at medium size"
+  },
+  {
+    "name": {
+      "property": "base-padding-vertical-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d",
+    "description": "Vertical internal spacing for base UI elements at small size"
+  },
+  {
+    "name": {
+      "property": "border-width-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "b5525080-28e7-4eb7-aee9-fb2c71a16f68"
+  },
+  {
+    "name": {
+      "property": "border-width-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "cc8a43f4-0ba6-46e3-90af-653fbc59a328"
+  },
+  {
+    "name": {
+      "property": "border-width-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "18b0ff0d-494c-4d33-acab-a62528c5ca66"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "8b5b5dce-a9c4-4c03-a194-8a5bc716b18a",
+    "set_uuid": "a234522c-7f9e-481e-aa19-10398c0cb952",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-5px",
+    "uuid": "2cfe025b-8bf8-47a3-8ff1-733cf62dd182",
+    "set_uuid": "a234522c-7f9e-481e-aa19-10398c0cb952",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-3px",
+    "uuid": "3f385135-015a-44dd-bde3-60389b14c2ff",
+    "set_uuid": "120d71db-cd03-41a9-ab52-36ac7b1e62dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "cef58f98-9fb0-4fbb-b6aa-dc5786d7658a",
+    "set_uuid": "120d71db-cd03-41a9-ab52-36ac7b1e62dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-3px",
+    "uuid": "2ebe9ae0-3b74-47dc-af79-e1dd5f93b9bd",
+    "set_uuid": "899f64eb-79ae-4292-ad03-8cafe139d788",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "1cecea81-8c7f-4658-b3a2-0e1282f7eac9",
+    "set_uuid": "899f64eb-79ae-4292-ad03-8cafe139d788",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-3px",
+    "uuid": "f2f62625-dfd4-46b0-9113-033820745569",
+    "set_uuid": "d2115b45-9155-4037-b16e-7b8d8977da4f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "character-count-to-field-quiet-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-4px",
+    "uuid": "819cdbf4-9e26-4fdf-895d-8f60c06efa2a",
+    "set_uuid": "d2115b45-9155-4037-b16e-7b8d8977da4f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "color-control-track-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "424db2a9-5795-400b-a98a-58081d311bff",
+    "set_uuid": "03a7d531-c294-4a41-bd51-38c77a20317e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "color-control-track-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "07e3ac46-3f96-4c00-aa6a-09840ee04bdd",
+    "set_uuid": "03a7d531-c294-4a41-bd51-38c77a20317e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "24def269-4582-46f6-a00c-8b5a28410917",
+    "set_uuid": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "c8590269-dcaa-44f6-9c2d-d33274c3fe5e",
+    "set_uuid": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "ae65b844-9758-4708-8781-2c8df35af1e9",
+    "set_uuid": "36742697-2320-4bc0-8a29-ad98e342349f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "a39cef5c-631c-4942-b5d2-9121e05d47f8",
+    "set_uuid": "36742697-2320-4bc0-8a29-ad98e342349f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "4459554a-d872-4a6a-a620-4a1937605d29",
+    "set_uuid": "e731e2e4-c3bf-4dff-aca0-04201e7e17ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "a6aac364-d617-4e21-a1db-5523daaa3c6c",
+    "set_uuid": "e731e2e4-c3bf-4dff-aca0-04201e7e17ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "ee165c7d-3e9a-4a8d-a71f-3083fd7fdc4b",
+    "set_uuid": "66f28027-02df-4ff7-bab5-f2ea3fa482c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "80f01183-a152-4c55-ac11-24edae62df64",
+    "set_uuid": "66f28027-02df-4ff7-bab5-f2ea3fa482c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "923c46e1-b6f7-4d8a-844d-b4c0661b5e60",
+    "set_uuid": "861fff6a-7163-495d-bcb1-caa87693fb55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-bottom-to-text-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "0f1a6c63-bc4f-444c-9a18-67b6c35464b1",
+    "set_uuid": "861fff6a-7163-495d-bcb1-caa87693fb55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "0c0d6d38-6734-4312-9be5-dd48dd571841",
+    "set_uuid": "7f2bb2ef-58c0-41f9-8109-0edf0ccf3d5d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "0b3ecfcf-8fb9-4faf-ab7f-ff4baf733df5",
+    "set_uuid": "7f2bb2ef-58c0-41f9-8109-0edf0ccf3d5d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "44a668d6-e013-4138-a262-383994b0637f",
+    "set_uuid": "d4e8c9a0-af84-445b-b7b3-ca55ced11875",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "c567f435-928c-4bf8-b9c0-ac2f22d58348",
+    "set_uuid": "d4e8c9a0-af84-445b-b7b3-ca55ced11875",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "11088de1-8e3b-4021-968d-a8c59c7b00bd",
+    "set_uuid": "c1e05fb1-09f6-49b9-86d9-a508cbec1dd6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "616de468-71fc-4315-87ea-47cdc508a599",
+    "set_uuid": "c1e05fb1-09f6-49b9-86d9-a508cbec1dd6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "b8af0ff9-1e4b-4298-907d-3ffcde88ba03",
+    "set_uuid": "de0a3da6-a982-40d9-8196-5c7b5e9f6f78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "d660beeb-278b-4157-b6fc-852c680ecae7",
+    "set_uuid": "de0a3da6-a982-40d9-8196-5c7b5e9f6f78",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "40778817-6e47-4b58-a495-c4f34cee78df",
+    "set_uuid": "7c44b345-e7eb-49ff-9276-7460559d1b43",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-text-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "942f0f34-611a-4318-9b0e-3632e7f520b3",
+    "set_uuid": "7c44b345-e7eb-49ff-9276-7460559d1b43",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "e220eb52-f821-4807-9ab7-b5f3905d769f",
+    "set_uuid": "57eb05a3-85d0-4aa5-ae22-0df4b2f2f429",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "e77f525e-5043-49c1-a663-9f6c30067043",
+    "set_uuid": "57eb05a3-85d0-4aa5-ae22-0df4b2f2f429",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "e0673a9f-7993-490c-b2db-e8e836837e83",
+    "set_uuid": "062bb2be-32ee-4fd9-846e-5b94dc5fdf30",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "85f7f49a-7b87-4e2f-b44e-70e3ccde6291",
+    "set_uuid": "062bb2be-32ee-4fd9-846e-5b94dc5fdf30",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "a0ce87ca-29e0-40e3-b7dc-c53678effd9b",
+    "set_uuid": "b076e022-a80a-4a2b-aee9-baa287c88ad4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "4973c83c-792d-4bc1-9e3d-d047993292ba",
+    "set_uuid": "b076e022-a80a-4a2b-aee9-baa287c88ad4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "a0b6c266-499d-4292-9be4-705ddd5e9fbc",
+    "set_uuid": "c99f282c-7e8f-4d3e-9e08-fbe40a3d4676",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "0b157417-e40f-481c-87e3-8563d55b3135",
+    "set_uuid": "c99f282c-7e8f-4d3e-9e08-fbe40a3d4676",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "e1030243-729a-4afe-a6d5-47b8e620e2ce"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "8d128c7d-ab8e-4a4e-9243-a2e919cb6e6f",
+    "set_uuid": "a72fe016-4be0-44ee-8400-877e7914879c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "acc3e1b9-532d-485e-84e4-06e744c744b3",
+    "set_uuid": "a72fe016-4be0-44ee-8400-877e7914879c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "8fec6012-7cba-4ac5-94d7-14f39fce7612",
+    "set_uuid": "fe65b840-a0b2-48b5-88c4-052d48f0c0c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "93e42bfc-c2f0-40cd-a561-9045c68cb5d1",
+    "set_uuid": "fe65b840-a0b2-48b5-88c4-052d48f0c0c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "0bf1ad10-235a-4c81-aba7-5bf55acc877d",
+    "set_uuid": "37dfa899-aec4-4273-a8de-6a8d2ff08c57",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "9dffd6f3-6230-425e-9208-296cf4d5c185",
+    "set_uuid": "37dfa899-aec4-4273-a8de-6a8d2ff08c57",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "815523cd-8c01-4125-bb22-3a548f1cc702",
+    "set_uuid": "3d33bea5-f19d-438a-88d3-908188ff3e2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "090b3da5-0aa3-4bf8-b3bd-dd8dabb40721",
+    "set_uuid": "3d33bea5-f19d-438a-88d3-908188ff3e2e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "9c536051-7794-4282-bf07-c920cda83cbe",
+    "set_uuid": "1afe4259-26f6-405d-8db1-9f976a846917",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "fd1c11a6-53d5-4253-a7d7-c4131c4b1a5e",
+    "set_uuid": "1afe4259-26f6-405d-8db1-9f976a846917",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "c38259e9-87f4-4e7d-a041-692ca676a638",
+    "set_uuid": "676c9089-353a-4ea0-8692-6aae56552143",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-edge-to-visual-only-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "5c4f1f7a-2218-4d03-ac83-9750c2c9336b",
+    "set_uuid": "676c9089-353a-4ea0-8692-6aae56552143",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Using consistent spacing regardless of text or visual",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-height-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "3d7afc6a-f66b-4033-9ed4-e60cde661a18",
+    "set_uuid": "965c85ea-398f-4a75-8014-91b86061f33e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "5c31197d-0412-469d-a2dd-684efbd4b7e6",
+    "set_uuid": "965c85ea-398f-4a75-8014-91b86061f33e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "8bf70f40-b282-4c5d-98f0-329245bdb6f9",
+    "set_uuid": "a8f083cd-131e-4375-b948-3ef5c520cb42",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "7c69efb5-bde7-4ee0-ad1e-2f20e85ebc24",
+    "set_uuid": "a8f083cd-131e-4375-b948-3ef5c520cb42",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "f4aaa7bb-e724-42ad-8ddf-934cc972995a",
+    "set_uuid": "0cc8906e-a9a2-4995-a6c2-920cb5f2b83c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "60px",
+    "uuid": "53c665a4-83ae-45f2-b90d-33ce52430b84",
+    "set_uuid": "0cc8906e-a9a2-4995-a6c2-920cb5f2b83c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "e146c28f-3349-48fc-8281-6997ab9da222",
+    "set_uuid": "b00a338c-f297-486a-94c8-cbfa8f6392c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "70px",
+    "uuid": "4fcbb85f-afbe-41bc-a979-dc09fb98946a",
+    "set_uuid": "b00a338c-f297-486a-94c8-cbfa8f6392c2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "81ebf2b1-01fd-45a3-a099-72048e7d7991",
+    "set_uuid": "693fb390-cc46-40cf-b99a-f8c80bbcfcba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "fede8012-f00b-412b-8981-16f60a6133ab",
+    "set_uuid": "693fb390-cc46-40cf-b99a-f8c80bbcfcba",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "b5211351-b7df-430a-93bf-906ac66ebf2e",
+    "set_uuid": "752a9a44-712b-429b-8161-91f7eaad8377",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "8135e75c-9536-4743-ab6d-05ed5adb0448",
+    "set_uuid": "752a9a44-712b-429b-8161-91f7eaad8377",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "f70d4c16-f588-4fa9-9318-b7184a739193",
+    "set_uuid": "fbdf2291-b332-4436-9e57-430c0a81d526",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-height-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "5f363452-6317-4e7c-965a-291b3dfa8a8f",
+    "set_uuid": "fbdf2291-b332-4436-9e57-430c0a81d526",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "5b2e9907-858e-41f9-9c63-a37e30ec472e",
+    "set_uuid": "b449c7b9-e88c-47ad-ac3c-09b4c6ac59ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "67715127-dfd9-44ed-a3bf-4816e9dafb34",
+    "set_uuid": "b449c7b9-e88c-47ad-ac3c-09b4c6ac59ed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "2af29e94-8c2c-475c-bde0-4e3f2ebd5df4",
+    "set_uuid": "67a7d15d-10d6-476e-b130-cd7a0bc9300b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "e5202547-d71b-4e1f-8d60-fe1e63cf18f9",
+    "set_uuid": "67a7d15d-10d6-476e-b130-cd7a0bc9300b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "894526c7-315d-4325-be16-8e99a8a2586b",
+    "set_uuid": "8c72f949-3f29-4e48-98fa-2d1670245c0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "ae78edbb-1b08-44d6-9c5a-37baf2fe94f6",
+    "set_uuid": "8c72f949-3f29-4e48-98fa-2d1670245c0c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "409b876c-ae13-4d31-8487-9bfcd9b8be69",
+    "set_uuid": "f5a258bc-64be-4497-87d9-1946e1684415",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "262dd415-ea5d-4f07-9493-030ac33a2dce",
+    "set_uuid": "f5a258bc-64be-4497-87d9-1946e1684415",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "6ff7a5b7-4344-4498-887d-3af9585035a7",
+    "set_uuid": "1ba30b7a-fa69-41da-828b-37df5a59d0ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-padding-vertical-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "ae87b22b-17dd-46a1-9c40-ec4fbe701e95",
+    "set_uuid": "1ba30b7a-fa69-41da-828b-37df5a59d0ac",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "3c96bdad-6e05-4a1b-930b-92d35adf5d9d",
+    "set_uuid": "4bc3ba2a-1e76-464a-9886-2db2d8dd961c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "10e326b3-bcce-47df-a1ab-0e3ab9964dd2",
+    "set_uuid": "4bc3ba2a-1e76-464a-9886-2db2d8dd961c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "4cca2097-286e-46d5-bc8e-273ea50354e7",
+    "set_uuid": "5facff87-0dd6-4193-9634-dedd452ca35e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "25px",
+    "uuid": "c77f6b68-32b7-499c-81d9-50855cc68279",
+    "set_uuid": "5facff87-0dd6-4193-9634-dedd452ca35e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "29fa8da5-3f74-4141-bfb1-0f2847655345",
+    "set_uuid": "fa5beb85-a5d3-42cb-aa40-e5dc4b5976d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "dd7bc474-d5f1-46fe-8a6e-b1645c34c982",
+    "set_uuid": "fa5beb85-a5d3-42cb-aa40-e5dc4b5976d3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "5c80900c-ff68-4b78-86fa-571bbf1eb9aa",
+    "set_uuid": "7f421435-8922-49e3-a598-8f1391051554",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-text-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "8a23edfc-b993-48bb-917f-377051e02dff",
+    "set_uuid": "7f421435-8922-49e3-a598-8f1391051554",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "fff86b73-4e28-4453-9ba3-7c40998ace07",
+    "set_uuid": "73e613ee-50a2-4666-b091-9cc36cf8f717",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "14624bfc-b08f-4637-991b-94a703a7b808",
+    "set_uuid": "73e613ee-50a2-4666-b091-9cc36cf8f717",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "b9324a3c-557e-4832-8418-1d7783e7b9be",
+    "set_uuid": "ad42620f-70e0-49a2-8727-01314f2dc88b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "053363f2-5b8e-4365-8353-3cffac169608",
+    "set_uuid": "ad42620f-70e0-49a2-8727-01314f2dc88b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "4ccb4a02-6aa9-459a-a459-1d0ebbe2dc11",
+    "set_uuid": "e82f9abf-54e8-483c-8a0a-338becca7ba3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "7ae3b6ee-2f80-4596-9d4a-08a5bf9612a7",
+    "set_uuid": "e82f9abf-54e8-483c-8a0a-338becca7ba3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "3eaca9fb-25c0-4a1d-8c44-320cc0e0305b",
+    "set_uuid": "11128037-8bd7-46a1-9915-3655e1824ee4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "64343da6-f1a6-4615-b2b8-41f9509679e5",
+    "set_uuid": "11128037-8bd7-46a1-9915-3655e1824ee4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "dd9e6e28-a382-46a1-a6e0-f73c8cc0ed70",
+    "set_uuid": "ede2c7d6-a602-42f3-a1e0-54e642bcd5f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "cf58ae75-8f3f-4b9e-809b-ee78abbb2f2f",
+    "set_uuid": "ede2c7d6-a602-42f3-a1e0-54e642bcd5f5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "c97051d7-eccb-4d55-8487-7ffdec2b1c78"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "64cdd254-d3fe-40e6-97a8-76dd8156afa8",
+    "set_uuid": "30720515-0648-4cdd-a5cd-411d5dd9d6d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "989aee4c-5c90-454a-b68d-a7564669c2bd",
+    "set_uuid": "30720515-0648-4cdd-a5cd-411d5dd9d6d6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "2a1b4c8d-46ca-4b7c-922f-6f117faba404"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "9654369a-5bf8-4436-a331-aeac1fd25a70",
+    "set_uuid": "3c029bf1-8fef-4356-9b95-f5d15b6b54d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "cb4f356c-2dcd-4043-8f5c-3da904716b48",
+    "set_uuid": "3c029bf1-8fef-4356-9b95-f5d15b6b54d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "f644cf28-8586-43d6-9831-bbf23d4e465a"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "47f5ab02-22db-4d82-be1d-804669d7fbd4",
+    "set_uuid": "2c5317e6-a13f-4592-8e71-c37953fb4a55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-pill-edge-to-visual-only-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "7332a4d3-3775-4247-a4c0-fb01f0604d63",
+    "set_uuid": "2c5317e6-a13f-4592-8e71-c37953fb4a55",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Eliminating pill-specific padding to align with Spectrum Future Foundations designs",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-size-difference",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "-2px",
+    "uuid": "9ef4a0a5-b81c-4f54-8927-286ece29a824"
+  },
+  {
+    "name": {
+      "property": "component-size-maximum-perspective",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "96px",
+    "uuid": "437f2e57-2aa6-41b5-bdcc-e4993dc42168"
+  },
+  {
+    "name": {
+      "property": "component-size-minimum-perspective",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "103daec0-9711-4422-84d1-62ab77afa00d"
+  },
+  {
+    "name": {
+      "property": "component-size-width-ratio",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.3333,
+    "uuid": "4ee7342c-f2ef-4554-af0f-011052ff6177"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "31f44472-9681-469c-8ba2-9efc27eb981d",
+    "set_uuid": "c5ff0c89-a9ad-4f9e-a050-afea29822149",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "9fa90167-54ec-4343-a14c-4cd18963dcc5",
+    "set_uuid": "c5ff0c89-a9ad-4f9e-a050-afea29822149",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "d03d1199-f49d-4e57-8434-b94efe5da440",
+    "set_uuid": "d4ed0bd1-8d06-42e0-a480-8d07291a1b61",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "b33acdfa-525e-45c6-ab2b-c959760c4024",
+    "set_uuid": "d4ed0bd1-8d06-42e0-a480-8d07291a1b61",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "0190ca9d-9f28-45b2-9dc7-c715089faebb",
+    "set_uuid": "480244fc-5cb5-4156-b03f-b1aef8c8e111",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "e8602fbe-1bf9-4aec-9cb0-5b4e994558c9",
+    "set_uuid": "480244fc-5cb5-4156-b03f-b1aef8c8e111",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "4db24ebf-e169-4220-b895-787fe09f8658",
+    "set_uuid": "bb51e98e-bf71-4348-86b2-3a560cc2035d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-to-menu-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "cc2c2606-500a-45e2-b460-2b498dcddb26",
+    "set_uuid": "bb51e98e-bf71-4348-86b2-3a560cc2035d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token popover-gap instead. Unifying to a single popover-gap value across use cases",
+    "replaced_by": "6bae40ba-3b57-4e4b-a8a7-4044cd729068"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "15bf492b-3a65-4577-8a3b-df09026b96a7",
+    "set_uuid": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "bed358a2-0559-4501-a147-b375887f25af",
+    "set_uuid": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "c7914376-3769-4172-8467-fb811b3c155f",
+    "set_uuid": "306b871f-cbfa-49a2-a74b-dd120bbff503",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "621c9cf1-02e2-478b-9f47-0804f0183531",
+    "set_uuid": "306b871f-cbfa-49a2-a74b-dd120bbff503",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "9bf3970e-eb76-4be5-82c4-0df2538df753",
+    "set_uuid": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "e0ae8c97-73ee-4b09-839f-5ebfb6eb0d7a",
+    "set_uuid": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "c71c0953-d9da-4e22-93a1-6982c7665ed6",
+    "set_uuid": "320554e7-5437-4c16-a851-3e5b74e6a6af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "cb2a6539-4cee-420c-aeef-dbdd3220039d",
+    "set_uuid": "320554e7-5437-4c16-a851-3e5b74e6a6af",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "477d659b-6489-4e90-84db-75a93174559a",
+    "set_uuid": "1a76668b-c733-4ec0-ae84-774f4e6e861a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-top-to-text-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "54a0e5cf-3e4a-454b-9dba-a6a2c277fa5e",
+    "set_uuid": "1a76668b-c733-4ec0-ae84-774f4e6e861a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "c3a280b0-bc84-4a7c-8048-c689f8deef86",
+    "set_uuid": "2b17325c-eec1-43e2-9a31-957adf67e44d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "a3d3f9e9-a784-445a-a052-22f84b832512",
+    "set_uuid": "2b17325c-eec1-43e2-9a31-957adf67e44d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change required for VF upgrade",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "ef82b92a-2cbd-4b70-920c-4b999b018e07",
+    "set_uuid": "81bfcc6f-348b-4728-bfdc-10f2f181b041",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "259c0cf5-d321-4a6b-a3ae-b8c58fc1c9d6",
+    "set_uuid": "81bfcc6f-348b-4728-bfdc-10f2f181b041",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change required for VF upgrade",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "72d6ae5c-e133-4e7f-bc96-3e4c28d586fd",
+    "set_uuid": "955bbeaf-dc4e-460b-8957-d145d4b6fc3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "bac14298-68f0-4fb6-a152-c95ab19fd27f",
+    "set_uuid": "955bbeaf-dc4e-460b-8957-d145d4b6fc3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change required for VF upgrade",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "0fafc819-d65b-4952-849a-b3c426e9a4a9",
+    "set_uuid": "dbd9a29e-259d-4291-a24a-2926989edc46",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "24853983-c1b0-422d-84b6-05b9313066ed",
+    "set_uuid": "dbd9a29e-259d-4291-a24a-2926989edc46",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-small instead. Change required for VF upgrade",
+    "replaced_by": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
+    "set_uuid": "3b07cd46-add6-4cd9-b3f8-626f113905dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "component-top-to-workflow-icon-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3",
+    "set_uuid": "3b07cd46-add6-4cd9-b3f8-626f113905dd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change required for VF upgrade",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "container-gap-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-500",
+    "uuid": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412",
+    "description": "Spacing between child elements for containers at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "container-gap-2x-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-85",
+    "uuid": "b83df7f2-8811-4bad-b012-213e430e2aaf",
+    "description": "Spacing between child elements for containers at 2x-small size"
+  },
+  {
+    "name": {
+      "property": "container-gap-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-400",
+    "uuid": "c9c7652f-0332-417f-8520-e2202d7a08dc",
+    "description": "Spacing between child elements for containers at extra-large size"
+  },
+  {
+    "name": {
+      "property": "container-gap-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "9c79efdc-ab56-4f2e-b44d-5641d2480964",
+    "description": "Spacing between child elements for containers at extra-small size"
+  },
+  {
+    "name": {
+      "property": "container-gap-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-350",
+    "uuid": "236385bb-9e50-484c-912d-a71fe33924f4",
+    "description": "Spacing between child elements for containers at large size"
+  },
+  {
+    "name": {
+      "property": "container-gap-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "06d1563b-7d67-400a-bcfa-bc320c2b7a28",
+    "description": "Spacing between child elements for containers at medium size"
+  },
+  {
+    "name": {
+      "property": "container-gap-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935",
+    "description": "Spacing between child elements for containers at small size"
+  },
+  {
+    "name": {
+      "property": "container-padding-2x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-500",
+    "uuid": "3801295f-e52b-412a-baf4-0b8e20449333",
+    "description": "Internal spacing for containers at 2x-large size"
+  },
+  {
+    "name": {
+      "property": "container-padding-2x-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-85",
+    "uuid": "f0d9117a-5606-4e49-a81f-f89938b34ca4",
+    "description": "Internal spacing for containers at 2x-small size"
+  },
+  {
+    "name": {
+      "property": "container-padding-3x-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-600",
+    "uuid": "e595caf6-37f9-4f84-b81b-dd44ed0d6431",
+    "description": "Internal spacing for containers at 3x-large size"
+  },
+  {
+    "name": {
+      "property": "container-padding-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-400",
+    "uuid": "2e855806-0f65-4df0-9d8f-74428daa358d",
+    "description": "Internal spacing for containers at extra-large size"
+  },
+  {
+    "name": {
+      "property": "container-padding-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "9fcd2823-9a13-44c0-a613-7dbe272b99a9",
+    "description": "Internal spacing for containers at extra-small size"
+  },
+  {
+    "name": {
+      "property": "container-padding-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-350",
+    "uuid": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f",
+    "description": "Internal spacing for containers at large size"
+  },
+  {
+    "name": {
+      "property": "container-padding-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "81e5f983-4ca0-4d45-89f0-4accd78d7946",
+    "description": "Internal spacing for containers at medium size"
+  },
+  {
+    "name": {
+      "property": "container-padding-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97",
+    "description": "Internal spacing for containers at small size"
+  },
+  {
+    "name": {
+      "property": "corner-radius-0"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "bb9d8350-b1fb-4496-9c22-6ec9647ff117"
+  },
+  {
+    "name": {
+      "property": "corner-radius-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "bf24d15e-ad86-4b6a-a9e0-e8fd49a5ae30"
+  },
+  {
+    "name": {
+      "property": "corner-radius-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.5,
+    "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b"
+  },
+  {
+    "name": {
+      "property": "corner-radius-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "52ad01be-f512-4fa3-ae67-8c6cef70810c"
+  },
+  {
+    "name": {
+      "property": "corner-radius-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "154642d7-c23d-44fd-9d79-b719ef32922e"
+  },
+  {
+    "name": {
+      "property": "corner-radius-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "690db7ae-cae8-49bb-8777-b4f1829b2f0b"
+  },
+  {
+    "name": {
+      "property": "corner-radius-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "ada2ea1d-1728-411a-8aae-a198ce390a25"
+  },
+  {
+    "name": {
+      "property": "corner-radius-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "abc0f309-3bd2-4800-af12-b27386e86617"
+  },
+  {
+    "name": {
+      "property": "corner-radius-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "cb6b72ed-a9a1-4113-b147-1ef369fe6269"
+  },
+  {
+    "name": {
+      "property": "corner-radius-75"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "3px",
+    "uuid": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20"
+  },
+  {
+    "name": {
+      "property": "corner-radius-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "8fc023ca-8aec-40fe-9130-087aa035bac7"
+  },
+  {
+    "name": {
+      "property": "corner-radius-extra-large",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-800",
+    "uuid": "d639a0b5-16b4-4d75-ab37-d87815c7b500"
+  },
+  {
+    "name": {
+      "property": "corner-radius-full"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-1000",
+    "uuid": "4853520b-bda3-45d1-bd20-8508cac08847"
+  },
+  {
+    "name": {
+      "property": "corner-radius-large",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-700",
+    "uuid": "29981aef-aea6-4cde-849f-4bc67e320ea7"
+  },
+  {
+    "name": {
+      "property": "corner-radius-medium",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-500",
+    "uuid": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6"
+  },
+  {
+    "name": {
+      "property": "corner-radius-medium-size-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-700",
+    "uuid": "81752b3e-488a-4273-abb5-4ba8b7f278d9"
+  },
+  {
+    "name": {
+      "property": "corner-radius-medium-size-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-300",
+    "uuid": "d0e02d98-e93f-4f81-8d81-8f95e06ad360"
+  },
+  {
+    "name": {
+      "property": "corner-radius-medium-size-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-600",
+    "uuid": "ede17e00-83ef-40c5-a1d0-a46372d3fc90"
+  },
+  {
+    "name": {
+      "property": "corner-radius-medium-size-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-500",
+    "uuid": "67fb5355-6d7c-4e4e-a4cb-cdba10a85d84"
+  },
+  {
+    "name": {
+      "property": "corner-radius-medium-size-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-400",
+    "uuid": "892bc9de-16b2-4c51-9c18-b239e52ffd14"
+  },
+  {
+    "name": {
+      "property": "corner-radius-none"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-0",
+    "uuid": "7a11b308-bed2-4b6f-bb4a-c9ae4ef8e03d"
+  },
+  {
+    "name": {
+      "property": "corner-radius-small",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-100",
+    "uuid": "b4971f86-aeea-42c9-9ba7-a74cf4d1a545"
+  },
+  {
+    "name": {
+      "property": "corner-radius-small-size-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-300",
+    "uuid": "d59337d1-4cec-43c0-821e-06a56745cbcc"
+  },
+  {
+    "name": {
+      "property": "corner-radius-small-size-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-200",
+    "uuid": "f4f0bfc9-ce6d-473f-8dda-c9f21fb8a7b7"
+  },
+  {
+    "name": {
+      "property": "corner-radius-small-size-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-100",
+    "uuid": "a62a43dd-cb2a-4e18-bb94-7a9518668400"
+  },
+  {
+    "name": {
+      "property": "corner-radius-small-size-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "corner-radius-75",
+    "uuid": "3d39e5de-0800-4629-ae1a-99a34706a772"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "6fcfc18c-c5e0-4f50-beab-6c4a10bfdaa7",
+    "set_uuid": "623e55f9-ec0f-48f1-91ed-d88e36d41d18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "1352ad8f-a8ec-459d-8ae3-71c27038a29d",
+    "set_uuid": "623e55f9-ec0f-48f1-91ed-d88e36d41d18",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "9c2db47b-f017-432a-a44f-238bc461c4c1",
+    "set_uuid": "e16424f5-12e3-4577-a3a4-414aa9eaacbf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "2be65bca-0f16-4754-bc8a-4a491ba87b90",
+    "set_uuid": "e16424f5-12e3-4577-a3a4-414aa9eaacbf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "c9c18669-11bf-4ba3-b36f-26115981327c",
+    "set_uuid": "587b1bdb-f6a8-4526-a454-db5dc2997e67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "d396d74a-425d-4f06-837f-349f81ebf486",
+    "set_uuid": "587b1bdb-f6a8-4526-a454-db5dc2997e67",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "490fac13-d347-4c21-85fa-57814bff7537",
+    "set_uuid": "c12846fb-bd7e-4df0-8345-5148f68a5e7e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "corner-triangle-icon-size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "434b019c-efde-437a-967b-b841ec95e621",
+    "set_uuid": "c12846fb-bd7e-4df0-8345-5148f68a5e7e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "ba7492f3-1a19-4d75-98cc-34a0d46ea802",
+    "set_uuid": "4c5c2390-1571-4141-9ebd-a3e0b1e58322",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "9c38e8f6-cca7-4f7f-a7c3-9d4ee7af24b8",
+    "set_uuid": "4c5c2390-1571-4141-9ebd-a3e0b1e58322",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "ae9bbf8d-a896-4667-9034-2fd2dfeb1981",
+    "set_uuid": "62e0b1be-4808-48b9-9781-6f1e7dc03bfa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "24dd2c12-17f0-4d38-9af3-a3b112c40c74",
+    "set_uuid": "62e0b1be-4808-48b9-9781-6f1e7dc03bfa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "1e644622-9b4a-4cce-9cf7-2474d58f4956",
+    "set_uuid": "0d3919ac-7385-44e7-81b8-c01bc74694ea",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "049e0fe7-03d4-4d9b-bdcd-9c8a06852010",
+    "set_uuid": "0d3919ac-7385-44e7-81b8-c01bc74694ea",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "e8e0164f-2588-4c8e-9b85-543ce5a8fadb",
+    "set_uuid": "6cc29d18-30d9-48bf-88c0-3e56945725b3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "disclosure-indicator-top-to-disclosure-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "d7c1f2a1-b679-42ae-8512-27883d9789f9",
+    "set_uuid": "6cc29d18-30d9-48bf-88c0-3e56945725b3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "NO USAGE FOUND / Not in design specs, files, or findable by Spectrum Fluffyjaws AI. Recommend to deprecate."
+  },
+  {
+    "name": {
+      "property": "drop-shadow-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-blur-100",
+    "uuid": "ac20a6da-31a7-4c8b-b361-0ad820cd8429",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-blur-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "025e39f4-dfe7-4a8a-beb5-bd0577f72eac"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-blur-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "2b08d425-ecf2-4891-83cd-005a2d5e76ce"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-blur-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "34812e0c-7ccf-49c2-884a-6fecd45f7c5a"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-blur-300",
+    "uuid": "f6015252-21fb-48f9-aadb-5ad050e3d590"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-x"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-x-300",
+    "uuid": "be5c80b4-5769-491b-9550-fcf94f0c762e"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-dragged-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-y-300",
+    "uuid": "ff8d4fda-72fa-4256-b2c8-f22a9d3e644f"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-blur-200",
+    "uuid": "f3487a86-3aea-4527-8b5c-287c0bddad6c"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-x"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-x-200",
+    "uuid": "59324423-4428-40d7-a227-5f75aeb38312"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-elevated-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-y-200",
+    "uuid": "45f313a5-1749-4b95-b5e3-20944adbea84"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-default-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-blur-100",
+    "uuid": "57920fe8-72ad-48d2-aa9b-feec4c989106"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-default-x"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-x-100",
+    "uuid": "5b611aa8-9db2-495d-a119-3385eee62442"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-default-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-y-100",
+    "uuid": "02949dd5-0596-44bc-8b63-dcc7d2ba628b"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-blur"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-blur-200",
+    "uuid": "5f6674e8-ef00-490a-800d-3b946059bae2"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-x"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-x-200",
+    "uuid": "d86f7c89-92a6-4bad-83b0-43953472ce7f"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-emphasized-hover-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-y-200",
+    "uuid": "da17e314-f3e9-4d49-9362-533eb65c0f7b"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-x"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-x-100",
+    "uuid": "81415747-aa3f-4ef3-b0bc-7c33f07a4316",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-x-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "751d636e-efb5-411e-a5b8-06b11439cc90"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-x-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "0c76c925-4d29-49a3-b882-e946bd7fe9f1"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-x-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "cb6d74fe-cc32-47ff-bf8b-74597643a8a6"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-y"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "drop-shadow-y-100",
+    "uuid": "c530129f-248c-4e36-ba7f-05d6d6a53962",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-y-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "ed1f46fd-a586-46a5-8cc1-d843a57e2cc2"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-y-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "d2d0320a-6984-4b3f-8f5d-ccb88892a26c"
+  },
+  {
+    "name": {
+      "property": "drop-shadow-y-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "5d09089b-c0c5-4122-a3be-3e989562acda"
+  },
+  {
+    "name": {
+      "property": "drop-target-dash-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-85",
+    "uuid": "5582026a-22e6-4e0e-9a21-2a7a43b026a6",
+    "description": "Dash gap spacing for drop targets"
+  },
+  {
+    "name": {
+      "property": "drop-target-dash-length"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "24cd8175-3dc5-46ae-b1af-01632787fcd8",
+    "description": "Dash length for drop targets"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "7ea18d45-d6e1-4ef0-859d-4d39a3e0527a",
+    "set_uuid": "f68f57de-df8c-49b5-9af8-566c2382f669",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "2a77de7a-20cb-40a2-b3a9-252fcaa7a7d2",
+    "set_uuid": "f68f57de-df8c-49b5-9af8-566c2382f669",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "e0b53a9a-e95a-45b8-b9b2-a16b70096c05",
+    "set_uuid": "78b56170-dc93-4f41-a110-94f9415c2222",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "a7c0e1fc-bc57-450e-bdc2-1c2cf2823d98",
+    "set_uuid": "78b56170-dc93-4f41-a110-94f9415c2222",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "dd684a30-2e49-4096-8b1c-40fbd6c8cac2",
+    "set_uuid": "4507a27d-3072-47f0-a2b9-ca8523e7d3c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "b98d3a2d-94fb-4491-9650-1c9a62365a19",
+    "set_uuid": "4507a27d-3072-47f0-a2b9-ca8523e7d3c9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "7858fdf3-e35f-4bc5-997a-0d480ec1cb32",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "20658099-94df-4c6c-a2f2-558c92174121",
+    "set_uuid": "c1aa6fda-f075-415a-b9f4-008885d7fccd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-alert-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "68c4dc34-49cb-4174-bd06-5f5dfbd0b64e",
+    "set_uuid": "c1aa6fda-f075-415a-b9f4-008885d7fccd",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-border-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "7fb81dcf-3329-4353-917d-75de8f43c05d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "71b53c8b-fbbb-4f84-847a-45db5ad8006f",
+    "set_uuid": "08c0704d-7431-47b9-a69c-1d2f22276cf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "26d578cb-9228-4643-b042-8b00ba4d9b61",
+    "set_uuid": "08c0704d-7431-47b9-a69c-1d2f22276cf4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "77792f9d-b462-48e6-a4de-abf804bed3cd",
+    "set_uuid": "c6883771-d661-4330-9be6-508218cc5854",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "fcc139c1-08ed-4641-932d-5050237abfaa",
+    "set_uuid": "c6883771-d661-4330-9be6-508218cc5854",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "e84ef1dc-392b-4ab9-a13b-76364484a28d",
+    "set_uuid": "9b70b304-6f74-466e-9515-cfd8aa2e42de",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "0d3045e2-a493-406a-a247-8d20f35db2d9",
+    "set_uuid": "9b70b304-6f74-466e-9515-cfd8aa2e42de",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "7b68e88f-8ddd-496e-9fae-7fbe44317965",
+    "set_uuid": "8fca1357-25ac-4bbf-afe5-86c4b70431d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-disclosure-icon-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "87d3f491-f45f-4bee-9dbd-00086cca5858",
+    "set_uuid": "8fca1357-25ac-4bbf-afe5-86c4b70431d2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-text-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "3f7cee20-c187-4066-be4b-f5a1335736f5",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "9379019f-5498-45d1-8590-deb8a234a3d4",
+    "set_uuid": "81a3d661-160e-448d-8f3a-994a01b4c0e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "539800f6-7bbc-4b67-8b61-99d1ee2f69a4",
+    "set_uuid": "81a3d661-160e-448d-8f3a-994a01b4c0e4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "faf7879f-d9c1-4bf1-8af7-95f48240bcf0",
+    "set_uuid": "3efc3753-19da-4e87-9c07-f0b379a3ac98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "9525d928-4cdb-4cf5-8616-2024ed6fb7c0",
+    "set_uuid": "3efc3753-19da-4e87-9c07-f0b379a3ac98",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "a93c8845-c89b-4e8d-b06e-c34e7c7b0e99",
+    "set_uuid": "700aa9e4-d819-490f-ac2f-b0311b643620",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "c51f02a2-35d4-460f-9f14-a97d9e8e6616",
+    "set_uuid": "700aa9e4-d819-490f-ac2f-b0311b643620",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "151915e5-f946-474f-9595-18d8a159a6ff",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "9ab112d7-af82-4b28-9bc2-a1216af87aea",
+    "set_uuid": "5f116e74-21ad-4397-8fd0-72697de194c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-validation-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "a1c55785-3ae3-4c23-81e2-f088e76e4e04",
+    "set_uuid": "5f116e74-21ad-4397-8fd0-72697de194c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-edge-to-visual-quiet"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "89f16f89-fd7d-41d7-8e5c-464007fd0277",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "9fa71233-f98e-4d48-b2af-29552a62a479",
+    "set_uuid": "2f97eb00-aff0-41b5-b896-dc8bbc80f231",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "7b3ab0f8-8bde-461f-b658-6848d64de0e3",
+    "set_uuid": "2f97eb00-aff0-41b5-b896-dc8bbc80f231",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "622a39c4-4ed1-4637-8e8d-e8e6a72099b2",
+    "set_uuid": "7ba0ae7a-0e9f-4bec-a08c-d016a25b94c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "417eb2ee-3fe9-47fc-a122-d466eb4e7b26",
+    "set_uuid": "7ba0ae7a-0e9f-4bec-a08c-d016a25b94c4",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "43ec5915-b039-4210-9bc0-ce547f90ce32",
+    "set_uuid": "15f664f0-b351-4a6c-b7cd-b252d3979a38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "7c2b5cc0-01c0-4e5f-a157-1d2432f8bbc1",
+    "set_uuid": "15f664f0-b351-4a6c-b7cd-b252d3979a38",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "b79e5061-87c4-495c-ab01-90dcc5ae14ab",
+    "set_uuid": "8cdd703c-9931-43bd-9ff9-3cc129f7316e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-end-edge-to-disclosure-icon-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "927e7b5a-57b4-4d47-9ad8-e287199e68a3",
+    "set_uuid": "8cdd703c-9931-43bd-9ff9-3cc129f7316e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "248144ce-6640-40ce-96a3-162c406c7edf",
+    "set_uuid": "3507c44d-62d4-4422-a62e-d463a23eb9cf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "ec794a47-71af-42ea-87f2-048fab8dbf9d",
+    "set_uuid": "3507c44d-62d4-4422-a62e-d463a23eb9cf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "0f40702e-876a-4fb4-aeb7-ea56c26c081b",
+    "set_uuid": "8cee0a0d-2faf-4620-ad54-0c48780a9add",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "73025a05-6203-460b-830b-458f8109abce",
+    "set_uuid": "8cee0a0d-2faf-4620-ad54-0c48780a9add",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "cce2dfd4-b10f-4386-8f16-2bc2d47e49f5",
+    "set_uuid": "dcce6c23-1a67-49db-826f-e4e3e2d94f01",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "03d088d2-4ec9-45bc-896d-8423bf72317e",
+    "set_uuid": "dcce6c23-1a67-49db-826f-e4e3e2d94f01",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "2d900e70-913e-4d45-9ef4-2ef8d80798fc",
+    "set_uuid": "3975bf43-b0fb-4ab9-92fb-c4936e1d31b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-text-to-alert-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "01ad9b7d-926e-4db4-a86a-a804fdfc7d68",
+    "set_uuid": "3975bf43-b0fb-4ab9-92fb-c4936e1d31b9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "8a573d4a-0543-4e77-8f54-5ad1706d87e7",
+    "set_uuid": "461753a3-581e-4675-bcff-13386fe17123",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "8926578a-c326-4a75-aafb-d90112aaedb5",
+    "set_uuid": "461753a3-581e-4675-bcff-13386fe17123",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "26cedd5b-5c67-4da7-974f-806b20064a5b"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "f9729ef3-9807-4401-80dd-b1c209c00065",
+    "set_uuid": "5d8df662-c7ca-4b45-931d-92c4b27c00c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "b28a0156-4930-484c-a518-ee00e0292db5",
+    "set_uuid": "5d8df662-c7ca-4b45-931d-92c4b27c00c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "ef179042-3ad8-4db5-8e23-983134f5906c"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "da53a8e5-95c3-48dd-a9c0-5ed2de25240d",
+    "set_uuid": "ac8e642d-666a-4d38-be97-6fe05edf1006",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "87e221ab-fb8c-4d59-9d4b-9815a672cc23",
+    "set_uuid": "ac8e642d-666a-4d38-be97-6fe05edf1006",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "574ddef0-b45b-49a1-b057-fb2eacfbd36f",
+    "set_uuid": "6d6c6035-1f3f-4e6c-8140-f5dc5a06a8d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-text-to-validation-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "c2181581-6aa1-4e1f-80bc-1ca2e85ea01b",
+    "set_uuid": "6d6c6035-1f3f-4e6c-8140-f5dc5a06a8d8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
+    "replaced_by": "0732ae91-c85b-45ab-8a57-e21622768db3"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "78286e58-d73a-42a8-a13c-a910d7fbb82d",
+    "set_uuid": "91d122d2-799b-45c3-aa4e-4f1a0c7336b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "246058b4-e152-4673-91ab-34384fceb798",
+    "set_uuid": "91d122d2-799b-45c3-aa4e-4f1a0c7336b2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "7e21ccc7-ba55-4e0f-b5a5-1bd95406546f",
+    "set_uuid": "2ec841a0-c05a-43d6-a77f-093ccf710819",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "6247903e-2c00-4242-b2d5-da2864b6aa87",
+    "set_uuid": "2ec841a0-c05a-43d6-a77f-093ccf710819",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "adac6224-8e2f-4cdb-8684-9365164a1499",
+    "set_uuid": "e0425fc4-00bc-4bbd-9d07-576303dca294",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "1def1d88-0098-4e00-987f-17a8656047da",
+    "set_uuid": "e0425fc4-00bc-4bbd-9d07-576303dca294",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "f265e6d5-8bbd-464e-b6c7-637224756e95",
+    "set_uuid": "785eb0f4-da05-495d-820b-b0b0423b1c14",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-alert-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "580b677d-5d7e-4306-87ee-640a4613254b",
+    "set_uuid": "785eb0f4-da05-495d-820b-b0b0423b1c14",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "62c3618c-f28f-4b56-9227-a061dc54d19d",
+    "set_uuid": "987dc285-af97-4789-9b3f-e5b5d5ec9fb8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "1357cf8e-6e41-4d3c-be39-9aa87d010b78",
+    "set_uuid": "987dc285-af97-4789-9b3f-e5b5d5ec9fb8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "bdf0fc6a-404c-492c-86bb-5d2ba06714e6",
+    "set_uuid": "82ae361f-08a5-4b1a-836c-b04ef78f4858",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "2af47c9c-dba6-4340-b5fc-af00dcbaa05c",
+    "set_uuid": "82ae361f-08a5-4b1a-836c-b04ef78f4858",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "d5db6c17-700e-4782-9c29-001269b50200",
+    "set_uuid": "e1b2120f-2776-4ba9-80f8-a0179fc1c875",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "631146ab-f3f2-4ea0-aac1-2bea622d0c85",
+    "set_uuid": "e1b2120f-2776-4ba9-80f8-a0179fc1c875",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "c5778e77-0ff1-431a-a72e-37f3066d3257",
+    "set_uuid": "f5f8ca7b-afdb-45e7-a800-ce1c2ba42455",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "2f62718d-3df8-498b-9520-baf8be65f3bd",
+    "set_uuid": "f5f8ca7b-afdb-45e7-a800-ce1c2ba42455",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "39f7e2c2-219b-4f4d-a45a-c0e2e458312e",
+    "set_uuid": "c2526e95-2c98-44ae-85f9-1cadab28a1f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "88fbbbe8-6dda-4d11-8d13-ed0fabaf0088",
+    "set_uuid": "c2526e95-2c98-44ae-85f9-1cadab28a1f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "101de772-de06-40dc-b3fb-9f3ff4ff4b45",
+    "set_uuid": "8d37cc81-84fc-46d8-b629-860adf5da2f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "d00bddef-eb79-4c0a-8794-52fa5b3d9b5c",
+    "set_uuid": "8d37cc81-84fc-46d8-b629-860adf5da2f3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "b1e50285-c36d-4d95-a609-255a39845436",
+    "set_uuid": "423eb2e6-f1c8-4f22-8440-24e4357a997e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "45385813-55dc-4a9f-81f8-c77a482b7268",
+    "set_uuid": "423eb2e6-f1c8-4f22-8440-24e4357a997e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "6138a3a4-4d5f-42ae-b1eb-6d2b44b51072",
+    "set_uuid": "36306a18-68d0-4f08-9787-d068b6886597",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-compact-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "bc3eee47-eb83-4ed7-9414-f9fbf620395b",
+    "set_uuid": "36306a18-68d0-4f08-9787-d068b6886597",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "21px",
+    "uuid": "8ac99ac4-b63c-4824-a49f-35f0820cde81",
+    "set_uuid": "3a61c18d-594e-48c4-b97a-1d0f5cb8fc7d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "4a5f821c-2703-48ba-85d2-15c922514839",
+    "set_uuid": "3a61c18d-594e-48c4-b97a-1d0f5cb8fc7d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "b7093f51-e97a-4cdc-b068-f00ef8bb6658",
+    "set_uuid": "51fc01cc-6abc-4f90-863b-c32a7832bde8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "ef7a07e3-a405-4788-a62b-771b0db019a8",
+    "set_uuid": "51fc01cc-6abc-4f90-863b-c32a7832bde8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "54198ff3-d745-40b1-bcc0-2bca4fe1955e",
+    "set_uuid": "44f67c88-cec3-4f0e-8450-37238b579fb9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "854384ce-1548-4e55-b19e-042b7a82db0e",
+    "set_uuid": "44f67c88-cec3-4f0e-8450-37238b579fb9",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "0516bc3d-36a1-4dcb-9d1d-1fce7c431890",
+    "set_uuid": "8920c8e0-863d-433e-aeec-3f860b840e3c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "2bdf7b47-450a-4da9-bddb-f4cef626c889",
+    "set_uuid": "8920c8e0-863d-433e-aeec-3f860b840e3c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "25px",
+    "uuid": "ca7c26d4-38eb-4382-b524-a27c73a34b7a",
+    "set_uuid": "3b949237-530a-41f5-8d54-50bbc8365c87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "31px",
+    "uuid": "45f97901-f614-42bc-b22b-c0b6cebb945b",
+    "set_uuid": "3b949237-530a-41f5-8d54-50bbc8365c87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "a3ee5984-d111-47f6-98b7-ad96b525e1ef",
+    "set_uuid": "52aedc0a-d0c8-4eaf-aa08-023aacc78f2c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "27px",
+    "uuid": "14cb8fe0-892a-438f-a794-9b013ef96d96",
+    "set_uuid": "52aedc0a-d0c8-4eaf-aa08-023aacc78f2c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "35900436-1a71-4a06-8b21-53b98398f7bc",
+    "set_uuid": "7a986039-e496-4c6c-8536-3d19f2a7232c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "23px",
+    "uuid": "b7cde8bc-0553-4045-8fc1-edaf8f429950",
+    "set_uuid": "7a986039-e496-4c6c-8536-3d19f2a7232c",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "0f68ff7a-b68e-4688-9da1-bbce083d2b98",
+    "set_uuid": "64c68ea1-20c2-4c2a-821f-cad39e8476de",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-disclosure-icon-spacious-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "178832d2-9ead-4804-a025-5883eec850d6",
+    "set_uuid": "64c68ea1-20c2-4c2a-821f-cad39e8476de",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icon will need to be in a frame with height equal to workflow-icon-[size] for this value to work. Accordion density addressed differently; refactor required.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "efcd740a-033e-493a-a902-e2f657897bd4",
+    "set_uuid": "84872a73-c77a-41e4-9ea1-8b00eb983283",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "263428f7-3b5a-449a-87d1-874cebf50fa8",
+    "set_uuid": "84872a73-c77a-41e4-9ea1-8b00eb983283",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "24784275-a117-4767-98ee-5d8a08c89296",
+    "set_uuid": "1bf807cd-f255-4e31-b337-83ff635bd043",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "7a17cc60-fa76-4234-a99e-c4f711e63f5f",
+    "set_uuid": "1bf807cd-f255-4e31-b337-83ff635bd043",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "7a3120a8-3c98-4227-afb4-5d6a8aa78e14",
+    "set_uuid": "0aa91d86-b000-453b-bfe8-ba2320288282",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "7b4b7283-1223-4d2e-9f24-5ed6dada4711",
+    "set_uuid": "0aa91d86-b000-453b-bfe8-ba2320288282",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "9aac1df2-1693-43f1-ae43-b23c21a42f71",
+    "set_uuid": "797ba48e-a1ff-4c18-8489-0d59be960616",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-progress-circle-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "5da7e575-d0c3-44e7-bbfa-6fa58972343b",
+    "set_uuid": "797ba48e-a1ff-4c18-8489-0d59be960616",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Change progress circle to equal size as workflow icon, that way we can reuse tokens",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "aa10c6ff-8cf6-4e68-8181-ca5e64f5c26f",
+    "set_uuid": "a5ad9ef8-fed7-4726-8ae6-5a87b8ee66c1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "a6da1cb9-6085-4c58-b3dc-3b1377f64fa4",
+    "set_uuid": "a5ad9ef8-fed7-4726-8ae6-5a87b8ee66c1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "97435915-44ba-4ace-993f-a0fac52e41f2",
+    "set_uuid": "5aa2d68f-472b-420e-892d-08025e1e962f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "17px",
+    "uuid": "f4f9d889-130a-4e71-9a9c-1ee82c2a4a4b",
+    "set_uuid": "5aa2d68f-472b-420e-892d-08025e1e962f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "2cdb6de8-d494-467d-bf9d-7fa96829bf82",
+    "set_uuid": "58d6a35b-1158-43fb-8b0c-06d479682ebf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "7bb6c4c7-4157-4da9-bf06-1d2527022d6a",
+    "set_uuid": "58d6a35b-1158-43fb-8b0c-06d479682ebf",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "2aad124e-19f5-404c-921e-e2060bc48f07",
+    "set_uuid": "da1ccd21-d162-464a-8772-2f0609b7accc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-top-to-validation-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "1a5b6e87-12a8-4fda-a8f7-2928b0b68a46",
+    "set_uuid": "da1ccd21-d162-464a-8772-2f0609b7accc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "field-width",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "field-width-small",
+    "uuid": "096ddcb7-5afd-416f-9a11-4275556c4b52",
+    "set_uuid": "ad37a519-be52-492e-a816-03ed7608fe65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
+    "replaced_by": "7e5eb477-85b4-46c3-a5eb-ac986b3298e2"
+  },
+  {
+    "name": {
+      "property": "field-width",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "field-width-small",
+    "uuid": "08c2390a-353b-4e6b-b025-dbaeaa5fdff2",
+    "set_uuid": "ad37a519-be52-492e-a816-03ed7608fe65",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
+    "replaced_by": "7e5eb477-85b4-46c3-a5eb-ac986b3298e2"
+  },
+  {
+    "name": {
+      "property": "field-width-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "field-default-width-extra-large",
+    "uuid": "a903b595-ffe8-43ae-af9b-7b6577191dc5",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use field-default-width-extra-large instead.",
+    "replaced_by": "5ab58f4b-2493-499a-ab97-f7533de2c5fa"
+  },
+  {
+    "name": {
+      "property": "field-width-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "field-default-width-large",
+    "uuid": "cc43e053-1255-403f-aaf5-2182f5438592",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use field-default-width-large instead.",
+    "replaced_by": "4b7418ca-2384-4470-bfca-d8f742681740"
+  },
+  {
+    "name": {
+      "property": "field-width-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "field-default-width-medium",
+    "uuid": "935927d3-b25e-468a-999a-938643901e50",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
+    "replaced_by": "7e5eb477-85b4-46c3-a5eb-ac986b3298e2"
+  },
+  {
+    "name": {
+      "property": "field-width-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "field-default-width-small",
+    "uuid": "d316d676-b4cf-4d16-b89c-63ef1d969861",
+    "deprecated": "unknown",
+    "deprecated_comment": "This token has been deprecated, use field-default-width-small instead.",
+    "replaced_by": "2fe6f129-a722-46ca-9f87-2cebcd2faa38"
+  },
+  {
+    "name": {
+      "property": "focus-indicator-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "693651ef-71c7-4096-91a5-1c84cb861021",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token focus-ring-gap instead.",
+    "replaced_by": "fb035d45-e63b-4cd4-b220-675a52e99399"
+  },
+  {
+    "name": {
+      "property": "focus-indicator-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "b6148878-b78d-4fe7-bf78-e01e7cb314c2"
+  },
+  {
+    "name": {
+      "property": "focus-ring-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-50",
+    "uuid": "fb035d45-e63b-4cd4-b220-675a52e99399",
+    "description": "Spacing between child elements for focus indicators"
+  },
+  {
+    "name": {
+      "property": "gradient-stop-1-genai"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 0,
+    "uuid": "1b4e100e-3266-4212-84c7-ee6995aaff83"
+  },
+  {
+    "name": {
+      "property": "gradient-stop-1-premium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 0,
+    "uuid": "4cb26877-72bd-48e5-8266-6b29b1c2303d"
+  },
+  {
+    "name": {
+      "property": "gradient-stop-2-genai"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 0.3333,
+    "uuid": "224504c9-be85-4402-8c96-e9b3e3b7a45f"
+  },
+  {
+    "name": {
+      "property": "gradient-stop-2-premium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 0.6666,
+    "uuid": "579ad392-4529-457d-ab3e-4cef782beec1"
+  },
+  {
+    "name": {
+      "property": "gradient-stop-3-genai"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 1,
+    "uuid": "57f4b9b1-4994-48b5-ad14-5683b0ab034b"
+  },
+  {
+    "name": {
+      "property": "gradient-stop-3-premium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "value": 1,
+    "uuid": "ace894a3-3aa5-4307-a80c-3881c8a31642"
+  },
+  {
+    "name": {
+      "property": "group-gap-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-50",
+    "uuid": "0f93a6a8-0128-4ee3-81a1-53216e069acc",
+    "description": "Spacing between child elements (compact density)"
+  },
+  {
+    "name": {
+      "property": "group-gap-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "89e74f93-9124-41a8-96b0-0fcc5ce9ab08",
+    "description": "Spacing between child elements at extra-large size"
+  },
+  {
+    "name": {
+      "property": "group-gap-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "c3ada312-da94-4779-bbf0-0fde3beb8121",
+    "description": "Spacing between child elements at extra-small size"
+  },
+  {
+    "name": {
+      "property": "group-gap-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "fd40a531-eee6-48b2-8212-a33d012a2173",
+    "description": "Spacing between child elements at large size"
+  },
+  {
+    "name": {
+      "property": "group-gap-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "6f2ccc0b-42ff-4f1a-a789-527427440d13",
+    "description": "Spacing between child elements at medium size"
+  },
+  {
+    "name": {
+      "property": "group-gap-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-85",
+    "uuid": "ce1865aa-9f33-492a-80c6-981fd503d70c",
+    "description": "Spacing between child elements at small size"
+  },
+  {
+    "name": {
+      "property": "label-to-description-0"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "4a00c810-c099-4de1-85b8-aaa7ed9538bb",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "list-gap-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-50",
+    "uuid": "a66810ec-1839-4ca3-8036-d552a71b1511",
+    "description": "Spacing between child elements for list structures (compact density)"
+  },
+  {
+    "name": {
+      "property": "list-gap-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "b7e1af59-753e-4059-8f46-8d862f631ad8",
+    "description": "Spacing between child elements for list structures (regular density)"
+  },
+  {
+    "name": {
+      "property": "list-gap-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "2a22e67c-5c2b-452b-8d51-b0396677898c",
+    "description": "Spacing between child elements for list structures (spacious density)"
+  },
+  {
+    "name": {
+      "property": "list-indent-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-400",
+    "uuid": "c5c94124-c16d-46f1-a22a-acf1378846bc",
+    "description": "Indentation for list structures at large size"
+  },
+  {
+    "name": {
+      "property": "list-indent-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f",
+    "description": "Indentation for list structures at medium size"
+  },
+  {
+    "name": {
+      "property": "list-item-gap-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "3cd1e483-969b-492c-8d44-d29348c981a5",
+    "description": "Spacing between child elements for list structures items at medium size"
+  },
+  {
+    "name": {
+      "property": "list-item-gap-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-50",
+    "uuid": "a8a20ecd-480e-4681-8639-c44d6dcb0658",
+    "description": "Spacing between child elements for list structures items at small size"
+  },
+  {
+    "name": {
+      "property": "list-item-padding-horizontal"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-85",
+    "uuid": "2147f873-8f42-4821-9654-9db2b1adc2f9",
+    "description": "Horizontal internal spacing for list structures items"
+  },
+  {
+    "name": {
+      "property": "list-item-padding-vertical-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-75",
+    "uuid": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c",
+    "description": "Vertical internal spacing for list structures items (regular density)"
+  },
+  {
+    "name": {
+      "property": "list-item-padding-vertical-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a",
+    "description": "Vertical internal spacing for list structures items (spacious density)"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "ac4d18d5-361c-4425-82c3-83979d58f682",
+    "set_uuid": "1ead9248-4325-443a-9223-08175b82df95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "19px",
+    "uuid": "e68f2798-6a55-499a-b591-0cfc130607ba",
+    "set_uuid": "1ead9248-4325-443a-9223-08175b82df95",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-extra-large",
+    "replaced_by": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "c0e06d21-7372-401f-9ec2-926e2b1faf26",
+    "set_uuid": "f888e2bb-2fe5-45df-891f-3168a6737aed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "e84bc865-c89f-403e-bb14-2a11f03fd364",
+    "set_uuid": "f888e2bb-2fe5-45df-891f-3168a6737aed",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-large instead. UI icons must be in a frame that has height equal to workflow-icon-size-large",
+    "replaced_by": "cc707192-e70f-4965-8582-55fa97d02184"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "5561a148-fd77-44d3-b29d-3ed7389122a1",
+    "set_uuid": "e01b062a-4928-4999-9da0-17ef4fe2f05a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "74f8a686-0e06-4f7c-9e3d-694749beb420",
+    "set_uuid": "e01b062a-4928-4999-9da0-17ef4fe2f05a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. UI icons must be in a frame that has height equal to workflow-icon-size-medium",
+    "replaced_by": "5741f832-f012-45bc-9e87-6e07ab2cb87f"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "70de4f97-bc4a-44af-9995-1042e3c7c78f",
+    "set_uuid": "5a394022-1daa-4052-852d-a47c256e13c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "navigational-indicator-top-to-back-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "d11ab0de-19bd-4f56-8798-0192fd0cfe0e",
+    "set_uuid": "5a394022-1daa-4052-852d-a47c256e13c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-vertical-small instead. UI icons must be in a frame that has height equal to workflow-icon-size-small",
+    "replaced_by": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
+  },
+  {
+    "name": {
+      "property": "popover-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "6bae40ba-3b57-4e4b-a8a7-4044cd729068",
+    "description": "Spacing between child elements for popover components"
+  },
+  {
+    "name": {
+      "property": "popover-padding"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "c872da51-317e-44cf-aef8-2f5f9fb77ae8",
+    "description": "Internal spacing for popover components"
+  },
+  {
+    "name": {
+      "property": "side-focus-indicator"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "d33433fd-6430-4769-a0b8-6d8c32a64803"
+  },
+  {
+    "name": {
+      "property": "side-label-character-count-to-field",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "146add82-4f20-46c3-bacf-4d24d60d0e10",
+    "set_uuid": "99abd526-5415-44cc-bee7-f6fd6cfb6396",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "side-label-character-count-to-field",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "ec387876-31d5-42a5-99aa-02c5d35e6223",
+    "set_uuid": "99abd526-5415-44cc-bee7-f6fd6cfb6396",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead.",
+    "replaced_by": "4043f679-9ec2-4eef-b934-19f60d7e74f5"
+  },
+  {
+    "name": {
+      "property": "side-label-character-count-top-margin-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "9b1f15bf-ea4f-4f82-8c4f-3770b7f47353",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "side-label-character-count-top-margin-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "e2d9e241-469a-4b03-bd6a-a105a8ed5e00",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "side-label-character-count-top-margin-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "4d93210f-f01a-4d1c-8c10-2cb4b9d14626",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "side-label-character-count-top-margin-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0px",
+    "uuid": "a86ae363-b6b4-4da0-9630-97336922b3a1",
+    "deprecated": "unknown",
+    "deprecated_comment": "Zero values are removed without token replacements; hardcode a zero-pixel value in implementation."
+  },
+  {
+    "name": {
+      "property": "spacing-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9"
+  },
+  {
+    "name": {
+      "property": "spacing-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "96px",
+    "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1"
+  },
+  {
+    "name": {
+      "property": "spacing-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "79fca32b-214b-4760-9d3a-28f4d1bdf86f"
+  },
+  {
+    "name": {
+      "property": "spacing-25"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "e832d8ae-a96c-4770-8cbc-4ca81ecf5a41"
+  },
+  {
+    "name": {
+      "property": "spacing-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "ba632ede-84a7-4e56-91ef-8143b2499452"
+  },
+  {
+    "name": {
+      "property": "spacing-350"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "b352f0f0-5843-4c65-8357-625b938ccaa0"
+  },
+  {
+    "name": {
+      "property": "spacing-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "ec565065-0820-460f-9a1b-b81911c48cb5"
+  },
+  {
+    "name": {
+      "property": "spacing-50"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104"
+  },
+  {
+    "name": {
+      "property": "spacing-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "490b4010-1561-4b12-8cbb-cdb4b650ba74"
+  },
+  {
+    "name": {
+      "property": "spacing-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "b6d0b881-d25e-452c-9069-c18745d21f33"
+  },
+  {
+    "name": {
+      "property": "spacing-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "48px",
+    "uuid": "26639049-ec07-430d-983f-4d036758564a"
+  },
+  {
+    "name": {
+      "property": "spacing-75"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd"
+  },
+  {
+    "name": {
+      "property": "spacing-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "eeb099cb-707f-4e5e-97b9-1fdba35b2314"
+  },
+  {
+    "name": {
+      "property": "spacing-85"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "4adbd869-2ead-49b8-bed6-950fb14c695d"
+  },
+  {
+    "name": {
+      "property": "spacing-900"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "d04e5d81-0b6e-48e7-9e47-744753dfcff3"
+  },
+  {
+    "name": {
+      "property": "tab-gap-horizontal-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-600",
+    "uuid": "0c958750-2c96-453b-9464-f041ac126749",
+    "description": "Spacing between child elements for tab components at extra-large size"
+  },
+  {
+    "name": {
+      "property": "tab-gap-horizontal-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-500",
+    "uuid": "8932b4cf-300f-4377-bbda-7fc02011cd37",
+    "description": "Spacing between child elements for tab components at large size"
+  },
+  {
+    "name": {
+      "property": "tab-gap-horizontal-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-400",
+    "uuid": "7a5f3049-0c20-4ff8-84ea-d161e58546fb",
+    "description": "Spacing between child elements for tab components at medium size"
+  },
+  {
+    "name": {
+      "property": "tab-gap-horizontal-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-350",
+    "uuid": "a41aaa58-77af-476e-9050-4f4864c8c3f9",
+    "description": "Spacing between child elements for tab components at small size"
+  },
+  {
+    "name": {
+      "property": "table-item-padding-compact"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-100",
+    "uuid": "42473d6e-5f40-46c7-9bbc-302e355ae6ae",
+    "description": "Internal spacing for table structures items (compact density)"
+  },
+  {
+    "name": {
+      "property": "table-item-padding-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-200",
+    "uuid": "15ffb38e-341b-4c47-a6b3-c197e05afffe",
+    "description": "Internal spacing for table structures items (regular density)"
+  },
+  {
+    "name": {
+      "property": "table-item-padding-spacious"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-300",
+    "uuid": "a775a186-802e-4256-947c-7fda3ac53caa",
+    "description": "Internal spacing for table structures items (spacious density)"
+  },
+  {
+    "name": {
+      "property": "text-gap-extra-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "7489ed61-af2a-44ef-b9a9-b4eb226a47fb",
+    "description": "Spacing between child elements for text content at extra-large size"
+  },
+  {
+    "name": {
+      "property": "text-gap-extra-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "6631e337-bf73-4779-aa2f-b70ff552b25e",
+    "description": "Spacing between child elements for text content at extra-small size"
+  },
+  {
+    "name": {
+      "property": "text-gap-large"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "2px",
+    "uuid": "52f0ce69-d419-4f27-b1fd-eaad3726017a",
+    "description": "Spacing between child elements for text content at large size"
+  },
+  {
+    "name": {
+      "property": "text-gap-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "62e8853d-9c4f-4e9d-be75-0020344d13ee",
+    "description": "Spacing between child elements for text content at medium size"
+  },
+  {
+    "name": {
+      "property": "text-gap-small"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "d61248dc-0a2d-469d-a81f-0417e0bb5de2",
+    "description": "Spacing between child elements for text content at small size"
+  },
+  {
+    "name": {
+      "property": "text-to-control-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "24a438ce-be6a-477e-aa0e-a3e97e286904",
+    "set_uuid": "ce43ae27-fb9c-422f-9f82-494c0491edd8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "property": "text-to-control-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "b4ce04fa-bc03-44c9-afef-a38810ac9c65",
+    "set_uuid": "ce43ae27-fb9c-422f-9f82-494c0491edd8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "property": "text-to-control-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "307fb510-8759-41ee-89d2-fcfe4d554b85",
+    "set_uuid": "a71a56bf-2c9f-45de-b0b4-9e03f1a9febb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "property": "text-to-control-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "8991287c-763f-4a39-ad5b-7ccdbc39b3f6",
+    "set_uuid": "a71a56bf-2c9f-45de-b0b4-9e03f1a9febb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "property": "text-to-control-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "13px",
+    "uuid": "7cde8c74-2ac9-4468-a25e-06c1a6cd9cbe",
+    "set_uuid": "72908bb2-fb57-4455-aed4-0f3f40ab3365",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "property": "text-to-control-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "53a33d46-8d81-4f13-8c79-c4d9257a5b68",
+    "set_uuid": "72908bb2-fb57-4455-aed4-0f3f40ab3365",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "property": "text-to-control-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "4px",
+    "uuid": "4b47e7a8-b330-4c6c-a497-9ee9eed0c50a",
+    "set_uuid": "f9da434a-7742-4d38-ad52-05dec8d09cfa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "property": "text-to-control-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "56e2cc0c-7d56-454e-bb4f-4517f412eeac",
+    "set_uuid": "f9da434a-7742-4d38-ad52-05dec8d09cfa",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "property": "text-to-control-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "aa27af6e-baef-4d7c-bf8c-f9a972e51713",
+    "set_uuid": "f0974e76-c721-44ca-ad5a-2594b63aaaea",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "property": "text-to-control-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "45f94495-0f53-42b2-94f6-7a6d91eb2ca1",
+    "set_uuid": "f0974e76-c721-44ca-ad5a-2594b63aaaea",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "6px",
+    "uuid": "1d601d0a-d6d0-4711-9fb9-71898c2bcc9a",
+    "set_uuid": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "09d55113-8d94-429f-b0c8-ffabe8ccba27",
+    "set_uuid": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "7ce11af3-b94b-4239-a310-f8d09635779a",
+    "set_uuid": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "dc4ec555-72eb-4328-aba4-e8d594102f45",
+    "set_uuid": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-large instead.",
+    "replaced_by": "2f10fab2-66e0-4007-9c01-9643d472ba3b"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "4366909e-3bfb-481c-abdc-4ae71f965bc3",
+    "set_uuid": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "205f0c77-6588-4cc7-927f-3ba767200bac",
+    "set_uuid": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
+    "replaced_by": "42da5f00-7ba7-4a9a-8ab4-6f3552e22fdd"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "9px",
+    "uuid": "3d393d59-b358-48a7-82c6-a7802408cd0d",
+    "set_uuid": "7140744e-5e07-4967-baac-3651f8cc408f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "11px",
+    "uuid": "b496071f-4151-4bc2-86eb-f2e41947e0f6",
+    "set_uuid": "7140744e-5e07-4967-baac-3651f8cc408f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-2x-large instead.",
+    "replaced_by": "f3078f76-5c45-4b40-8d3c-523afcc4d2af"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "ff1fadc2-9ec0-456f-a054-4512e51c85c8",
+    "set_uuid": "8cbec20e-d19d-4281-9447-16c128db23a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "8588bf80-96df-40fb-8b6f-61d06899f8dd",
+    "set_uuid": "8cbec20e-d19d-4281-9447-16c128db23a0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-extra-small instead.",
+    "replaced_by": "2fca8c2d-dad0-4441-8e52-e623d76ef701"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "5px",
+    "uuid": "50763a0d-c6eb-47f0-8b56-4c86ee22a430",
+    "set_uuid": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "property": "text-to-visual-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "7px",
+    "uuid": "77dc4cd4-8e4e-4873-b6f3-d573eb7fc315",
+    "set_uuid": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-small instead.",
+    "replaced_by": "1247c1ab-9e31-482a-832c-d32911a1e698"
+  },
+  {
+    "name": {
+      "property": "text-underline-gap"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "d9d51235-f3fe-4e2a-bdca-b6a104d9a9e5",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token text-gap-medium instead.",
+    "replaced_by": "62e8853d-9c4f-4e9d-be75-0020344d13ee"
+  },
+  {
+    "name": {
+      "property": "text-underline-thickness"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "1px",
+    "uuid": "13f36ce1-84bb-41db-bec8-6d6e8f5c6ed3"
+  },
+  {
+    "name": {
+      "property": "visual-to-control-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "8px",
+    "uuid": "0a392deb-fee3-4968-bc52-1377f9e23307",
+    "set_uuid": "1b567a73-7b2e-44bd-8e4d-1e324343083f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "property": "visual-to-control-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "16b8c9c7-a601-4ff9-bf9d-c5a118738506",
+    "set_uuid": "1b567a73-7b2e-44bd-8e4d-1e324343083f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token base-gap-medium instead.",
+    "replaced_by": "9898011f-a47c-4d5d-a74e-70b5f8d0b91c"
+  },
+  {
+    "name": {
+      "property": "window-to-edge"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "spacing-600",
+    "uuid": "a3e53161-c38a-4ee0-88c2-4a36fd530e51",
+    "deprecated": "unknown",
+    "deprecated_comment": "Use semantic token container-padding-3x-large instead.",
+    "replaced_by": "e595caf6-37f9-4f84-b81b-dd44ed0d6431"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-2x-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "dd8315dd-3691-4999-ae34-4139cba08daa",
+    "set_uuid": "f49f066a-b5e5-47f3-b4f8-beae1de1ea5e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-2x-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "beff962d-f7fd-4c15-b80c-890090b4bdeb",
+    "set_uuid": "f49f066a-b5e5-47f3-b4f8-beae1de1ea5e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-2x-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "d6887224-4857-42a4-8bcf-3fd64b06f5fa",
+    "set_uuid": "2125b9ae-3b19-45ee-b0e6-f0b7c0c688c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-2x-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "71e065c1-95c3-430f-86e4-5e428e1fe81d",
+    "set_uuid": "2125b9ae-3b19-45ee-b0e6-f0b7c0c688c3",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-3x-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "10px",
+    "uuid": "ac7d7f1b-09b9-4ea2-9e5f-913dd9cbf24a",
+    "set_uuid": "8a0fb227-d80f-4187-9b4d-3f66f9af6ec6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-3x-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "11f893cd-8d7c-44cb-a572-d71d73fcfb2e",
+    "set_uuid": "8a0fb227-d80f-4187-9b4d-3f66f9af6ec6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "e12d9f17-3ddf-4fbc-ba06-79a92208c6b4",
+    "set_uuid": "d48a8109-9004-4fc3-8b98-dbbbb5669466",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "65f791f8-a88f-4765-a57e-3e023a436642",
+    "set_uuid": "d48a8109-9004-4fc3-8b98-dbbbb5669466",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-extra-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "986ccd9d-7310-43c6-b5a2-ad5a9a7e7275",
+    "set_uuid": "05d2272f-0f98-4614-b42f-246c9c472208",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-extra-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "9b324b14-b1cf-4932-b5a7-fd5b9410b71b",
+    "set_uuid": "05d2272f-0f98-4614-b42f-246c9c472208",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "dc8b54c5-d70c-46ff-838f-9e64e1877cc0",
+    "set_uuid": "688352ee-b386-4a4e-8137-e1f77f0b431b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "94f62adc-c5fb-48f8-ba05-7c639b936643",
+    "set_uuid": "688352ee-b386-4a4e-8137-e1f77f0b431b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "54a8eb69-a730-4871-b1eb-2958a2d9a8c5",
+    "set_uuid": "1cfbc0a9-9b7e-454e-9bd4-150b6e062b5f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "f272e08b-f6e6-4681-8dc0-abe071b8977a",
+    "set_uuid": "1cfbc0a9-9b7e-454e-9bd4-150b6e062b5f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "40abc60f-ab65-41ef-b724-a0f0bdd94d14",
+    "set_uuid": "dccab61e-8eed-4fa6-99c3-b997c987dd62",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "9e882a20-b8e1-4e9b-89f9-26f21db3cd78",
+    "set_uuid": "dccab61e-8eed-4fa6-99c3-b997c987dd62",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "6392e605-932e-456d-be53-149b624a04e2",
+    "set_uuid": "6650d78d-2317-41c2-bb9b-e2789cffb5c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "9948e083-8c75-48f7-8e58-32c75ec76116",
+    "set_uuid": "6650d78d-2317-41c2-bb9b-e2789cffb5c0",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "25908278-79d3-47f4-9b53-adbdd1c13e2a",
+    "set_uuid": "c50ba02d-538f-456c-9d8d-f6ca5b1b5881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "df0dc6c3-59fc-4ee0-87a9-c3d49a07cf9c",
+    "set_uuid": "c50ba02d-538f-456c-9d8d-f6ca5b1b5881",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "1423caf1-75ca-4ca8-aa6a-22dcf3655b0e",
+    "set_uuid": "10abd2ac-fdb8-4dee-86a6-1588acc7b366",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "4c4cb541-7d42-4bb4-9c86-7197c4600896",
+    "set_uuid": "10abd2ac-fdb8-4dee-86a6-1588acc7b366",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "85cdef34-0682-45eb-ac06-98c76883cdf7",
+    "set_uuid": "e1029ff5-5b9c-4717-8cdb-4ced6b554c01",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "b720c214-babe-426d-9629-9ec60d5e8622",
+    "set_uuid": "e1029ff5-5b9c-4717-8cdb-4ced6b554c01",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "vertical-align-items"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
+    "value": "center",
+    "uuid": "b2f48da9-58a4-4e86-8340-78e0f52c67ba"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "f7d9ca4c-6d3f-4053-962a-152a19531389",
+    "set_uuid": "dd3133de-94a6-4007-a68e-4202762f0eb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "workflow-icon-small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "a659c66d-1e77-4818-95ea-501e65162841",
+    "set_uuid": "dd3133de-94a6-4007-a68e-4202762f0eb5",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  }
+]

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -1,0 +1,902 @@
+[
+  {
+    "name": {
+      "property": "accent-color-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-100",
+    "uuid": "2e080bb5-6f2c-4fd9-96a2-bf9fc19d2649"
+  },
+  {
+    "name": {
+      "property": "accent-color-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1000",
+    "uuid": "9bf3fa2f-75d3-44d3-ae30-d88893665366"
+  },
+  {
+    "name": {
+      "property": "accent-color-1100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1100",
+    "uuid": "f7f853a5-f091-4a7e-8aea-68d060c840f0"
+  },
+  {
+    "name": {
+      "property": "accent-color-1200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1200",
+    "uuid": "7c141cdb-1e5e-468a-ba48-0df01b275402"
+  },
+  {
+    "name": {
+      "property": "accent-color-1300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1300",
+    "uuid": "f7307eba-e311-41a8-bb50-0b1e96833dfa"
+  },
+  {
+    "name": {
+      "property": "accent-color-1400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1400",
+    "uuid": "06585cf4-a924-49b2-b6c8-f0e80b57c576"
+  },
+  {
+    "name": {
+      "property": "accent-color-1500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1500",
+    "uuid": "c43d9991-8929-4b1c-8631-670eef6bde83"
+  },
+  {
+    "name": {
+      "property": "accent-color-1600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1600",
+    "uuid": "4b70c929-f48d-403d-9607-5963203433dc"
+  },
+  {
+    "name": {
+      "property": "accent-color-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-200",
+    "uuid": "cf583998-4dfd-4222-a554-8e05ed7fb5d6"
+  },
+  {
+    "name": {
+      "property": "accent-color-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-300",
+    "uuid": "ea67f054-1f42-427e-a768-beb8d21de2a3"
+  },
+  {
+    "name": {
+      "property": "accent-color-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-400",
+    "uuid": "a249e4b1-e6f9-4ef3-96c6-1559059839a7"
+  },
+  {
+    "name": {
+      "property": "accent-color-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-500",
+    "uuid": "c1c0e6fb-ce21-49d7-91bb-73ce873aa69f"
+  },
+  {
+    "name": {
+      "property": "accent-color-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-600",
+    "uuid": "5a2000be-5640-4389-a128-b2c164ad2253"
+  },
+  {
+    "name": {
+      "property": "accent-color-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-700",
+    "uuid": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae"
+  },
+  {
+    "name": {
+      "property": "accent-color-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "87a2c8f0-54fd-4939-8f42-3124fde1e49e"
+  },
+  {
+    "name": {
+      "property": "accent-color-900"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54"
+  },
+  {
+    "name": {
+      "property": "accent-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-200",
+    "uuid": "97293b77-c21d-4ba1-bd2c-5d1de37d75eb",
+    "set_uuid": "14e7dcde-b29d-42ba-8a90-327ada3af3e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-300",
+    "uuid": "c120499e-98c4-442d-971f-31dee8d16c4d",
+    "set_uuid": "14e7dcde-b29d-42ba-8a90-327ada3af3e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "accent-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "accent-color-200",
+    "uuid": "5c9c8a1c-c4ac-45e5-ba5f-b08edd9f4297",
+    "set_uuid": "14e7dcde-b29d-42ba-8a90-327ada3af3e7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "icon-color-informative"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-visual-color",
+    "uuid": "2296b0de-6231-4f89-9992-499b67c6879c"
+  },
+  {
+    "name": {
+      "property": "icon-color-negative"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-visual-color",
+    "uuid": "adf2a3f0-d1cd-4b53-8a9c-47ab9cb7bb0f"
+  },
+  {
+    "name": {
+      "property": "icon-color-neutral"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "neutral-visual-color",
+    "uuid": "29f5b73c-e8e8-4162-b9af-5a8e327baab8"
+  },
+  {
+    "name": {
+      "property": "icon-color-notice"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-visual-color",
+    "uuid": "4bdb8681-f7a1-4bbe-b788-a64c6f9df6ea"
+  },
+  {
+    "name": {
+      "property": "icon-color-positive"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-visual-color",
+    "uuid": "02f093b3-ab51-42e7-8f6e-26bc7c7cba63"
+  },
+  {
+    "name": {
+      "property": "informative-color-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-100",
+    "uuid": "b9fc8b82-275a-49fe-98d7-95f136b48772"
+  },
+  {
+    "name": {
+      "property": "informative-color-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1000",
+    "uuid": "6b609325-2bcf-491a-ad38-1409025caae0"
+  },
+  {
+    "name": {
+      "property": "informative-color-1100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1100",
+    "uuid": "7bf54313-58b6-4581-b5ac-a2e51df4a9ed"
+  },
+  {
+    "name": {
+      "property": "informative-color-1200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1200",
+    "uuid": "4504d6a9-87f7-48ea-94a0-d075f28bbcff"
+  },
+  {
+    "name": {
+      "property": "informative-color-1300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1300",
+    "uuid": "f7a736c2-db44-4668-90a8-c27778ae9892"
+  },
+  {
+    "name": {
+      "property": "informative-color-1400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1400",
+    "uuid": "b178b13b-93ee-422c-af98-3bf89105754b"
+  },
+  {
+    "name": {
+      "property": "informative-color-1500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1500",
+    "uuid": "beeee44c-dc6b-4892-949e-67f069fc4a94"
+  },
+  {
+    "name": {
+      "property": "informative-color-1600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-1600",
+    "uuid": "68aa069d-d8a6-413a-b330-0ec6af905e6d"
+  },
+  {
+    "name": {
+      "property": "informative-color-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-200",
+    "uuid": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c"
+  },
+  {
+    "name": {
+      "property": "informative-color-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-300",
+    "uuid": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a"
+  },
+  {
+    "name": {
+      "property": "informative-color-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-400",
+    "uuid": "46f3f214-5211-452b-8dc0-ffb7e9f9712b"
+  },
+  {
+    "name": {
+      "property": "informative-color-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-500",
+    "uuid": "546f860f-4e17-455a-a6eb-f7a6a3b37128"
+  },
+  {
+    "name": {
+      "property": "informative-color-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-600",
+    "uuid": "79a0fe09-63fb-4c96-a3bf-a8e126e7838c"
+  },
+  {
+    "name": {
+      "property": "informative-color-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-700",
+    "uuid": "04a018bd-229c-47da-99e9-d338d05f0fb6"
+  },
+  {
+    "name": {
+      "property": "informative-color-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-800",
+    "uuid": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f"
+  },
+  {
+    "name": {
+      "property": "informative-color-900"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "blue-900",
+    "uuid": "41b73196-0bc1-493e-9b5d-49f608914f5a"
+  },
+  {
+    "name": {
+      "property": "informative-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-200",
+    "uuid": "62dfb07f-5eee-451c-9c77-745d8f714766",
+    "set_uuid": "beaee709-482e-4678-99d5-585da056f5c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-300",
+    "uuid": "4cbe010f-0608-47e3-bf27-c7da70a70b9e",
+    "set_uuid": "beaee709-482e-4678-99d5-585da056f5c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "informative-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "informative-color-200",
+    "uuid": "71ebebf0-95e7-45f7-9f6f-d14ef51cf4f0",
+    "set_uuid": "beaee709-482e-4678-99d5-585da056f5c8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-color-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-100",
+    "uuid": "c37f795e-e338-4220-b0ab-5cf899f114c0"
+  },
+  {
+    "name": {
+      "property": "negative-color-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1000",
+    "uuid": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2"
+  },
+  {
+    "name": {
+      "property": "negative-color-1100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1100",
+    "uuid": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489"
+  },
+  {
+    "name": {
+      "property": "negative-color-1200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1200",
+    "uuid": "1b24f4e8-224c-41f9-b0eb-6a01e9261598"
+  },
+  {
+    "name": {
+      "property": "negative-color-1300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1300",
+    "uuid": "fa641bdd-0714-4ae4-9a8f-8d829a9977e5"
+  },
+  {
+    "name": {
+      "property": "negative-color-1400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1400",
+    "uuid": "58824d04-e2c0-4f0c-a3d7-9b88a01bf28d"
+  },
+  {
+    "name": {
+      "property": "negative-color-1500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1500",
+    "uuid": "b4c1f747-e665-43bb-a1a9-1bf9f252471d"
+  },
+  {
+    "name": {
+      "property": "negative-color-1600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-1600",
+    "uuid": "62beb7ee-c347-4cd7-a84b-40c84fcbc135"
+  },
+  {
+    "name": {
+      "property": "negative-color-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-200",
+    "uuid": "14919f0c-a40f-48d1-adfd-55826de8e600"
+  },
+  {
+    "name": {
+      "property": "negative-color-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-300",
+    "uuid": "53486ec0-79f7-4853-ad5b-dacc5a904f8a"
+  },
+  {
+    "name": {
+      "property": "negative-color-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-400",
+    "uuid": "de87c624-7f43-406e-8cdf-584343a55edc"
+  },
+  {
+    "name": {
+      "property": "negative-color-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-500",
+    "uuid": "67d09223-03a0-444a-95b6-645a2d66f8c7"
+  },
+  {
+    "name": {
+      "property": "negative-color-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-600",
+    "uuid": "4a0c11a4-4e77-43e0-a2cd-9931ac51d87d"
+  },
+  {
+    "name": {
+      "property": "negative-color-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-700",
+    "uuid": "b7d5d2db-0282-436b-8cb0-873e891b22a6"
+  },
+  {
+    "name": {
+      "property": "negative-color-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-800",
+    "uuid": "d858b481-8970-4547-aed1-b6388c36aba4"
+  },
+  {
+    "name": {
+      "property": "negative-color-900"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "red-900",
+    "uuid": "0b469d2e-7c66-4188-b6bf-bbc379f75538"
+  },
+  {
+    "name": {
+      "property": "negative-subdued-background-color",
+      "state": "default"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-subtle-background-color-default",
+    "uuid": "a553db3e-a051-4023-87eb-da6545b983b2",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "negative-subdued-background-color",
+      "state": "down"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-300",
+    "uuid": "1eea917c-52e7-4295-b0e1-d33c2e73a137",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "negative-subdued-background-color",
+      "state": "hover"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-300",
+    "uuid": "9513cf13-8537-443f-81ce-f9d88292ba32",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "negative-subdued-background-color",
+      "state": "key-focus"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-300",
+    "uuid": "4b6aaf76-e0ab-4be0-81c0-d5f64cacee88",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "negative-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-200",
+    "uuid": "8e9429cf-4c89-47be-bc6e-eeecc632aeb1",
+    "set_uuid": "30fa3891-135b-405a-bf0f-3cc17f711079",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-300",
+    "uuid": "c7575b76-8035-4037-8bd5-e8bdb82bddc3",
+    "set_uuid": "30fa3891-135b-405a-bf0f-3cc17f711079",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "negative-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "negative-color-200",
+    "uuid": "ea3ceaa2-235b-4c55-88b2-c0d744434d83",
+    "set_uuid": "30fa3891-135b-405a-bf0f-3cc17f711079",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-color-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-100",
+    "uuid": "d0382c45-0cf7-4c3b-89fb-3536459cbc31"
+  },
+  {
+    "name": {
+      "property": "notice-color-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1000",
+    "uuid": "d6fdcf63-c135-48a0-a767-e8f1e93e8190"
+  },
+  {
+    "name": {
+      "property": "notice-color-1100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1100",
+    "uuid": "c30c4ce0-ed40-44eb-ae0b-3549523d5bc9"
+  },
+  {
+    "name": {
+      "property": "notice-color-1200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1200",
+    "uuid": "7e22e4fe-bd28-4dac-b518-e35ec6900da3"
+  },
+  {
+    "name": {
+      "property": "notice-color-1300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1300",
+    "uuid": "197c8ecc-3d6a-46e5-82f2-c315a52169fb"
+  },
+  {
+    "name": {
+      "property": "notice-color-1400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1400",
+    "uuid": "4eccc44a-1cd5-4d9e-8627-18f7a363d3c8"
+  },
+  {
+    "name": {
+      "property": "notice-color-1500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1500",
+    "uuid": "3da89d37-cf33-4408-b316-05bb61c25759"
+  },
+  {
+    "name": {
+      "property": "notice-color-1600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-1600",
+    "uuid": "67e534f5-5421-493c-9324-624f0fd491f3"
+  },
+  {
+    "name": {
+      "property": "notice-color-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-200",
+    "uuid": "b9218264-6bd0-4fee-8ab7-346428c9bbaa"
+  },
+  {
+    "name": {
+      "property": "notice-color-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-300",
+    "uuid": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd"
+  },
+  {
+    "name": {
+      "property": "notice-color-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-400",
+    "uuid": "77535709-6e67-4d7c-aaeb-d2dea1918430"
+  },
+  {
+    "name": {
+      "property": "notice-color-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-500",
+    "uuid": "ab679012-b7cb-4f24-b401-b02e523d7c99"
+  },
+  {
+    "name": {
+      "property": "notice-color-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-600",
+    "uuid": "716af828-c64d-465d-8476-d142892ca59c"
+  },
+  {
+    "name": {
+      "property": "notice-color-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-700",
+    "uuid": "adb5159c-654f-4b9a-a101-3afa90328c42"
+  },
+  {
+    "name": {
+      "property": "notice-color-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-800",
+    "uuid": "a83cdd4d-b8a9-42af-98c4-459f721abbff"
+  },
+  {
+    "name": {
+      "property": "notice-color-900"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "orange-900",
+    "uuid": "df87ca09-ff38-485e-90f7-6d9cbfbb6714"
+  },
+  {
+    "name": {
+      "property": "notice-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-200",
+    "uuid": "f0799e87-dbb2-4e71-8253-65f45eddc078",
+    "set_uuid": "8a357a16-a337-4edd-b73f-e09d7a6d45f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-300",
+    "uuid": "c9bfd62b-95c7-47d3-bace-ce3f2bfaade8",
+    "set_uuid": "8a357a16-a337-4edd-b73f-e09d7a6d45f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "notice-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "notice-color-200",
+    "uuid": "163958bd-7303-4328-ad3c-b04f8dacaf32",
+    "set_uuid": "8a357a16-a337-4edd-b73f-e09d7a6d45f1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-color-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-100",
+    "uuid": "09503086-ccd2-4dfb-9bc1-6b86cf595976"
+  },
+  {
+    "name": {
+      "property": "positive-color-1000"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1000",
+    "uuid": "82d9fc42-d750-43d2-b227-b8df29abaca4"
+  },
+  {
+    "name": {
+      "property": "positive-color-1100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1100",
+    "uuid": "05f42672-455e-421c-8a7e-cb187355d23d"
+  },
+  {
+    "name": {
+      "property": "positive-color-1200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1200",
+    "uuid": "c4f84a4a-cfc4-42a6-81d4-11f27e1b38eb"
+  },
+  {
+    "name": {
+      "property": "positive-color-1300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1300",
+    "uuid": "7d2d9fe7-5498-4f73-be6a-3a4ac91b6e15"
+  },
+  {
+    "name": {
+      "property": "positive-color-1400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1400",
+    "uuid": "eb2fdab7-ea9e-42a3-a3d1-f9beec0c7b66"
+  },
+  {
+    "name": {
+      "property": "positive-color-1500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1500",
+    "uuid": "2381ba55-11ff-4ef0-a770-dfd402650d5d"
+  },
+  {
+    "name": {
+      "property": "positive-color-1600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-1600",
+    "uuid": "de206438-991f-4580-8aa1-1488acb03a09"
+  },
+  {
+    "name": {
+      "property": "positive-color-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-200",
+    "uuid": "00a2adcc-7b8a-4e94-97d2-51a647016265"
+  },
+  {
+    "name": {
+      "property": "positive-color-300"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-300",
+    "uuid": "2c75e63f-e628-487d-a143-e03de065d5ee"
+  },
+  {
+    "name": {
+      "property": "positive-color-400"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-400",
+    "uuid": "906a05ca-0b2f-4ada-9e71-507d9f0653be"
+  },
+  {
+    "name": {
+      "property": "positive-color-500"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-500",
+    "uuid": "b2e94182-57ae-479d-ab91-717edc0ec3f6"
+  },
+  {
+    "name": {
+      "property": "positive-color-600"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-600",
+    "uuid": "d3a018bf-0abe-4031-8c38-80a94b0d62ae"
+  },
+  {
+    "name": {
+      "property": "positive-color-700"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-700",
+    "uuid": "ffdde321-5c1d-489e-8a0f-afc582248594"
+  },
+  {
+    "name": {
+      "property": "positive-color-800"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-800",
+    "uuid": "ee02d9d5-b840-44af-be8a-0f10086e8f7e"
+  },
+  {
+    "name": {
+      "property": "positive-color-900"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "green-900",
+    "uuid": "1cd86108-ff79-4ccf-911e-8de9986c9053"
+  },
+  {
+    "name": {
+      "property": "positive-subtle-background-color",
+      "state": "default",
+      "colorScheme": "light"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-200",
+    "uuid": "57a1aa8f-5c06-4ff6-8d1c-0e278a433ebf",
+    "set_uuid": "a412cbb3-bcee-40d3-af69-99ead9be1954",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-subtle-background-color",
+      "state": "default",
+      "colorScheme": "dark"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-300",
+    "uuid": "c7644c81-1b2c-40ee-b3a6-b25e88fc34ea",
+    "set_uuid": "a412cbb3-bcee-40d3-af69-99ead9be1954",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  },
+  {
+    "name": {
+      "property": "positive-subtle-background-color",
+      "state": "default",
+      "colorScheme": "wireframe"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "positive-color-200",
+    "uuid": "531be3e1-ddfa-4d3b-9a7f-73d7f0e38cd9",
+    "set_uuid": "a412cbb3-bcee-40d3-af69-99ead9be1954",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
+  }
+]

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -1,0 +1,3369 @@
+[
+  {
+    "name": {
+      "property": "black-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "value": "black",
+    "uuid": "e2f23ca1-802b-40a2-a211-33090f9a043e"
+  },
+  {
+    "name": {
+      "property": "body-cjk-emphasized-font-style",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "3e90be19-62fd-4e53-abf9-4c697baba5da"
+  },
+  {
+    "name": {
+      "property": "body-cjk-emphasized-font-weight",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "0d8ada2f-272d-4f76-bf37-095e0b48cdae"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "cjk-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-font-family",
+    "uuid": "06d5790c-21e9-4135-843d-05007b046677"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "cjk-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "41389b62-c449-485b-bfa8-1659bacc8c42"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "cjk-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "a754c16b-2f0c-485f-813d-d472ee650660"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "cjk-line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-line-height-200",
+    "uuid": "2106b188-8520-4261-968b-2eb2928857f9"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "9f0e0ddb-a4d2-416e-a425-8d71527f77b2"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "7e01bc65-5823-456f-a830-9848a96ad85a"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "081aa502-e2f1-4bc8-8fb2-a00dcd4236dd"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "25d65a6e-e8e1-4849-848a-984373fd9cf9"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-50",
+    "uuid": "ba73926d-2ef4-4d7b-86c2-9044aa1cdf95"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-xxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "9aab03eb-c0c1-462c-aa7c-88c93b06f714"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-xxs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-25",
+    "uuid": "218f04ed-0679-4090-b1ad-76ef062dd07c"
+  },
+  {
+    "name": {
+      "property": "body-cjk-size-xxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-500",
+    "uuid": "71a41f9e-73da-4632-8877-7af7acf4db03"
+  },
+  {
+    "name": {
+      "property": "body-cjk-strong-emphasized-font-style",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "f792aac0-62f2-47e3-b6ac-158ae009d9c3"
+  },
+  {
+    "name": {
+      "property": "body-cjk-strong-emphasized-font-weight",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "54020791-a975-4e5d-a905-8bffcc9d2d93"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "cjk-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "11fe09ad-92eb-4d7d-8872-467cdd69659b"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "cjk-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "d79de2c4-ca7c-4316-ac44-fee1a66983d7"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "a7218010-91c1-4f20-8072-7b1801593014"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "line-height-200",
+    "uuid": "39accad7-3de1-4850-9773-4e0ff8080049"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "margin-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.75,
+    "uuid": "8f2e9283-4cbc-4374-9757-ed8d68542c89"
+  },
+  {
+    "name": {
+      "property": "body-sans-serif-emphasized-font-style",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "717c067c-55d1-4927-ad9c-8784769f581d"
+  },
+  {
+    "name": {
+      "property": "body-sans-serif-emphasized-font-weight",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "5640ac73-a482-4787-9ab2-035b57a87833"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "sans-serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "sans-serif-font-family",
+    "uuid": "32c3d84f-2b0d-4ccd-ba3c-b8475d82550b"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "sans-serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "e1da0eff-7482-46a0-8190-4c54c6b1e1dd"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "sans-serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "6813005d-9df4-459b-9fab-b2a054c32c31"
+  },
+  {
+    "name": {
+      "property": "body-sans-serif-strong-emphasized-font-style",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "b87e6738-af38-49be-9945-f3a307ce7b6f"
+  },
+  {
+    "name": {
+      "property": "body-sans-serif-strong-emphasized-font-weight",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "421dc907-5862-4ed5-95f4-41d654b2fdc0"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "sans-serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "b36db31f-eaaa-4310-9f54-f7b509d5f571"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "sans-serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "633953a9-c61b-44cc-9dee-aebece97ccbc"
+  },
+  {
+    "name": {
+      "property": "body-serif-emphasized-font-style",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "c817210d-2b1a-4648-bff3-33fa212491f1"
+  },
+  {
+    "name": {
+      "property": "body-serif-emphasized-font-weight",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "be2a8ff3-6117-4235-bcb8-72257b75d622"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "serif-font-family",
+    "uuid": "20df8bd4-5a61-4614-aa86-5b76c5976860"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "d317d387-9bc8-4258-a79a-a0dd4e22d952"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "f049ba7a-c52f-4d39-b38e-911b2b91d031"
+  },
+  {
+    "name": {
+      "property": "body-serif-strong-emphasized-font-style",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "b940bdc8-d373-4bd0-8620-d6c04134698b"
+  },
+  {
+    "name": {
+      "property": "body-serif-strong-emphasized-font-weight",
+      "component": "body"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "a87b77ff-5b27-47e0-a7df-f15092fb783e"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "c8b531d1-949e-4492-9897-450a477983ce"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "be263571-bd6b-4383-bdf9-3cdf80248b6a"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "884b74cb-d247-491d-acb9-d3dc84bfd9a6"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "4f7f6878-5304-48d3-8a42-5bb452c2163b"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "3927604f-eaf3-4605-aa34-80b7bc88ac0f"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "25e93322-8f0b-45f8-ae9a-18668251f064"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-xxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-500",
+    "uuid": "4d0d4ed9-af14-4d88-98f1-9237f65e192a"
+  },
+  {
+    "name": {
+      "property": "body-size-xxs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-50",
+    "uuid": "3aa79ac7-9e78-4413-b500-b8d1937705cb"
+  },
+  {
+    "name": {
+      "component": "body",
+      "property": "size-xxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-600",
+    "uuid": "e0b8ceea-3404-4c4b-9145-fe5d445020fe"
+  },
+  {
+    "name": {
+      "property": "bold-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "value": "bold",
+    "uuid": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8"
+  },
+  {
+    "name": {
+      "property": "cjk-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
+    "value": "Adobe Clean Han",
+    "uuid": "034892ba-eff6-4193-b4c5-61d20c8f22eb"
+  },
+  {
+    "name": {
+      "property": "cjk-letter-spacing"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "letter-spacing",
+    "uuid": "12e27721-35f5-4d03-95f3-3fc9e1cf50e4"
+  },
+  {
+    "name": {
+      "property": "cjk-line-height-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1.5,
+    "uuid": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4"
+  },
+  {
+    "name": {
+      "property": "cjk-line-height-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1.7,
+    "uuid": "c5a5d186-54b3-44a0-b1c6-e9b102871015"
+  },
+  {
+    "name": {
+      "property": "code-cjk-emphasized-font-style",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "f892e676-5218-4dc9-870b-c9d2df6f3152"
+  },
+  {
+    "name": {
+      "property": "code-cjk-emphasized-font-weight",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "61f8b443-95fa-46fd-8876-b4d7a2244af9"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "code-font-family",
+    "uuid": "322cb744-5837-4d0a-94a8-3c885d54568d"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "b26477bc-8bf1-41aa-b849-cfde54e27780"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "8455f34c-0c79-4699-aa7c-c77d28bfa617"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-line-height-200",
+    "uuid": "35580910-cb91-44df-9613-7b2e40a75a7c"
+  },
+  {
+    "name": {
+      "property": "code-cjk-strong-emphasized-font-style",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "38006d42-4f02-46ff-917f-6c0163525642"
+  },
+  {
+    "name": {
+      "property": "code-cjk-strong-emphasized-font-weight",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "8ed5c5e0-ff72-4937-98fd-fd09f1fab288"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "a30c9a18-1a49-4b16-87a0-e882c81dd1bd"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "cjk-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "ed73f5fc-5b7a-4414-8f1c-325e7944a9e1"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-800",
+    "uuid": "851aebc5-5aa2-42ae-9032-59a5c9e8db5f"
+  },
+  {
+    "name": {
+      "property": "code-emphasized-font-style",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "9d3151ad-4a37-4eeb-aadd-7389ccb09345"
+  },
+  {
+    "name": {
+      "property": "code-emphasized-font-weight",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "948436ba-23d7-4eec-a3fe-ef5829ccadb0"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
+    "value": "Source Code Pro",
+    "uuid": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "b98a9c39-7d39-4b6d-ad35-46c8b1725c0c"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "bf02dd59-4b3c-435a-b33b-49fff22674a3"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "line-height-200",
+    "uuid": "0d33b30d-96d6-4b5a-90d2-2a708bdae623"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "b7010f1a-c994-4b19-b273-3f609fe4be2b"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "efa9311b-27c5-45ea-93a7-bef6f9370179"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "7879adbc-6c38-4d29-9a90-a4ad91c75b90"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7"
+  },
+  {
+    "name": {
+      "property": "code-strong-emphasized-font-style",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "83d53fe1-372f-46ba-b8e0-f90ca2e59647"
+  },
+  {
+    "name": {
+      "property": "code-strong-emphasized-font-weight",
+      "component": "code"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "4d5f1937-552d-44a4-be8e-2edafefa46aa"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "dac3d8d5-3005-4fa6-b71a-6679470176cf"
+  },
+  {
+    "name": {
+      "component": "code",
+      "property": "strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "48d2b9b8-beac-4185-827d-0c552e47663f"
+  },
+  {
+    "name": {
+      "property": "component-l-bold"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-200}",
+      "fontWeight": "{bold-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-200}"
+    },
+    "uuid": "861ac736-b95b-4350-b40b-0dde0036c796"
+  },
+  {
+    "name": {
+      "property": "component-l-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-200}",
+      "fontWeight": "{medium-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-200}"
+    },
+    "uuid": "aa7cd308-279c-4c0f-ab5e-5053341c963b"
+  },
+  {
+    "name": {
+      "property": "component-l-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-200}",
+      "fontWeight": "{regular-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-200}"
+    },
+    "uuid": "5a58a097-2235-4302-a6ed-6c1fa854c523"
+  },
+  {
+    "name": {
+      "property": "component-m-bold"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-100}",
+      "fontWeight": "{bold-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-100}"
+    },
+    "uuid": "48422ecb-3993-4a96-b785-7661b9f662d2"
+  },
+  {
+    "name": {
+      "property": "component-m-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-100}",
+      "fontWeight": "{medium-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-100}"
+    },
+    "uuid": "633b828a-8623-4905-9dda-5a7b989768d7"
+  },
+  {
+    "name": {
+      "property": "component-m-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-100}",
+      "fontWeight": "{regular-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-100}"
+    },
+    "uuid": "567a8eff-028f-4de1-b58a-a0473775219f"
+  },
+  {
+    "name": {
+      "property": "component-s-bold"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-75}",
+      "fontWeight": "{bold-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-75}"
+    },
+    "uuid": "6510c875-e551-43f2-9e84-111cfccafce8"
+  },
+  {
+    "name": {
+      "property": "component-s-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-75}",
+      "fontWeight": "{medium-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-75}"
+    },
+    "uuid": "afa00f39-1fe1-4026-8693-189e6d051eb3"
+  },
+  {
+    "name": {
+      "property": "component-s-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-75}",
+      "fontWeight": "{regular-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-75}"
+    },
+    "uuid": "cde5212c-520d-4657-8184-f07739ffed07"
+  },
+  {
+    "name": {
+      "property": "component-xl-bold"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-300}",
+      "fontWeight": "{bold-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-300}"
+    },
+    "uuid": "1e7e87a6-cf8f-4827-ba46-ca6a9152a6d7"
+  },
+  {
+    "name": {
+      "property": "component-xl-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-300}",
+      "fontWeight": "{medium-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-300}"
+    },
+    "uuid": "657ca53c-178e-4526-9c37-e023499f3659"
+  },
+  {
+    "name": {
+      "property": "component-xl-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-300}",
+      "fontWeight": "{regular-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-300}"
+    },
+    "uuid": "5096f188-f728-4db4-8cd9-cc23b08956e1"
+  },
+  {
+    "name": {
+      "property": "component-xs-bold"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-50}",
+      "fontWeight": "{bold-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-50}"
+    },
+    "uuid": "dc560f13-3f9d-47ed-9adf-646c24fd5a0a"
+  },
+  {
+    "name": {
+      "property": "component-xs-medium"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-50}",
+      "fontWeight": "{medium-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-50}"
+    },
+    "uuid": "8bf6d008-d3d8-446d-afe8-62613b1c53a2"
+  },
+  {
+    "name": {
+      "property": "component-xs-regular"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
+    "value": {
+      "fontFamily": "{sans-serif-font-family}",
+      "fontSize": "{font-size-50}",
+      "fontWeight": "{regular-font-weight}",
+      "letterSpacing": "{letter-spacing}",
+      "lineHeight": "{line-height-font-size-50}"
+    },
+    "uuid": "5dca28f2-77f5-4b29-85f3-0075bf2cbe7f"
+  },
+  {
+    "name": {
+      "property": "default-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "sans-serif-font-family",
+    "uuid": "45d43d4e-a4e4-4c5f-94ec-644a81300eb0"
+  },
+  {
+    "name": {
+      "property": "default-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-style.json",
+    "value": "normal",
+    "uuid": "25668698-bf78-46f4-bc6c-8fea068ddb34"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "3dca0579-91c4-4f60-a2a6-25f16eb673b3"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "aa70fa2d-87ee-4e67-b230-85f400ddd7d1"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-font-family",
+    "uuid": "6cc647ab-1474-4094-974d-d079d7ef7565"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "4d2a9b37-101b-4025-95d6-aba18b701a58"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "9b11f80a-7600-4a6b-a366-218ba320a5cc"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-light-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "c7b1b312-cd81-4c65-8a67-017f91aee40b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-light-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "279d9a16-279f-4788-b5b0-af825a4b5d40",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-light-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "4cc06d86-326e-4b6f-a751-99445bb1d131",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "light-font-weight",
+    "uuid": "3b531775-a1fd-4a40-b169-7c42b8c6de38",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-light-strong-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "1d4235ff-c183-4d6c-8277-9783e3e1ce7a",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-light-strong-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "0bc51146-a3e5-48c4-8324-4490b9d30f4d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-light-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "ec87fefe-f35f-41a0-9be1-6d076f0db230",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-light-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "91231878-73dc-46ce-a277-1d14e0e36842",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-line-height-100",
+    "uuid": "93434006-5ed7-4656-96b7-8f355a1f07b2"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "92399d83-aa71-4207-b533-4fe69e6271e2"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "236c73fb-d3bc-4390-8682-dd06fbd92d23"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-50",
+    "uuid": "8eb0f29f-71a1-4aa5-a3ed-98a373baf620"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "533265d4-7304-4688-b2fb-379a086b20bf"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-25",
+    "uuid": "e6d8e8ae-d9a3-42fb-b4c7-f2e893b926f1"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-strong-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "75a3a4ec-2b57-4a49-b3bd-84b41a3cd314"
+  },
+  {
+    "name": {
+      "property": "detail-cjk-strong-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "a7007c07-15a4-4671-bd3b-7406f4b374bb"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "653358fc-5ee4-4e97-affc-c56896d370c0"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "cjk-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "ef2997f3-276c-4662-8644-9514590114f4"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-600",
+    "uuid": "5f6b9d7a-2433-44fa-8de5-1fb40137e334"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "letter-spacing"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0.06em",
+    "uuid": "c4dbe044-dc8c-4722-b36c-5442cd2bc279",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "line-height-100",
+    "uuid": "4ca9965a-24f9-454e-b0a7-dd5a0c5ae170"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "margin-bottom-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.25,
+    "uuid": "35ac24a4-0338-44c6-b780-120a0af0fc51"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "margin-top-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.88888889,
+    "uuid": "5d34c3b5-fddd-420b-bfe4-0dee4e07701c"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "5c7dcef1-514e-4d43-b2ef-76639e214b8c"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "6ca600be-010a-4aaa-a815-e5bfdbe36b21"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "sans-serif-font-family",
+    "uuid": "34101c26-b4cd-43aa-bddd-0758d21fef01"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "21a9500c-f9a4-4ff3-9eb5-6da81bf314f6"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "medium-font-weight",
+    "uuid": "d06a4346-ec24-4922-8985-4b8a05e0bfc6"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-light-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "fc6098a2-3263-433c-8378-ba609629ef53",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-light-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "64972012-5050-41d0-9c9b-269b533a58b7",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-light-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "a6b7c26e-3ff5-4241-b9cc-3026604fe30e",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "cf8f93e2-2b79-4a4c-bb31-313e013148e3",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-light-strong-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "b7364639-2686-4e12-9ede-d6543d0d0d6d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-light-strong-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "53f16a1c-9d44-4384-9a7e-88a2c4319486",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-light-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "c1966f09-1c6e-4fe0-89ad-8fb8e847e3ba",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-light-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "4f0f95d3-098a-4852-bd21-785f5bf054b5",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-strong-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "82d04795-da5f-4868-a90d-980f5376a878"
+  },
+  {
+    "name": {
+      "property": "detail-sans-serif-strong-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "c57f8682-52d2-43fa-a306-a588a13ead6b"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "c56642f3-043c-4738-bed0-61b324221f4e"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "a150e66c-daf4-4c71-a2e2-577600878988"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "sans-serif-text-transform"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/text-transform.json",
+    "value": "uppercase",
+    "uuid": "8646d403-21f9-4e77-8a21-92289c303715",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-serif-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "cfaf6a70-3eb5-4887-bae6-8ae41c094192"
+  },
+  {
+    "name": {
+      "property": "detail-serif-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "medium-font-weight",
+    "uuid": "247b2004-e0bc-42b9-ba83-6edbe417c4cb"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "serif-font-family",
+    "uuid": "365c6166-e17d-40bd-841e-495aa9c6acd7"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "524c5101-f745-47e6-b233-62cd005850f8"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "medium-font-weight",
+    "uuid": "87ef8843-f44e-4526-80cd-9635f3e0261e"
+  },
+  {
+    "name": {
+      "property": "detail-serif-light-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "320bcd8e-2bb8-4e9e-9b1d-4838b2966857",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-serif-light-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "3d27f76e-b068-4f06-bea8-ee31fcbc49b2",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-light-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "f6478d1d-5dcf-43eb-a4fc-498479b29aa7",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "2a15a805-fd08-4f8e-82e6-9264ef8937cb",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-serif-light-strong-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "42d2049f-cda2-4ae4-8d0a-41f7789f768b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-serif-light-strong-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "1c524d85-9fca-433c-b5c4-5eaa456cc3a2",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-light-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "7a878a3f-b663-41ee-8357-6e62f2e51d80",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-light-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "fc5df058-f678-4dc8-953f-e2738798ee2b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "detail-serif-strong-emphasized-font-style",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "7fdffa4e-4370-45cf-aab0-316561a56a24"
+  },
+  {
+    "name": {
+      "property": "detail-serif-strong-emphasized-font-weight",
+      "component": "detail"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "863cf841-7b83-4f66-a01f-12dccd47fee6"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "3b2124e3-e50b-4ab7-8340-f97b1f8fef1e"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "d737931b-f63c-4874-8fa5-872b95048727"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "serif-text-transform"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/text-transform.json",
+    "value": "uppercase",
+    "uuid": "0e161c32-c412-4cda-bacb-7eaa548b5534",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "613da587-5c48-4efa-abb5-36378c1e81f0"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "07840554-1ec1-4823-b119-474ec9cc31f0"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-75",
+    "uuid": "585e1bec-ee93-4983-b0bb-3a1f6ec28218"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "ab476eec-b592-4890-af8f-74de808cb87f"
+  },
+  {
+    "name": {
+      "component": "detail",
+      "property": "size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-50",
+    "uuid": "b33a59b4-1ec2-4f09-8cb3-9bfd09d7c695"
+  },
+  {
+    "name": {
+      "property": "extra-bold-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "value": "extra-bold",
+    "uuid": "ccadf44e-5424-4920-979f-ea1ef39687c4"
+  },
+  {
+    "name": {
+      "property": "font-size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "14px",
+    "uuid": "938e2d24-1e90-48f0-a596-595a69103707",
+    "set_uuid": "ee894aad-f166-42eb-b08b-859f73db742a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "17px",
+    "uuid": "2f9ee3cf-ccb1-4f0b-aed6-96e472fb7411",
+    "set_uuid": "ee894aad-f166-42eb-b08b-859f73db742a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1000",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "40px",
+    "uuid": "27f694f9-6770-49e0-b7fc-833618b3fc2f",
+    "set_uuid": "200d964e-b6f4-4011-a40d-33b1bfb7aa68",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1000",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "49px",
+    "uuid": "8b158ab0-7e82-4dab-a4d9-84cf7a71fa0a",
+    "set_uuid": "200d964e-b6f4-4011-a40d-33b1bfb7aa68",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "45px",
+    "uuid": "00dc3fcd-383f-4bc6-8940-e0884f0ffb7e",
+    "set_uuid": "202a2c3e-5bfc-4871-9481-13c771bdc8dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "55px",
+    "uuid": "5eb96c78-c8f6-4e31-9bc8-fa62794ac4db",
+    "set_uuid": "202a2c3e-5bfc-4871-9481-13c771bdc8dc",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "51px",
+    "uuid": "b73bfb12-80ef-453f-b7dc-52bf2258ef47",
+    "set_uuid": "dbd67b04-f114-4549-8e36-223b7d7007c7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "62px",
+    "uuid": "0ab38fb2-0de9-4be0-8967-8241379706be",
+    "set_uuid": "dbd67b04-f114-4549-8e36-223b7d7007c7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "58px",
+    "uuid": "e8853e10-cc03-47c1-9b66-11755ff513a5",
+    "set_uuid": "760d6969-7e0e-4744-b1c6-d89d3a02af8d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "70px",
+    "uuid": "bd880141-81f6-47fe-a421-01124fe66b67",
+    "set_uuid": "760d6969-7e0e-4744-b1c6-d89d3a02af8d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "65px",
+    "uuid": "5af5e5bd-fc76-4688-aae9-6e7528d41341",
+    "set_uuid": "21c1f04f-3a63-4bf8-9f60-e9afa0e672a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "79px",
+    "uuid": "999b22ec-e19e-4fee-a1db-3cb89c58a51c",
+    "set_uuid": "21c1f04f-3a63-4bf8-9f60-e9afa0e672a2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "73px",
+    "uuid": "509b3100-9034-4b23-adb0-8c56dbd72a48",
+    "set_uuid": "d59c0cd1-efb8-4f5b-9d5a-7ecbcd79f758",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-1500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "88px",
+    "uuid": "94741f6e-8c95-4329-8e06-d6f261e5b0eb",
+    "set_uuid": "d59c0cd1-efb8-4f5b-9d5a-7ecbcd79f758",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "16px",
+    "uuid": "b36caaa3-7047-4dfb-8a84-f990a8ac3a91",
+    "set_uuid": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "19px",
+    "uuid": "7e51ff4e-2749-49d1-b9ed-75de92a73991",
+    "set_uuid": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-25",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "10px",
+    "uuid": "26ab49ea-7e86-4f0d-812e-ef1ba794c8a8",
+    "set_uuid": "73ef03ac-5b7b-4182-8991-0bb62006d276",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-25",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "12px",
+    "uuid": "5946a4e5-8bed-4dd7-aa73-9ebe232f9790",
+    "set_uuid": "73ef03ac-5b7b-4182-8991-0bb62006d276",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "18px",
+    "uuid": "3dc9b6a4-77e3-484b-be8c-fbc2f50e6175",
+    "set_uuid": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "22px",
+    "uuid": "9b9a7175-dcca-43aa-98ce-f1c3e4eefda7",
+    "set_uuid": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "20px",
+    "uuid": "292a28d6-2e15-46e2-80cd-5171d977e9b5",
+    "set_uuid": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "24px",
+    "uuid": "d5ed0e8d-01ac-495f-bd15-fecc30af17c4",
+    "set_uuid": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "11px",
+    "uuid": "8593a326-de37-414d-b3f6-5254b41dce07",
+    "set_uuid": "c6074b73-d460-439d-9401-498f52c88340",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "13px",
+    "uuid": "b7561ce1-e12e-4aed-9766-181f7eca309e",
+    "set_uuid": "c6074b73-d460-439d-9401-498f52c88340",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "22px",
+    "uuid": "9be56e29-2e79-41e0-b5a9-6a2dabc70aa1",
+    "set_uuid": "935af8c5-6f70-49ee-b5ba-5e9650682753",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "27px",
+    "uuid": "a69a5079-1b5b-4ccf-946f-8b6e3fae4d7e",
+    "set_uuid": "935af8c5-6f70-49ee-b5ba-5e9650682753",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "25px",
+    "uuid": "db1d7d01-8dd4-4c27-b58c-686f030e5e46",
+    "set_uuid": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "31px",
+    "uuid": "ac892307-2559-48f5-9e2c-98dabbb0abc2",
+    "set_uuid": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-700",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "28px",
+    "uuid": "77da1638-cb39-4c80-8c13-db77b9aa528e",
+    "set_uuid": "c9a3ec61-f116-4298-be2d-6149d6eae889",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-700",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "34px",
+    "uuid": "6bd6456c-b73b-4926-8e67-7b942e32bbc2",
+    "set_uuid": "c9a3ec61-f116-4298-be2d-6149d6eae889",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "12px",
+    "uuid": "55d90327-8cc9-4d4f-891f-9d42751d989a",
+    "set_uuid": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "15px",
+    "uuid": "07e1c2a8-3925-4d71-8fae-3486483ff44c",
+    "set_uuid": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-800",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "32px",
+    "uuid": "8425654d-7f46-4b6d-8997-5ae6b6980e06",
+    "set_uuid": "d46d987e-44dd-4113-81b3-1b28c0f5cfe6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-800",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "39px",
+    "uuid": "bdfae93d-ae49-456b-af54-8620ea976ca8",
+    "set_uuid": "d46d987e-44dd-4113-81b3-1b28c0f5cfe6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-900",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "36px",
+    "uuid": "df2d6c8d-dc03-4581-96c6-d6a92a270b77",
+    "set_uuid": "cf1791b4-dcc2-4620-a508-d95bbd44504b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "font-size-900",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
+    "value": "44px",
+    "uuid": "5296e771-6d04-4e9a-b1fe-ab22d4dfd92b",
+    "set_uuid": "cf1791b4-dcc2-4620-a508-d95bbd44504b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "05c74b28-3051-498c-874a-5dc523bc27e5"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "d854afd2-290a-40ae-a627-c4cdabeb546a"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-font-family",
+    "uuid": "b6652ee5-466f-4117-a77c-a93a40f2a791"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "c93b39df-82e9-4e87-920f-1747e5d48e8e"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "bd54516c-2fda-4421-ab62-720c3a887a34"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-heavy-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "aef21944-3dac-4b2d-ba7b-0a4df3f406bb"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-heavy-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "9315971c-6e83-42c8-9c24-d1bc6fa5e106"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-heavy-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "b2f50ba2-e694-47ba-b81a-ea8fc813247e"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-heavy-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "73c20d2f-1227-46bc-8548-102358405b0b"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-heavy-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "619a15ba-f74e-4ff4-a604-312b810f1a50"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-heavy-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "a0f680fa-2453-4bcc-b06c-9ff82de50c0c"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-heavy-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "26817f91-2742-4170-aa01-1e1e67ef01e8"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-heavy-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "b7d2203c-c651-493e-80c2-b71b7c7c2692"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-light-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "dac03eec-6910-4176-bfca-33f8a57cf3d7",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-light-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "aea9787b-ee0b-40cc-9089-5973e52b18bd",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-light-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "b5704c75-2914-4268-9023-7f7452e826c1",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "light-font-weight",
+    "uuid": "9da0ba4c-b4e3-4052-8b2e-d2fde714bb9d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-light-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "9136e25e-563b-4485-bad7-41809d5317de",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-light-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "83cc347c-7a1a-4665-9de4-cf19903f1043",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-light-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "be854057-43b1-40ce-bdc7-69960cd7638c",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-light-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "5ca91bc2-215b-4cbb-b966-80bfffd569ad",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "cjk-line-height-100",
+    "uuid": "3e038db9-c5f7-4b8b-b1af-31075a31e0cc"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-600",
+    "uuid": "f57ffe02-2e41-46f3-a0ac-1feb63bdd748"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "43f45659-314b-45aa-9886-1beb096fc4ce"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "c1242a8c-ca10-40d0-8fc4-67bbbce8fc5f"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-800",
+    "uuid": "43535e5f-607e-43f4-bd37-8230b1f7993f"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-200",
+    "uuid": "132688a7-917d-44b9-a34f-a7135599b299"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-xxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-1000",
+    "uuid": "fbf59302-1ad2-4327-bfde-d638a0ca2429"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-xxs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "bddd6a96-c280-47ca-8858-20df055e488d",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-size-xxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-1200",
+    "uuid": "5a44e177-2478-4bb0-9212-ba2df64c8b00"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-size-xxxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-1400",
+    "uuid": "3b954e15-341a-40f4-a47e-9abd2813fec4"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "22934d4d-4952-40a7-a5e5-256a7a3c9371"
+  },
+  {
+    "name": {
+      "property": "heading-cjk-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "0080a817-b26f-42f1-84c4-5ed1ac08c12c"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "4f061165-0e86-46b9-83c3-c95eeb8ff956"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "cjk-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "eaf179aa-4514-4206-b3e2-a99b7d4d2029"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "color"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "gray-900",
+    "uuid": "60300cd2-9b30-4ee3-b7a1-b8dae00270d9"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "line-height"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "line-height-100",
+    "uuid": "64f28fe4-20f7-48cb-baeb-ff1898573727"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "margin-bottom-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.25,
+    "uuid": "dd2035b4-506f-41ab-a656-de3668d44e0f"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "margin-top-multiplier"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 0.88888889,
+    "uuid": "008fa04b-6d74-416b-a6ae-ceec90f08642"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "2f17833a-28a4-4152-8999-12b077557797"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-emphasized-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "e4a183fd-53c5-4dbb-afd1-6308e2e74f80"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "sans-serif-font-family",
+    "uuid": "234d7b9d-bddc-4988-8be5-ef5e41e08185"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "561d905e-7f44-43da-b2b4-26e12551ef6d"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "extra-bold-font-weight",
+    "uuid": "1d4d09b4-021a-48e8-a724-bfecc13df325"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-heavy-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "924c338f-7141-490a-a842-ad632c26160c"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-heavy-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "a7cb3274-e48e-435b-a066-32027ac19e84"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-heavy-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "0c4cdd06-8180-40b1-9b1f-d7d973a7b772"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-heavy-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "ef13b8f0-f686-492d-990f-691ec91ebb96"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-heavy-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "c20ea22a-c34d-4c7c-a816-75b533e28c92"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-heavy-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "8779e773-7b37-4eb0-ae7a-2ba0104ad9d5"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-heavy-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "86775b10-5682-49fb-9d38-6bdb857da801"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-heavy-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "2104c3c2-d834-436a-a26d-508056f1013d"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-light-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "5f88eb81-7052-4c21-9896-f14cb09f0e70",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-light-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "light-font-weight",
+    "uuid": "e882ea46-8f0a-4313-84f5-85bb8d9f1f5e",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-light-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "c5551fd5-4ee2-4c93-b91f-9ed295fa63a4",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "light-font-weight",
+    "uuid": "ff84a748-5923-451d-967c-a346d2dee46c",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-light-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "bc5d65e0-e13a-424c-a260-9268a0dee66c",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-light-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "c297a503-fc3c-4939-8c5a-6611b9b04719",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-light-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "67271ca0-c9fd-4047-a615-6314d7333f7a",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-light-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "75437f9a-7ee8-4194-b4b3-0746be097396",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "f692d35f-1b11-43d1-ad29-967436b90928"
+  },
+  {
+    "name": {
+      "property": "heading-sans-serif-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "9d834e30-53c1-4cea-9e17-2326038cb6cb"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "2117cb6e-67f7-4509-b4fb-e9e442b6dc0e"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "sans-serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "79275989-91ed-408a-b884-a31d9f8bac26"
+  },
+  {
+    "name": {
+      "property": "heading-serif-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "fe694554-832d-457d-a320-f02629f9c441"
+  },
+  {
+    "name": {
+      "property": "heading-serif-emphasized-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "a0983216-b0c5-4a3f-97dc-96ee711acb1f"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "serif-font-family",
+    "uuid": "f2430818-41b5-439a-8347-6b384e78d141"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "938f3684-44c6-4ae2-935a-b88921fcd7fe"
+  },
+  {
+    "name": {
+      "property": "heading-serif-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "350aa193-9996-49c8-b5e4-54d4f7bef3c2"
+  },
+  {
+    "name": {
+      "property": "heading-serif-heavy-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "a18ac621-eade-4224-9660-3e9a080219ec"
+  },
+  {
+    "name": {
+      "property": "heading-serif-heavy-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "82e9d579-8918-4114-bafa-3a9757556f84"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-heavy-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "14532cb8-6c88-46ce-886b-96fac971e7b9"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-heavy-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "6b74c5ea-6bf4-46bb-bee1-3841606f1500"
+  },
+  {
+    "name": {
+      "property": "heading-serif-heavy-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "adf303e8-1e27-4aec-9bbc-5abe166358ec"
+  },
+  {
+    "name": {
+      "property": "heading-serif-heavy-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "2d8e76cd-f123-488d-893d-54a9f48f679e"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-heavy-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "b2875bbe-b5cb-452f-b7d6-3dcb4fc59921"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-heavy-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "af0010c7-5134-4fe4-bee1-bbb7dd31de3a"
+  },
+  {
+    "name": {
+      "property": "heading-serif-light-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "7bd831cd-3fe0-402b-a105-f65b8e8023e2",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-serif-light-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "b5f79fde-07f7-4c07-897e-0bfdf27e2839",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-light-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "5f30418a-aa76-434e-bca9-902d5be0d929",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "regular-font-weight",
+    "uuid": "66958795-6459-4750-8c68-dc39ab383837",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-serif-light-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "71c8e302-6bc1-4f45-b804-c847dd153d1b",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-serif-light-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "98c61df3-057d-4345-881e-0c04628757f3",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-light-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "73906871-24e5-48cc-9140-ec700c08d144",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-light-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "bold-font-weight",
+    "uuid": "29ad1c96-62e4-4143-88e8-fc8e08913a52",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "property": "heading-serif-strong-emphasized-font-style",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "italic-font-style",
+    "uuid": "da6e1593-9d2a-4fd8-8877-d30d6e1d1c07"
+  },
+  {
+    "name": {
+      "property": "heading-serif-strong-emphasized-font-weight",
+      "component": "heading"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "cd32f2b7-3e9f-47ae-ad34-2c7783dd5b2f"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-strong-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "default-font-style",
+    "uuid": "2e0ef484-406a-4902-995d-9a3d5177ec12"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "serif-strong-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "black-font-weight",
+    "uuid": "6df0fb95-4aa0-4c67-896d-fa6aa3d34e95"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-l"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-700",
+    "uuid": "336e434c-9026-4bb3-96b1-5bb44376b868"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-m"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-500",
+    "uuid": "4cdcefe1-2006-4560-839f-5bdef6db8c1a"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-s"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-400",
+    "uuid": "96673fee-b75c-4867-9041-48362af044bc"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-xl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-900",
+    "uuid": "94bb5ad9-503a-428a-a8ba-6cf3f70592ac"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-xs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-300",
+    "uuid": "4f179af6-c31f-48f8-927c-a45150668ad3"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-xxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-1100",
+    "uuid": "464e34cd-e768-4a38-a72b-cae1a4852ef3"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-xxs"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-100",
+    "uuid": "82a831b4-b624-475b-b2be-4eb949e48626",
+    "deprecated": "unknown"
+  },
+  {
+    "name": {
+      "component": "heading",
+      "property": "size-xxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-1300",
+    "uuid": "db884bf9-e7b5-420a-b408-bd9a4d6bb0a4"
+  },
+  {
+    "name": {
+      "property": "heading-size-xxxxl"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "$ref": "font-size-1500",
+    "uuid": "517d86cc-2e66-4cdc-8841-cb32db9e56f4"
+  },
+  {
+    "name": {
+      "property": "italic-font-style"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-style.json",
+    "value": "italic",
+    "uuid": "9a58e4ae-dfa1-428b-9d90-11f4275418da"
+  },
+  {
+    "name": {
+      "property": "letter-spacing"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "0em",
+    "uuid": "d8caf3aa-1261-411f-b383-18f87334c117"
+  },
+  {
+    "name": {
+      "property": "light-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "value": "light",
+    "uuid": "fd477873-3767-4883-ab3f-5ee2758b923b"
+  },
+  {
+    "name": {
+      "property": "line-height-100"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1.3,
+    "uuid": "dd125d1d-cf4d-45c8-ab21-52331a9a264b"
+  },
+  {
+    "name": {
+      "property": "line-height-200"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "value": 1.5,
+    "uuid": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "18px",
+    "uuid": "0c323ed8-47c4-4fbb-bb66-a393a1e992cd",
+    "set_uuid": "65b87e13-5799-43e0-a8d3-7f8288ccc3f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "898fde6d-f477-46a6-8323-698dee558580",
+    "set_uuid": "65b87e13-5799-43e0-a8d3-7f8288ccc3f7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1000",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "46px",
+    "uuid": "8b37acbd-a978-4de3-aa1e-981afa09868c",
+    "set_uuid": "9c0a5092-0faa-4f70-bd5e-dfeda66ae286",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1000",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "56px",
+    "uuid": "48b573ce-0e43-4550-83db-1f44d06aafda",
+    "set_uuid": "9c0a5092-0faa-4f70-bd5e-dfeda66ae286",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1100",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "52px",
+    "uuid": "a8db4407-791a-4fca-9e2a-12f703089223",
+    "set_uuid": "55494016-ab3d-475c-99b3-6824e8df227a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1100",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "64px",
+    "uuid": "cd0d821b-015c-40be-9156-c2dab18b5977",
+    "set_uuid": "55494016-ab3d-475c-99b3-6824e8df227a",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "58px",
+    "uuid": "f3b61670-1a19-4c9f-aae7-cac247d24af6",
+    "set_uuid": "f94ee04e-f2d7-4cb3-8d5f-f35119766fc8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "72px",
+    "uuid": "10f70d36-8574-4476-bc0a-2b03b7db5448",
+    "set_uuid": "f94ee04e-f2d7-4cb3-8d5f-f35119766fc8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "66px",
+    "uuid": "9b7a0ea3-22e1-472e-af82-153eac1e077e",
+    "set_uuid": "6a5986cd-4bcb-4de2-a474-d5d0fad5187f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "80px",
+    "uuid": "533402b6-9b8b-4615-b9db-17ea35914369",
+    "set_uuid": "6a5986cd-4bcb-4de2-a474-d5d0fad5187f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "74px",
+    "uuid": "76fa374d-f759-4198-9fc0-e61d378c3258",
+    "set_uuid": "15edb168-9840-4fad-ab60-c1c3423ec855",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "90px",
+    "uuid": "1251799e-a10a-4625-b487-6b93839c6be8",
+    "set_uuid": "15edb168-9840-4fad-ab60-c1c3423ec855",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "84px",
+    "uuid": "c915185b-86ab-421b-8a58-e3965e9904dc",
+    "set_uuid": "330c5167-53ef-46cc-8a7c-3cb5b3ee0b2b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-1500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "102px",
+    "uuid": "185be0f6-8283-4068-80f1-68ee8dd06c25",
+    "set_uuid": "330c5167-53ef-46cc-8a7c-3cb5b3ee0b2b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-200",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "efb450f9-976a-47cb-a7cc-667b9fe967a9",
+    "set_uuid": "f8763297-f04f-4294-a7ba-376e3b12f1eb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-200",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "790dde8d-c117-4759-be93-2498297c6fa3",
+    "set_uuid": "f8763297-f04f-4294-a7ba-376e3b12f1eb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-25",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "d1853d46-038f-4fd1-a0b2-4434bbf95099",
+    "set_uuid": "1894b682-105c-409b-916a-d2e08de4f6a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-25",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "422ef89d-75dc-4110-b38d-45abf2b12f8d",
+    "set_uuid": "1894b682-105c-409b-916a-d2e08de4f6a8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-300",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "22px",
+    "uuid": "52e64384-f918-4415-8d02-da3af639890f",
+    "set_uuid": "228d27b4-ff57-4308-9761-3ad5cf7f39d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-300",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "80beb678-586c-4277-9db0-1ab373ec8f80",
+    "set_uuid": "228d27b4-ff57-4308-9761-3ad5cf7f39d1",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-400",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "03676924-ace1-418a-97a0-17ce62f4a832",
+    "set_uuid": "97f2ab52-9c62-43c3-b7b6-3eeb6c561e87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-400",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "28px",
+    "uuid": "92adf566-babe-43cf-aefa-e4d04364cdbe",
+    "set_uuid": "97f2ab52-9c62-43c3-b7b6-3eeb6c561e87",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-50",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "14px",
+    "uuid": "3696e3bf-2b72-4b08-9893-ac618f904771",
+    "set_uuid": "1553daaa-14c0-405e-bd80-e04a059b52e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-50",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "242bf245-e7f0-4826-bcec-e19c0ed5e93f",
+    "set_uuid": "1553daaa-14c0-405e-bd80-e04a059b52e2",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-500",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "26px",
+    "uuid": "cec9acbc-6b54-480f-91a2-067d947dd73e",
+    "set_uuid": "7f8c6173-2708-4196-b04d-2d5027fface8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-500",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "143a00de-eac6-4bb5-9b25-18011efa69f5",
+    "set_uuid": "7f8c6173-2708-4196-b04d-2d5027fface8",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-600",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "1cb847c8-4b6d-494f-b50f-98e46e82c9c0",
+    "set_uuid": "7d112d28-28c4-4bca-aef7-a7a0af1b7d1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-600",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "51dbd9c7-37e5-4968-a84b-9f8563030f89",
+    "set_uuid": "7d112d28-28c4-4bca-aef7-a7a0af1b7d1d",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-700",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "32px",
+    "uuid": "2629dfc5-f358-4bd0-a24b-e683b214efb4",
+    "set_uuid": "cbb416af-7b54-4024-b495-fa87fb9f742f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-700",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "40px",
+    "uuid": "3a43e8bf-6d36-4f4d-8b32-0c5b69d68cfd",
+    "set_uuid": "cbb416af-7b54-4024-b495-fa87fb9f742f",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-75",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "8e85a017-2c5d-4a52-92df-c0426e00c3c3",
+    "set_uuid": "6214acc2-2130-4b31-857f-0f865673a9ad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-75",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "25be5bf4-e450-4a58-89e2-a04e02b7b78b",
+    "set_uuid": "6214acc2-2130-4b31-857f-0f865673a9ad",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-800",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "36px",
+    "uuid": "3e6bd373-90f5-4164-80a0-6dcdfdc87beb",
+    "set_uuid": "8bd1d897-56c3-432f-a2c7-d6138e337de6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-800",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "44px",
+    "uuid": "05f9ed71-4b9e-4109-a8ec-bb09edfd6348",
+    "set_uuid": "8bd1d897-56c3-432f-a2c7-d6138e337de6",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-900",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "42px",
+    "uuid": "6f6a137d-f54e-45b4-a7a4-2586fa99bf3a",
+    "set_uuid": "4ff1f344-dad7-4b12-9c38-2d9561d433a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "line-height-font-size-900",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "50px",
+    "uuid": "c881e6cd-404b-48eb-a6f1-5dd84313de72",
+    "set_uuid": "4ff1f344-dad7-4b12-9c38-2d9561d433a7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
+  },
+  {
+    "name": {
+      "property": "medium-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "value": "medium",
+    "uuid": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4"
+  },
+  {
+    "name": {
+      "property": "regular-font-weight"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "value": "regular",
+    "uuid": "02a94ddf-1007-4c86-8863-905874e40f95"
+  },
+  {
+    "name": {
+      "property": "sans-serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
+    "value": "Adobe Clean Spectrum VF",
+    "uuid": "a552c422-c51c-458a-87b0-c6fe5178bf4b"
+  },
+  {
+    "name": {
+      "property": "serif-font-family"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
+    "value": "Adobe Clean Serif",
+    "uuid": "7f83198f-26ec-4156-9573-826dd7feb718"
+  },
+  {
+    "name": {
+      "property": "text-align-center"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
+    "value": "center",
+    "uuid": "df252e5a-f115-471d-bb35-c79e733d868b"
+  },
+  {
+    "name": {
+      "property": "text-align-end"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
+    "value": "end",
+    "uuid": "a0c425b3-668b-4413-8739-c7844b26ebad"
+  },
+  {
+    "name": {
+      "property": "text-align-start"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
+    "value": "start",
+    "uuid": "3a7f9e91-6e1a-4937-a6d2-6c39566dc875"
+  }
+]

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,5 +1,9 @@
 # Spectrum Tokens
 
+> **⚠ `src/` is generated.** Do not edit files in `packages/tokens/src/` directly —
+> they are regenerated from [`packages/design-data/tokens/`](../design-data/tokens) via
+> `moon run design-data:legacy-output`. Edit the cascade source instead.
+
 Design tokens are primarily name-value pairs used to store design decisions and distributed in a way platforms, implementations, and products can use across design tools and coding languages. These value types are represented as data, which include spacing, color, typography, object styles, animation, etc. These can represent anything defined by design: a color as an RGB value, an opacity as a number, and an animation ease function as Bezier coordinates. They're used in place of hard-coded values to ensure flexibility and unity across all product experiences.
 
 Design tokens are directly integrated into our component libraries, UI kits, and the Spectrum XD plugin. They cover the various options of platform scales, color themes, component states, and more. We also offer teams a variety of token types to use directly within their products if they are not using a Spectrum component library.

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,9 +1,5 @@
 # Spectrum Tokens
 
-> **⚠ `src/` is generated.** Do not edit files in `packages/tokens/src/` directly —
-> they are regenerated from [`packages/design-data/tokens/`](../design-data/tokens) via
-> `moon run design-data:legacy-output`. Edit the cascade source instead.
-
 Design tokens are primarily name-value pairs used to store design decisions and distributed in a way platforms, implementations, and products can use across design tools and coding languages. These value types are represented as data, which include spacing, color, typography, object styles, animation, etc. These can represent anything defined by design: a color as an RGB value, an opacity as a number, and an animation ease function as Bezier coordinates. They're used in place of hard-coded values to ensure flexibility and unity across all product experiences.
 
 Design tokens are directly integrated into our component libraries, UI kits, and the Spectrum XD plugin. They cover the various options of platform scales, color themes, component states, and more. We also offer teams a variety of token types to use directly within their products if they are not using a Spectrum component library.


### PR DESCRIPTION
## Description

Creates `packages/design-data/` — a new `@adobe/spectrum-design-data` package holding the full Spectrum token corpus in spec-compliant cascade format (`.tokens.json` arrays with structured name objects).

This is the follow-up to #1095 (the feasibility spike). `packages/tokens/src/` (legacy format) is now regenerated from this package rather than being edited directly.

## Package structure

```
packages/design-data/
├── package.json      (@adobe/spectrum-design-data v1.0.0)
├── moon.yml          (validate / legacy-output / generate tasks)
└── tokens/
    ├── color-aliases.tokens.json
    ├── color-component.tokens.json
    ├── color-palette.tokens.json
    ├── semantic-color-palette.tokens.json
    ├── typography.tokens.json
    ├── layout.tokens.json
    ├── layout-component.tokens.json
    └── icons.tokens.json
```

## Token corpus (4166 cascade tokens from 2460 legacy)

Name-object resolution quality:
```
  972  sidecar    (23%) — colorFamily, scaleIndex, variant etc.
 2965  decomposed (71%) — component + property + state
  229  thin        (6%) — full key as property (SPEC-017 tech debt backlog)
 ─────
 4166  total      (95% structured name objects)
```

## moon tasks

| Task | Purpose |
|---|---|
| `validate` | Validate cascade files against design-data-spec rules |
| `legacy-output` | Regenerate `packages/tokens/src/` from cascade source |
| `generate` | Re-sync cascade files from legacy (for upstream changes) |

## Roundtrip verification

`migrate roundtrip-verify packages/tokens/src` → **Roundtrip OK** — `legacy-output` from the cascade package produces an identical `packages/tokens/src/`.

## Motivation and Context

With #1095 landed, the converter can produce 95% structured name objects. This PR commits the output as a versioned package, establishing the workflow where:
1. Token authors edit `packages/design-data/tokens/*.tokens.json`
2. `moon run design-data:legacy-output` regenerates `packages/tokens/src/`
3. Downstream consumers (`@adobe/spectrum-tokens`) remain unchanged

The 229 thin tokens (6%) are tracked as SPEC-017 tech debt — their names can't yet be cleanly decomposed and use the string escape hatch as a temporary measure.

## Related Issue

Follows from #1095 (feasibility spike for cascade format conversion).

## How Has This Been Tested?

- `migrate roundtrip-verify packages/tokens/src` — **OK**
- `migrate legacy-output packages/design-data/tokens --output /tmp/verify` then `diff packages/tokens/src /tmp/verify` — 0 key/value differences (only pre-existing lifecycle normalization)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.