### PR TITLE
fix(design-data-agent-mcp): start server when launched via symlink

### DIFF
--- a/.changeset/symlink-safe-mcp-entry.md
+++ b/.changeset/symlink-safe-mcp-entry.md
@@ -1,0 +1,10 @@
+---
+"@adobe/design-data-agent-mcp": patch
+---
+
+Fix the MCP server failing to start when launched via npx or a node_modules/.bin shim.
+
+- **src/index.js**: the entry-point guard compared `process.argv[1]` to the
+  module URL directly, which never matched when invoked through a symlink (npx,
+  pnpm `.bin`). The server exited 0 without starting, surfacing to clients as
+  `Failed to reconnect: -32000`. The check now compares resolved real paths.

--- a/tools/design-data-agent-mcp/src/index.js
+++ b/tools/design-data-agent-mcp/src/index.js
@@ -9,7 +9,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { readFileSync } from "fs";
+import { readFileSync, realpathSync } from "fs";
 import { fileURLToPath } from "url";
 import { resolve, dirname } from "path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -89,7 +89,21 @@ async function startServer() {
   console.error("design-data-agent-mcp started");
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+// Resolve real paths so the entry-point check still matches when this module is
+// launched through a symlink (e.g. node_modules/.bin shim created by npx/pnpm).
+function isMainModule() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const here = fileURLToPath(import.meta.url);
+  if (entry === here) return true;
+  try {
+    return realpathSync(entry) === realpathSync(here);
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
   startServer().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/tools/design-data-agent-mcp/test/index.test.js
+++ b/tools/design-data-agent-mcp/test/index.test.js
@@ -9,7 +9,45 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
+import { spawn } from "child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
 import { createMCPServer, createAllTools } from "../src/index.js";
+
+const entryPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../src/index.js",
+);
+
+// Spawn the given entry script and resolve once it logs the startup marker to
+// stderr (or reject after a timeout). The server then waits on stdin, so we
+// kill it as soon as the marker appears.
+function startupStderr(scriptPath) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`timed out; stderr so far: ${stderr}`));
+    }, 10000);
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.includes("design-data-agent-mcp started")) {
+        clearTimeout(timer);
+        child.kill();
+        resolvePromise(stderr);
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
 
 test("server initializes", (t) => {
   const server = createMCPServer();
@@ -19,4 +57,21 @@ test("server initializes", (t) => {
 test("server exposes 15 tools", (t) => {
   const tools = createAllTools();
   t.is(tools.length, 15);
+});
+
+test("starts when launched via the real file path", async (t) => {
+  const stderr = await startupStderr(entryPath);
+  t.true(stderr.includes("design-data-agent-mcp started"));
+});
+
+test("starts when launched via a symlink (npx/.bin shim)", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "dd-mcp-symlink-"));
+  const link = join(dir, "index.js");
+  try {
+    symlinkSync(entryPath, link);
+    const stderr = await startupStderr(link);
+    t.true(stderr.includes("design-data-agent-mcp started"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Description

Fixes the `@adobe/design-data-agent-mcp` server failing to start when launched via `npx` or any `node_modules/.bin` shim.

The entry-point guard in `src/index.js` compared `process.argv[1]` directly to the module's resolved file URL:

```js
if (process.argv[1] === fileURLToPath(import.meta.url)) { startServer()... }
```

When the bin is invoked through a symlink (which is how `npx` and pnpm launch it), `process.argv[1]` is the symlink path while `import.meta.url` resolves to the real `src/index.js`. The two never match, so `startServer()` is skipped, the process exits `0` with no output, and MCP clients report `Failed to reconnect: -32000`.

The fix introduces an `isMainModule()` helper that falls back to comparing `realpathSync()` of both paths, so the guard holds whether the module is launched directly or via a symlink.

## Related Issue

N/A — discovered while diagnosing a local MCP connection failure (`Failed to reconnect to design-data: -32000`).

## Motivation and Context

The published package (v1.3.0) is effectively unusable as an MCP server via the documented `npx -y @adobe/design-data-agent-mcp` invocation, because the server never starts. This restores that workflow.

## How Has This Been Tested?

- Reproduced the failure: launching `src/index.js` through a symlink produced no output and exited `0`; launching the real path printed `design-data-agent-mcp started`.
- After the fix, launching through a symlink starts the server and returns a valid `initialize` response over stdio.
- `pnpm ava` in the package passes, including two new tests that launch the entry script directly and via a temp symlink and assert the startup marker is emitted. The symlink test times out against the old guard, confirming it is a real regression test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

