### PR TITLE
fix(tokens): re-apply 100 spec-order renames from PR #814 gap analysis

### DIFF
--- a/.changeset/pr814-spec-order-renames.md
+++ b/.changeset/pr814-spec-order-renames.md
@@ -1,0 +1,21 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Re-apply 100 spec-order token renames from PR #814 gap analysis.
+
+- **color-aliases.json**: 19 tokens deprecated (key-focus→keyboard-focus,
+  state-last and structure reordering).
+- **color-component.json**: 1 token deprecated (key-focus→keyboard-focus).
+- **layout-component.json**: 38 tokens deprecated (divider, illustrated-message,
+  list-view, select-box, tab, table, title, tree-view ordering).
+- **layout.json**: 7 tokens deprecated (padding-uniform ordering,
+  control-color, list-item-padding).
+- **semantic-color-palette.json**: 5 tokens deprecated
+  (icon-color-* → *-icon-color spec ordering).
+- **typography.json**: 30 tokens deprecated (size abbreviations expanded,
+  margin multiplier ordering, font-weight rename).
+- **snapshots/validation-snapshot.json**: regenerated.
+
+22 icon background tokens and 4 rename-chain intermediaries deferred —
+require name-object disambiguation before canonical entries can be added.

--- a/packages/tokens/src/color-aliases.json
+++ b/packages/tokens/src/color-aliases.json
@@ -81,7 +81,31 @@
         "value": "{accent-color-1000}"
       }
     },
-    "uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54"
+    "uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `accent-background-color-keyboard-focus` instead.",
+    "renamed": "accent-background-color-keyboard-focus"
+  },
+  "accent-background-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "sets": {
+      "dark": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "be4fc5d8-39eb-400f-9f14-8183a2ba51ad",
+        "value": "{accent-color-700}"
+      },
+      "light": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "42d3cd91-5edb-405a-8247-3232044429ba",
+        "value": "{accent-color-1000}"
+      },
+      "wireframe": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "63e4cee3-9996-4d08-96b0-762b8e147da5",
+        "value": "{accent-color-1000}"
+      }
+    },
+    "uuid": "e9d74a5a-6211-4e73-a934-ede3a37ccdea"
   },
   "accent-content-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -101,6 +125,14 @@
   "accent-content-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "71dcd137-f767-4d2c-b6ac-942b99ac8621",
+    "value": "{accent-color-1000}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `accent-content-color-keyboard-focus` instead.",
+    "renamed": "accent-content-color-keyboard-focus"
+  },
+  "accent-content-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "fcb20072-7a42-43eb-8a93-3af2765b8d04",
     "value": "{accent-color-1000}"
   },
   "accent-content-color-selected": {
@@ -132,6 +164,14 @@
   "background-base-color": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "e0d8739d-18dd-44bc-92ea-e443882a780b",
+    "value": "{gray-25}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-background-color` instead.",
+    "renamed": "base-background-color"
+  },
+  "base-background-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "79d52e1d-1c25-41b3-9eaf-448e24cc69be",
     "value": "{gray-25}"
   },
   "background-elevated-color": {
@@ -199,6 +239,14 @@
   "background-opacity-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "uuid": "a35883a9-43fd-4be5-97ee-62fdf3a33f39",
+    "value": "0.1",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `background-opacity-keyboard-focus` instead.",
+    "renamed": "background-opacity-keyboard-focus"
+  },
+  "background-opacity-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
+    "uuid": "987d474e-f51e-4c35-8b36-1d3fd3dd942d",
     "value": "0.1"
   },
   "background-pasteboard-color": {
@@ -1309,7 +1357,31 @@
         "value": "{informative-color-1000}"
       }
     },
-    "uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234"
+    "uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `informative-background-color-keyboard-focus` instead.",
+    "renamed": "informative-background-color-keyboard-focus"
+  },
+  "informative-background-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "sets": {
+      "dark": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "2d98c6d2-4e96-45ee-9b96-905584663e21",
+        "value": "{informative-color-700}"
+      },
+      "light": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "0671682c-a152-4713-b655-3fd7f96df6f5",
+        "value": "{informative-color-1000}"
+      },
+      "wireframe": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "a39229d1-4286-4205-8c1d-5696235580d9",
+        "value": "{informative-color-1000}"
+      }
+    },
+    "uuid": "dd6b7244-c5a1-4e6b-9cb4-9be250a57452"
   },
   "informative-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -1477,7 +1549,31 @@
         "value": "{negative-color-1000}"
       }
     },
-    "uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4"
+    "uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `negative-background-color-keyboard-focus` instead.",
+    "renamed": "negative-background-color-keyboard-focus"
+  },
+  "negative-background-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "sets": {
+      "dark": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "f3c8fa8c-c516-41ac-83dc-12e9fb4c8c37",
+        "value": "{negative-color-700}"
+      },
+      "light": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "0f18636e-7725-4158-8bc1-24b33c3915e5",
+        "value": "{negative-color-1000}"
+      },
+      "wireframe": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "c775842f-a159-4f5d-b297-6dd60760f878",
+        "value": "{negative-color-1000}"
+      }
+    },
+    "uuid": "b3550207-86e8-4379-ac8d-fab2f9974a7f"
   },
   "negative-border-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1497,6 +1593,14 @@
   "negative-border-color-focus-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "63abd660-13c4-47b8-be9e-61e270b95212",
+    "value": "{negative-border-color-down}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `negative-border-color-hover-focus` instead.",
+    "renamed": "negative-border-color-hover-focus"
+  },
+  "negative-border-color-hover-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "092161ea-0cc1-4597-a553-5348daa2d0ab",
     "value": "{negative-border-color-down}"
   },
   "negative-border-color-hover": {
@@ -1507,6 +1611,14 @@
   "negative-border-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "393cb93a-3d0a-4118-a2ee-451fdc871b0f",
+    "value": "{negative-color-1000}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `negative-border-color-keyboard-focus` instead.",
+    "renamed": "negative-border-color-keyboard-focus"
+  },
+  "negative-border-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "fde56fe8-11b3-4fa3-97da-a3d150d50bd1",
     "value": "{negative-color-1000}"
   },
   "negative-content-color-default": {
@@ -1527,6 +1639,14 @@
   "negative-content-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "03a7aa1f-9493-4054-bb21-eb10e593da73",
+    "value": "{negative-color-1000}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `negative-content-color-keyboard-focus` instead.",
+    "renamed": "negative-content-color-keyboard-focus"
+  },
+  "negative-content-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "d6930dfa-b9f0-4475-a1fc-f9b27a0c2472",
     "value": "{negative-color-1000}"
   },
   "negative-visual-color": {
@@ -1568,26 +1688,66 @@
   "neutral-background-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "f52c6bfb-2d62-4fc8-a1cd-6c8d7420eeb4",
+    "value": "{gray-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-background-color-keyboard-focus` instead.",
+    "renamed": "neutral-background-color-keyboard-focus"
+  },
+  "neutral-background-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "7e374e3a-91c0-46a0-a747-5f58056faa06",
     "value": "{gray-900}"
   },
   "neutral-background-color-selected-default": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc",
+    "value": "{gray-800}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-background-color-default-selected` instead.",
+    "renamed": "neutral-background-color-default-selected"
+  },
+  "neutral-background-color-default-selected": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "b8290e3a-6938-434c-9a73-675e5f1ea23f",
     "value": "{gray-800}"
   },
   "neutral-background-color-selected-down": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "966c56d0-4461-45e7-9e20-0277f2111a34",
+    "value": "{gray-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-background-color-down-selected` instead.",
+    "renamed": "neutral-background-color-down-selected"
+  },
+  "neutral-background-color-down-selected": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "ebaa02d5-e201-4ffe-977c-29bafea06283",
     "value": "{gray-900}"
   },
   "neutral-background-color-selected-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "1c220122-5f32-42f9-848f-ae10061241e5",
+    "value": "{gray-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-background-color-hover-selected` instead.",
+    "renamed": "neutral-background-color-hover-selected"
+  },
+  "neutral-background-color-hover-selected": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "297b17f8-e146-443a-900a-c2f71ead6258",
     "value": "{gray-900}"
   },
   "neutral-background-color-selected-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "9b8df7df-3439-4614-b446-97a4de782e27",
+    "value": "{gray-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-background-color-selected-keyboard-focus` instead.",
+    "renamed": "neutral-background-color-selected-keyboard-focus"
+  },
+  "neutral-background-color-selected-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "67ec460e-c5e2-4fcb-97ca-0c8485eb3a0f",
     "value": "{gray-900}"
   },
   "neutral-content-color-default": {
@@ -1608,6 +1768,14 @@
   "neutral-content-color-focus-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "a370f375-b3b1-4af8-9628-fa901c0252fb",
+    "value": "{neutral-content-color-down}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-content-color-hover-focus` instead.",
+    "renamed": "neutral-content-color-hover-focus"
+  },
+  "neutral-content-color-hover-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "3762c252-1ff9-4e85-8c1a-e65713bb6d0f",
     "value": "{neutral-content-color-down}"
   },
   "neutral-content-color-hover": {
@@ -1618,6 +1786,14 @@
   "neutral-content-color-key-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "c2c538e0-6f8d-4586-953a-b98ef40c9eca",
+    "value": "{gray-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-content-color-keyboard-focus` instead.",
+    "renamed": "neutral-content-color-keyboard-focus"
+  },
+  "neutral-content-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "1d1003a3-4d8a-45ec-a3df-3f78f4f57d7b",
     "value": "{gray-900}"
   },
   "neutral-subdued-background-color-default": {
@@ -2052,7 +2228,31 @@
         "value": "{positive-color-1000}"
       }
     },
-    "uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d"
+    "uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `positive-background-color-keyboard-focus` instead.",
+    "renamed": "positive-background-color-keyboard-focus"
+  },
+  "positive-background-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
+    "sets": {
+      "dark": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "d0e2548d-fae0-43de-a27d-22de46585059",
+        "value": "{positive-color-700}"
+      },
+      "light": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "ae8903b7-c522-4e1e-9aa6-3e0ae1d12e58",
+        "value": "{positive-color-1000}"
+      },
+      "wireframe": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "a7fc7887-5d39-4610-bd9b-836153681efc",
+        "value": "{positive-color-1000}"
+      }
+    },
+    "uuid": "00171d4b-1708-4ee1-8db3-080dcf1d8c10"
   },
   "positive-visual-color": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
@@ -2345,6 +2545,14 @@
   "static-black-track-indicator-color": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "0599d3b0-4d9e-4a12-ae0e-8f60e3533ab9",
+    "value": "{transparent-black-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `static-track-black-indicator-color` instead.",
+    "renamed": "static-track-black-indicator-color"
+  },
+  "static-track-black-indicator-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "1da0b833-07c5-43e9-b2e6-5413aa6b7842",
     "value": "{transparent-black-900}"
   },
   "static-white-focus-indicator-color": {
@@ -2365,6 +2573,14 @@
   "static-white-track-indicator-color": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "a1cbc282-1376-48d1-b8bb-92f10aef7c6f",
+    "value": "{transparent-white-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `static-track-white-indicator-color` instead.",
+    "renamed": "static-track-white-indicator-color"
+  },
+  "static-track-white-indicator-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "2c30b064-e2eb-48eb-9a83-828f25979f45",
     "value": "{transparent-white-900}"
   },
   "title-color": {

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -438,6 +438,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "stack-item",
     "uuid": "a0251da6-7517-4712-85a1-29ca7f16ef91",
+    "value": "{gray-100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `stack-item-background-color-keyboard-focus` instead.",
+    "renamed": "stack-item-background-color-keyboard-focus"
+  },
+  "stack-item-background-color-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "stack-item",
+    "uuid": "ed627f68-7ac3-4f84-8682-d740d57c921e",
     "value": "{gray-100}"
   },
   "stack-item-selected-background-color-default": {

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -3255,6 +3255,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "coach-indicator",
     "uuid": "fff486aa-26a4-4b41-91a7-762f8b29d47a",
+    "value": "4px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `coach-indicator-ring-collapsed-thickness` instead.",
+    "renamed": "coach-indicator-ring-collapsed-thickness"
+  },
+  "coach-indicator-ring-collapsed-thickness": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "coach-indicator",
+    "uuid": "70b4d622-faaa-41ef-83bf-341c5d2923ad",
     "value": "4px"
   },
   "coach-indicator-expanded-gap": {
@@ -3276,6 +3285,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "coach-indicator",
     "uuid": "09c84cdf-0c82-4201-8203-9eb05d8b9486",
+    "value": "8px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `coach-indicator-ring-expanded-thickness` instead.",
+    "renamed": "coach-indicator-ring-expanded-thickness"
+  },
+  "coach-indicator-ring-expanded-thickness": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "coach-indicator",
+    "uuid": "ad714bf2-c290-4664-8909-fdc65e5a43cc",
     "value": "8px"
   },
   "coach-indicator-opacity": {
@@ -3725,7 +3743,27 @@
         "value": "40px"
       }
     },
-    "uuid": "1ff02a51-9266-411d-a8e4-02222f45bac8"
+    "uuid": "1ff02a51-9266-411d-a8e4-02222f45bac8",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `color-handle-size-keyboard-focus` instead.",
+    "renamed": "color-handle-size-keyboard-focus"
+  },
+  "color-handle-size-keyboard-focus": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "color-handle",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "935d29e8-59f7-4a5a-ab0f-17175975ea71",
+        "value": "32px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "ed62f1b1-2c6f-4466-8b96-1a3035ad6c91",
+        "value": "40px"
+      }
+    },
+    "uuid": "9c10056c-1a2c-4f97-bf05-a9b0ea630325"
   },
   "color-loupe-bottom-to-color-handle": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -4289,6 +4327,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "divider",
     "uuid": "a0093378-0b2c-474b-9fe5-76940fd1398b",
+    "value": "200px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `divider-minimum-width-horizontal` instead.",
+    "renamed": "divider-minimum-width-horizontal"
+  },
+  "divider-minimum-width-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "divider",
+    "uuid": "21faed80-7a43-4dd2-a0b5-75e44da72733",
     "value": "200px"
   },
   "divider-thickness-large": {
@@ -4313,6 +4360,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "divider",
     "uuid": "299db7d6-66f6-4fcb-890d-223406c85ae4",
+    "value": "200px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `divider-minimum-height-vertical` instead.",
+    "renamed": "divider-minimum-height-vertical"
+  },
+  "divider-minimum-height-vertical": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "divider",
+    "uuid": "4857c976-ea6a-4522-a7a3-81ae31def044",
     "value": "200px"
   },
   "double-calendar-popover-minimum-height": {
@@ -4908,6 +4964,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "illustrated-message",
     "uuid": "4413ee4d-86b1-4d88-b2ee-64c0939698b9",
+    "value": "535px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `illustrated-message-maximum-width-horizontal` instead.",
+    "renamed": "illustrated-message-maximum-width-horizontal"
+  },
+  "illustrated-message-maximum-width-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "illustrated-message",
+    "uuid": "9ebfca63-ceb1-4d02-971a-1bd84ad7601c",
     "value": "535px"
   },
   "illustrated-message-large-body-font-size": {
@@ -4925,7 +4990,27 @@
         "value": "{body-size-xs}"
       }
     },
-    "uuid": "83e747ed-01c0-484c-9c89-53bd77e4d2c8"
+    "uuid": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `illustrated-message-body-font-size-large` instead.",
+    "renamed": "illustrated-message-body-font-size-large"
+  },
+  "illustrated-message-body-font-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "illustrated-message",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "d4f6d0f7-a129-48f6-8ee2-664b90fd262d",
+        "value": "{body-size-s}"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "6bae1b8c-967e-4d65-a640-b6c3a406409d",
+        "value": "{body-size-xs}"
+      }
+    },
+    "uuid": "52c22401-ae96-475b-aa10-4ee97349f083"
   },
   "illustrated-message-large-cjk-title-font-size": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -4959,7 +5044,27 @@
         "value": "{title-size-xl}"
       }
     },
-    "uuid": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca"
+    "uuid": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `illustrated-message-title-font-size-large` instead.",
+    "renamed": "illustrated-message-title-font-size-large"
+  },
+  "illustrated-message-title-font-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "illustrated-message",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "0d813a86-db04-4bf2-be03-aa7d9f18d44e",
+        "value": "{title-size-xxl}"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "811ae787-5327-4751-ab5c-1c80d6c96d52",
+        "value": "{title-size-xl}"
+      }
+    },
+    "uuid": "1c1f4ab9-a2c9-453a-a7b9-7aa218f90e34"
   },
   "illustrated-message-maximum-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -5023,6 +5128,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "illustrated-message",
     "uuid": "fad078e5-1791-4003-994d-3567162d8233",
+    "value": "{body-size-xs}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `illustrated-message-body-font-size-small` instead.",
+    "renamed": "illustrated-message-body-font-size-small"
+  },
+  "illustrated-message-body-font-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "illustrated-message",
+    "uuid": "2e3d908a-c4f4-4b12-9817-7d510de3cf13",
     "value": "{body-size-xs}"
   },
   "illustrated-message-small-cjk-title-font-size": {
@@ -5057,7 +5171,27 @@
         "value": "{title-size-s}"
       }
     },
-    "uuid": "2164a3c7-b90d-4072-8f72-f364d07edb38"
+    "uuid": "2164a3c7-b90d-4072-8f72-f364d07edb38",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `illustrated-message-title-font-size-small` instead.",
+    "renamed": "illustrated-message-title-font-size-small"
+  },
+  "illustrated-message-title-font-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "illustrated-message",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "fb396f03-1cd3-4257-bce8-932160ef0d70",
+        "value": "{title-size-m}"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+        "uuid": "808d1661-4e73-44e2-842c-1ed403788700",
+        "value": "{title-size-s}"
+      }
+    },
+    "uuid": "5c19a199-d542-43a9-806d-5aae5abe3c94"
   },
   "illustrated-message-title-size": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -5072,6 +5206,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "illustrated-message",
     "uuid": "95c055b0-f688-4405-8426-1b2302e32ebd",
+    "value": "380px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `illustrated-message-maximum-width-vertical` instead.",
+    "renamed": "illustrated-message-maximum-width-vertical"
+  },
+  "illustrated-message-maximum-width-vertical": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "illustrated-message",
+    "uuid": "2e0a903b-0155-4f81-b384-4ced0d7f31f6",
     "value": "380px"
   },
   "in-field-button-edge-to-disclosure-icon-stacked-extra-large": {
@@ -5555,12 +5698,30 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "list-view",
     "uuid": "57821e37-d39e-49d5-b978-4ece3747e531",
+    "value": "{corner-radius-medium-default}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `list-view-item-corner-radius-bottom` instead.",
+    "renamed": "list-view-item-corner-radius-bottom"
+  },
+  "list-view-item-corner-radius-bottom": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "list-view",
+    "uuid": "da15b83b-ed0c-4407-981a-7d4bcdffe9b4",
     "value": "{corner-radius-medium-default}"
   },
   "list-view-item-top-corner-radius": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "list-view",
     "uuid": "6e4611f7-f202-4003-94b4-587d48d07e32",
+    "value": "{corner-radius-medium-default}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `list-view-item-corner-radius-top` instead.",
+    "renamed": "list-view-item-corner-radius-top"
+  },
+  "list-view-item-corner-radius-top": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "list-view",
+    "uuid": "fdf6782b-933c-47cf-94a6-69fed4536570",
     "value": "{corner-radius-medium-default}"
   },
   "list-view-minimum-height": {
@@ -5726,6 +5887,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "menu",
     "uuid": "dac5c077-b948-434b-91bd-0759c2414007",
+    "value": "12px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `menu-item-divider-section-height` instead.",
+    "renamed": "menu-item-divider-section-height"
+  },
+  "menu-item-divider-section-height": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "menu",
+    "uuid": "4bbcefb0-b50d-406e-8411-9a4e5b13d981",
     "value": "12px"
   },
   "menu-item-top-to-disclosure-icon-extra-large": {
@@ -7031,7 +7201,27 @@
         "value": "100px"
       }
     },
-    "uuid": "dddfd124-708d-4f7a-b9ba-196ba2019c47"
+    "uuid": "dddfd124-708d-4f7a-b9ba-196ba2019c47",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `select-box-minimum-height-horizontal` instead.",
+    "renamed": "select-box-minimum-height-horizontal"
+  },
+  "select-box-minimum-height-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "select-box",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "8d56da16-301e-4049-9f17-45ed57d6a6f7",
+        "value": "80px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "456c2b74-89ed-49fe-9bb9-bd50429903bc",
+        "value": "100px"
+      }
+    },
+    "uuid": "d9ba2134-3145-4da2-9644-e7205beac459"
   },
   "select-box-horizontal-minimum-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -7048,7 +7238,27 @@
         "value": "220px"
       }
     },
-    "uuid": "df8589d3-7c0f-4c4a-9b7a-9fb1b885d98a"
+    "uuid": "df8589d3-7c0f-4c4a-9b7a-9fb1b885d98a",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `select-box-minimum-width-horizontal` instead.",
+    "renamed": "select-box-minimum-width-horizontal"
+  },
+  "select-box-minimum-width-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "select-box",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "c14f5b60-0e1a-4741-a085-7e5bd14ba772",
+        "value": "188px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "cd559737-6eda-4289-b6b8-371471b7100e",
+        "value": "220px"
+      }
+    },
+    "uuid": "941e6217-6438-4619-955e-5c8c23b155fb"
   },
   "select-box-horizontal-start-to-content": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -7105,7 +7315,27 @@
         "value": "460px"
       }
     },
-    "uuid": "b1e398f1-86a7-4d3d-a424-7164a3f726e9"
+    "uuid": "b1e398f1-86a7-4d3d-a424-7164a3f726e9",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `select-box-width-horizontal` instead.",
+    "renamed": "select-box-width-horizontal"
+  },
+  "select-box-width-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "select-box",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "9cb2632f-1fc9-42a9-941d-eaa53768671a",
+        "value": "368px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "de1ca875-efc1-4ec2-850c-d12f5c9c2413",
+        "value": "460px"
+      }
+    },
+    "uuid": "d1ae9486-3972-443f-a42d-4aea9a1ba395"
   },
   "select-box-top-to-checkbox": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -7162,7 +7392,27 @@
         "value": "212px"
       }
     },
-    "uuid": "c5d2bdb6-e266-4883-b6e2-e81b88630c67"
+    "uuid": "c5d2bdb6-e266-4883-b6e2-e81b88630c67",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `select-box-height-vertical` instead.",
+    "renamed": "select-box-height-vertical"
+  },
+  "select-box-height-vertical": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "select-box",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "7f80f6b4-7815-4231-93f1-89414426403f",
+        "value": "170px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "3df58aab-f70e-4a1c-bfd7-ca4adfe595ee",
+        "value": "212px"
+      }
+    },
+    "uuid": "277f5769-1349-44c8-b03a-06f9fca26f7c"
   },
   "select-box-vertical-illustration-to-label": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -9679,24 +9929,60 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "tab-item",
     "uuid": "49130d66-edfb-48bd-8648-96c47f40a884",
+    "value": "{component-height-300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `tab-item-height-extra-large-compact` instead.",
+    "renamed": "tab-item-height-extra-large-compact"
+  },
+  "tab-item-height-extra-large-compact": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tab-item",
+    "uuid": "7351a78a-962b-4c59-87de-e3972bbece34",
     "value": "{component-height-300}"
   },
   "tab-item-compact-height-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "tab-item",
     "uuid": "6d781a0e-e03d-4750-ae4f-67a29d731702",
+    "value": "{component-height-200}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `tab-item-height-large-compact` instead.",
+    "renamed": "tab-item-height-large-compact"
+  },
+  "tab-item-height-large-compact": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tab-item",
+    "uuid": "87bddd43-a0ab-4c26-837d-36e082266d50",
     "value": "{component-height-200}"
   },
   "tab-item-compact-height-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "tab-item",
     "uuid": "e8c7c826-548d-4037-b064-3cf699675d35",
+    "value": "{component-height-100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `tab-item-height-medium-compact` instead.",
+    "renamed": "tab-item-height-medium-compact"
+  },
+  "tab-item-height-medium-compact": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tab-item",
+    "uuid": "890f03bb-69d7-4282-a3d5-ded08f4848df",
     "value": "{component-height-100}"
   },
   "tab-item-compact-height-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "tab-item",
     "uuid": "25f7d9a5-9464-4447-97d9-97839b371f96",
+    "value": "{component-height-75}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `tab-item-height-small-compact` instead.",
+    "renamed": "tab-item-height-small-compact"
+  },
+  "tab-item-height-small-compact": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tab-item",
+    "uuid": "520a2d1e-d607-4dfa-bb4c-96740a0c8d03",
     "value": "{component-height-75}"
   },
   "tab-item-focus-indicator-gap-extra-large": {
@@ -10375,6 +10661,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "component": "table",
     "uuid": "b6f2536c-deda-409f-8667-a5a99abdfa46",
+    "value": "1px",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `table-divider-border-width` instead.",
+    "renamed": "table-divider-border-width"
+  },
+  "table-divider-border-width": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "table",
+    "uuid": "572c57fd-1edc-4b3c-9b30-3c47a1d8ee5a",
     "value": "1px"
   },
   "table-checkbox-to-text": {
@@ -11773,7 +12068,27 @@
         "value": "60px"
       }
     },
-    "uuid": "7ec12e53-f33b-40ff-a051-cb62f71a376e"
+    "uuid": "7ec12e53-f33b-40ff-a051-cb62f71a376e",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `table-header-section-row-height-extra-large` instead.",
+    "renamed": "table-header-section-row-height-extra-large"
+  },
+  "table-header-section-row-height-extra-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "table",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "deb85438-be81-4b06-bb99-a8c6bff5b53f",
+        "value": "48px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "459ba50b-aac1-4d31-9665-2df2f30e46c2",
+        "value": "60px"
+      }
+    },
+    "uuid": "f46dc21c-a590-4d14-a549-9ad756a32cfb"
   },
   "table-section-header-row-height-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -11790,7 +12105,27 @@
         "value": "50px"
       }
     },
-    "uuid": "db3b99d0-492f-4360-8d36-d497e1e00462"
+    "uuid": "db3b99d0-492f-4360-8d36-d497e1e00462",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `table-header-section-row-height-large` instead.",
+    "renamed": "table-header-section-row-height-large"
+  },
+  "table-header-section-row-height-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "table",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "db38b8cb-e966-4bf8-980e-0366fa69a1cd",
+        "value": "40px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "4b979a23-5481-498d-8a78-4830a79fd811",
+        "value": "50px"
+      }
+    },
+    "uuid": "b0d2d97c-b261-4d78-a9d1-37b9ab537f17"
   },
   "table-section-header-row-height-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -11807,7 +12142,27 @@
         "value": "40px"
       }
     },
-    "uuid": "9b7fb04a-96c6-4eb2-87ff-e0703b02617b"
+    "uuid": "9b7fb04a-96c6-4eb2-87ff-e0703b02617b",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `table-header-section-row-height-medium` instead.",
+    "renamed": "table-header-section-row-height-medium"
+  },
+  "table-header-section-row-height-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "table",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "9efe2bc6-8806-476b-96a2-e260c1027206",
+        "value": "32px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "312de095-5912-498c-a870-e4f4b224a155",
+        "value": "40px"
+      }
+    },
+    "uuid": "8b61bebe-f8ce-41a4-951f-26c40196e12e"
   },
   "table-section-header-row-height-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -11824,7 +12179,27 @@
         "value": "30px"
       }
     },
-    "uuid": "58fd11fd-232a-474b-b53e-3b54a5d96266"
+    "uuid": "58fd11fd-232a-474b-b53e-3b54a5d96266",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `table-header-section-row-height-small` instead.",
+    "renamed": "table-header-section-row-height-small"
+  },
+  "table-header-section-row-height-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "table",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "baf2eab0-ea78-486a-921d-97041c28ee5d",
+        "value": "24px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "126920d9-d2c4-4809-9c5e-071cadcc4c0d",
+        "value": "30px"
+      }
+    },
+    "uuid": "2d8222b0-20eb-4cca-a4c1-e94663b380e6"
   },
   "table-thumbnail-to-top-minimum-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -13025,12 +13400,30 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "title",
     "uuid": "73a0bd28-7691-47b0-9e9b-62ec22940e63",
+    "value": 0.25,
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-margin-multiplier-bottom` instead.",
+    "renamed": "title-margin-multiplier-bottom"
+  },
+  "title-margin-multiplier-bottom": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "component": "title",
+    "uuid": "7e1a9dc7-8e24-4f98-ba41-04450ba4af93",
     "value": 0.25
   },
   "title-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "title",
     "uuid": "14d9dc6c-28fc-41cf-a1ae-600a150f520a",
+    "value": 0.88888889,
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-margin-multiplier-top` instead.",
+    "renamed": "title-margin-multiplier-top"
+  },
+  "title-margin-multiplier-top": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "component": "title",
+    "uuid": "a73864ae-2277-4bab-a5ae-b590f2c7fd3e",
     "value": 0.88888889
   },
   "title-sans-serif-emphasized-font-style": {
@@ -13145,42 +13538,105 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "0fb9e5ec-e5b7-41e0-8ef4-db9e4e33e060",
+    "value": "{font-size-300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-large` instead.",
+    "renamed": "title-size-large"
+  },
+  "title-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "63deb9d0-0467-40ef-bcdd-80ce25e43265",
     "value": "{font-size-300}"
   },
   "title-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
+    "value": "{font-size-200}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-medium` instead.",
+    "renamed": "title-size-medium"
+  },
+  "title-size-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "f4e498ec-9b80-47ce-9fbe-dfd9096a06d6",
     "value": "{font-size-200}"
   },
   "title-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "0babc342-b506-495d-aaf1-20fe9e571e1b",
+    "value": "{font-size-100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-small` instead.",
+    "renamed": "title-size-small"
+  },
+  "title-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "8d419010-3b82-4e0c-83fe-a6181d126e28",
     "value": "{font-size-100}"
   },
   "title-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
+    "value": "{font-size-400}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-extra-large` instead.",
+    "renamed": "title-size-extra-large"
+  },
+  "title-size-extra-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "0458e34c-3279-451b-9d24-427db68a8309",
     "value": "{font-size-400}"
   },
   "title-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "68dac9e8-9b07-4453-8cb2-24ed349d2134",
+    "value": "{font-size-75}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-extra-small` instead.",
+    "renamed": "title-size-extra-small"
+  },
+  "title-size-extra-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "c7bfaab0-657b-4520-a530-0042e0514e77",
     "value": "{font-size-75}"
   },
   "title-size-xxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "d4c4db99-70f2-4c79-8595-4d23407de068",
+    "value": "{font-size-500}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-2x-large` instead.",
+    "renamed": "title-size-2x-large"
+  },
+  "title-size-2x-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "75d2c781-c8a4-4e46-a831-988cf3c92c29",
     "value": "{font-size-500}"
   },
   "title-size-xxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "title",
     "uuid": "56152e6a-3058-4467-86a1-34fa2b6f75b2",
+    "value": "{font-size-600}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `title-size-3x-large` instead.",
+    "renamed": "title-size-3x-large"
+  },
+  "title-size-3x-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "title",
+    "uuid": "b5cb5985-5590-4d58-9c00-b0ffcc5274b8",
     "value": "{font-size-600}"
   },
   "toast-bottom-to-text": {
@@ -13389,7 +13845,27 @@
         "value": "40px"
       }
     },
-    "uuid": "65d6c69e-0d00-4d31-8e18-a27cb4ddd464"
+    "uuid": "65d6c69e-0d00-4d31-8e18-a27cb4ddd464",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `tree-view-indicator-disclosure-height` instead.",
+    "renamed": "tree-view-indicator-disclosure-height"
+  },
+  "tree-view-indicator-disclosure-height": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "tree-view",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "56971401-cb39-4734-a517-6beec43820d3",
+        "value": "32px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "5ad3099b-3b8a-4399-ab20-f8d79c903e0d",
+        "value": "40px"
+      }
+    },
+    "uuid": "be63a174-d0b9-4737-a0c3-83e5b843b3df"
   },
   "tree-view-disclosure-indicator-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -13406,7 +13882,27 @@
         "value": "42px"
       }
     },
-    "uuid": "a9a4a8fe-327f-4c81-9c86-8d824e159de4"
+    "uuid": "a9a4a8fe-327f-4c81-9c86-8d824e159de4",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `tree-view-indicator-disclosure-width` instead.",
+    "renamed": "tree-view-indicator-disclosure-width"
+  },
+  "tree-view-indicator-disclosure-width": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "tree-view",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "e0d0b27e-d79a-42b3-9dbf-bbc4a1954efa",
+        "value": "34px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "37707cfe-3345-467b-8cdf-08126f0487f5",
+        "value": "42px"
+      }
+    },
+    "uuid": "f8ebf73b-258a-4254-aa1d-e71345cb8e15"
   },
   "tree-view-drag-handle-to-checkbox": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -230,30 +230,75 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-large size",
     "uuid": "9c571815-ef7f-4baa-9c7f-32a6f89052b7",
+    "value": "{base-padding-vertical-2x-large}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-padding-horizontal-2x-large-uniform` instead.",
+    "renamed": "base-padding-horizontal-2x-large-uniform"
+  },
+  "base-padding-horizontal-2x-large-uniform": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-large size",
+    "uuid": "d1b4b30c-6fdf-4697-9ded-58e2dc2ef4dc",
     "value": "{base-padding-vertical-2x-large}"
   },
   "base-padding-horizontal-uniform-2x-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-small size",
     "uuid": "af1d798e-4235-44a3-a327-1779c134b72b",
+    "value": "{base-padding-vertical-2x-small}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-padding-horizontal-2x-small-uniform` instead.",
+    "renamed": "base-padding-horizontal-2x-small-uniform"
+  },
+  "base-padding-horizontal-2x-small-uniform": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-small size",
+    "uuid": "91a54f26-b583-4993-805b-a2cb61830366",
     "value": "{base-padding-vertical-2x-small}"
   },
   "base-padding-horizontal-uniform-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-large size",
     "uuid": "54f547dc-cb51-4eb2-91ff-b0f7b383f072",
+    "value": "{base-padding-vertical-extra-large}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-padding-horizontal-extra-large-uniform` instead.",
+    "renamed": "base-padding-horizontal-extra-large-uniform"
+  },
+  "base-padding-horizontal-extra-large-uniform": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-large size",
+    "uuid": "4c944d82-7f9f-4672-bbad-15bd5fb37349",
     "value": "{base-padding-vertical-extra-large}"
   },
   "base-padding-horizontal-uniform-extra-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-small size",
     "uuid": "337ce5da-d735-4930-a9c8-9fecf4dcb9b0",
+    "value": "{base-padding-vertical-extra-small}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-padding-horizontal-extra-small-uniform` instead.",
+    "renamed": "base-padding-horizontal-extra-small-uniform"
+  },
+  "base-padding-horizontal-extra-small-uniform": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-small size",
+    "uuid": "68017185-a9d2-4b2f-8a19-fda1f248ab5a",
     "value": "{base-padding-vertical-extra-small}"
   },
   "base-padding-horizontal-uniform-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at large size",
     "uuid": "1006824d-539b-408e-afd6-1e77779b9d21",
+    "value": "{base-padding-vertical-large}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-padding-horizontal-large-uniform` instead.",
+    "renamed": "base-padding-horizontal-large-uniform"
+  },
+  "base-padding-horizontal-large-uniform": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at large size",
+    "uuid": "ed8ae947-d375-435f-ba23-a58830b2e169",
     "value": "{base-padding-vertical-large}"
   },
   "base-padding-horizontal-uniform-medium": {
@@ -266,6 +311,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at small size",
     "uuid": "3c42cb65-d84e-4cfd-bf17-e9f21ce17b7e",
+    "value": "{base-padding-vertical-small}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `base-padding-horizontal-small-uniform` instead.",
+    "renamed": "base-padding-horizontal-small-uniform"
+  },
+  "base-padding-horizontal-small-uniform": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "description": "Horizontal internal spacing with uniform dimensions for base UI elements at small size",
+    "uuid": "0809d6da-adc4-4d49-98e2-af6a67778842",
     "value": "{base-padding-vertical-small}"
   },
   "base-padding-vertical-2x-large": {
@@ -417,7 +471,26 @@
         "value": "30px"
       }
     },
-    "uuid": "03a7d531-c294-4a41-bd51-38c77a20317e"
+    "uuid": "03a7d531-c294-4a41-bd51-38c77a20317e",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `control-color-track-width` instead.",
+    "renamed": "control-color-track-width"
+  },
+  "control-color-track-width": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "sets": {
+      "desktop": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "dd31d7b9-0ff7-4c40-84ab-fcec1833945a",
+        "value": "24px"
+      },
+      "mobile": {
+        "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+        "uuid": "5cc87e8a-99db-4b86-ac17-b874122a9c58",
+        "value": "30px"
+      }
+    },
+    "uuid": "3289386e-37c0-4d85-b9b6-682fea65aae7"
   },
   "component-bottom-to-text-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",

--- a/packages/tokens/src/semantic-color-palette.json
+++ b/packages/tokens/src/semantic-color-palette.json
@@ -103,26 +103,66 @@
   "icon-color-informative": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "2296b0de-6231-4f89-9992-499b67c6879c",
+    "value": "{informative-visual-color}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `informative-icon-color` instead.",
+    "renamed": "informative-icon-color"
+  },
+  "informative-icon-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "3a5c3fe8-1077-418e-80c0-785eec757f18",
     "value": "{informative-visual-color}"
   },
   "icon-color-negative": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "adf2a3f0-d1cd-4b53-8a9c-47ab9cb7bb0f",
+    "value": "{negative-visual-color}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `negative-icon-color` instead.",
+    "renamed": "negative-icon-color"
+  },
+  "negative-icon-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "968e0adc-37a6-4d24-80b6-c8868bf808a7",
     "value": "{negative-visual-color}"
   },
   "icon-color-neutral": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "29f5b73c-e8e8-4162-b9af-5a8e327baab8",
+    "value": "{neutral-visual-color}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `neutral-icon-color` instead.",
+    "renamed": "neutral-icon-color"
+  },
+  "neutral-icon-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "f03f2e81-6d3b-4d2d-9e05-6b42de248272",
     "value": "{neutral-visual-color}"
   },
   "icon-color-notice": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "4bdb8681-f7a1-4bbe-b788-a64c6f9df6ea",
+    "value": "{notice-visual-color}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `notice-icon-color` instead.",
+    "renamed": "notice-icon-color"
+  },
+  "notice-icon-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "5c4b8576-6294-46c7-838a-ef40fda99c9c",
     "value": "{notice-visual-color}"
   },
   "icon-color-positive": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "02f093b3-ab51-42e7-8f6e-26bc7c7cba63",
+    "value": "{positive-visual-color}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `positive-icon-color` instead.",
+    "renamed": "positive-icon-color"
+  },
+  "positive-icon-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "9a8c5b2d-8c09-4d66-9a70-3e7fb44a859a",
     "value": "{positive-visual-color}"
   },
   "informative-color-100": {

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -234,47 +234,118 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "884b74cb-d247-491d-acb9-d3dc84bfd9a6",
+    "value": "{font-size-300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-large` instead.",
+    "renamed": "body-size-large"
+  },
+  "body-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "541627a2-297f-4c55-a75f-ac187127aeb5",
     "value": "{font-size-300}"
   },
   "body-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
+    "value": "{font-size-200}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-medium` instead.",
+    "renamed": "body-size-medium"
+  },
+  "body-size-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "0cf815b0-0fd6-43a4-bb1e-da2dbaaf475b",
     "value": "{font-size-200}"
   },
   "body-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
+    "value": "{font-size-100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-small` instead.",
+    "renamed": "body-size-small"
+  },
+  "body-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "13c4359b-336c-496d-b01a-fabde4b10b43",
     "value": "{font-size-100}"
   },
   "body-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "3927604f-eaf3-4605-aa34-80b7bc88ac0f",
+    "value": "{font-size-400}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-extra-large` instead.",
+    "renamed": "body-size-extra-large"
+  },
+  "body-size-extra-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "40578e4a-8ffb-47e7-9198-d82c18441a94",
     "value": "{font-size-400}"
   },
   "body-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "25e93322-8f0b-45f8-ae9a-18668251f064",
+    "value": "{font-size-75}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-extra-small` instead.",
+    "renamed": "body-size-extra-small"
+  },
+  "body-size-extra-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "c891a862-6d59-4408-9486-796c8350cda2",
     "value": "{font-size-75}"
   },
   "body-size-xxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "4d0d4ed9-af14-4d88-98f1-9237f65e192a",
+    "value": "{font-size-500}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-2x-large` instead.",
+    "renamed": "body-size-2x-large"
+  },
+  "body-size-2x-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "71ae47da-18ea-49e0-a363-ad8f88ef46c2",
     "value": "{font-size-500}"
   },
   "body-size-xxs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "uuid": "3aa79ac7-9e78-4413-b500-b8d1937705cb",
+    "value": "{font-size-50}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-2x-small` instead.",
+    "renamed": "body-size-2x-small"
+  },
+  "body-size-2x-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "uuid": "0398da58-07e6-43e4-9b38-1789b869296e",
     "value": "{font-size-50}"
   },
   "body-size-xxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "body",
     "uuid": "e0b8ceea-3404-4c4b-9145-fe5d445020fe",
+    "value": "{font-size-600}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `body-size-3x-large` instead.",
+    "renamed": "body-size-3x-large"
+  },
+  "body-size-3x-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
+    "uuid": "c3fac4f0-b8bd-45b9-a6ac-3cc7b961af59",
     "value": "{font-size-600}"
   },
   "bold-font-weight": {
@@ -408,30 +479,75 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "code",
     "uuid": "b7010f1a-c994-4b19-b273-3f609fe4be2b",
+    "value": "{font-size-300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `code-size-large` instead.",
+    "renamed": "code-size-large"
+  },
+  "code-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "code",
+    "uuid": "75290ca0-581c-483c-9c55-d70c2d97530e",
     "value": "{font-size-300}"
   },
   "code-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "code",
     "uuid": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3",
+    "value": "{font-size-200}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `code-size-medium` instead.",
+    "renamed": "code-size-medium"
+  },
+  "code-size-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "code",
+    "uuid": "cf842aa7-96dc-4079-99ff-1ad98b5e74a8",
     "value": "{font-size-200}"
   },
   "code-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "code",
     "uuid": "efa9311b-27c5-45ea-93a7-bef6f9370179",
+    "value": "{font-size-100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `code-size-small` instead.",
+    "renamed": "code-size-small"
+  },
+  "code-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "code",
+    "uuid": "d2b4971d-3807-49ca-9f84-0c89dedb29b8",
     "value": "{font-size-100}"
   },
   "code-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "code",
     "uuid": "7879adbc-6c38-4d29-9a90-a4ad91c75b90",
+    "value": "{font-size-400}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `code-size-extra-large` instead.",
+    "renamed": "code-size-extra-large"
+  },
+  "code-size-extra-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "code",
+    "uuid": "5cbcce3a-b6f0-4466-a23a-76462c26d3c4",
     "value": "{font-size-400}"
   },
   "code-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "code",
     "uuid": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7",
+    "value": "{font-size-75}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `code-size-extra-small` instead.",
+    "renamed": "code-size-extra-small"
+  },
+  "code-size-extra-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "code",
+    "uuid": "8f69c407-4274-4f7a-95b2-f4df5422084f",
     "value": "{font-size-75}"
   },
   "code-strong-emphasized-font-style": {
@@ -802,12 +918,30 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "detail",
     "uuid": "35ac24a4-0338-44c6-b780-120a0af0fc51",
+    "value": 0.25,
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-margin-multiplier-bottom` instead.",
+    "renamed": "detail-margin-multiplier-bottom"
+  },
+  "detail-margin-multiplier-bottom": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "component": "detail",
+    "uuid": "ec39b178-3be2-45ca-98b1-2c578336678c",
     "value": 0.25
   },
   "detail-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "detail",
     "uuid": "5d34c3b5-fddd-420b-bfe4-0dee4e07701c",
+    "value": 0.88888889,
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-margin-multiplier-top` instead.",
+    "renamed": "detail-margin-multiplier-top"
+  },
+  "detail-margin-multiplier-top": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "component": "detail",
+    "uuid": "ea4c6e48-acdb-4323-8da8-86d156cc556a",
     "value": 0.88888889
   },
   "detail-sans-serif-emphasized-font-style": {
@@ -1048,30 +1182,75 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "detail",
     "uuid": "613da587-5c48-4efa-abb5-36378c1e81f0",
+    "value": "{font-size-200}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-size-large` instead.",
+    "renamed": "detail-size-large"
+  },
+  "detail-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "detail",
+    "uuid": "877c3a51-cc66-4d4e-9a77-d447987a2218",
     "value": "{font-size-200}"
   },
   "detail-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "detail",
     "uuid": "07840554-1ec1-4823-b119-474ec9cc31f0",
+    "value": "{font-size-100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-size-medium` instead.",
+    "renamed": "detail-size-medium"
+  },
+  "detail-size-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "detail",
+    "uuid": "65ed22d8-472f-42df-ae61-8182a0399a46",
     "value": "{font-size-100}"
   },
   "detail-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "detail",
     "uuid": "585e1bec-ee93-4983-b0bb-3a1f6ec28218",
+    "value": "{font-size-75}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-size-small` instead.",
+    "renamed": "detail-size-small"
+  },
+  "detail-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "detail",
+    "uuid": "8af617c6-51de-4bc3-8a9a-7ea11e977f60",
     "value": "{font-size-75}"
   },
   "detail-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "detail",
     "uuid": "ab476eec-b592-4890-af8f-74de808cb87f",
+    "value": "{font-size-300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-size-extra-large` instead.",
+    "renamed": "detail-size-extra-large"
+  },
+  "detail-size-extra-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "detail",
+    "uuid": "31b06a7b-857f-492d-b51d-c17a83023918",
     "value": "{font-size-300}"
   },
   "detail-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "detail",
     "uuid": "b33a59b4-1ec2-4f09-8cb3-9bfd09d7c695",
+    "value": "{font-size-50}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `detail-size-extra-small` instead.",
+    "renamed": "detail-size-extra-small"
+  },
+  "detail-size-extra-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "detail",
+    "uuid": "4ab8c98e-6914-4639-9aab-db82f0995b07",
     "value": "{font-size-50}"
   },
   "extra-bold-font-weight": {
@@ -1600,12 +1779,30 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "heading",
     "uuid": "dd2035b4-506f-41ab-a656-de3668d44e0f",
+    "value": 0.25,
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-margin-multiplier-bottom` instead.",
+    "renamed": "heading-margin-multiplier-bottom"
+  },
+  "heading-margin-multiplier-bottom": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "component": "heading",
+    "uuid": "7fa5a902-9ca7-4747-846d-bb2e8ce7c684",
     "value": 0.25
   },
   "heading-margin-top-multiplier": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "component": "heading",
     "uuid": "008fa04b-6d74-416b-a6ae-ceec90f08642",
+    "value": 0.88888889,
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-margin-multiplier-top` instead.",
+    "renamed": "heading-margin-multiplier-top"
+  },
+  "heading-margin-multiplier-top": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
+    "component": "heading",
+    "uuid": "c913bc07-d4de-43a3-aab5-89501ed9434c",
     "value": 0.88888889
   },
   "heading-sans-serif-emphasized-font-style": {
@@ -1924,36 +2121,90 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "336e434c-9026-4bb3-96b1-5bb44376b868",
+    "value": "{font-size-700}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-large` instead.",
+    "renamed": "heading-size-large"
+  },
+  "heading-size-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "0058375b-94ac-4256-9cc6-777bf56a85b1",
     "value": "{font-size-700}"
   },
   "heading-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "4cdcefe1-2006-4560-839f-5bdef6db8c1a",
+    "value": "{font-size-500}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-medium` instead.",
+    "renamed": "heading-size-medium"
+  },
+  "heading-size-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "d51dc90c-6d2c-49f0-a8f7-beafbcaa2e1d",
     "value": "{font-size-500}"
   },
   "heading-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "96673fee-b75c-4867-9041-48362af044bc",
+    "value": "{font-size-400}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-small` instead.",
+    "renamed": "heading-size-small"
+  },
+  "heading-size-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "1da05f1d-0397-4972-ac0e-f7660dce6729",
     "value": "{font-size-400}"
   },
   "heading-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "94bb5ad9-503a-428a-a8ba-6cf3f70592ac",
+    "value": "{font-size-900}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-extra-large` instead.",
+    "renamed": "heading-size-extra-large"
+  },
+  "heading-size-extra-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "80ee588f-dea3-4b12-a0cd-ba542d771d25",
     "value": "{font-size-900}"
   },
   "heading-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "4f179af6-c31f-48f8-927c-a45150668ad3",
+    "value": "{font-size-300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-extra-small` instead.",
+    "renamed": "heading-size-extra-small"
+  },
+  "heading-size-extra-small": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "0f5071e4-0d2c-46d5-b441-ea66b9ac3faa",
     "value": "{font-size-300}"
   },
   "heading-size-xxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "464e34cd-e768-4a38-a72b-cae1a4852ef3",
+    "value": "{font-size-1100}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-2x-large` instead.",
+    "renamed": "heading-size-2x-large"
+  },
+  "heading-size-2x-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "920fa886-3d98-47ea-89d1-22d5b0ecd5cc",
     "value": "{font-size-1100}"
   },
   "heading-size-xxs": {
@@ -1967,6 +2218,15 @@
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "heading",
     "uuid": "db884bf9-e7b5-420a-b408-bd9a4d6bb0a4",
+    "value": "{font-size-1300}",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `heading-size-3x-large` instead.",
+    "renamed": "heading-size-3x-large"
+  },
+  "heading-size-3x-large": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
+    "uuid": "fcefa23c-e481-4d93-be28-0c83617be60a",
     "value": "{font-size-1300}"
   },
   "heading-size-xxxxl": {
@@ -2290,6 +2550,14 @@
   "medium-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "uuid": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
+    "value": "medium",
+    "deprecated": true,
+    "deprecated_comment": "Renamed to spec-order name. Use `font-weight-medium` instead.",
+    "renamed": "font-weight-medium"
+  },
+  "font-weight-medium": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
+    "uuid": "228afe79-2ba6-4979-9f4d-1b7f13219814",
     "value": "medium"
   },
   "regular-font-weight": {


### PR DESCRIPTION
## Description

Re-applies the 100 token renames from closed PR #814 (`feat/token-spec-gap-analysis`) that were not yet reflected on `main`. Each renamed token gets `deprecated=true`, `deprecated_comment`, and a `renamed` pointer to its canonical spec-order name; a new canonical entry is added with a fresh UUID.

## Related Issue

Closes beads issue `spectrum-design-data-zfi` — Verify residual token-corpus renames from closed PR #814 are covered on main.

## Motivation and Context

PR #814 was closed without merging because most of its content had already landed on main via other routes. Investigation confirmed 176 rename pairs were proposed:

| Category | Count |
|----------|-------|
| Already in `naming-exceptions.json` (intentionally deferred) | 50 |
| **Applied in this PR** | **100** |
| Icon background tokens deferred (cascade ambiguity) | 22 |
| Rename-chain intermediaries deferred | 4 |

The 22 icon tokens (`icon-color-XXX-background → icon-XXX-icon-background-color`) are skipped because adding canonical entries alongside existing deprecated entries with explicit `name` objects creates non-deterministic SPEC-006 cascade specificity ties. They require name-object disambiguation before the canonical entries can be safely added.

The 4 chain-target tokens are already the `renamed` target of other pre-existing deprecated tokens; making them deprecated too would create rename chain instability in the legacy roundtrip.

Rename categories applied:
- `key-focus` → `keyboard-focus` vocabulary normalization (17 tokens)
- Size abbreviations expanded (`body-size-l` → `body-size-large`, etc.)
- State-last ordering (`disabled-background-color` → `background-color-disabled`)
- Component layout ordering (`divider-horizontal-minimum-width` → `divider-minimum-width-horizontal`, etc.)
- Structure/object ordering (`background-base-color` → `base-background-color`)
- Semantic icon-color reordering (`icon-color-informative` → `informative-icon-color`)

## How Has This Been Tested?

- `moon run tokens:verifyLegacyRoundtrip` — Roundtrip OK
- `moon run tokens:verifyDesignDataSnapshot` — Snapshot OK (regenerated)
- `moon run tokens:test` — All 20 tests pass
- `node tools/token-naming-audit/src/cli.js --root packages/tokens/src` — Zero violations

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.