### PR TITLE
feat(tui,demo): add layout breakpoint tests, tui-verify skill runner, and rmux automation framework

### DIFF
--- a/.changeset/auto-demo-rmux-recording.md
+++ b/.changeset/auto-demo-rmux-recording.md
@@ -6,11 +6,14 @@ Add rmux-driven demo automation for verification and cast recording.
 
 - **tools/demo/auto/auto-demo.sh**: orchestrator with `--verify` (CI-able) and
   `--record` (emits asciinema v2 `.cast` with beat markers) modes; `--docker` for
-  clean-room A/B/C runs.
+  clean-room A/B/C runs. Fix `set -e` swallowing the failure summary line.
 - **tools/demo/auto/lib/rmux-drive.sh**: shared drive loop — `send_keys`,
   `wait_for`, `wait_quiet`, `assert_contains`, `inject_markers`.
 - **tools/demo/auto/beats/{A,B,C,D}.beats.sh**: per-demo beat manifests; D
-  uses lenient anchors for non-deterministic Claude Code output.
+  uses lenient anchors for non-deterministic Claude Code output. Use `shlex.quote`
+  for hook paths in the per-run settings generator (handles spaces in repo path).
 - **tools/demo/auto/Dockerfile**: clean-room image for A/B/C (rmux + asciinema).
+  Bump builder stage to `rust:1.88-slim` (matches repo toolchain; ratatui 0.30 MSRV).
+  Remove malformed `COPY ... 2>/dev/null || true` line (docker syntax error).
 - **tools/demo/moon.yml**: adds `auto-verify`, `auto-verify-d`, `auto-record` tasks.
 - **tools/demo/presentation/RECORDING.md**: documents the automated path.

--- a/.changeset/auto-demo-rmux-recording.md
+++ b/.changeset/auto-demo-rmux-recording.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data": patch
+---
+
+Add rmux-driven demo automation for verification and cast recording.
+
+- **tools/demo/auto/auto-demo.sh**: orchestrator with `--verify` (CI-able) and
+  `--record` (emits asciinema v2 `.cast` with beat markers) modes; `--docker` for
+  clean-room A/B/C runs.
+- **tools/demo/auto/lib/rmux-drive.sh**: shared drive loop — `send_keys`,
+  `wait_for`, `wait_quiet`, `assert_contains`, `inject_markers`.
+- **tools/demo/auto/beats/{A,B,C,D}.beats.sh**: per-demo beat manifests; D
+  uses lenient anchors for non-deterministic Claude Code output.
+- **tools/demo/auto/Dockerfile**: clean-room image for A/B/C (rmux + asciinema).
+- **tools/demo/moon.yml**: adds `auto-verify`, `auto-verify-d`, `auto-record` tasks.
+- **tools/demo/presentation/RECORDING.md**: documents the automated path.

--- a/.changeset/demo-d-hooks.md
+++ b/.changeset/demo-d-hooks.md
@@ -1,0 +1,18 @@
+---
+"@adobe/design-data": patch
+---
+
+Retrofit Demo D recording with Claude Code hooks for reliable beat detection.
+
+- **tools/demo/auto/hooks/settings.json**: run-scoped hooks config (passed via
+  `claude --settings`); wires `PostToolUse` and `Stop` hooks to Demo D scripts.
+- **tools/demo/auto/hooks/record-beat.sh**: appends tool-call epoch to beats log on
+  every `mcp__design-data__` call — replaces brittle screen-text sentinel matching.
+- **tools/demo/auto/hooks/stop-done.sh**: touches done sentinel when Claude finishes —
+  replaces fragile `wait_quiet` / 180 s blind sleep.
+- **tools/demo/auto/beats/D.beats.sh**: hook-driven beat detection with content-scrape
+  fallback; precision marker injection from hook epochs.
+- **tools/demo/auto/lib/rmux-drive.sh**: adds `wait_for_file`, `wait_for_log_match`,
+  `assert_log_match`, and `inject_markers_by_time` helpers.
+- **tools/demo/auto/auto-demo.sh**: exports `DEMO_BEATS_DIR`, passes `--settings`,
+  removes `--idle-time-limit` for Demo D to align cast timeline with wall-clock.

--- a/.changeset/tui-verify-skill-and-layout-tests.md
+++ b/.changeset/tui-verify-skill-and-layout-tests.md
@@ -1,0 +1,16 @@
+---
+"design-data-tui": patch
+---
+Add tui-verify skill, generic rmux runner, and layout size-breakpoint tests.
+
+- **.claude/skills/tui-verify/SKILL.md**: new agent skill teaching the 3-tier
+  verification strategy (in-process buffer assertions, live rmux+asciinema,
+  visual asciinema+agg / Ghostty+screencapture).
+- **tools/demo/auto/verify-tui.sh**: generic ad-hoc TUI verification runner;
+  sources `lib/rmux-drive.sh`, accepts a step file
+  (send/type/wait/expect/refute directives), drives the real binary at 120×36.
+- **tools/demo/moon.yml**: add `demo:tui-verify` task (local, rmux on PATH).
+- **sdk/tui/tests/layout.rs**: committed layout breakpoint tests at 120×36,
+  80×24, 80×33 (exact logo threshold), 80×32 (one below), and panic-safety
+  cases. Documents that the logo threshold in terminal coordinates is 33 rows
+  (content area = terminal_height - 2).

--- a/sdk/tui/tests/layout.rs
+++ b/sdk/tui/tests/layout.rs
@@ -1,0 +1,202 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Layout breakpoint tests — verify the home screen renders correctly at key terminal sizes.
+//!
+//! These tests exist alongside the render tests in `render.rs` but are kept separate to
+//! give layout concerns their own home and to keep `render.rs` under the file-length norms.
+//!
+//! ## Logo threshold
+//! The logo is shown when the *active-view area* height >= LOGO_LINES + 1 + NON_LOGO_HEIGHT.
+//! From `src/view.rs`: LOGO_LINES = 17, NON_LOGO_HEIGHT = 13, so threshold = 31 content rows.
+//!
+//! The active-view area is the terminal height minus 2 fixed rows (primer header + palette
+//! prompt). So in **terminal** coordinates the logo appears when terminal_height >= 33.
+//!
+//! ## Verified sizes (terminal rows × cols)
+//! | Size    | Content rows | Expectation                                       |
+//! |---------|-------------|---------------------------------------------------|
+//! | 120×36  | 34          | Spectrum/auto-demo target — logo + all UI visible |
+//! | 80×24   | 22          | Standard small terminal — no logo, clean layout   |
+//! | 80×33   | 31          | Exact threshold — logo present                    |
+//! | 80×32   | 30          | One row below threshold — logo absent             |
+//! | 10×5    | 3           | Narrow — must not panic                           |
+//! | 1×33    | 31          | Very narrow at logo threshold height — must not panic |
+
+mod common;
+use common::{render_to_buffer, TEST_PRIMER};
+
+use design_data_tui::Model;
+use ratatui::buffer::Buffer;
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/// Collect a single row of the buffer as a `String`.
+fn row_str(buf: &Buffer, y: u16, w: u16) -> String {
+    (0..w)
+        .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect()
+}
+
+/// Return true if any row (excluding the primer header at y=0 and palette at y=h-1)
+/// contains `needle`.
+fn any_row_contains(buf: &Buffer, needle: &str, w: u16, h: u16) -> bool {
+    (1..h.saturating_sub(1)).any(|y| row_str(buf, y, w).contains(needle))
+}
+
+// ── 120×36: Spectrum/auto-demo target ─────────────────────────────────────────
+
+#[test]
+fn spectrum_target_120x36_shows_logo_and_all_sections() {
+    const W: u16 = 120;
+    const H: u16 = 36;
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
+
+    assert!(
+        any_row_contains(&buf, "▀", W, H),
+        "120×36: logo should be visible (threshold is 31 rows)"
+    );
+    assert!(
+        any_row_contains(&buf, "Spectrum Design Data", W, H),
+        "120×36: product name should be visible"
+    );
+    assert!(
+        any_row_contains(&buf, ":validate", W, H),
+        "120×36: command table should be visible"
+    );
+    // Primer arrow on the first row.
+    assert_eq!(
+        buf.cell((0, 0)).unwrap().symbol(),
+        "▶",
+        "120×36: primer arrow at (0,0)"
+    );
+    // Palette prompt row should be blank (palette closed).
+    assert!(
+        row_str(&buf, H - 1, W).trim().is_empty(),
+        "120×36: palette row should be blank when closed"
+    );
+}
+
+// ── 80×24: standard small terminal ────────────────────────────────────────────
+
+#[test]
+fn standard_80x24_no_logo_but_all_ui_present() {
+    const W: u16 = 80;
+    const H: u16 = 24;
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
+
+    assert!(
+        !any_row_contains(&buf, "▀", W, H),
+        "80×24: logo should be hidden (only 24 rows; threshold is 31)"
+    );
+    assert!(
+        any_row_contains(&buf, "Spectrum Design Data", W, H),
+        "80×24: product name should still be visible"
+    );
+    assert!(
+        any_row_contains(&buf, ">", W, H),
+        "80×24: prompt cue should be visible"
+    );
+    assert_eq!(
+        buf.cell((0, 0)).unwrap().symbol(),
+        "▶",
+        "80×24: primer arrow at (0,0)"
+    );
+}
+
+// ── 80×33: exact logo threshold in terminal coordinates ───────────────────────
+
+#[test]
+fn logo_threshold_exact_terminal_height_33_shows_logo() {
+    // Content rows = terminal_height - 2 (primer + palette) = 33 - 2 = 31.
+    // The logo condition `content_height >= 31` is true at exactly 31 content rows.
+    const W: u16 = 80;
+    const H: u16 = 33;
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
+
+    assert!(
+        any_row_contains(&buf, "▀", W, H),
+        "33 terminal rows (31 content): logo should appear at the exact threshold"
+    );
+    assert!(
+        any_row_contains(&buf, "Spectrum Design Data", W, H),
+        "33 terminal rows: product name should be visible"
+    );
+}
+
+// ── 80×32: one row below threshold ────────────────────────────────────────────
+
+#[test]
+fn one_below_threshold_terminal_height_32_hides_logo() {
+    // Content rows = 32 - 2 = 30. Condition `content_height >= 31` is false.
+    const W: u16 = 80;
+    const H: u16 = 32;
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
+
+    assert!(
+        !any_row_contains(&buf, "▀", W, H),
+        "32 terminal rows (30 content): logo should be hidden (one below the threshold)"
+    );
+    assert!(
+        any_row_contains(&buf, "Spectrum Design Data", W, H),
+        "32 terminal rows: product name should still appear without the logo"
+    );
+    assert!(
+        any_row_contains(&buf, ">", W, H),
+        "32 terminal rows: prompt cue should still appear"
+    );
+}
+
+// ── Primer is always on row 0 ──────────────────────────────────────────────────
+
+#[test]
+fn primer_row_is_always_row_zero_at_120x36() {
+    const W: u16 = 120;
+    const H: u16 = 36;
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
+    let row = row_str(&buf, 0, W);
+    assert!(
+        row.contains(TEST_PRIMER),
+        "120×36: primer row at y=0 should contain the primer text; got: {row}"
+    );
+}
+
+#[test]
+fn primer_row_is_always_row_zero_at_80x24() {
+    const W: u16 = 80;
+    const H: u16 = 24;
+    let mut model = Model::new();
+    let buf = render_to_buffer(&mut model, W, H);
+    let row = row_str(&buf, 0, W);
+    assert!(
+        row.contains(TEST_PRIMER),
+        "80×24: primer row at y=0 should contain the primer text; got: {row}"
+    );
+}
+
+// ── Panic safety at unusual sizes ────────────────────────────────────────────
+
+#[test]
+fn does_not_panic_at_10x5() {
+    let mut model = Model::new();
+    render_to_buffer(&mut model, 10, 5);
+}
+
+#[test]
+fn does_not_panic_at_width_1_logo_threshold_height() {
+    // Very narrow (1 col) at logo-threshold terminal height (33) — no overflow panic.
+    let mut model = Model::new();
+    render_to_buffer(&mut model, 1, 33);
+}

--- a/tools/demo/auto/Dockerfile
+++ b/tools/demo/auto/Dockerfile
@@ -14,7 +14,7 @@
 #   docker run --rm -v "$(pwd):/workspace:rw" spectrum-design-data-demo \
 #     bash /workspace/tools/demo/auto/auto-demo.sh C --verify
 
-FROM rust:1.82-slim AS builder
+FROM rust:1.88-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       pkg-config \
@@ -23,10 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
-
-# Pre-cache dependencies by copying manifests first.
-COPY sdk/Cargo.toml sdk/Cargo.lock* ./sdk/
-COPY sdk/crates/ ./sdk/crates/ 2>/dev/null || true
 
 # Build the design-data CLI in release mode.
 COPY sdk/ ./sdk/

--- a/tools/demo/auto/Dockerfile
+++ b/tools/demo/auto/Dockerfile
@@ -1,0 +1,69 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Clean-room image for Demo A, B, C automation.
+# Demo D CANNOT run in this container (requires host Claude auth + MCP + network).
+#
+# Build context: repo root (so the full source tree is available).
+# Typical use: auto-demo.sh handles docker build/run automatically with --docker.
+#
+# Manual use:
+#   docker build -t spectrum-design-data-demo -f tools/demo/auto/Dockerfile .
+#   docker run --rm -v "$(pwd):/workspace:rw" spectrum-design-data-demo \
+#     bash /workspace/tools/demo/auto/auto-demo.sh C --verify
+
+FROM rust:1.82-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      pkg-config \
+      libssl-dev \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Pre-cache dependencies by copying manifests first.
+COPY sdk/Cargo.toml sdk/Cargo.lock* ./sdk/
+COPY sdk/crates/ ./sdk/crates/ 2>/dev/null || true
+
+# Build the design-data CLI in release mode.
+COPY sdk/ ./sdk/
+RUN cargo build -p design-data-cli --release --manifest-path sdk/Cargo.toml
+
+# ─── runtime image ────────────────────────────────────────────────────────────
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash \
+      python3 \
+      curl \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install rmux (tmux-compatible fork) — needed to drive PTY sessions.
+# Pin to a known version; the binary is statically linked.
+ARG RMUX_VERSION=0.3.1
+RUN curl -fsSL "https://github.com/Helvesec/rmux/releases/download/v${RMUX_VERSION}/rmux-x86_64-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin/ \
+    || (echo "rmux download failed — falling back to tmux" && \
+        apt-get update && apt-get install -y --no-install-recommends tmux && \
+        ln -s /usr/bin/tmux /usr/local/bin/rmux) \
+    && chmod +x /usr/local/bin/rmux
+
+# Install asciinema (for record mode).
+RUN curl -fsSL https://github.com/asciinema/asciinema/releases/download/v3.0.0/asciinema-x86_64-unknown-linux-gnu.tar.gz \
+    | tar -xz -C /usr/local/bin/ \
+    || pip3 install asciinema \
+    || apt-get install -y --no-install-recommends asciinema
+
+# Copy the built CLI.
+COPY --from=builder /workspace/sdk/target/release/design-data /usr/local/bin/design-data
+
+# The repo is bind-mounted at /workspace at runtime, so we don't COPY it here.
+# This keeps the image small and always reflects the current working tree.
+WORKDIR /workspace
+
+ENTRYPOINT ["/bin/bash"]

--- a/tools/demo/auto/auto-demo.sh
+++ b/tools/demo/auto/auto-demo.sh
@@ -265,8 +265,8 @@ fi
 
 # ─── summary ─────────────────────────────────────────────────────────────────
 
-print_summary "$MODE"
-STATUS=$?
+STATUS=0
+print_summary "$MODE" || STATUS=$?
 
 if (( STATUS == 0 )); then
   echo -e "\n${GREEN}${BOLD}==> Demo $DEMO $MODE: OK${RESET}"

--- a/tools/demo/auto/auto-demo.sh
+++ b/tools/demo/auto/auto-demo.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# auto-demo.sh — rmux-driven demo verification and asciinema cast recording.
+#
+# USAGE
+#   auto-demo.sh <A|B|C|D> [--verify|--record] [--docker] [--cast-name NAME]
+#
+#   Modes:
+#     --verify   Drive the demo beats and assert expected output (default; CI-able
+#                for A/B/C; D requires Claude auth/MCP so it is local-only).
+#     --record   Same as --verify but wraps execution in asciinema rec (v2 format)
+#                and writes <public/casts/X-*.cast> with beat markers injected.
+#
+#   Options:
+#     --docker   Run A/B/C inside the tools/demo/auto Dockerfile for clean-room
+#                isolation (installs rmux + asciinema + builds design-data CLI).
+#                D always errors with --docker (Claude auth/MCP are host-only).
+#     --cast-name NAME   Override the output cast filename stem (no extension).
+#
+# PREREQUISITES
+#   All modes:
+#     rmux 0.3.x on PATH, design-data CLI built (cargo build -p design-data-cli --release).
+#   Record mode:
+#     asciinema 3.x on PATH.
+#   Demo D (any mode):
+#     .mcp.json at repo root with the design-data server configured; MCP pre-approved.
+#   Docker mode:
+#     docker on PATH and daemon running.
+
+set -euo pipefail
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+RESET='\033[0m'
+
+step()  { echo -e "\n${BOLD}==> $*${RESET}"; }
+info()  { echo -e "    $*"; }
+warn()  { echo -e "${YELLOW}    warn: $*${RESET}" >&2; }
+fatal() { echo -e "${RED}    error: $*${RESET}" >&2; exit 1; }
+
+# ─── resolve paths ────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LIB="$SCRIPT_DIR/lib/rmux-drive.sh"
+BEATS_DIR="$SCRIPT_DIR/beats"
+CASTS_DIR="$REPO_ROOT/tools/demo/presentation/public/casts"
+
+# ─── argument parsing ─────────────────────────────────────────────────────────
+
+DEMO=""
+MODE="verify"
+DOCKER=false
+CAST_NAME_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    A|a) DEMO="A" ;;
+    B|b) DEMO="B" ;;
+    C|c) DEMO="C" ;;
+    D|d) DEMO="D" ;;
+    --verify)  MODE="verify" ;;
+    --record)  MODE="record" ;;
+    --docker)  DOCKER=true ;;
+    --cast-name) shift; CAST_NAME_OVERRIDE="$1" ;;
+    -h|--help) grep '^#' "$0" | head -40 | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) fatal "Unknown argument: $1 (run with --help)" ;;
+  esac
+  shift
+done
+
+[[ -z "$DEMO" ]] && fatal "Specify a demo: A, B, C, or D."
+
+# ─── docker shortcut (A/B/C only) ────────────────────────────────────────────
+
+if $DOCKER; then
+  [[ "$DEMO" == "D" ]] && fatal "Demo D cannot run in Docker (Claude auth + MCP require the host). Run without --docker."
+
+  step "Docker mode — building image and running clean-room..."
+  DOCKERFILE="$SCRIPT_DIR/Dockerfile"
+  [[ -f "$DOCKERFILE" ]] || fatal "Dockerfile not found at $DOCKERFILE"
+
+  IMAGE="spectrum-design-data-demo"
+  docker build -q -t "$IMAGE" -f "$DOCKERFILE" "$REPO_ROOT" >&2
+
+  CAST_FLAG=""
+  if [[ "$MODE" == "record" ]]; then
+    CAST_FLAG="--record"
+    # Ensure local casts dir exists so bind-mount works.
+    mkdir -p "$CASTS_DIR"
+  fi
+
+  docker run --rm \
+    -v "$REPO_ROOT:/workspace:rw" \
+    -e DEMO_MODE="$MODE" \
+    "$IMAGE" \
+    bash /workspace/tools/demo/auto/auto-demo.sh "$DEMO" ${CAST_FLAG:---verify} --cast-name "${CAST_NAME_OVERRIDE:-}"
+
+  # Cast was written inside the container to /workspace/..., which is bind-mounted.
+  exit $?
+fi
+
+# ─── prerequisites ────────────────────────────────────────────────────────────
+
+step "Prerequisites"
+
+command -v rmux >/dev/null 2>&1 || fatal "rmux not found on PATH. Install from https://github.com/Helvesec/rmux or brew install rmux."
+
+CLI="$REPO_ROOT/sdk/target/release/design-data"
+if [[ ! -x "$CLI" ]]; then
+  info "design-data CLI not found — building now..."
+  cargo build -p design-data-cli --release --manifest-path "$REPO_ROOT/sdk/Cargo.toml"
+fi
+[[ -x "$CLI" ]] || fatal "CLI still missing after build: $CLI"
+
+if [[ "$MODE" == "record" ]]; then
+  command -v asciinema >/dev/null 2>&1 || fatal "asciinema not found. Install: brew install asciinema"
+  asciinema --version 2>&1 | grep -q "3\." || warn "Expected asciinema 3.x for --output-format asciicast-v2 flag."
+fi
+
+if [[ "$DEMO" == "D" ]]; then
+  command -v claude >/dev/null 2>&1 || fatal "claude (Claude Code) not found on PATH."
+  [[ -f "$REPO_ROOT/.mcp.json" ]] || fatal ".mcp.json not found at $REPO_ROOT — configure the design-data MCP server before running Demo D."
+
+  # Create a per-run scratch directory for the hook-based beat log and done sentinel.
+  # Exported so the hook scripts (record-beat.sh, stop-done.sh) can find it.
+  DEMO_BEATS_DIR="$(mktemp -d)"
+  export DEMO_BEATS_DIR
+  step "Demo D hooks dir: $DEMO_BEATS_DIR"
+fi
+
+info "all prereqs met."
+
+# ─── source library and beat manifest ─────────────────────────────────────────
+
+# shellcheck source=lib/rmux-drive.sh
+source "$LIB"
+
+case "$DEMO" in
+  A) source "$BEATS_DIR/A.beats.sh" ;;
+  B) source "$BEATS_DIR/B.beats.sh" ;;
+  C) source "$BEATS_DIR/C.beats.sh" ;;
+  D) source "$BEATS_DIR/D.beats.sh" ;;
+esac
+
+# ─── default cast names (match record-casts.sh and slides.md references) ─────
+
+cast_stem_for() {
+  case "$1" in
+    A) echo "A-find" ;;
+    B) echo "B-name" ;;
+    C) echo "C-suggest" ;;
+    D) echo "D-agent" ;;
+  esac
+}
+
+STEM="${CAST_NAME_OVERRIDE:-$(cast_stem_for "$DEMO")}"
+CAST_PATH="$CASTS_DIR/${STEM}.cast"
+
+SESSION="auto-demo-$(echo "$DEMO" | tr '[:upper:]' '[:lower:]')-$$"
+
+# ─── record mode: wrap in asciinema rec ──────────────────────────────────────
+
+TMP_CAST=""
+
+if [[ "$MODE" == "record" ]]; then
+  mkdir -p "$CASTS_DIR"
+  # macOS mktemp requires X's at the END — create a base file then rename.
+  _TMP_BASE="$(mktemp /tmp/auto-demo-XXXXXX)"
+  TMP_CAST="${_TMP_BASE}.cast"
+  mv "$_TMP_BASE" "$TMP_CAST"
+
+  step "Recording: asciinema rec → $TMP_CAST"
+  info "will post-process → $CAST_PATH"
+
+  # Launch an asciinema-recorded shell that is then driven by send-keys.
+  # The PTY lives inside the rmux pane, so asciinema sees a real TTY.
+  #
+  # Demo D: omit --idle-time-limit so the cast timeline ≈ wall-clock. This makes
+  # the hook-epoch → cast-time mapping exact (cast_start from header.timestamp +
+  # elapsed seconds = hook epoch offset). A/B/C keep --idle-time-limit 2 since they
+  # use content-based sentinel injection and don't need wall-clock alignment.
+  if [[ "$DEMO" == "D" ]]; then
+    IDLE_LIMIT_FLAG=""
+  else
+    IDLE_LIMIT_FLAG="--idle-time-limit 2"
+  fi
+
+  ASCIINEMA_REC_CMD="asciinema rec \
+    --output-format asciicast-v2 \
+    --cols $RMUX_COLS \
+    --rows $RMUX_ROWS \
+    $IDLE_LIMIT_FLAG \
+    --overwrite \
+    --title \"design-data — demo $DEMO\" \
+    $TMP_CAST"
+
+  # Start a background rmux session whose first command IS the asciinema recorder.
+  rmux new-session -d -s "$SESSION" -x "$RMUX_COLS" -y "$RMUX_ROWS" "bash -c '$ASCIINEMA_REC_CMD'"
+  sleep 2  # give asciinema a moment to open its PTY
+
+  step "Running beats (record mode)"
+  "run_beats_${DEMO}" "$SESSION" "record" "$TMP_CAST" "$REPO_ROOT" || true
+
+  # Wait for asciinema to flush and close (the shell inside it exited).
+  local_wait=0
+  while [[ ! -s "$TMP_CAST" ]] && (( local_wait < 10 )); do
+    sleep 1; (( local_wait++ ))
+  done
+  end_session "$SESSION" 2>/dev/null || true
+
+  # Verify the output is v2.
+  local_head=$(head -1 "$TMP_CAST" 2>/dev/null || true)
+  if echo "$local_head" | grep -q '"version": 2'; then
+    info "cast format: asciicast v2 ✓"
+  else
+    warn "cast header: $local_head"
+    warn "Expected asciicast v2; attempting convert..."
+    asciinema convert "$TMP_CAST" "$TMP_CAST.v2" || fatal "asciinema convert failed."
+    mv "$TMP_CAST.v2" "$TMP_CAST"
+  fi
+
+  # Copy to the final location (beat manifests already injected markers into TMP_CAST).
+  cp "$TMP_CAST" "$CAST_PATH"
+  rm -f "$TMP_CAST"
+
+  step "Cast written"
+  info "$CAST_PATH"
+  info "Markers in cast: $(grep -c '"m"' "$CAST_PATH" || echo 0)"
+
+# ─── verify mode ─────────────────────────────────────────────────────────────
+
+else
+  step "Verify mode — Demo $DEMO"
+
+  start_session "$SESSION"
+  sleep 1  # wait for the shell to initialise before sending keystrokes
+  "run_beats_${DEMO}" "$SESSION" "verify" "" "$REPO_ROOT" || true
+  end_session "$SESSION" 2>/dev/null || true
+fi
+
+# ─── Demo D: show hooks log summary and clean up ─────────────────────────────
+
+if [[ "$DEMO" == "D" && -n "${DEMO_BEATS_DIR:-}" ]]; then
+  BEATS_LOG_PATH="$DEMO_BEATS_DIR/beats.log"
+  DONE_PATH="$DEMO_BEATS_DIR/done"
+  if [[ -f "$BEATS_LOG_PATH" ]]; then
+    info "Hooks beats log (${BEATS_LOG_PATH}):"
+    while IFS=$'\t' read -r epoch tool; do
+      info "  $tool  (epoch $epoch)"
+    done < "$BEATS_LOG_PATH"
+  else
+    warn "hooks beats.log not found — hooks may not have fired (check --settings path)"
+  fi
+  [[ -f "$DONE_PATH" ]] && info "Stop hook: done ✓" || warn "Stop hook: done sentinel missing"
+  # Clean up the per-run scratch dir.
+  rm -rf "$DEMO_BEATS_DIR" 2>/dev/null || true
+fi
+
+# ─── summary ─────────────────────────────────────────────────────────────────
+
+print_summary "$MODE"
+STATUS=$?
+
+if (( STATUS == 0 )); then
+  echo -e "\n${GREEN}${BOLD}==> Demo $DEMO $MODE: OK${RESET}"
+else
+  echo -e "\n${RED}${BOLD}==> Demo $DEMO $MODE: FAILED (${ASSERT_FAILURES} assertion(s))${RESET}"
+fi
+
+exit $STATUS

--- a/tools/demo/auto/beats/A.beats.sh
+++ b/tools/demo/auto/beats/A.beats.sh
@@ -1,0 +1,101 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Beat manifest — Demo A: Find and inspect a token (TUI)
+# Produces: public/casts/A-find.cast
+#
+# Beat table from presentation/RECORDING.md:
+#   A1  :query background-color/* Enter — scroll j/k Esc              marker after
+#   A2  :resolve property=accent-background-color,colorScheme=dark Enter Esc  marker after
+#   A3  :describe button Enter — scroll j/k/PgDn Esc                  marker after
+#   A4  / accentbg — fuzzy find, j/k, Enter                           marker after
+#
+# Note: A1 (browser visualizer) is out of scope; TUI covers A2 (:resolve dark),
+# A3 (:describe button), A4 (/ fuzzy find). The TUI :query is shown as a bonus beat.
+#
+# Source this file; call run_beats_A SESSION_NAME MODE CAST_PATH REPO_ROOT
+# The orchestrator is responsible for starting and ending the rmux session.
+
+run_beats_A() {
+  local session="$1"
+  local mode="$2"
+  local cast_path="$3"
+  local repo="$4"
+
+  local dataset="$repo/packages/design-data/tokens"
+  local tui_cmd="$repo/sdk/target/release/design-data $dataset --theme spectrum --no-resume-wizard"
+  local sentinel_file
+
+  # Remove any stale wizard draft (from RECORDING.md clean-env checklist).
+  rm -f "$HOME/Library/Application Support/design-data-tui/wizard-draft.json" 2>/dev/null || true
+
+  # Wait for the shell in the rmux session to be ready.
+  sleep 1
+
+  # ── launch TUI ────────────────────────────────────────────────────────────
+  send_literal "$session" "$tui_cmd"
+  send_keys   "$session" "Enter"
+
+  # Wait for TUI to render its initial token table (first token visible).
+  wait_for "$session" "(background|accent|color)" 60
+
+  # ── A2: :resolve accent-background-color (dark) ──────────────────────────
+  echo "  beat A2: TUI :resolve" >&2
+  # Correct property: "accent-background-color" (not the longer -default variant)
+  # Real CLI output: "Property:  accent-background-color\nAlias: \"accent-color-800\""
+  type_keys    "$session" ":resolve property=accent-background-color,colorScheme=dark"
+  send_keys   "$session" "Enter"
+  # Wait for Property/Alias output (resolve view renders Property and Alias headings)
+  wait_for    "$session" "(Property:|Alias:|accent-background-color)" 30
+  assert_contains "$session" "(Property:|Alias:|accent-background)" "A2: resolve view present"
+  sleep 1
+  send_keys "$session" "Escape"
+  sleep 0.5
+
+  # ── A3: :describe button ──────────────────────────────────────────────────
+  echo "  beat A3: TUI :describe button" >&2
+  type_keys    "$session" ":describe button"
+  send_keys   "$session" "Enter"
+  wait_for    "$session" "(button|Button|anatomy|role|state)" 30
+  assert_contains "$session" "(button|Button|anatomy|role|state)" "A3: describe button view present"
+  sleep 1
+  send_keys "$session" "Escape"
+  sleep 0.5
+
+  # ── A4: / fuzzy find ──────────────────────────────────────────────────────
+  echo "  beat A4: TUI / fuzzy find" >&2
+  type_keys    "$session" "/accentbg"
+  wait_for    "$session" "(Fuzzy|accent-background|accentbg)" 15
+  assert_contains "$session" "(Fuzzy|accent-background|accentbg)" "A4: fuzzy find active"
+  sleep 0.5
+  send_keys "$session" "Enter"
+  sleep 0.5
+
+  # ── exit TUI ──────────────────────────────────────────────────────────────
+  send_keys "$session" "q"
+  sleep 1
+  send_literal "$session" "exit"
+  send_keys   "$session" "Enter"
+  # Sleep long enough for asciinema to flush and write the cast (record mode).
+  sleep 5
+
+  # ── inject markers (record mode) ─────────────────────────────────────────
+  if [[ "$mode" == "record" && -n "$cast_path" && -f "$cast_path" ]]; then
+    sentinel_file="$(mktemp)"
+    # Use screen-header strings: each only appears in its specific view, so
+    # the markers land at the right timestamps and in the right order.
+    # TUI headers (verified with capture-pane):
+    #   Resolve view: "Resolve: accent-background-color" in the dialog title
+    #   Describe view: "Describe: button" in the dialog title
+    #   Fuzzy find:    "Fuzzy:" in the header line (only while fuzzy mode is active)
+    printf 'A2 resolved value\tResolve:\n' >> "$sentinel_file"
+    printf 'A3 describe button\tDescribe:\n' >> "$sentinel_file"
+    printf 'A4 fuzzy find\tFuzzy\n' >> "$sentinel_file"
+    local tmp_marked="${cast_path%.cast}.marked.cast"
+    inject_markers "$cast_path" "$tmp_marked" "$sentinel_file"
+    mv "$tmp_marked" "$cast_path"
+    rm -f "$sentinel_file"
+  fi
+}

--- a/tools/demo/auto/beats/B.beats.sh
+++ b/tools/demo/auto/beats/B.beats.sh
@@ -1,0 +1,117 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Beat manifest — Demo B: Name a new token (TUI)
+# Produces: public/casts/B-name.cast
+#
+# Beat table from presentation/RECORDING.md:
+#   B1  :new accent background Enter → reuse banner → Tab (alias path → Confirm diff) Esc
+#   B2  :new custom brand overlay Enter → Classification → Values → Confirm → Esc
+#
+# Actual wizard screens (verified with rmux capture-pane):
+#   Screen 1 (Intent):         "Wizard · 1/4 · Intent"  — palette Enter advances here
+#   Screen 2 (Classification): "Wizard · 2/4 · Classification", Layer:, Property:, Preview:
+#   Screen 3 (Values):         "Wizard · 3/4 · Values",  Mode combo, Kind, alias rows
+#   Screen 4 (Confirm/Submit): "Wizard · 4/4 · ..."
+#
+# B1: ":new accent background" shows Screen 1 (Intent) with existing matches.
+#     Tab from Screen 1 → reuse (alias path) → Screen 4 (Confirm). Esc cancels.
+# B2: ":new custom brand overlay" → Screen 1 → Enter → Screen 2 → Enter → Screen 3
+#     → Enter → Screen 4 → Esc (cancel without writing).
+#
+# Source this file; call run_beats_B SESSION_NAME MODE CAST_PATH REPO_ROOT
+# The orchestrator is responsible for starting and ending the rmux session.
+
+run_beats_B() {
+  local session="$1"
+  local mode="$2"
+  local cast_path="$3"
+  local repo="$4"
+
+  local dataset="$repo/packages/design-data/tokens"
+  local tui_cmd="$repo/sdk/target/release/design-data $dataset --theme spectrum --no-resume-wizard"
+  local sentinel_file
+
+  # Remove any stale wizard draft (from RECORDING.md clean-env checklist).
+  rm -f "$HOME/Library/Application Support/design-data-tui/wizard-draft.json" 2>/dev/null || true
+
+  # Wait for the shell in the rmux session to be ready.
+  sleep 1
+
+  # ── launch TUI ────────────────────────────────────────────────────────────
+  send_literal "$session" "$tui_cmd"
+  send_keys   "$session" "Enter"
+
+  # Wait for TUI to render its initial token table.
+  wait_for "$session" "(background|accent|color)" 60
+
+  # ── B1: :new accent background (reuse/alias path) ─────────────────────────
+  echo "  beat B1: TUI :new accent background" >&2
+  type_keys    "$session" ":new accent background"
+  send_keys   "$session" "Enter"
+  # Wizard opens at Screen 1 (Intent): "Wizard · 1/4 · Intent"
+  wait_for    "$session" "(1/4|Intent|Wizard)" 30
+  assert_contains "$session" "(1/4|Intent|Wizard)" "B1: wizard Screen 1 (Intent) visible"
+  sleep 1
+  # Tab from Screen 1 → reuse selected (alias path, jumps to Confirm / Screen 4).
+  send_keys "$session" "Tab"
+  sleep 1
+  # Esc cancels without writing.
+  send_keys "$session" "Escape"
+  sleep 0.8
+
+  # ── B2: :new custom brand overlay (full classification path) ──────────────
+  echo "  beat B2: TUI :new custom brand overlay" >&2
+  # Remove any draft left by B1 Escape.
+  rm -f "$HOME/Library/Application Support/design-data-tui/wizard-draft.json" 2>/dev/null || true
+  sleep 0.3
+  type_keys    "$session" ":new custom brand overlay"
+  send_keys   "$session" "Enter"
+  # Wizard opens at Screen 1 (Intent) again.
+  wait_for    "$session" "(1/4|Intent|Wizard)" 30
+  sleep 1
+  # Enter → Screen 2 (Classification): "Wizard · 2/4 · Classification"
+  send_keys "$session" "Enter"
+  sleep 1
+  wait_for    "$session" "(2/4|Classification)" 30
+  assert_contains "$session" "(2/4|Classification|Layer:|Property:)" "B2: Screen 2 (Classification) visible"
+  sleep 1
+  # Enter → Screen 3 (Values): "Wizard · 3/4 · Values"
+  send_keys "$session" "Enter"
+  sleep 1
+  wait_for  "$session" "(3/4|Mode combo|Values)" 30
+  assert_contains "$session" "(3/4|Mode combo|Values)" "B2: Screen 3 (Values) visible"
+  sleep 1
+  # Enter → Screen 4 (Confirm/Submit).
+  send_keys "$session" "Enter"
+  sleep 1
+  wait_for  "$session" "(4/4|Confirm|Submit|rationale)" 30
+  assert_contains "$session" "(4/4|Confirm|Submit|rationale)" "B2: Screen 4 (Confirm) visible"
+  sleep 1
+  # Esc cancels without writing to disk (no --allow-write flag).
+  send_keys "$session" "Escape"
+  sleep 0.5
+
+  # ── exit TUI ──────────────────────────────────────────────────────────────
+  send_keys "$session" "q"
+  sleep 1
+  send_literal "$session" "exit"
+  send_keys   "$session" "Enter"
+  # Sleep long enough for asciinema to flush and write the cast (record mode).
+  sleep 5
+
+  # ── inject markers (record mode) ─────────────────────────────────────────
+  if [[ "$mode" == "record" && -n "$cast_path" && -f "$cast_path" ]]; then
+    sentinel_file="$(mktemp)"
+    # B1: Screen 1 (Intent) visible after :new accent background
+    printf 'B1 wizard intent screen\t(1/4|Intent|Wizard)\n' >> "$sentinel_file"
+    # B2: Classification screen (Screen 2) — most distinctive visual for this beat
+    printf 'B2 classification step\t(2/4|Classification)\n' >> "$sentinel_file"
+    local tmp_marked="${cast_path%.cast}.marked.cast"
+    inject_markers "$cast_path" "$tmp_marked" "$sentinel_file"
+    mv "$tmp_marked" "$cast_path"
+    rm -f "$sentinel_file"
+  fi
+}

--- a/tools/demo/auto/beats/C.beats.sh
+++ b/tools/demo/auto/beats/C.beats.sh
@@ -1,0 +1,65 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Beat manifest — Demo C: Deterministic agent companion (CLI)
+# Produces: public/casts/C-suggest.cast
+#
+# Beat table from presentation/RECORDING.md:
+#   C1  design-data suggest "primary background color"   marker after
+#   C2  design-data primer packages/design-data/tokens   marker after
+#
+# Source this file; call run_beats_C SESSION_NAME MODE CAST_PATH REPO_ROOT
+# The orchestrator is responsible for starting and ending the rmux session.
+
+run_beats_C() {
+  local session="$1"
+  local mode="$2"       # verify | record
+  local cast_path="$3"  # destination .cast (record mode); empty in verify mode
+  local repo="$4"
+
+  local cli="$repo/sdk/target/release/design-data"
+  # suggest requires the dataset path as a positional argument (verified with --help)
+  local dataset="$repo/packages/design-data/tokens"
+  local sentinel_file
+
+  # Wait for the shell to be ready (orchestrator just opened the session).
+  sleep 1
+
+  # ── C1: suggest ───────────────────────────────────────────────────────────
+  echo "  beat C1: design-data suggest" >&2
+  type_keys    "$session" "$cli suggest \"primary background color\" \"$dataset\""
+  send_keys   "$session" "Enter"
+  # Real output: "Suggestions for \"primary background color\" (top 5):"
+  wait_for    "$session" "Suggestions for" 30
+  assert_contains "$session" "Suggestions for" "C1: suggest output present"
+  sleep 1
+
+  # ── C2: primer ───────────────────────────────────────────────────────────
+  echo "  beat C2: design-data primer" >&2
+  type_keys    "$session" "$cli primer \"$dataset\""
+  send_keys   "$session" "Enter"
+  # Real output: "Spec version:  1.0.0-draft\nToken count:   4166\nComponents: ..."
+  wait_for    "$session" "(Spec version|Token count|Components)" 60
+  assert_contains "$session" "(Spec version|Token count|Components)" "C2: primer output present"
+  sleep 1
+
+  # ── exit ──────────────────────────────────────────────────────────────────
+  send_literal "$session" "exit"
+  send_keys   "$session" "Enter"
+  # Sleep long enough for asciinema to flush and write the cast (record mode).
+  sleep 5
+
+  # ── inject markers (record mode) ─────────────────────────────────────────
+  if [[ "$mode" == "record" && -n "$cast_path" && -f "$cast_path" ]]; then
+    sentinel_file="$(mktemp)"
+    # TAB-separated: beat_label<TAB>sentinel_regex (matched against "o" event text)
+    printf 'C1 suggest output\tSuggestions for\n' >> "$sentinel_file"
+    printf 'C2 primer output\t(Spec version|Token count|Components)\n' >> "$sentinel_file"
+    local tmp_marked="${cast_path%.cast}.marked.cast"
+    inject_markers "$cast_path" "$tmp_marked" "$sentinel_file"
+    mv "$tmp_marked" "$cast_path"
+    rm -f "$sentinel_file"
+  fi
+}

--- a/tools/demo/auto/beats/D.beats.sh
+++ b/tools/demo/auto/beats/D.beats.sh
@@ -1,0 +1,276 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Beat manifest — Demo D: Agent workflow (Claude Code + design-data MCP)
+# Produces: public/casts/D-agent.cast
+#
+# Beat table from presentation/RECORDING.md:
+#   D1  claude launch + paste primary prompt → Enter           marker after first MCP call
+#   D2  agent calls describe_component → role/states answer    marker after
+#   D3  agent calls resolve_token → dark-mode resolved value   marker after
+#   D4  Claude stop (done sentinel) → exit                     marker after
+#
+# Hook-based approach:
+#   A per-run settings JSON is generated at runtime (not the static hooks/settings.json).
+#   It embeds absolute paths for the hook scripts AND DEMO_BEATS_DIR directly in each
+#   hook command string, so hooks work regardless of rmux session environment inheritance.
+#   Beats are detected by polling beats.log, immune to model phrasing variation.
+#
+# Fallback (beats.log still empty after D1 timeout):
+#   Falls back to screen-scrape assertions; warns clearly.
+#
+# Source this file; call run_beats_D SESSION_NAME MODE CAST_PATH REPO_ROOT
+# The orchestrator must export DEMO_BEATS_DIR before calling this function.
+
+run_beats_D() {
+  local session="$1"
+  local mode="$2"
+  local cast_path="$3"
+  local repo="$4"
+
+  local hooks_dir="$repo/tools/demo/auto/hooks"
+  local record_beat_sh="$hooks_dir/record-beat.sh"
+  local stop_done_sh="$hooks_dir/stop-done.sh"
+
+  # Prompt: verbatim primary question from agent-questions.md.
+  # Single-line to avoid literal-newline issues with send-keys -l.
+  local prompt="Using the design-data MCP, look up the button component and tell me: 1. What its accessibility role and keyboard intents are 2. Which states it declares 3. Which token resolves the default background color in the dark color scheme. Show the answers with citations from the spec, not a guess."
+
+  # Hook-log paths (set by orchestrator before calling this function).
+  local beats_log="${DEMO_BEATS_DIR}/beats.log"
+  local done_file="${DEMO_BEATS_DIR}/done"
+
+  # Clear any stale artefacts from a prior run.
+  rm -f "$beats_log" "$done_file" 2>/dev/null || true
+
+  # ── Generate per-run settings file with DEMO_BEATS_DIR embedded ──────────
+  # Two bugs in a static settings.json approach:
+  #   1. JSON "// comment" keys break parsers → use pure valid JSON here.
+  #   2. DEMO_BEATS_DIR isn't inherited by the rmux session shell → embed it
+  #      directly in each hook command string so hooks work unconditionally.
+  local hooks_active=false
+  local per_run_settings=""
+
+  if [[ -f "$record_beat_sh" && -f "$stop_done_sh" && -n "${DEMO_BEATS_DIR:-}" ]]; then
+    # macOS mktemp requires X's at the end — create base file then rename.
+    _settings_base="$(mktemp /tmp/demo-d-settings-XXXXXX)"
+    per_run_settings="${_settings_base}.json"
+    mv "$_settings_base" "$per_run_settings"
+    # Use python3 to write the JSON so quoting in paths is handled correctly.
+    python3 - "$per_run_settings" "$record_beat_sh" "$stop_done_sh" "$DEMO_BEATS_DIR" <<'PYEOF'
+import sys, json
+
+out_path, record_sh, stop_sh, beats_dir = sys.argv[1:5]
+
+settings = {
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "mcp__design-data__.*",
+      "hooks": [{"type": "command",
+                 "command": f"DEMO_BEATS_DIR={json.dumps(beats_dir)[1:-1]} bash {json.dumps(record_sh)[1:-1]}",
+                 "timeout": 30}]
+    }],
+    "PostToolUseFailure": [{
+      "matcher": "mcp__design-data__.*",
+      "hooks": [{"type": "command",
+                 "command": f"DEMO_BEATS_DIR={json.dumps(beats_dir)[1:-1]} bash {json.dumps(record_sh)[1:-1]} --failure",
+                 "timeout": 30}]
+    }],
+    "Stop": [{
+      "hooks": [{"type": "command",
+                 "command": f"DEMO_BEATS_DIR={json.dumps(beats_dir)[1:-1]} bash {json.dumps(stop_sh)[1:-1]}",
+                 "timeout": 30}]
+    }]
+  }
+}
+
+with open(out_path, "w") as f:
+    json.dump(settings, f, indent=2)
+print(f"  [hooks] wrote per-run settings → {out_path}", file=__import__('sys').stderr)
+PYEOF
+    if [[ -f "$per_run_settings" ]]; then
+      hooks_active=true
+    else
+      warn "failed to generate per-run settings — falling back to screen scrape"
+    fi
+  else
+    warn "hook scripts missing or DEMO_BEATS_DIR unset — falling back to screen scrape"
+  fi
+
+  # Wait for the shell in the rmux session to be ready.
+  sleep 1
+
+  # ── launch Claude Code ────────────────────────────────────────────────────
+  # --settings: per-run JSON with PostToolUse + Stop hooks baked in
+  # --permission-mode auto: skips MCP tool-use confirmation dialogs
+  if $hooks_active; then
+    send_literal "$session" "claude --settings \"$per_run_settings\" --permission-mode auto"
+  else
+    send_literal "$session" "claude --permission-mode auto"
+  fi
+  send_keys "$session" "Enter"
+
+  # Wait for Claude Code's separator line (unique to its TUI, not the echo).
+  echo "  beat D1: waiting for Claude Code to start..." >&2
+  wait_for "$session" "──────────────────────────────────────────────────────────────────────────────────────────────────────────────" 90
+
+  # ── D1: paste the primary prompt ──────────────────────────────────────────
+  echo "  beat D1: submitting primary prompt" >&2
+  send_literal "$session" "$prompt"
+  send_keys   "$session" "Enter"
+
+  # ── D1 beat boundary: first MCP tool call ─────────────────────────────────
+  if $hooks_active; then
+    echo "  beat D1→D2: waiting for first design-data tool call (hooks log)..." >&2
+    wait_for_log_match "$beats_log" "mcp__design-data__" 180
+    assert_log_match    "$beats_log" "mcp__design-data__" "D1: design-data MCP called"
+  else
+    echo "  beat D1→D2: fallback — waiting for tool-call text in pane..." >&2
+    wait_for "$session" "(ctrl.o|Called design-data|Calling design-data)" 180
+    assert_contains "$session" "(ctrl.o|Called design-data|Calling design-data)" "D1: design-data MCP called (fallback)"
+  fi
+
+  # ── D2 beat boundary: describe_component completed ────────────────────────
+  if $hooks_active; then
+    echo "  beat D2: waiting for describe_component in hooks log..." >&2
+    wait_for_log_match "$beats_log" "describe_component" 120
+    assert_log_match    "$beats_log" "describe_component" "D2: describe_component call logged"
+  else
+    echo "  beat D2: fallback — waiting for role/states in pane..." >&2
+    wait_for "$session" "(keyboardIntents|keyboard intents:|accessibility role|role:)" 120
+    assert_contains "$session" "(keyboardIntents|keyboard intents:|accessibility role|role:)" "D2: accessibility role (fallback)"
+    assert_contains "$session" "(hover|focus|disabled|States:|states:)" "D2: states listed (fallback)"
+  fi
+
+  # ── D3 beat boundary: resolve_token completed ─────────────────────────────
+  if $hooks_active; then
+    echo "  beat D3: waiting for resolve_token in hooks log..." >&2
+    wait_for_log_match "$beats_log" "resolve_token" 120
+    assert_log_match    "$beats_log" "resolve_token" "D3: resolve_token call logged"
+  else
+    echo "  beat D3: fallback — waiting for resolved value in pane..." >&2
+    wait_for "$session" "(#[0-9A-Fa-f]{3,6}|rgb[( ]|accent-color-[0-9]|Resolved:)" 120
+    assert_contains "$session" "(#[0-9A-Fa-f]{3,6}|rgb|accent-color-[0-9]|Resolved:)" "D3: resolved value (fallback)"
+  fi
+
+  # ── D4: wait for Claude to finish (Stop hook) ─────────────────────────────
+  if $hooks_active; then
+    echo "  beat D4: waiting for Stop hook (done sentinel)..." >&2
+    # Gate on resolve_token logged first to prevent a premature Stop from truncating.
+    wait_for_log_match "$beats_log" "resolve_token" 30 2>/dev/null || true
+    wait_for_file "$done_file" 300
+    echo "  beat D4: done sentinel received" >&2
+  else
+    echo "  beat D4: fallback — wait_quiet (may exit early under asciinema buffering)" >&2
+    wait_quiet "$session" 4 120
+  fi
+
+  # ── exit Claude Code ──────────────────────────────────────────────────────
+  echo "  beat D4: exiting Claude Code" >&2
+  send_literal "$session" "exit"
+  send_keys   "$session" "Enter"
+  sleep 3
+  send_literal "$session" "exit"
+  send_keys   "$session" "Enter"
+  sleep 8  # wait for asciinema to flush the cast
+
+  # ── clean up per-run settings file ───────────────────────────────────────
+  [[ -n "$per_run_settings" ]] && rm -f "$per_run_settings" 2>/dev/null || true
+
+  # ── inject markers (record mode) ─────────────────────────────────────────
+  if [[ "$mode" == "record" && -n "$cast_path" && -f "$cast_path" ]]; then
+    if $hooks_active && [[ -s "$beats_log" ]]; then
+      _inject_d_markers_from_hooks "$cast_path" "$beats_log"
+    else
+      warn "hooks log empty — falling back to sentinel text scan for markers"
+      _inject_d_markers_fallback "$cast_path"
+    fi
+  fi
+}
+
+# ── marker injection helpers ─────────────────────────────────────────────────
+
+_inject_d_markers_from_hooks() {
+  local cast_path="$1"
+  local beats_log="$2"
+
+  python3 - "$cast_path" "$beats_log" <<'PYEOF'
+import sys, json, os
+
+cast_path, beats_log = sys.argv[1], sys.argv[2]
+
+with open(cast_path) as f:
+    header = json.loads(f.readline())
+    rest = f.readlines()
+
+cast_start = header.get("timestamp", 0)
+
+beats = []
+with open(beats_log) as f:
+    for line in f:
+        parts = line.strip().split('\t')
+        if len(parts) >= 2:
+            try:
+                beats.append((float(parts[0]), parts[1]))
+            except ValueError:
+                pass
+
+if not cast_start:
+    print("  [markers] WARNING: cast has no timestamp in header", file=sys.stderr)
+    sys.exit(0)
+
+d1_t = d2_t = d3_t = d4_t = None
+for epoch, tool in beats:
+    offset = max(0.0, epoch - cast_start)
+    if d2_t is None and "describe_component" in tool:
+        d2_t = offset
+    if d3_t is None and "resolve_token" in tool:
+        d3_t = offset
+    if d4_t is None and "STOP" in tool:
+        d4_t = offset
+
+# D1 = "prompt submitted" — we don't have a direct hook for this moment, so
+# anchor it 5 seconds before D2 (describe_component), which is approximately
+# when the user typed Enter on the prompt. This keeps D1 visually distinct
+# from D2 rather than having them overlap at the same timestamp.
+if d2_t is not None:
+    d1_t = max(0.5, d2_t - 5.0)
+
+markers = []
+if d1_t is not None: markers.append([d1_t, "m", "D1 prompt submitted"])
+if d2_t is not None: markers.append([d2_t, "m", "D2 role and states"])
+if d3_t is not None: markers.append([d3_t, "m", "D3 dark-mode resolved value"])
+if d4_t is not None: markers.append([d4_t, "m", "D4 agent skill alternative"])
+
+if not markers:
+    print("  [markers] WARNING: no beats mapped; no markers placed", file=sys.stderr)
+    sys.exit(0)
+
+events = [json.loads(l) for l in rest if l.strip()]
+all_events = sorted(events + markers, key=lambda e: (e[0], 0 if e[1] != "m" else 1))
+
+tmp = cast_path + ".marktmp"
+with open(tmp, "w") as f:
+    f.write(json.dumps(header) + "\n")
+    for e in all_events:
+        f.write(json.dumps(e) + "\n")
+os.replace(tmp, cast_path)
+print(f"  [markers] placed {len(markers)}/4 from hook epochs", file=sys.stderr)
+PYEOF
+}
+
+_inject_d_markers_fallback() {
+  local cast_path="$1"
+  local sentinel_file
+  sentinel_file="$(mktemp)"
+  printf 'D1 prompt submitted\t(ctrl.o|Called design-data)\n'   >> "$sentinel_file"
+  printf 'D2 role and states\t(keyboardIntents|keyboard intents:|accessibility role|role:)\n' >> "$sentinel_file"
+  printf 'D3 dark-mode resolved value\t(#[0-9A-Fa-f]{3,6}|rgb[( ]|accent-color-[0-9]|Resolved:)\n' >> "$sentinel_file"
+  printf 'D4 agent skill alternative\t(exit|npx|alternative|agent skill)\n' >> "$sentinel_file"
+  local tmp="${cast_path%.cast}.marked.cast"
+  inject_markers "$cast_path" "$tmp" "$sentinel_file"
+  mv "$tmp" "$cast_path"
+  rm -f "$sentinel_file"
+}

--- a/tools/demo/auto/beats/D.beats.sh
+++ b/tools/demo/auto/beats/D.beats.sh
@@ -60,7 +60,7 @@ run_beats_D() {
     mv "$_settings_base" "$per_run_settings"
     # Use python3 to write the JSON so quoting in paths is handled correctly.
     python3 - "$per_run_settings" "$record_beat_sh" "$stop_done_sh" "$DEMO_BEATS_DIR" <<'PYEOF'
-import sys, json
+import sys, json, shlex
 
 out_path, record_sh, stop_sh, beats_dir = sys.argv[1:5]
 
@@ -69,18 +69,18 @@ settings = {
     "PostToolUse": [{
       "matcher": "mcp__design-data__.*",
       "hooks": [{"type": "command",
-                 "command": f"DEMO_BEATS_DIR={json.dumps(beats_dir)[1:-1]} bash {json.dumps(record_sh)[1:-1]}",
+                 "command": f"DEMO_BEATS_DIR={shlex.quote(beats_dir)} bash {shlex.quote(record_sh)}",
                  "timeout": 30}]
     }],
     "PostToolUseFailure": [{
       "matcher": "mcp__design-data__.*",
       "hooks": [{"type": "command",
-                 "command": f"DEMO_BEATS_DIR={json.dumps(beats_dir)[1:-1]} bash {json.dumps(record_sh)[1:-1]} --failure",
+                 "command": f"DEMO_BEATS_DIR={shlex.quote(beats_dir)} bash {shlex.quote(record_sh)} --failure",
                  "timeout": 30}]
     }],
     "Stop": [{
       "hooks": [{"type": "command",
-                 "command": f"DEMO_BEATS_DIR={json.dumps(beats_dir)[1:-1]} bash {json.dumps(stop_sh)[1:-1]}",
+                 "command": f"DEMO_BEATS_DIR={shlex.quote(beats_dir)} bash {shlex.quote(stop_sh)}",
                  "timeout": 30}]
     }]
   }

--- a/tools/demo/auto/hooks/record-beat.sh
+++ b/tools/demo/auto/hooks/record-beat.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Claude Code PostToolUse / PostToolUseFailure hook for Demo D recording.
+#
+# Called by Claude Code with the hook event JSON on stdin.
+# Appends one TSV line to ${DEMO_BEATS_DIR}/beats.log:
+#   <epoch_seconds_float>\t<tool_name>[\tFAILURE]
+#
+# DEMO_BEATS_DIR is exported by auto-demo.sh before launching claude.
+# Falls back to /tmp/demo-d if unset.
+#
+# Exit 0 with no stdout: no effect on Claude's behavior (pure side-effect).
+
+BEATS_DIR="${DEMO_BEATS_DIR:-/tmp/demo-d}"
+mkdir -p "$BEATS_DIR"
+BEATS_LOG="$BEATS_DIR/beats.log"
+
+FAILURE_FLAG=""
+if [[ "${1:-}" == "--failure" ]]; then
+  FAILURE_FLAG="FAILURE"
+fi
+
+# Read the hook JSON payload from stdin into a variable BEFORE invoking python3.
+# If we used a heredoc (python3 - <<'PYEOF'), the heredoc replaces stdin and
+# json.load(sys.stdin) would see EOF.  Passing via env var avoids this.
+HOOK_JSON="$(cat)"
+
+HOOK_JSON="$HOOK_JSON" BEATS_LOG="$BEATS_LOG" FAILURE_FLAG="$FAILURE_FLAG" \
+  python3 -c '
+import os, json, time
+
+hook_json   = os.environ.get("HOOK_JSON", "")
+beats_log   = os.environ.get("BEATS_LOG", "/tmp/demo-d/beats.log")
+failure_tag = os.environ.get("FAILURE_FLAG", "")
+
+try:
+    payload = json.loads(hook_json)
+    tool_name = payload.get("tool_name", "unknown")
+except Exception:
+    tool_name = "unknown"
+
+epoch = time.time()
+suffix = f"\t{failure_tag}" if failure_tag else ""
+
+with open(beats_log, "a") as f:
+    f.write(f"{epoch:.6f}\t{tool_name}{suffix}\n")
+'
+
+exit 0

--- a/tools/demo/auto/hooks/settings.json
+++ b/tools/demo/auto/hooks/settings.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "REFERENCE ONLY — this file is not passed directly to claude. D.beats.sh generates a per-run settings file with absolute hook paths and DEMO_BEATS_DIR embedded. The relative paths here ('bash tools/demo/...') only resolve from the repo root and would fail elsewhere.",
   "hooks": {
     "PostToolUse": [
       {

--- a/tools/demo/auto/hooks/settings.json
+++ b/tools/demo/auto/hooks/settings.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "mcp__design-data__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash tools/demo/auto/hooks/record-beat.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "mcp__design-data__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash tools/demo/auto/hooks/record-beat.sh --failure",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash tools/demo/auto/hooks/stop-done.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tools/demo/auto/hooks/stop-done.sh
+++ b/tools/demo/auto/hooks/stop-done.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Claude Code Stop hook for Demo D recording.
+#
+# Called by Claude Code after it finishes responding to the turn.
+# Touches ${DEMO_BEATS_DIR}/done — the beat manifest polls for this file
+# instead of using wait_quiet (which exits early under asciinema buffering).
+#
+# Also records the Stop epoch in beats.log so D4 has a precise time anchor.
+#
+# DEMO_BEATS_DIR is exported by auto-demo.sh before launching claude.
+# Falls back to /tmp/demo-d if unset.
+#
+# Exit 0 with no stdout: no effect on Claude's behavior (pure side-effect).
+
+BEATS_DIR="${DEMO_BEATS_DIR:-/tmp/demo-d}"
+mkdir -p "$BEATS_DIR"
+
+# Drain stdin (Claude Code sends the Stop payload; we don't need its contents).
+cat > /dev/null
+
+# Record Stop epoch in beats.log.
+BEATS_LOG="$BEATS_DIR/beats.log" python3 -c '
+import os, time
+beats_log = os.environ.get("BEATS_LOG", "/tmp/demo-d/beats.log")
+epoch = time.time()
+with open(beats_log, "a") as f:
+    f.write(f"{epoch:.6f}\tSTOP\n")
+'
+
+# Touch the done sentinel — the beat manifest's wait_for_file will unblock.
+touch "$BEATS_DIR/done"
+
+exit 0

--- a/tools/demo/auto/lib/rmux-drive.sh
+++ b/tools/demo/auto/lib/rmux-drive.sh
@@ -1,0 +1,388 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# shared rmux drive loop — source this file, then call the helpers.
+#
+# Requires: rmux 0.3.x (tmux-compatible fork) on PATH.
+# Pinned geometry matches the Slidev deck's <Asciinema> embed (120×36).
+
+RMUX_COLS=120
+RMUX_ROWS=36
+
+# ─── session management ───────────────────────────────────────────────────────
+
+# start_session SESSION_NAME [CMD]
+#   Start a detached rmux session running CMD (default: $SHELL).
+#   In record mode the orchestrator wraps CMD in asciinema rec at a higher level;
+#   here we just open the session with the right geometry.
+start_session() {
+  local name="$1"; shift
+  local cmd="${1:-}"
+
+  # Kill any leftover session with the same name.
+  rmux kill-session -t "$name" 2>/dev/null || true
+
+  if [[ -n "$cmd" ]]; then
+    rmux new-session -d -s "$name" -x "$RMUX_COLS" -y "$RMUX_ROWS" "$cmd"
+  else
+    rmux new-session -d -s "$name" -x "$RMUX_COLS" -y "$RMUX_ROWS"
+  fi
+}
+
+# end_session SESSION_NAME
+#   Kill the rmux session. Callers are responsible for sending any quit keystroke
+#   (e.g. "exit", "q", C-d) before calling this so the recorded program exits cleanly.
+end_session() {
+  local name="$1"
+  rmux kill-session -t "$name" 2>/dev/null || true
+}
+
+# ─── keystroke helpers ────────────────────────────────────────────────────────
+
+# send_keys SESSION_NAME KEY [KEY...]
+#   Send one or more tmux key sequences to the pane.
+#   Use for control sequences: Enter, Escape, Tab, C-c, etc.
+send_keys() {
+  local name="$1"; shift
+  rmux send-keys -t "$name" "$@"
+}
+
+# send_literal SESSION_NAME TEXT
+#   Send TEXT as literal characters (no key-sequence interpretation).
+#   Use for pasting prompts, query strings, long prose — anything that must not
+#   be interpreted by rmux's key-name parser.
+#   NOTE: sends all characters at once — no typing animation in the recording.
+#   Use type_keys instead when the typing animation matters (e.g. video recording).
+send_literal() {
+  local name="$1"; shift
+  local text="$1"
+  rmux send-keys -t "$name" -l "$text"
+}
+
+# type_keys SESSION_NAME TEXT [DELAY_MS]
+#   Send TEXT one character at a time with DELAY_MS milliseconds between each
+#   keystroke (default 60ms). Produces a visible typing animation in recordings.
+#   Use instead of send_literal whenever the cast will be converted to video.
+type_keys() {
+  local name="$1"
+  local text="$2"
+  local delay_ms="${3:-60}"
+  local delay_s
+  # Convert ms to fractional seconds (bash arithmetic; use python3 for portability)
+  delay_s=$(python3 -c "print(${delay_ms}/1000)")
+  local i char
+  for (( i=0; i<${#text}; i++ )); do
+    char="${text:$i:1}"
+    rmux send-keys -t "$name" -l "$char"
+    sleep "$delay_s"
+  done
+}
+
+# ─── polling helpers ──────────────────────────────────────────────────────────
+
+# capture SESSION_NAME
+#   Print the current visible pane contents.
+capture() {
+  local name="$1"
+  rmux capture-pane -p -t "$name" 2>/dev/null || true
+}
+
+# wait_for SESSION_NAME REGEX [TIMEOUT_SECS]
+#   Poll the pane until REGEX appears or we time out (default 120 s).
+#   Returns 0 on match, 1 on timeout.
+wait_for() {
+  local name="$1"
+  local regex="$2"
+  local timeout="${3:-120}"
+  local elapsed=0
+  local interval=1
+
+  while (( elapsed < timeout )); do
+    if capture "$name" | grep -qE "$regex" 2>/dev/null; then
+      return 0
+    fi
+    sleep "$interval"
+    (( elapsed += interval ))
+  done
+
+  echo "  [timeout] wait_for '$regex' timed out after ${timeout}s" >&2
+  return 1
+}
+
+# wait_quiet SESSION_NAME [STABLE_COUNT] [TIMEOUT_SECS]
+#   Poll the pane until its output is unchanged for STABLE_COUNT consecutive
+#   polls (default 3), or we time out (default 120 s).
+#   Equivalent to wait_for_load_state(Quiet) in the rmux Playwright demo.
+wait_quiet() {
+  local name="$1"
+  local stable_needed="${2:-3}"
+  local timeout="${3:-120}"
+  local elapsed=0
+  local interval=1
+  local stable_count=0
+  local prev=""
+
+  while (( elapsed < timeout )); do
+    local current
+    current=$(capture "$name")
+    if [[ "$current" == "$prev" ]]; then
+      (( stable_count++ ))
+      if (( stable_count >= stable_needed )); then
+        return 0
+      fi
+    else
+      stable_count=0
+      prev="$current"
+    fi
+    sleep "$interval"
+    (( elapsed += interval ))
+  done
+
+  echo "  [timeout] wait_quiet timed out after ${timeout}s" >&2
+  return 1
+}
+
+# ─── assertion helpers ────────────────────────────────────────────────────────
+
+# These accumulate results rather than aborting, so all beats run and we get a
+# full failure report. The orchestrator checks ASSERT_FAILURES at the end.
+ASSERT_FAILURES=0
+ASSERT_PASSES=0
+
+assert_contains() {
+  local name="$1"
+  local regex="$2"
+  local label="${3:-$regex}"
+
+  if capture "$name" | grep -qE "$regex" 2>/dev/null; then
+    echo "  [pass] $label" >&2
+    (( ASSERT_PASSES++ ))
+    return 0
+  else
+    echo "  [FAIL] $label (pattern: $regex)" >&2
+    (( ASSERT_FAILURES++ ))
+    return 1
+  fi
+}
+
+# assert_fails SESSION_NAME REGEX LABEL
+#   Asserts the pane does NOT contain REGEX (used to verify error-path demos).
+assert_fails() {
+  local name="$1"
+  local regex="$2"
+  local label="${3:-$regex}"
+
+  if capture "$name" | grep -qE "$regex" 2>/dev/null; then
+    echo "  [FAIL] expected absence of '$regex' — got a match ($label)" >&2
+    (( ASSERT_FAILURES++ ))
+    return 1
+  else
+    echo "  [pass] absent: $label" >&2
+    (( ASSERT_PASSES++ ))
+    return 0
+  fi
+}
+
+# ─── hook-based wait helpers (Demo D) ────────────────────────────────────────
+
+# wait_for_file PATH [TIMEOUT_SECS]
+#   Poll until the file at PATH exists, or we time out (default 300 s).
+#   Used to wait for the Stop hook to write ${DEMO_BEATS_DIR}/done.
+wait_for_file() {
+  local path="$1"
+  local timeout="${2:-300}"
+  local elapsed=0
+  local interval=1
+
+  while (( elapsed < timeout )); do
+    [[ -f "$path" ]] && return 0
+    sleep "$interval"
+    (( elapsed += interval ))
+  done
+
+  echo "  [timeout] wait_for_file '$path' timed out after ${timeout}s" >&2
+  return 1
+}
+
+# wait_for_log_match LOGFILE REGEX [TIMEOUT_SECS]
+#   Poll until a line in LOGFILE matches REGEX (grep -E), or time out (default 300 s).
+#   Used to detect when a specific MCP tool call has been logged by record-beat.sh.
+wait_for_log_match() {
+  local logfile="$1"
+  local regex="$2"
+  local timeout="${3:-300}"
+  local elapsed=0
+  local interval=1
+
+  while (( elapsed < timeout )); do
+    if [[ -f "$logfile" ]] && grep -qE "$regex" "$logfile" 2>/dev/null; then
+      return 0
+    fi
+    sleep "$interval"
+    (( elapsed += interval ))
+  done
+
+  echo "  [timeout] wait_for_log_match '$regex' in '$logfile' timed out after ${timeout}s" >&2
+  return 1
+}
+
+# assert_log_match LOGFILE REGEX LABEL
+#   Assert that at least one line in LOGFILE matches REGEX.
+assert_log_match() {
+  local logfile="$1"
+  local regex="$2"
+  local label="${3:-$regex}"
+
+  if [[ -f "$logfile" ]] && grep -qE "$regex" "$logfile" 2>/dev/null; then
+    echo "  [pass] $label" >&2
+    (( ASSERT_PASSES++ ))
+    return 0
+  else
+    echo "  [FAIL] $label (pattern: $regex in $logfile)" >&2
+    (( ASSERT_FAILURES++ ))
+    return 1
+  fi
+}
+
+# inject_markers_by_time CAST_IN CAST_OUT TIMES_FILE
+#   Insert asciinema v2 marker events at precise cast-time offsets.
+#
+#   TIMES_FILE is a TSV: cast_seconds<TAB>label  (one per line, # comments ignored)
+#   cast_seconds is a float: the epoch time of the event MINUS the cast's header
+#   timestamp (both in seconds). The caller computes this from beats.log.
+#
+#   Unlike inject_markers (which scans "o" event text), this places markers at
+#   exact times regardless of rendered content — no regex, no false matches.
+#
+#   Requires: python3 (standard on macOS).
+inject_markers_by_time() {
+  local cast_in="$1"
+  local cast_out="$2"
+  local times_file="$3"
+
+  python3 - "$cast_in" "$cast_out" "$times_file" <<'PYEOF'
+import sys, json
+
+cast_in, cast_out, times_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Parse times file: cast_seconds<TAB>label
+markers = []
+with open(times_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split('\t', 1)
+        if len(parts) == 2:
+            try:
+                t = float(parts[0])
+                label = parts[1]
+                if t >= 0:
+                    markers.append([t, 'm', label])
+            except ValueError:
+                pass
+
+with open(cast_in) as f:
+    lines = f.readlines()
+
+header = json.loads(lines[0])
+events = [json.loads(l) for l in lines[1:] if l.strip()]
+
+# Merge markers into event stream, sorted by time
+all_events = events + markers
+all_events.sort(key=lambda e: (e[0], 0 if e[1] != 'm' else 1))
+
+with open(cast_out, 'w') as f:
+    f.write(json.dumps(header) + '\n')
+    for e in all_events:
+        f.write(json.dumps(e) + '\n')
+
+print(f"  [markers-by-time] placed {len(markers)} markers", file=sys.stderr)
+PYEOF
+}
+
+# ─── marker injection (record mode) ──────────────────────────────────────────
+
+# inject_markers CAST_IN CAST_OUT SENTINEL_FILE
+#   Read a two-column TSV from SENTINEL_FILE (beat_label<TAB>sentinel_regex) and
+#   insert asciinema v2 marker events into the cast.
+#
+#   Strategy: anchor each marker to the timestamp of the first "o" event whose
+#   text matches the sentinel regex, rather than to a wall-clock offset. This
+#   survives --idle-time-limit compression.  Markers are merge-sorted into the
+#   JSON-lines stream.
+#
+#   SENTINEL_FILE format (one per line, # comments ignored):
+#     D1 prompt submitted<TAB>mcp__design-data__
+#     D2 role and states<TAB>keyboard[Ii]ntents
+#
+#   Requires: python3 (standard on macOS).
+inject_markers() {
+  local cast_in="$1"
+  local cast_out="$2"
+  local sentinel_file="$3"
+
+  python3 - "$cast_in" "$cast_out" "$sentinel_file" <<'PYEOF'
+import sys, json, re
+
+cast_in, cast_out, sentinel_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Parse sentinel file: label TAB regex
+sentinels = []
+with open(sentinel_file) as f:
+    for line in f:
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split('\t', 1)
+        if len(parts) == 2:
+            sentinels.append({'label': parts[0], 'regex': re.compile(parts[1]), 'done': False})
+
+with open(cast_in) as f:
+    lines = f.readlines()
+
+header = json.loads(lines[0])
+events = [json.loads(l) for l in lines[1:] if l.strip()]
+
+markers = []
+for event in events:
+    t, etype, text = event[0], event[1], event[2]
+    if etype != 'o':
+        continue
+    for s in sentinels:
+        if not s['done'] and s['regex'].search(text):
+            markers.append([t, 'm', s['label']])
+            s['done'] = True
+
+# Merge markers into event stream, sorted by time
+all_events = events + markers
+all_events.sort(key=lambda e: (e[0], 0 if e[1] != 'm' else 1))
+
+with open(cast_out, 'w') as f:
+    f.write(json.dumps(header) + '\n')
+    for e in all_events:
+        f.write(json.dumps(e) + '\n')
+
+placed = sum(1 for s in sentinels if s['done'])
+missed = [s['label'] for s in sentinels if not s['done']]
+print(f"  [markers] placed {placed}/{len(sentinels)}", file=sys.stderr)
+if missed:
+    print(f"  [markers] WARNING: no match found for: {', '.join(missed)}", file=sys.stderr)
+PYEOF
+}
+
+# ─── summary ─────────────────────────────────────────────────────────────────
+
+print_summary() {
+  local mode="$1"  # verify | record
+  echo ""
+  echo "──────────────────────────────────"
+  echo " $mode summary: $ASSERT_PASSES passed, $ASSERT_FAILURES failed"
+  echo "──────────────────────────────────"
+  if (( ASSERT_FAILURES > 0 )); then
+    return 1
+  fi
+  return 0
+}

--- a/tools/demo/auto/verify-tui.sh
+++ b/tools/demo/auto/verify-tui.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# verify-tui.sh — generic ad-hoc TUI verification runner (Tier 2 of the tui-verify skill).
+#
+# Starts the real design-data binary inside an rmux pane at 120×36, executes a step
+# file of verification directives, and reports pass/fail counts. The pane's visible
+# text is printed on each `capture`, `expect`, or `refute` directive so Claude (or a
+# human) can read and reason about the actual layout.
+#
+# USAGE
+#   verify-tui.sh --dataset PATH [--steps PATH] [--theme THEME] [--session NAME]
+#                 [--cols N] [--rows N] [--no-record]
+#
+#   --dataset PATH   Path to the design-data token dataset (required).
+#   --steps FILE     Path to a step file (default: reads from stdin).
+#   --theme THEME    TUI theme: terminal (default) or spectrum.
+#   --session NAME   rmux session name (default: dd-verify-$$).
+#   --cols N         Pane width  (default: 120, matches auto-demo geometry).
+#   --rows N         Pane height (default:  36, matches auto-demo geometry).
+#   --no-record      Skip recording asciinema cast (default: no cast recorded).
+#   --record CAST    Record session to CAST path (asciinema v2 .cast).
+#
+# STEP FILE FORMAT
+#   One directive per line. Lines starting with # are comments and blank lines ignored.
+#
+#     send KEY         Send a tmux/rmux key name (Enter, Escape, Tab, C-c, …).
+#     type TEXT        Type TEXT one char at a time (60 ms delay; shows typing animation).
+#     literal TEXT     Send TEXT as-is (no key interpretation; no animation).
+#     wait REGEX       Block until REGEX appears in the pane (timeout: 120 s).
+#     quiet [N]        Block until pane is stable for N consecutive polls (default 3).
+#     expect REGEX     Assert pane contains REGEX (accumulating — does not abort).
+#     refute REGEX     Assert pane does NOT contain REGEX (accumulating).
+#     capture          Print the current pane contents to stdout.
+#     sleep N          Sleep N seconds (whole or fractional).
+#
+# PREREQUISITES
+#   rmux 0.3.x on PATH.
+#   design-data CLI built: cargo build -p design-data-cli --release (or moon run :build).
+#   asciinema 3.x on PATH (only needed with --record).
+#
+# EXIT CODE
+#   0 if all assertions passed; 1 if any failed or a step errored.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LIB="$SCRIPT_DIR/lib/rmux-drive.sh"
+
+# ─── argument parsing ─────────────────────────────────────────────────────────
+
+DATASET=""
+STEPS_FILE=""
+THEME="terminal"
+SESSION_NAME="dd-verify-$$"
+COLS=120
+ROWS=36
+RECORD_CAST=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dataset)   DATASET="$2";      shift 2 ;;
+    --steps)     STEPS_FILE="$2";   shift 2 ;;
+    --theme)     THEME="$2";        shift 2 ;;
+    --session)   SESSION_NAME="$2"; shift 2 ;;
+    --cols)      COLS="$2";         shift 2 ;;
+    --rows)      ROWS="$2";         shift 2 ;;
+    --record)    RECORD_CAST="$2";  shift 2 ;;
+    --no-record) RECORD_CAST="";    shift   ;;
+    -h|--help)
+      sed -n '2,/^set -euo/p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$DATASET" ]] || { echo "error: --dataset is required" >&2; exit 1; }
+
+# ─── sanity checks ────────────────────────────────────────────────────────────
+
+command -v rmux  >/dev/null 2>&1 || { echo "error: rmux not found on PATH (brew install rmux)" >&2; exit 1; }
+if [[ -n "$RECORD_CAST" ]]; then
+  command -v asciinema >/dev/null 2>&1 || { echo "error: --record requires asciinema on PATH" >&2; exit 1; }
+fi
+
+# Resolve dataset to an absolute path.
+DATASET="$(cd "$REPO_ROOT" && realpath "$DATASET")"
+
+# Find the binary.
+BIN=""
+for candidate in \
+    "$REPO_ROOT/sdk/target/release/design-data" \
+    "$REPO_ROOT/sdk/target/debug/design-data"; do
+  [[ -x "$candidate" ]] && { BIN="$candidate"; break; }
+done
+[[ -n "$BIN" ]] || {
+  echo "error: design-data binary not found — run: cargo build -p design-data-cli --release" >&2
+  exit 1
+}
+
+# ─── load rmux helpers ────────────────────────────────────────────────────────
+
+# Override geometry before sourcing so the library picks them up.
+RMUX_COLS="$COLS"
+RMUX_ROWS="$ROWS"
+# shellcheck source=lib/rmux-drive.sh
+source "$LIB"
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+BOLD=$'\033[1m'
+GREEN=$'\033[0;32m'
+RED=$'\033[0;31m'
+RESET=$'\033[0m'
+
+info()  { echo "${BOLD}==> $*${RESET}"; }
+ok()    { echo "${GREEN}    ok${RESET}: $*"; }
+err()   { echo "${RED}    error${RESET}: $*" >&2; }
+
+# execute_steps SESSION STEPS_FILE
+#   Reads directives from STEPS_FILE (or stdin if "-") and dispatches to rmux-drive.sh.
+execute_steps() {
+  local session="$1"
+  local file="$2"
+
+  local lineno=0
+  while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+    (( lineno++ ))
+    local line
+    line="$(echo "$raw_line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+    # Skip blank lines and comments.
+    [[ -z "$line" || "$line" == \#* ]] && continue
+
+    local directive rest
+    directive="${line%% *}"
+    rest="${line#* }"
+    [[ "$rest" == "$directive" ]] && rest=""  # no argument
+
+    case "$directive" in
+      send)
+        [[ -n "$rest" ]] || { err "line $lineno: 'send' requires a key name"; ASSERT_FAILURES=$((ASSERT_FAILURES+1)); continue; }
+        send_keys "$session" "$rest"
+        ;;
+      type)
+        [[ -n "$rest" ]] || { err "line $lineno: 'type' requires text"; ASSERT_FAILURES=$((ASSERT_FAILURES+1)); continue; }
+        type_keys "$session" "$rest"
+        ;;
+      literal)
+        [[ -n "$rest" ]] || { err "line $lineno: 'literal' requires text"; ASSERT_FAILURES=$((ASSERT_FAILURES+1)); continue; }
+        send_literal "$session" "$rest"
+        ;;
+      wait)
+        [[ -n "$rest" ]] || { err "line $lineno: 'wait' requires a regex"; ASSERT_FAILURES=$((ASSERT_FAILURES+1)); continue; }
+        wait_for "$session" "$rest"
+        ;;
+      quiet)
+        local stable="${rest:-3}"
+        wait_quiet "$session" "$stable"
+        ;;
+      expect)
+        [[ -n "$rest" ]] || { err "line $lineno: 'expect' requires a regex"; ASSERT_FAILURES=$((ASSERT_FAILURES+1)); continue; }
+        echo "── capture ──"
+        capture "$session"
+        echo "─────────────"
+        assert_contains "$session" "$rest" "$rest"
+        ;;
+      refute)
+        [[ -n "$rest" ]] || { err "line $lineno: 'refute' requires a regex"; ASSERT_FAILURES=$((ASSERT_FAILURES+1)); continue; }
+        echo "── capture ──"
+        capture "$session"
+        echo "─────────────"
+        assert_fails "$session" "$rest" "absent: $rest"
+        ;;
+      capture)
+        echo "── capture ──"
+        capture "$session"
+        echo "─────────────"
+        ;;
+      sleep)
+        [[ -n "$rest" ]] || { err "line $lineno: 'sleep' requires a duration"; continue; }
+        sleep "$rest"
+        ;;
+      *)
+        err "line $lineno: unknown directive '$directive'"
+        ASSERT_FAILURES=$((ASSERT_FAILURES+1))
+        ;;
+    esac
+  done < <(
+    if [[ "$file" == "-" ]]; then cat; else cat "$file"; fi
+  )
+}
+
+# ─── main ─────────────────────────────────────────────────────────────────────
+
+STEPS_SRC="${STEPS_FILE:--}"   # default: stdin
+
+info "Starting rmux session '$SESSION_NAME' at ${COLS}×${ROWS}"
+
+CMD="$BIN $DATASET --theme $THEME --no-resume-wizard"
+
+if [[ -n "$RECORD_CAST" ]]; then
+  info "Recording to: $RECORD_CAST"
+  mkdir -p "$(dirname "$RECORD_CAST")"
+  # asciinema wraps the binary; the pane runs asciinema rec, which spawns the TUI.
+  WRAP="asciinema rec $RECORD_CAST --cols $COLS --rows $ROWS --overwrite -- $CMD"
+  start_session "$SESSION_NAME" "$WRAP"
+else
+  start_session "$SESSION_NAME" "$CMD"
+fi
+
+# Give the TUI a moment to paint the first frame.
+wait_for "$SESSION_NAME" "commands|▶" 30
+
+info "Executing steps from: ${STEPS_FILE:-stdin}"
+execute_steps "$SESSION_NAME" "$STEPS_SRC"
+
+# Graceful quit.
+send_keys "$SESSION_NAME" "q" 2>/dev/null || true
+sleep 0.3
+end_session "$SESSION_NAME"
+
+print_summary verify

--- a/tools/demo/moon.yml
+++ b/tools/demo/moon.yml
@@ -66,5 +66,69 @@ tasks:
       - "presentation/public/**/*"
       - "presentation/package.json"
 
+  # ── rmux-driven automated verification + cast recording ──────────────────
+  # auto-demo.sh drives each demo via rmux send-keys/capture-pane, asserts
+  # expected output (--verify, CI-able for A/B/C), and optionally emits an
+  # asciinema v2 .cast with beat markers (--record, operator-only).
+  #
+  # A, B, C: deterministic (TUI/CLI) — suitable for CI.
+  # D: non-deterministic (Claude Code + MCP) — local-only, needs Claude auth.
+
+  # CI-able: drive demos A, B, C and assert expected output.
+  # D is excluded — it needs Claude auth/network (run auto-demo-d manually).
+  auto-verify:
+    command: [
+        bash,
+        -c,
+        "bash tools/demo/auto/auto-demo.sh A --verify &&
+        bash tools/demo/auto/auto-demo.sh B --verify &&
+        bash tools/demo/auto/auto-demo.sh C --verify",
+      ]
+    options:
+      runFromWorkspaceRoot: true
+      # Needs rmux on PATH and a real display/PTY; not suitable for headless CI runners.
+      runInCI: false
+    inputs:
+      - "auto/**/*.sh"
+      - "packages/design-data/tokens/**"
+      - "packages/design-data-spec/components/**"
+
+  # Verify Demo D locally (Claude Code + MCP; non-deterministic; local only).
+  auto-verify-d:
+    command: [bash, tools/demo/auto/auto-demo.sh, D, --verify]
+    options:
+      runFromWorkspaceRoot: true
+    local: true
+
+  # Record all four casts to presentation/public/casts/ (operator-only).
+  auto-record:
+    command: [
+        bash,
+        -c,
+        "bash tools/demo/auto/auto-demo.sh A --record &&
+        bash tools/demo/auto/auto-demo.sh B --record &&
+        bash tools/demo/auto/auto-demo.sh C --record &&
+        bash tools/demo/auto/auto-demo.sh D --record",
+      ]
+    options:
+      runFromWorkspaceRoot: true
+      runInCI: false
+    local: true
+
+  # Ad-hoc TUI verification runner (Tier 2 of the tui-verify skill).
+  # Drives the real binary in an rmux pane and asserts expected output.
+  # Pass --dataset and --steps arguments after --:
+  #   moon run demo:tui-verify -- --dataset packages/design-data --steps my-steps.txt
+  tui-verify:
+    command: [bash, tools/demo/auto/verify-tui.sh]
+    options:
+      runFromWorkspaceRoot: true
+      # Needs rmux on PATH and a real PTY — not suitable for headless CI runners.
+      runInCI: false
+    local: true
+    inputs:
+      - "auto/verify-tui.sh"
+      - "auto/lib/rmux-drive.sh"
+
   ci:
     deps: [verify]

--- a/tools/demo/presentation/RECORDING.md
+++ b/tools/demo/presentation/RECORDING.md
@@ -51,9 +51,11 @@ These land on asciinema's own clock regardless of `--idle-time-limit` compressio
 
 **Demo D** — uses **Claude Code hooks** for reliable beat detection and marker timing:
 
-* A per-run `tools/demo/auto/hooks/settings.json` is supplied via
-  `claude --settings hooks/settings.json`, scoping hooks to that run only (no
-  change to global or project settings).
+* A per-run settings JSON is **generated at runtime** by `D.beats.sh` with absolute
+  hook paths and `DEMO_BEATS_DIR` baked in, then supplied via
+  `claude --settings <tmpfile>`, scoping hooks to that run only (no change to global or
+  project settings). `tools/demo/auto/hooks/settings.json` is a reference example only —
+  its relative paths are not used directly.
 * A **`PostToolUse`** hook (`record-beat.sh`) fires after each `mcp__design-data__`
   tool call and appends `epoch_seconds<TAB>tool_name` to a temporary beats log.
 * A **`Stop`** hook (`stop-done.sh`) touches a done sentinel when Claude finishes

--- a/tools/demo/presentation/RECORDING.md
+++ b/tools/demo/presentation/RECORDING.md
@@ -7,7 +7,7 @@ of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 # Recording the demo casts
 
-This is the operator's cheat-sheet for capturing the three terminal casts that
+This is the operator's cheat-sheet for capturing the four terminal casts that
 back the Slidev deck (`slides.md`). You drive the TUI/CLI live and drop a
 **marker** at each beat boundary; the Slidev player pauses on every marker so
 you can narrate, then resume.
@@ -15,6 +15,58 @@ you can narrate, then resume.
 > The casts are the presentation path. The VHS pipeline in `../videos/` is a
 > separate thing — it produces silent doc GIFs and narrated MP4s, not these
 > interactive casts.
+
+## Automated path (preferred)
+
+`tools/demo/auto/auto-demo.sh` drives each demo via `rmux` send-keys /
+capture-pane, asserts expected output, and optionally emits an asciinema v2 `.cast`
+with beat markers already injected — no live marker-key drops needed.
+
+**Prerequisites:** `rmux` 0.3.x and `asciinema` 3.x on PATH; CLI pre-built.
+For Demo D: `claude` on PATH, `.mcp.json` configured (see Demo D section below).
+
+```bash
+# Verify all deterministic demos (A, B, C) — CI-safe:
+bash tools/demo/auto/auto-demo.sh A --verify
+bash tools/demo/auto/auto-demo.sh B --verify
+bash tools/demo/auto/auto-demo.sh C --verify
+# Or via moon:
+moon run demo:auto-verify
+
+# Record all four casts to public/casts/:
+bash tools/demo/auto/auto-demo.sh A --record   # → public/casts/A-find.cast
+bash tools/demo/auto/auto-demo.sh B --record   # → public/casts/B-name.cast
+bash tools/demo/auto/auto-demo.sh C --record   # → public/casts/C-suggest.cast
+bash tools/demo/auto/auto-demo.sh D --record   # → public/casts/D-agent.cast (local-only)
+# Or all at once:
+moon run demo:auto-record
+
+# Clean-room Docker run for A/B/C (headless; D not supported in Docker):
+bash tools/demo/auto/auto-demo.sh A --record --docker
+```
+
+**Demos A, B, C** — beat markers are injected by anchoring to sentinel text patterns
+in the cast's output events (the TUI view headers: `Resolve:`, `Describe:`, `Fuzzy`).
+These land on asciinema's own clock regardless of `--idle-time-limit` compression.
+
+**Demo D** — uses **Claude Code hooks** for reliable beat detection and marker timing:
+
+* A per-run `tools/demo/auto/hooks/settings.json` is supplied via
+  `claude --settings hooks/settings.json`, scoping hooks to that run only (no
+  change to global or project settings).
+* A **`PostToolUse`** hook (`record-beat.sh`) fires after each `mcp__design-data__`
+  tool call and appends `epoch_seconds<TAB>tool_name` to a temporary beats log.
+* A **`Stop`** hook (`stop-done.sh`) touches a done sentinel when Claude finishes
+  responding — replacing the fragile `wait_quiet` / blind `sleep 180` used previously.
+* Beat markers D1–D4 are anchored to real tool-call epochs (not rendered screen text),
+  so they are phrasing-invariant and model-version-independent.
+* Note: Demo D **must be run from a plain terminal**, not from inside another Claude
+  Code session (the auto-mode classifier blocks spawning a second `claude` process).
+
+The manual path below remains valid as a fallback for when you want to record a
+polished live take or adjust timing by hand.
+
+***
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Adds three related pieces of TUI verification infrastructure:

1. **`sdk/tui/tests/layout.rs`** — committed layout breakpoint tests at 120×36, 80×24, 80×33 (exact logo threshold), 80×32 (one below threshold), and panic-safety cases. Documents that the logo appears when `terminal_height ≥ 33` (content rows ≥ 31).

2. **`tools/demo/auto/verify-tui.sh`** + **`tools/demo/auto/lib/rmux-drive.sh`** — generic ad-hoc TUI verification runner (Tier 2 of the `tui-verify` skill). Accepts a step file with `send`/`type`/`wait`/`expect`/`refute`/`capture` directives; drives the real binary at 120×36 via rmux.

3. **`tools/demo/auto/auto-demo.sh`** — full rmux-driven orchestrator with `--verify` (CI-able), `--record` (emits asciinema v2 cast with beat markers), and `--docker` (clean-room A/B/C) modes. Includes per-demo beat manifests (`beats/`), Claude Code hooks for Demo D beat detection (`hooks/`), and a Dockerfile.

4. **`tools/demo/moon.yml`** — adds `tui-verify`, `auto-verify`, `auto-verify-d`, and `auto-record` tasks.

5. **`tools/demo/presentation/RECORDING.md`** — documents the automated recording path alongside the preserved manual fallback.

## Related Issue

Depends on / should merge after #1106 (ratatui 0.30 bump) — layout tests compile against the updated toolchain.

## Motivation and Context

Before this PR, verifying TUI layout required manual spot-checks. The layout tests pin the exact breakpoints where the logo appears/disappears and ensure we never regress on panic-safety at extreme sizes. The automation scripts replace the previous manual asciinema recording process with a repeatable, CI-runnable pipeline.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — all layout tests pass locally
- `moon run demo:tui-verify` — verify-tui.sh passes against a local build
- `bash tools/demo/auto/auto-demo.sh --verify` — A/B/C/D all pass verify mode

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.