### PR TITLE
feat(design-data): migrate cascade token $ref aliases from name strings to UUIDs

### DIFF
--- a/.changeset/cascade-uuid-refs.md
+++ b/.changeset/cascade-uuid-refs.md
@@ -1,0 +1,23 @@
+---
+"@adobe/spectrum-design-data": minor
+"@adobe/design-data-spec": minor
+"design-data-core": minor
+---
+Migrate cascade token `$ref` aliases from name strings to UUIDs.
+
+- **packages/design-data/tokens/\*.tokens.json**: alias `$ref` now holds the
+  target's UUID (rename-proof, cascade canonical). Legacy `packages/tokens/src`
+  is unchanged — roundtrip-verify stays clean.
+- **sdk/core/src/graph.rs**: add `resolve_alias_key` (UUID-first + slug + legacy-
+  name-index fallback); fix cycle-guard to key on resolved graph key; index
+  `set_uuid` so set-targeted aliases resolve.
+- **sdk/core/src/migrate.rs**: emit UUID `$ref` via `global_name_to_uuid`;
+  add `MigrateSummary.dangling_alias_refs` counter.
+- **sdk/core/src/legacy.rs**: denormalize UUID `$ref` → `{name}` via
+  `global_uuid_to_name` so legacy output is byte-semantically identical.
+- **sdk/core/src/validate/rules/spec001–003,015,042**: route alias lookups
+  through `resolve_alias_key` for correct UUID resolution.
+- **packages/tokens/schemas/token-types/alias.json**: accept `value: "{name}"`
+  (legacy) or `$ref: "<uuid>"` (cascade) via `oneOf`.
+- **packages/design-data-spec/schemas/token.schema.json**, **spec/token-format.md**:
+  document UUID as the cascade canonical `$ref`; activate the reserved direction.

--- a/docs/site/public/schemas/token-types/token.json
+++ b/docs/site/public/schemas/token-types/token.json
@@ -45,7 +45,7 @@
     },
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
       "format": "uuid"
     }
   },

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -218,7 +218,7 @@
         "$ref": {
           "type": "string",
           "minLength": 1,
-          "description": "Alias target path or stable token id (resolution is Layer 2)."
+          "description": "Alias target. In cascade format: the target token's UUID (canonical, rename-proof, resolved via uuid_index — Layer 2). In the legacy transition format: the target's kebab-case name slug."
         },
         "uuid": {
           "type": "string",

--- a/packages/design-data-spec/spec/cascade.md
+++ b/packages/design-data-spec/spec/cascade.md
@@ -55,7 +55,7 @@ Exact matching rules for omitted mode sets are defined alongside mode set declar
 
 **NORMATIVE:** Alias (`$ref`) resolution **MUST** occur **after** cascade selection. The resolution algorithm selects the winning candidate using layer, specificity, and tie-breaking rules before any alias chain is followed.
 
-**NORMATIVE:** If the winning candidate is an alias, its `$ref` chain **MUST** be resolved to a literal value using the standard alias-resolution rules (SPEC-001 through SPEC-003 in `rules/rules.yaml`). The alias target is resolved within the same dataset (i.e. the same merged layer stack), not relative to any single layer.
+**NORMATIVE:** If the winning candidate is an alias, its `$ref` chain **MUST** be resolved to a literal value using the standard alias-resolution rules (SPEC-001 through SPEC-003 in `rules/rules.yaml`). The alias target is resolved within the same dataset (i.e. the same merged layer stack), not relative to any single layer. In cascade format, `$ref` holds the **UUID** of the target token (see [`token-format.md` §Alias](token-format.md#alias-ref)); resolution proceeds UUID-first, then direct graph key (legacy slug), then serialised name.
 
 **RATIONALE:** Aliases participate in cascade as opaque references — their target values are not examined during specificity calculation or layer comparison. This keeps resolution deterministic and allows aliases to be valid candidates at any specificity level.
 

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -98,7 +98,15 @@ The table below lists all semantic fields. Fields marked with a scope are domain
 
 ### Alias (`$ref`)
 
-When **`$ref`** is present, the token is an **alias**. The value **MUST** be a non-empty string interpreted as a **token path** or **stable identifier** resolvable by the validator (resolution rules are Layer 2; see rule `SPEC-001` in `rules/rules.yaml`).
+When **`$ref`** is present, the token is an **alias**. The value **MUST** be a non-empty string. In cascade format the value is the **UUID** of the target token (rename-proof, resolved via the graph's `uuid_index`). In the legacy transition format the value is the target token's kebab-case name (serialized legacy slug). Both forms are accepted; resolution rules are Layer 2 (see rule `SPEC-001` in `rules/rules.yaml`).
+
+```json
+// Cascade canonical form (recommended) — the UUID is stable across renames.
+{ "name": { "property": "accent-background-color", "state": "default", "colorScheme": "dark" },
+  "$schema": "…/alias.json",
+  "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
+  "uuid": "f24eb871-6419-4cef-88a2-cca8548ae31e" }
+```
 
 ### Literal `value`
 
@@ -268,7 +276,7 @@ Within a composite value, a string sub-value **MAY** be an **inline alias**: a r
 }
 ```
 
-**NORMATIVE:** In legacy format, inline aliases use the syntax `{token-name}` (curly-brace-wrapped token property name). In cascade format, the inline alias syntax is `{token-name}` for backward compatibility; UUID-based inline aliases are reserved for a future spec version.
+**NORMATIVE:** In legacy format, inline aliases use the syntax `{token-name}` (curly-brace-wrapped token property name). In cascade format, top-level `$ref` aliases use a UUID (canonical, rename-proof); inline composite aliases within `value` objects remain `{token-name}` for backward compatibility. UUID-based inline composite aliases are reserved for a future spec version.
 
 **NORMATIVE:** Inline aliases within composite values are subject to alias resolution rules. Validators **MUST** resolve inline aliases and report errors for missing targets (SPEC-014), type mismatches (SPEC-015), and circular references (SPEC-003, extended).
 

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -6,7 +6,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-900",
+    "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
     "uuid": "d9d8488d-9b38-47e0-9660-dcad040f3ca8",
     "set_uuid": "e05251ac-d64a-4157-9b20-224f0392269e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -18,7 +18,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-800",
+    "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
     "uuid": "f24eb871-6419-4cef-88a2-cca8548ae31e",
     "set_uuid": "e05251ac-d64a-4157-9b20-224f0392269e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -30,7 +30,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-900",
+    "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
     "uuid": "1f4f6c48-633c-4eb5-b7d6-bf5a9a7fde18",
     "set_uuid": "e05251ac-d64a-4157-9b20-224f0392269e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -42,7 +42,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "026b1d5e-7cbc-4ee9-91e8-19766b9ac541",
     "set_uuid": "1cc745b9-a6a8-4252-b7ea-84998a5654e5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -54,7 +54,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-700",
+    "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
     "uuid": "e2c0de7e-d271-4b2c-9393-d864a95732e6",
     "set_uuid": "1cc745b9-a6a8-4252-b7ea-84998a5654e5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -66,7 +66,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "a5201034-a592-47c6-be78-050ae951043e",
     "set_uuid": "1cc745b9-a6a8-4252-b7ea-84998a5654e5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -78,7 +78,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "9651d413-47dc-4b55-976f-91e5c6c91fb5",
     "set_uuid": "ce776087-ee7b-4696-87b8-1520a0da8ecd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -90,7 +90,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-700",
+    "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
     "uuid": "9e140a94-c11f-470b-b7af-49880e58d4ce",
     "set_uuid": "ce776087-ee7b-4696-87b8-1520a0da8ecd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -102,7 +102,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "a4fb3dc6-b724-4e5d-bbc4-c4d985e85975",
     "set_uuid": "ce776087-ee7b-4696-87b8-1520a0da8ecd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -114,7 +114,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "43ca5f34-decc-4de8-9413-74ce57802b65",
     "set_uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -126,7 +126,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-700",
+    "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
     "uuid": "af809118-7a97-409c-925f-8d7636a791c8",
     "set_uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -138,7 +138,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "afb8dd77-7de2-4749-a594-1ff68b2fcd67",
     "set_uuid": "5c8e3c22-193b-4ffb-bd8d-0a879ee85c54",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -149,7 +149,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-900",
+    "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
     "uuid": "b14c876e-2930-413b-8688-1e0cf2358185"
   },
   {
@@ -158,7 +158,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "25d3b2d2-e7d5-4686-95ff-bfaaddc14ff1"
   },
   {
@@ -167,7 +167,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "d6cd141c-d7a4-457f-bed5-9a725ca7a0fe"
   },
   {
@@ -176,7 +176,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-1000",
+    "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
     "uuid": "71dcd137-f767-4d2c-b6ac-942b99ac8621"
   },
   {
@@ -185,7 +185,7 @@
       "state": "selected"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-content-color-down",
+    "$ref": "25d3b2d2-e7d5-4686-95ff-bfaaddc14ff1",
     "uuid": "9cfbf8bc-e4f3-4658-922e-9421e2ed126b"
   },
   {
@@ -194,7 +194,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-800",
+    "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
     "uuid": "dbcb4372-f250-42bd-a5bc-b9d48cfb9322",
     "set_uuid": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -205,7 +205,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-900",
+    "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
     "uuid": "8ccd197f-fc8e-4d31-866c-2b96049eea89",
     "set_uuid": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -216,7 +216,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-800",
+    "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
     "uuid": "6e12afb7-c76e-4a83-acc2-f891953d5190",
     "set_uuid": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -226,7 +226,7 @@
       "property": "background-base-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "e0d8739d-18dd-44bc-92ea-e443882a780b"
   },
   {
@@ -235,7 +235,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "2275e0fa-69a3-4542-9ec6-919e44035118",
     "set_uuid": "68fc2ac3-45b4-4067-a238-45a930ae9485",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -246,7 +246,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-75",
+    "$ref": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
     "uuid": "4c19885d-0411-43dc-8f4a-db81905728e6",
     "set_uuid": "68fc2ac3-45b4-4067-a238-45a930ae9485",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -257,7 +257,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "644ca621-9138-44e3-bdd7-123a9fccd9a6",
     "set_uuid": "68fc2ac3-45b4-4067-a238-45a930ae9485",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -267,7 +267,7 @@
       "property": "background-layer-1-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-50",
+    "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
     "uuid": "7e6678b7-2903-434b-8ee2-06c83815b01d"
   },
   {
@@ -276,7 +276,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "b7b2bf98-b96a-40ca-b51e-5876d3418085",
     "set_uuid": "5b441187-fb00-4d55-8534-9e7e313fed60",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -287,7 +287,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-75",
+    "$ref": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
     "uuid": "e30b7936-6ae7-4ada-8892-94a1f67d55c9",
     "set_uuid": "5b441187-fb00-4d55-8534-9e7e313fed60",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -298,7 +298,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "b834a6a5-e582-4450-b87a-57fa23e12179",
     "set_uuid": "5b441187-fb00-4d55-8534-9e7e313fed60",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -345,7 +345,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "4938710b-5a69-49eb-8517-6f5556c23298",
     "set_uuid": "f8e93285-b100-4dd9-a943-435e173321af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -356,7 +356,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "6a7c5092-c262-49b0-b5ec-5b8b4fa66d1e",
     "set_uuid": "f8e93285-b100-4dd9-a943-435e173321af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -367,7 +367,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "93e51c98-d83e-4dad-86b7-f060a80a601e",
     "set_uuid": "f8e93285-b100-4dd9-a943-435e173321af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -379,7 +379,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "c6c435b6-34b3-4fc1-bf96-a56a15e01fe5",
     "set_uuid": "65651644-f0b3-4464-b656-d3c7896b01c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -391,7 +391,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "83591a94-83e1-4557-8f50-cc1fe9793b76",
     "set_uuid": "65651644-f0b3-4464-b656-d3c7896b01c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -403,7 +403,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "db8b9268-68dc-46be-aace-1adf8d85061b",
     "set_uuid": "65651644-f0b3-4464-b656-d3c7896b01c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -415,7 +415,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-200",
+    "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
     "uuid": "7d52711e-43fa-4a95-a7b1-3a7367570596",
     "set_uuid": "f6080c78-c400-40cf-8b83-e81b15bc0373",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -427,7 +427,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-300",
+    "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
     "uuid": "7da4709c-caf3-401a-a2ce-07186a7e8e8c",
     "set_uuid": "f6080c78-c400-40cf-8b83-e81b15bc0373",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -439,7 +439,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-200",
+    "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
     "uuid": "93563495-60af-4a84-b811-9672fc46a1cc",
     "set_uuid": "f6080c78-c400-40cf-8b83-e81b15bc0373",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -450,7 +450,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "b7cca44c-7c7d-4904-8f2c-d5bde4ea42a2",
     "set_uuid": "3ea5b3ef-e671-444c-a1e9-fbe2566ec771",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -461,7 +461,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "63fe16ed-70fa-4eaf-918c-f642ff69ce05",
     "set_uuid": "3ea5b3ef-e671-444c-a1e9-fbe2566ec771",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -472,7 +472,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "0f058412-085d-4670-8cd5-964ed903a20a",
     "set_uuid": "3ea5b3ef-e671-444c-a1e9-fbe2566ec771",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -484,7 +484,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-900",
+    "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
     "uuid": "168c3534-c54e-415b-a623-27c2a8caea8c",
     "set_uuid": "428f3605-6727-4b75-900e-76f8f57c2ce3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -496,7 +496,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-800",
+    "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
     "uuid": "c6dcdb8e-4966-4de6-a74a-fffa0793d58e",
     "set_uuid": "428f3605-6727-4b75-900e-76f8f57c2ce3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -508,7 +508,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-900",
+    "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
     "uuid": "fbd8df06-a6c9-462b-ad25-a3f77016128e",
     "set_uuid": "428f3605-6727-4b75-900e-76f8f57c2ce3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -520,7 +520,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-200",
+    "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
     "uuid": "4f1f131b-b6d1-401b-82ff-be6fc0cce9f3",
     "set_uuid": "00aeee53-1402-4410-add3-9f648d68fefd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -532,7 +532,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-300",
+    "$ref": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
     "uuid": "77b47209-4527-462b-a11f-b3e5f47857ec",
     "set_uuid": "00aeee53-1402-4410-add3-9f648d68fefd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -544,7 +544,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-200",
+    "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
     "uuid": "ac6995d9-8982-4dac-ba85-4c79ec7850a1",
     "set_uuid": "00aeee53-1402-4410-add3-9f648d68fefd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -555,7 +555,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-800",
+    "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
     "uuid": "12fd4bac-b0ef-4285-a0e4-5947526a91a9",
     "set_uuid": "4e301679-a594-4e25-a26a-030c844f4e74",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -566,7 +566,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-900",
+    "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
     "uuid": "a25ac05c-c108-4caf-a77e-79b4fd36ee91",
     "set_uuid": "4e301679-a594-4e25-a26a-030c844f4e74",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -577,7 +577,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-800",
+    "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
     "uuid": "349dc3c5-fd57-403c-bc42-2a60b8325bd3",
     "set_uuid": "4e301679-a594-4e25-a26a-030c844f4e74",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -589,7 +589,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-600",
+    "$ref": "b908fb61-f581-4942-9d00-57a828a0660b",
     "uuid": "d4fd682d-4bef-4a92-bf14-90ce02b534e6",
     "set_uuid": "5bd340a5-45fc-4666-82b2-827f9f17d6e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -601,7 +601,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-900",
+    "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
     "uuid": "a9ab7a59-9cab-47fb-876d-6f0af93dc5df",
     "set_uuid": "5bd340a5-45fc-4666-82b2-827f9f17d6e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -613,7 +613,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-600",
+    "$ref": "b908fb61-f581-4942-9d00-57a828a0660b",
     "uuid": "b6e14409-7a61-46fc-80d0-2b7854baf871",
     "set_uuid": "5bd340a5-45fc-4666-82b2-827f9f17d6e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -625,7 +625,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-200",
+    "$ref": "d22658b0-6638-45f9-8567-a2ad056f7c10",
     "uuid": "cf459b71-0d91-4cb4-96b8-f536e553f66e",
     "set_uuid": "9a8c68d6-51bb-4c93-afcf-d7c497b51049",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -637,7 +637,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-300",
+    "$ref": "577626d4-7631-4de5-bd71-350b9748a4dd",
     "uuid": "67618d20-60a0-44d9-b98a-a84faf409788",
     "set_uuid": "9a8c68d6-51bb-4c93-afcf-d7c497b51049",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -649,7 +649,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-200",
+    "$ref": "d22658b0-6638-45f9-8567-a2ad056f7c10",
     "uuid": "2182ee3c-55aa-4d07-9cc1-f827c88ce3d6",
     "set_uuid": "9a8c68d6-51bb-4c93-afcf-d7c497b51049",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -660,7 +660,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-700",
+    "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
     "uuid": "8f6f9f6e-1762-4ac3-a9b9-6cacd135dfac",
     "set_uuid": "bac88d84-8bb8-49eb-82c5-43f8f5cfdc52",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -671,7 +671,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-800",
+    "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
     "uuid": "37c1311b-29ed-44ab-b656-a7538726ad77",
     "set_uuid": "bac88d84-8bb8-49eb-82c5-43f8f5cfdc52",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -682,7 +682,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-700",
+    "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
     "uuid": "d8adaaf1-b6a3-400a-853b-6ba5a5c873e7",
     "set_uuid": "bac88d84-8bb8-49eb-82c5-43f8f5cfdc52",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -694,7 +694,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-500",
+    "$ref": "b72ad072-4768-463a-b951-00f1cbe4f657",
     "uuid": "f6e68186-e7fe-4d36-b371-72461a271358",
     "set_uuid": "4b6aeec7-d8be-41a8-ae4b-b668aa320eb7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -706,7 +706,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-1000",
+    "$ref": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
     "uuid": "5df9a029-dc91-4078-a198-574486948834",
     "set_uuid": "4b6aeec7-d8be-41a8-ae4b-b668aa320eb7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -718,7 +718,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-500",
+    "$ref": "b72ad072-4768-463a-b951-00f1cbe4f657",
     "uuid": "67d55f09-a468-4174-9b59-13008b32b44e",
     "set_uuid": "4b6aeec7-d8be-41a8-ae4b-b668aa320eb7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -730,7 +730,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-200",
+    "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
     "uuid": "2dd50902-f9bb-4f79-b31c-3997f4fd2163",
     "set_uuid": "090131f4-60e4-4e0e-b9cc-84b0116f0c60",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -742,7 +742,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-300",
+    "$ref": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
     "uuid": "b80c47b0-222b-49a2-9012-1465a4575092",
     "set_uuid": "090131f4-60e4-4e0e-b9cc-84b0116f0c60",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -754,7 +754,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-200",
+    "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
     "uuid": "ab75a3ba-17ce-4aae-902f-2b3e0233b726",
     "set_uuid": "090131f4-60e4-4e0e-b9cc-84b0116f0c60",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -765,7 +765,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-600",
+    "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
     "uuid": "18735078-a942-442b-bc04-1b72bac77c98",
     "set_uuid": "29c04d77-755d-4d81-bc5b-ab0ab3e6a6ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -776,7 +776,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-900",
+    "$ref": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
     "uuid": "a46d8e05-4f56-4b46-a279-0164abfa42e8",
     "set_uuid": "29c04d77-755d-4d81-bc5b-ab0ab3e6a6ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -787,7 +787,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-600",
+    "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
     "uuid": "a2cc3b6e-014f-4522-8d05-9e9d06464504",
     "set_uuid": "29c04d77-755d-4d81-bc5b-ab0ab3e6a6ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -799,7 +799,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-900",
+    "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
     "uuid": "6dc7df67-2cfb-440f-9b1c-b7262a7cc2d3",
     "set_uuid": "4db12eba-db54-4121-9968-caccedaa18d1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -811,7 +811,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-800",
+    "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
     "uuid": "d442e5b5-5083-443d-ba60-12c60406c452",
     "set_uuid": "4db12eba-db54-4121-9968-caccedaa18d1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -823,7 +823,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-900",
+    "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
     "uuid": "8e940601-2401-46ff-a5fb-9137d12678b7",
     "set_uuid": "4db12eba-db54-4121-9968-caccedaa18d1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -835,7 +835,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-200",
+    "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
     "uuid": "4d114a18-a876-4b01-a356-64b6098496f4",
     "set_uuid": "820f61ee-85e3-4173-b08b-6196bdc51e8f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -847,7 +847,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-300",
+    "$ref": "3527fc94-a410-4933-bbb7-bedecd37e477",
     "uuid": "68b6af88-a951-48f8-89c3-9d599a05f4dc",
     "set_uuid": "820f61ee-85e3-4173-b08b-6196bdc51e8f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -859,7 +859,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-200",
+    "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
     "uuid": "f326443a-8f5d-4aa2-8bbb-17dc7b0420d6",
     "set_uuid": "820f61ee-85e3-4173-b08b-6196bdc51e8f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -870,7 +870,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-800",
+    "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
     "uuid": "86aa8b9c-b124-45ba-a359-a58295d28509",
     "set_uuid": "229f3603-edcf-4e55-a5d2-7a805f991ac5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -881,7 +881,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-900",
+    "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
     "uuid": "24026c61-470e-41b9-a247-58605b54706d",
     "set_uuid": "229f3603-edcf-4e55-a5d2-7a805f991ac5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -892,7 +892,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-800",
+    "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
     "uuid": "9022dc27-f9d9-4697-b808-ebe36d216f8b",
     "set_uuid": "229f3603-edcf-4e55-a5d2-7a805f991ac5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -904,7 +904,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-900",
+    "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
     "uuid": "12c060c6-db12-41ca-8b53-f4fc0afd2ed7",
     "set_uuid": "b21d509c-0067-468f-8ae7-dc38bf67d179",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -916,7 +916,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-800",
+    "$ref": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
     "uuid": "543af64f-9c28-4e88-8597-3259cd7ebf1f",
     "set_uuid": "b21d509c-0067-468f-8ae7-dc38bf67d179",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -928,7 +928,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-900",
+    "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
     "uuid": "764bb832-de5a-4c21-b429-f911a931ead6",
     "set_uuid": "b21d509c-0067-468f-8ae7-dc38bf67d179",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -940,7 +940,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-200",
+    "$ref": "c7fd6eda-f850-4dec-a883-e970cdfca622",
     "uuid": "084200e3-85bf-496e-b12a-b439e108b9fb",
     "set_uuid": "0cec96af-08f3-4c3e-b9ed-33b48c47b302",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -952,7 +952,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-300",
+    "$ref": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
     "uuid": "740e1c42-e68c-4c10-9bcd-30dc0bae6418",
     "set_uuid": "0cec96af-08f3-4c3e-b9ed-33b48c47b302",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -964,7 +964,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-200",
+    "$ref": "c7fd6eda-f850-4dec-a883-e970cdfca622",
     "uuid": "2f72eaf9-547a-436e-86ab-695979db4f93",
     "set_uuid": "0cec96af-08f3-4c3e-b9ed-33b48c47b302",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -975,7 +975,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-600",
+    "$ref": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
     "uuid": "c3c126c9-2133-416a-ac0e-4ae00546941b",
     "set_uuid": "51dff390-8bc1-4652-9fd2-fd079d5795e9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -986,7 +986,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-900",
+    "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
     "uuid": "091a2073-baa0-4cc6-b943-9dddc285ad62",
     "set_uuid": "51dff390-8bc1-4652-9fd2-fd079d5795e9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -997,7 +997,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-600",
+    "$ref": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
     "uuid": "ad004c2f-8cab-45d5-8e22-921d3f0332ea",
     "set_uuid": "51dff390-8bc1-4652-9fd2-fd079d5795e9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1007,7 +1007,7 @@
       "property": "disabled-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "a46de9d2-5c68-4a1e-97cd-7cbaf4038303"
   },
   {
@@ -1015,7 +1015,7 @@
       "property": "disabled-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-300",
+    "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
     "uuid": "474ae56c-709a-4f5a-a56b-62d01093f412"
   },
   {
@@ -1023,7 +1023,7 @@
       "property": "disabled-content-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "8bf69fd3-1462-49b9-a78a-cc2f03380823"
   },
   {
@@ -1031,7 +1031,7 @@
       "property": "disabled-static-black-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-100",
+    "$ref": "7565eb32-d745-4fc3-8779-a717f8ba910a",
     "uuid": "579e401c-de49-41af-a8c7-a0a070c31979"
   },
   {
@@ -1039,7 +1039,7 @@
       "property": "disabled-static-black-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-300",
+    "$ref": "16a871e1-d9df-42bb-8889-99059d70e82e",
     "uuid": "2df7303f-3c34-47d1-9ec9-b901dfbcf947"
   },
   {
@@ -1047,7 +1047,7 @@
       "property": "disabled-static-black-content-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-400",
+    "$ref": "b769453b-586c-4dd2-b3a1-ddf5964160bc",
     "uuid": "e75dbb08-80eb-4de5-afd4-55a532c69c97"
   },
   {
@@ -1055,7 +1055,7 @@
       "property": "disabled-static-white-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-100",
+    "$ref": "a1b64a62-7c78-415e-a9be-c86acbf361ca",
     "uuid": "fbd40c55-bb12-43ff-9fa6-c93884befc89"
   },
   {
@@ -1063,7 +1063,7 @@
       "property": "disabled-static-white-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-300",
+    "$ref": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
     "uuid": "c0dfeb64-983e-4f4c-a13e-24b5fbd2b791"
   },
   {
@@ -1071,7 +1071,7 @@
       "property": "disabled-static-white-content-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-400",
+    "$ref": "12e610d4-e3dc-4e86-9c09-09d86915b6f1",
     "uuid": "fe319bca-0413-4ad8-a783-c64563e05816"
   },
   {
@@ -1112,7 +1112,7 @@
       "property": "drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-color-100",
+    "$ref": "92619056-db5a-45ab-ba0b-50e67cc497f6",
     "uuid": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with drop-shadow-color-100",
@@ -1252,7 +1252,7 @@
       "property": "drop-shadow-dragged-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-color-300",
+    "$ref": "ebb7effd-f156-41a9-823f-052e5733e53d",
     "uuid": "83c30113-68b5-475b-ba46-9179c9ff7e8d"
   },
   {
@@ -1323,7 +1323,7 @@
       "property": "drop-shadow-elevated-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-color-200",
+    "$ref": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
     "uuid": "e475981f-97af-479c-859b-7619dd87c448"
   },
   {
@@ -1395,7 +1395,7 @@
       "property": "drop-shadow-emphasized-default-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-color-100",
+    "$ref": "92619056-db5a-45ab-ba0b-50e67cc497f6",
     "uuid": "af4e0a7a-7c6a-4cf2-a17b-0b07ef365869"
   },
   {
@@ -1434,7 +1434,7 @@
       "property": "drop-shadow-emphasized-hover-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-color-200",
+    "$ref": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
     "uuid": "4c84adb3-9edf-4a5d-b39a-5f31a0d3529c"
   },
   {
@@ -1541,7 +1541,7 @@
       "property": "focus-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05"
   },
   {
@@ -1551,7 +1551,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-900",
+    "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
     "uuid": "5f61f890-93b3-4ab9-bc80-d75198a5bacf",
     "set_uuid": "807ddfc8-cfad-4221-b956-e5d16e9626ff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1563,7 +1563,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-800",
+    "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
     "uuid": "7b4d71d3-ad78-4e02-a48e-fa79f40854a2",
     "set_uuid": "807ddfc8-cfad-4221-b956-e5d16e9626ff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1575,7 +1575,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-900",
+    "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
     "uuid": "13e66afc-a9d8-46a9-8b15-310c5b35e52f",
     "set_uuid": "807ddfc8-cfad-4221-b956-e5d16e9626ff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1587,7 +1587,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-200",
+    "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
     "uuid": "9bb9c1e9-6067-49a4-b4af-13ccd87830d9",
     "set_uuid": "305b2ff0-425f-4ad1-a27d-00c96d2020ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1599,7 +1599,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-300",
+    "$ref": "09aef364-8827-48fa-9888-b0424ce8981c",
     "uuid": "3e62d682-c770-498d-a25a-5544775aeaa1",
     "set_uuid": "305b2ff0-425f-4ad1-a27d-00c96d2020ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1611,7 +1611,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-200",
+    "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
     "uuid": "28ef060d-098c-4388-b600-00f4f8fe49aa",
     "set_uuid": "305b2ff0-425f-4ad1-a27d-00c96d2020ed",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1622,7 +1622,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-800",
+    "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
     "uuid": "36b69bb1-d443-4ec6-807b-ea449a886825",
     "set_uuid": "e0b357b4-847d-491a-b7b9-7805af3bdf69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1633,7 +1633,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-900",
+    "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
     "uuid": "38e60263-cb08-4090-a653-5acbd1664ae0",
     "set_uuid": "e0b357b4-847d-491a-b7b9-7805af3bdf69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1644,7 +1644,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-800",
+    "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
     "uuid": "656af4f3-a545-4445-9d2b-2c4a17ab46db",
     "set_uuid": "e0b357b4-847d-491a-b7b9-7805af3bdf69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1656,7 +1656,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-700",
+    "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
     "uuid": "5adeb281-3183-43e0-b20c-bd4e29f4da7e",
     "set_uuid": "43aadc06-6f34-47a3-9e42-e1a99e3504ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1668,7 +1668,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "a3e71134-b44f-4b52-a84d-4841e01505e6",
     "set_uuid": "43aadc06-6f34-47a3-9e42-e1a99e3504ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1680,7 +1680,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-700",
+    "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
     "uuid": "385372e9-8b04-45ea-a7a2-f1f62ac68ad6",
     "set_uuid": "43aadc06-6f34-47a3-9e42-e1a99e3504ce",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1692,7 +1692,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "83fd0c1f-fbf3-4540-b370-6f44a6dbba7e",
     "set_uuid": "a3c90df5-60df-4936-a1f9-232783790380",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1704,7 +1704,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-300",
+    "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
     "uuid": "a95998aa-d6ce-4090-9743-614196862acf",
     "set_uuid": "a3c90df5-60df-4936-a1f9-232783790380",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1716,7 +1716,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "6529e76c-0c21-449f-a318-2629cf90a58a",
     "set_uuid": "a3c90df5-60df-4936-a1f9-232783790380",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1727,7 +1727,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "744537db-023b-4833-8262-9c349b0915ee",
     "set_uuid": "230b364f-f25a-4f55-baa3-56a1d3559b1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1738,7 +1738,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-600",
+    "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
     "uuid": "0f7a39c2-3ee7-4ff0-873f-334c81054b77",
     "set_uuid": "230b364f-f25a-4f55-baa3-56a1d3559b1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1749,7 +1749,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "e8113995-d2ec-4089-a050-9b393eb9e403",
     "set_uuid": "230b364f-f25a-4f55-baa3-56a1d3559b1a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1761,7 +1761,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-900",
+    "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
     "uuid": "d5cac08e-56e8-4217-a153-33f43c1a2059",
     "set_uuid": "544da90d-04a9-4753-b77b-9bf71f5b837f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1773,7 +1773,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-800",
+    "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
     "uuid": "49170573-9c22-42e1-a1ce-cd3d3972ddb7",
     "set_uuid": "544da90d-04a9-4753-b77b-9bf71f5b837f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1785,7 +1785,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-900",
+    "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
     "uuid": "f7814be9-b21f-40ff-9d34-8c0a96eea93e",
     "set_uuid": "544da90d-04a9-4753-b77b-9bf71f5b837f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1797,7 +1797,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-200",
+    "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
     "uuid": "3b582b64-988e-4b5d-a08d-e04269403536",
     "set_uuid": "b8fb4556-da03-4096-b180-cb9b915ab3e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1809,7 +1809,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-300",
+    "$ref": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
     "uuid": "e10ef55e-c18d-4b73-97d0-330b480e9aa4",
     "set_uuid": "b8fb4556-da03-4096-b180-cb9b915ab3e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1821,7 +1821,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-200",
+    "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
     "uuid": "3911fa84-a5b3-4ea1-b6ad-47f222482ddb",
     "set_uuid": "b8fb4556-da03-4096-b180-cb9b915ab3e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1832,7 +1832,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-700",
+    "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
     "uuid": "83f76815-8660-425e-80e6-825a5be0628f",
     "set_uuid": "f48d1bf4-5604-48c7-976c-0d696156e82b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1843,7 +1843,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-800",
+    "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
     "uuid": "1219770d-543d-4216-9e87-c158f8a74df6",
     "set_uuid": "f48d1bf4-5604-48c7-976c-0d696156e82b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1854,7 +1854,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-700",
+    "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
     "uuid": "4aba2da7-3eed-4a11-830c-58cc4f6bb6cb",
     "set_uuid": "f48d1bf4-5604-48c7-976c-0d696156e82b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1866,7 +1866,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-900",
+    "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
     "uuid": "23859fff-27f5-4576-83c9-0fbc316e880a",
     "set_uuid": "9def3006-8ddc-4212-a61b-8ccdcf9af786",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1878,7 +1878,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-800",
+    "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
     "uuid": "b7f5a677-4e89-40e1-8324-7619a628ce8b",
     "set_uuid": "9def3006-8ddc-4212-a61b-8ccdcf9af786",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1890,7 +1890,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-900",
+    "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
     "uuid": "dedf817e-2883-4632-936c-207fdafe7469",
     "set_uuid": "9def3006-8ddc-4212-a61b-8ccdcf9af786",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1902,7 +1902,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-200",
+    "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
     "uuid": "dda05431-bce9-4686-8738-78fb409ab28f",
     "set_uuid": "cf1d5f25-cde5-4008-9d81-3fc011266cb6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1914,7 +1914,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-300",
+    "$ref": "571bb191-0f29-4a11-95a2-831a454b4df1",
     "uuid": "533023cb-f78a-4f1c-af52-244b3c10a7bb",
     "set_uuid": "cf1d5f25-cde5-4008-9d81-3fc011266cb6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1926,7 +1926,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-200",
+    "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
     "uuid": "2110b943-24cf-4afd-81b2-31676f1400f8",
     "set_uuid": "cf1d5f25-cde5-4008-9d81-3fc011266cb6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1937,7 +1937,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-800",
+    "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
     "uuid": "cb59d4d5-c17e-428d-a22a-e9a3fc02ac9c",
     "set_uuid": "7d9c915f-bf12-4971-bd66-d8e629f07c55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1948,7 +1948,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-900",
+    "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
     "uuid": "584ccbd4-3243-4041-b665-e2342d2b26e8",
     "set_uuid": "7d9c915f-bf12-4971-bd66-d8e629f07c55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1959,7 +1959,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-800",
+    "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
     "uuid": "056968e0-d29e-4b1c-a9b1-50853f6d159b",
     "set_uuid": "7d9c915f-bf12-4971-bd66-d8e629f07c55",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1971,7 +1971,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-900",
+    "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
     "uuid": "3acd52f0-d19c-4174-9ad5-42885ec9d49d",
     "set_uuid": "6b40c677-e046-4a49-b421-8a4451844512",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1983,7 +1983,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-800",
+    "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
     "uuid": "da3a7c08-7f54-4486-bb66-146db21f0627",
     "set_uuid": "6b40c677-e046-4a49-b421-8a4451844512",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1995,7 +1995,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-900",
+    "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
     "uuid": "02e7121e-71eb-4228-a61a-963d7f2a531b",
     "set_uuid": "6b40c677-e046-4a49-b421-8a4451844512",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2007,7 +2007,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-1000",
+    "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
     "uuid": "91f91b8c-0e65-4b7b-8c7b-60d3b6e235d8",
     "set_uuid": "cbee87ce-48b0-4fd8-8292-61db059dd7f0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2019,7 +2019,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-700",
+    "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
     "uuid": "c9c09cc9-1ebd-4738-9613-6a0a67bea4f9",
     "set_uuid": "cbee87ce-48b0-4fd8-8292-61db059dd7f0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2031,7 +2031,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-1000",
+    "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
     "uuid": "109c9d4a-a024-4b41-9a99-4c0e671f1011",
     "set_uuid": "cbee87ce-48b0-4fd8-8292-61db059dd7f0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2043,7 +2043,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-1000",
+    "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
     "uuid": "06dcb775-28b2-454e-89ce-fda34f30c7d7",
     "set_uuid": "96433130-42c8-4ff5-9f12-fc5a7b45ee87",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2055,7 +2055,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-700",
+    "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
     "uuid": "092415a8-0054-4f6d-9a93-1541c767b2c5",
     "set_uuid": "96433130-42c8-4ff5-9f12-fc5a7b45ee87",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2067,7 +2067,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-1000",
+    "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
     "uuid": "d0ad5e30-c689-4831-bbd0-2de373aa11b5",
     "set_uuid": "96433130-42c8-4ff5-9f12-fc5a7b45ee87",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2079,7 +2079,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-1000",
+    "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
     "uuid": "ea314056-fd9a-4325-b19a-33f56fad2859",
     "set_uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2091,7 +2091,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-700",
+    "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
     "uuid": "e5292c94-ea4a-49ba-8c25-6ab1114e0fe3",
     "set_uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2103,7 +2103,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-1000",
+    "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
     "uuid": "5bcac2b7-7ebb-405a-bfe3-1785d4e6fde6",
     "set_uuid": "b0a6beaa-35b2-4daa-91aa-dff037aa6234",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2114,7 +2114,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-800",
+    "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
     "uuid": "cd900a8d-1852-4592-9031-9edab2f9721f",
     "set_uuid": "60aa72d2-3b00-4eea-973d-265a55d3095a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2125,7 +2125,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-900",
+    "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
     "uuid": "fd64c9ca-6ad7-415c-b0b8-2579399e33a5",
     "set_uuid": "60aa72d2-3b00-4eea-973d-265a55d3095a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2136,7 +2136,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-800",
+    "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
     "uuid": "556d02fd-fecb-4772-92cb-921ac509bcae",
     "set_uuid": "60aa72d2-3b00-4eea-973d-265a55d3095a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2148,7 +2148,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-900",
+    "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
     "uuid": "4e02601f-12da-4ce2-b58c-0aa0e309442d",
     "set_uuid": "3b100044-0453-4f8a-8ad0-83b1d2118d7b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2160,7 +2160,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-800",
+    "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
     "uuid": "5867d764-d909-4490-b947-533e89997d0a",
     "set_uuid": "3b100044-0453-4f8a-8ad0-83b1d2118d7b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2172,7 +2172,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-900",
+    "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
     "uuid": "c7b29eba-f8a3-43f7-b5b9-0c1a7f04bb38",
     "set_uuid": "3b100044-0453-4f8a-8ad0-83b1d2118d7b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2184,7 +2184,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-200",
+    "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
     "uuid": "09787c85-44e0-4efe-b427-f6e7dde544a4",
     "set_uuid": "34b86478-26f1-4b9c-87c5-465e614f5d48",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2196,7 +2196,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-300",
+    "$ref": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
     "uuid": "143b0387-7069-4bef-b852-9c456d692b88",
     "set_uuid": "34b86478-26f1-4b9c-87c5-465e614f5d48",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2208,7 +2208,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-200",
+    "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
     "uuid": "b526e518-47b2-4a1c-b54b-42596381b7fd",
     "set_uuid": "34b86478-26f1-4b9c-87c5-465e614f5d48",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2219,7 +2219,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-800",
+    "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
     "uuid": "8bc581a9-558c-424d-a72b-f24b48207b82",
     "set_uuid": "83f51bbb-8dc4-4191-88e0-9391fbc9157c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2230,7 +2230,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-900",
+    "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
     "uuid": "178e4bc6-6986-4e77-aab0-78dbe66f8e6f",
     "set_uuid": "83f51bbb-8dc4-4191-88e0-9391fbc9157c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2241,7 +2241,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-800",
+    "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
     "uuid": "9bf3d052-42d1-454b-8ae6-ee0b40d9a9c8",
     "set_uuid": "83f51bbb-8dc4-4191-88e0-9391fbc9157c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2253,7 +2253,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-900",
+    "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
     "uuid": "46204746-7fe7-4f22-887e-2c9b85c3b7bc",
     "set_uuid": "d0300f1c-9d79-4d73-a83e-915cb6566bf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2265,7 +2265,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-800",
+    "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
     "uuid": "1117b73b-42e3-4ad6-8b26-af76859a27bb",
     "set_uuid": "d0300f1c-9d79-4d73-a83e-915cb6566bf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2277,7 +2277,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-900",
+    "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
     "uuid": "ebadb88b-90a3-492e-ba3c-e9f1232b5ce5",
     "set_uuid": "d0300f1c-9d79-4d73-a83e-915cb6566bf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2289,7 +2289,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "3c2d5afe-fff4-487d-a312-000f738c8704",
     "set_uuid": "4b0af26c-61ca-4fe6-a792-01f527b4f216",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2301,7 +2301,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-700",
+    "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
     "uuid": "8565ec8e-2196-47ac-8636-40084acbfd4f",
     "set_uuid": "4b0af26c-61ca-4fe6-a792-01f527b4f216",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2313,7 +2313,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "ce2e6ea6-c692-4cff-a2ac-f0c1c2e054ca",
     "set_uuid": "4b0af26c-61ca-4fe6-a792-01f527b4f216",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2325,7 +2325,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "d2481a50-13a0-4f19-8faa-a1a215fee21d",
     "set_uuid": "3dc8ef4d-e6c0-4316-9df4-ecd7ffa9207b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2337,7 +2337,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-700",
+    "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
     "uuid": "648da867-549e-47c3-9312-e9cfda288705",
     "set_uuid": "3dc8ef4d-e6c0-4316-9df4-ecd7ffa9207b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2349,7 +2349,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "b1104fe3-4965-411e-95d3-87f59cdbc756",
     "set_uuid": "3dc8ef4d-e6c0-4316-9df4-ecd7ffa9207b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2361,7 +2361,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "41a6ee21-8db2-410b-a694-fca1fbf70f2a",
     "set_uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2373,7 +2373,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-700",
+    "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
     "uuid": "f1470931-f4f8-47d9-b118-5b813e4c154a",
     "set_uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2385,7 +2385,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "abcf178e-0e44-4f57-a62c-382cb9478be2",
     "set_uuid": "1a73eddc-911d-4218-b902-0abaffbb12e4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2396,7 +2396,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-900",
+    "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
     "uuid": "6effed65-3d52-465f-9eb2-7994f1ee90fb"
   },
   {
@@ -2405,7 +2405,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1100",
+    "$ref": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489",
     "uuid": "0c35da5c-cf37-4349-82e4-8739ea94aa65"
   },
   {
@@ -2414,7 +2414,7 @@
       "state": "focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "aae2b3a5-1f68-4832-9539-62227179e69e"
   },
   {
@@ -2423,7 +2423,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-border-color-down",
+    "$ref": "0c35da5c-cf37-4349-82e4-8739ea94aa65",
     "uuid": "63abd660-13c4-47b8-be9e-61e270b95212"
   },
   {
@@ -2432,7 +2432,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "496571fc-18ce-44a3-a89e-40ff6397adcd"
   },
   {
@@ -2441,7 +2441,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "393cb93a-3d0a-4118-a2ee-451fdc871b0f"
   },
   {
@@ -2450,7 +2450,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-900",
+    "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
     "uuid": "2a1b0c71-c3a4-4f4c-a625-346e026853e5"
   },
   {
@@ -2459,7 +2459,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "f760cc99-ebec-4d34-931e-5621aef995a0"
   },
   {
@@ -2468,7 +2468,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "ff90152d-86bf-4a34-9a7e-ede61966bda0"
   },
   {
@@ -2477,7 +2477,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-1000",
+    "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
     "uuid": "03a7aa1f-9493-4054-bb21-eb10e593da73"
   },
   {
@@ -2486,7 +2486,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-800",
+    "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
     "uuid": "d1beeda3-a00d-4f8c-8553-0a0f84093b1f",
     "set_uuid": "23cea5fe-acb5-4460-add7-3512aaceeb35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2497,7 +2497,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-900",
+    "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
     "uuid": "70cb0316-5b7a-416c-bf93-7d8885c4fce6",
     "set_uuid": "23cea5fe-acb5-4460-add7-3512aaceeb35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2508,7 +2508,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-800",
+    "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
     "uuid": "9211e320-de05-4097-8350-fef2293be6a0",
     "set_uuid": "23cea5fe-acb5-4460-add7-3512aaceeb35",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2519,7 +2519,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "95cf1481-f476-47ce-a45a-54da64b44255"
   },
   {
@@ -2528,7 +2528,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "5a0fdda5-6ac2-4a31-a7b9-6b3a5dd868d6"
   },
   {
@@ -2537,7 +2537,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "142f9467-e519-4ed7-bd98-69a31e876e70"
   },
   {
@@ -2546,7 +2546,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "f52c6bfb-2d62-4fc8-a1cd-6c8d7420eeb4"
   },
   {
@@ -2555,7 +2555,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc"
   },
   {
@@ -2564,7 +2564,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "966c56d0-4461-45e7-9e20-0277f2111a34"
   },
   {
@@ -2573,7 +2573,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "1c220122-5f32-42f9-848f-ae10061241e5"
   },
   {
@@ -2582,7 +2582,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "9b8df7df-3439-4614-b446-97a4de782e27"
   },
   {
@@ -2591,7 +2591,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "43ca4c0d-7803-4e8e-b444-26fe70d5304c"
   },
   {
@@ -2600,7 +2600,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "cf169d95-e427-4665-a983-c24727dbfa60"
   },
   {
@@ -2609,7 +2609,7 @@
       "state": "focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-content-color-down",
+    "$ref": "cf169d95-e427-4665-a983-c24727dbfa60",
     "uuid": "f218dfd0-23be-4f07-becb-6027cc971c8b"
   },
   {
@@ -2618,7 +2618,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-content-color-down",
+    "$ref": "cf169d95-e427-4665-a983-c24727dbfa60",
     "uuid": "a370f375-b3b1-4af8-9628-fa901c0252fb"
   },
   {
@@ -2627,7 +2627,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "d236bdc5-037b-4838-8401-8a0d5136936c"
   },
   {
@@ -2636,7 +2636,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "c2c538e0-6f8d-4586-953a-b98ef40c9eca"
   },
   {
@@ -2646,7 +2646,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-700",
+    "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
     "uuid": "3b09b2fd-cbf9-4933-9655-27a75d984f06",
     "set_uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2658,7 +2658,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "bc9979cb-e7c6-45b2-be4d-0ba3c817e2ef",
     "set_uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2670,7 +2670,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-700",
+    "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
     "uuid": "fdcab585-e3a9-4026-bf40-e7fdd01bf05b",
     "set_uuid": "08075b0a-0918-4302-b9af-16734a57b9bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2682,7 +2682,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "300d2800-a6e5-4b78-9b6c-aaf2f4af39c6",
     "set_uuid": "4ff21423-684b-4c78-b4e8-a5535b6e1cad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2694,7 +2694,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "11bf9149-d8df-4f37-ba21-51ff911b0517",
     "set_uuid": "4ff21423-684b-4c78-b4e8-a5535b6e1cad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2706,7 +2706,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "6e62476c-b60b-4d33-97c5-5fdf1f3a7930",
     "set_uuid": "4ff21423-684b-4c78-b4e8-a5535b6e1cad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2718,7 +2718,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "a1ab50d5-1aa1-4198-9510-7ea8458cc62f",
     "set_uuid": "e05475a2-de73-4ca5-a9c4-ef7e3fcb1b3a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2730,7 +2730,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "2d72c9fc-22d0-4e4d-9b00-fae4b30a47b5",
     "set_uuid": "e05475a2-de73-4ca5-a9c4-ef7e3fcb1b3a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2742,7 +2742,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "81fb8734-c8c3-4f6e-8a14-177ce1d7db02",
     "set_uuid": "e05475a2-de73-4ca5-a9c4-ef7e3fcb1b3a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2754,7 +2754,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "eece165c-743c-4d7a-b770-3ee50e1951cf",
     "set_uuid": "47944e17-0736-426b-9228-4591966bbc38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2766,7 +2766,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "a1e08db6-3a72-4b8e-9475-b54a7b9be506",
     "set_uuid": "47944e17-0736-426b-9228-4591966bbc38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2778,7 +2778,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "ee7dec87-de8b-4145-9985-f5ba78bc3a3b",
     "set_uuid": "47944e17-0736-426b-9228-4591966bbc38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2789,7 +2789,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-700",
+    "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
     "uuid": "7a058b23-341c-4dd3-83d8-358917277836"
   },
   {
@@ -2798,7 +2798,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "8ab4accc-bd95-48e0-ae3a-539740a07cc6"
   },
   {
@@ -2807,7 +2807,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "a6d8a177-3e5c-4d28-a675-c21c2695d2f6"
   },
   {
@@ -2816,7 +2816,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "4e79877b-254d-4226-a28f-4c80d2d8b2f3"
   },
   {
@@ -2825,7 +2825,7 @@
       "state": "selected"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-subdued-content-color-down",
+    "$ref": "8ab4accc-bd95-48e0-ae3a-539740a07cc6",
     "uuid": "ea46f6d3-4261-4482-a70f-2cddd113aa4a"
   },
   {
@@ -2835,7 +2835,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "cc79fbaf-a2e1-4761-82e7-1dbea52acee8",
     "set_uuid": "38777112-84a2-4a1f-a655-646997469521",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2847,7 +2847,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-300",
+    "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
     "uuid": "9a9589e8-c08c-486f-a42f-8e139dedaa37",
     "set_uuid": "38777112-84a2-4a1f-a655-646997469521",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2859,7 +2859,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "64b2528e-4c1b-4850-a67f-8bd7bb05d36c",
     "set_uuid": "38777112-84a2-4a1f-a655-646997469521",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2870,7 +2870,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "0dc6ed4d-17d5-4878-8ac3-bd99549b4f42",
     "set_uuid": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2881,7 +2881,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-600",
+    "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
     "uuid": "35ef6675-7e66-4ef5-8c8d-e8e70939b224",
     "set_uuid": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2892,7 +2892,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "57233b29-bbc6-4f9e-83c1-9325fd6f964c",
     "set_uuid": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2904,7 +2904,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-600",
+    "$ref": "716af828-c64d-465d-8476-d142892ca59c",
     "uuid": "48f3445a-63d8-4477-a2f5-1fee6a022328",
     "set_uuid": "f0cabe3c-ee14-4791-96ec-84abcd6867fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2916,7 +2916,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-900",
+    "$ref": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
     "uuid": "323428c1-792d-41b4-8a17-a12f1ac00e2a",
     "set_uuid": "f0cabe3c-ee14-4791-96ec-84abcd6867fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2928,7 +2928,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-600",
+    "$ref": "716af828-c64d-465d-8476-d142892ca59c",
     "uuid": "85515d6c-4674-435f-a2d4-b9bf8311781e",
     "set_uuid": "f0cabe3c-ee14-4791-96ec-84abcd6867fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2939,7 +2939,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-800",
+    "$ref": "a83cdd4d-b8a9-42af-98c4-459f721abbff",
     "uuid": "b8b38df6-aac5-49fc-99bb-d64a543c5bf8",
     "set_uuid": "da827479-f058-4117-9cd3-90cbe525d05d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2950,7 +2950,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-900",
+    "$ref": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
     "uuid": "2759c912-6385-40e4-9ed9-ff2e11815b4d",
     "set_uuid": "da827479-f058-4117-9cd3-90cbe525d05d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2961,7 +2961,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-800",
+    "$ref": "a83cdd4d-b8a9-42af-98c4-459f721abbff",
     "uuid": "e6e779ea-6015-467f-8df7-9027280bdea2",
     "set_uuid": "da827479-f058-4117-9cd3-90cbe525d05d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2982,7 +2982,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-600",
+    "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
     "uuid": "981c054e-9db5-4589-b9e7-eed307b115ca",
     "set_uuid": "b2896323-3d58-4394-ab8e-5c47f3f7c6af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2994,7 +2994,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-900",
+    "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
     "uuid": "3e9a6c2a-bd09-4d28-a95c-920109c1852f",
     "set_uuid": "b2896323-3d58-4394-ab8e-5c47f3f7c6af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3006,7 +3006,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-600",
+    "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
     "uuid": "37c3db03-6dd6-47e5-a03c-25663d116c52",
     "set_uuid": "b2896323-3d58-4394-ab8e-5c47f3f7c6af",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3018,7 +3018,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-200",
+    "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
     "uuid": "e7e1eb3c-7590-4622-a261-8de879bb1500",
     "set_uuid": "c023322e-930a-4206-b52a-2c4ee91e7cd3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3030,7 +3030,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-300",
+    "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
     "uuid": "9b2505cc-2a71-4b1e-804d-3f2ffa69d06c",
     "set_uuid": "c023322e-930a-4206-b52a-2c4ee91e7cd3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3042,7 +3042,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-200",
+    "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
     "uuid": "a9671857-3e09-4132-a522-cd8f5b4cf8ff",
     "set_uuid": "c023322e-930a-4206-b52a-2c4ee91e7cd3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3053,7 +3053,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-700",
+    "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
     "uuid": "8fdaf9e0-bd3e-4188-84bd-7abf72e50b58",
     "set_uuid": "434f94da-e44d-486d-bb7b-26a1dfbefc04",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3064,7 +3064,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-900",
+    "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
     "uuid": "e7bf9977-2edf-48bc-8099-ad95e57b55b1",
     "set_uuid": "434f94da-e44d-486d-bb7b-26a1dfbefc04",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3075,7 +3075,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-700",
+    "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
     "uuid": "f76b6279-2d64-47fe-a531-1737a834b21a",
     "set_uuid": "434f94da-e44d-486d-bb7b-26a1dfbefc04",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3085,7 +3085,7 @@
       "property": "overlay-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black",
+    "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
     "uuid": "af66daa6-9e52-4e68-a605-86d1de4ee971"
   },
   {
@@ -3128,7 +3128,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-900",
+    "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
     "uuid": "78fc6322-a961-429a-bd40-3e1c1bf2c4e9",
     "set_uuid": "dc44bb9a-f9a1-43f2-8d45-d3720d841671",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3140,7 +3140,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-800",
+    "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
     "uuid": "3a363aa8-cf27-48a1-8c61-b1f1eaff6110",
     "set_uuid": "dc44bb9a-f9a1-43f2-8d45-d3720d841671",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3152,7 +3152,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-900",
+    "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
     "uuid": "b60042cd-3ce7-4952-aeae-338d2b5fe98d",
     "set_uuid": "dc44bb9a-f9a1-43f2-8d45-d3720d841671",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3164,7 +3164,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-200",
+    "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
     "uuid": "41f3d269-85d6-4c82-9b1c-e40ea508fa78",
     "set_uuid": "45675d54-a787-43a3-ac45-1b8825939cbc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3176,7 +3176,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-300",
+    "$ref": "7bb48388-b3bc-47eb-a7ab-b15327996714",
     "uuid": "72400c8f-2e44-4757-8be6-3c1eb28d9606",
     "set_uuid": "45675d54-a787-43a3-ac45-1b8825939cbc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3188,7 +3188,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-200",
+    "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
     "uuid": "d726501f-8920-4434-b397-b0974037161a",
     "set_uuid": "45675d54-a787-43a3-ac45-1b8825939cbc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3199,7 +3199,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-800",
+    "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
     "uuid": "4be32a08-c731-4c59-b376-ba0ef134e14e",
     "set_uuid": "8204525c-1b1a-485b-950a-addef9f4db36",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3210,7 +3210,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-900",
+    "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
     "uuid": "496cef67-3a25-4d99-8545-e8aa9a7f0adc",
     "set_uuid": "8204525c-1b1a-485b-950a-addef9f4db36",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3221,7 +3221,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-800",
+    "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
     "uuid": "fcbf8451-ad82-4247-a867-a5d0034667b5",
     "set_uuid": "8204525c-1b1a-485b-950a-addef9f4db36",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3233,7 +3233,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-900",
+    "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
     "uuid": "d878d795-2292-4d90-a9e2-37af1d97a532",
     "set_uuid": "9639ac0a-827e-4969-9c2f-bb09420e7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3245,7 +3245,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-800",
+    "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
     "uuid": "82b54f71-7c9e-4388-9e3b-4d13f12fad60",
     "set_uuid": "9639ac0a-827e-4969-9c2f-bb09420e7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3257,7 +3257,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-900",
+    "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
     "uuid": "27688f39-6b46-4b40-a3c5-67694a0ff672",
     "set_uuid": "9639ac0a-827e-4969-9c2f-bb09420e7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3269,7 +3269,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-1000",
+    "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
     "uuid": "4096a319-241e-410c-ad51-521d57155004",
     "set_uuid": "621a6182-5fd5-479d-bd6a-7c739f651058",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3281,7 +3281,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-700",
+    "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
     "uuid": "58a934d2-a715-4544-aa79-7f94bd493f09",
     "set_uuid": "621a6182-5fd5-479d-bd6a-7c739f651058",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3293,7 +3293,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-1000",
+    "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
     "uuid": "45c598af-e0da-4e41-855a-55dfc77f198c",
     "set_uuid": "621a6182-5fd5-479d-bd6a-7c739f651058",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3305,7 +3305,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-1000",
+    "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
     "uuid": "d60ab5e9-9ada-4587-a75f-91f2b492800f",
     "set_uuid": "bf1f2daa-3449-4e3b-978a-e5c2bcbc8218",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3317,7 +3317,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-700",
+    "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
     "uuid": "2992a78b-9ce0-4b29-a4f6-ddbc51f820f2",
     "set_uuid": "bf1f2daa-3449-4e3b-978a-e5c2bcbc8218",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3329,7 +3329,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-1000",
+    "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
     "uuid": "7c4bd8ad-72ce-4518-b91d-a7b7721fe920",
     "set_uuid": "bf1f2daa-3449-4e3b-978a-e5c2bcbc8218",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3341,7 +3341,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-1000",
+    "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
     "uuid": "036525d0-c6c4-478c-9aa3-84242737c6b1",
     "set_uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3353,7 +3353,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-700",
+    "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
     "uuid": "56d371b4-437f-4ca9-854f-ae6daf5dcfce",
     "set_uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3365,7 +3365,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-1000",
+    "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
     "uuid": "74eef2ae-5b83-4a25-b882-5960f64ecef0",
     "set_uuid": "cdaa6f44-8833-44df-8c60-0068d180bd4d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3376,7 +3376,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-800",
+    "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
     "uuid": "455acfc0-1997-4fee-b1dc-3c91bbd9fca2",
     "set_uuid": "d439dfad-437a-4929-8d0d-9b9290dcb843",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3387,7 +3387,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-900",
+    "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
     "uuid": "25e8289f-6c82-4485-8920-a187f790cd47",
     "set_uuid": "d439dfad-437a-4929-8d0d-9b9290dcb843",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3398,7 +3398,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-800",
+    "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
     "uuid": "96075e1a-6739-41c8-985b-af30b09be6c3",
     "set_uuid": "d439dfad-437a-4929-8d0d-9b9290dcb843",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3410,7 +3410,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-900",
+    "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
     "uuid": "ed07d8f4-390f-4124-a4c4-81b62767c6cd",
     "set_uuid": "48c3ed16-e6b3-42ad-8806-7f3f78aa94f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3422,7 +3422,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-800",
+    "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
     "uuid": "e577d521-0271-4226-a094-624b35a05826",
     "set_uuid": "48c3ed16-e6b3-42ad-8806-7f3f78aa94f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3434,7 +3434,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-900",
+    "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
     "uuid": "720cfaa3-6bb1-4df1-946f-94fabae54e7b",
     "set_uuid": "48c3ed16-e6b3-42ad-8806-7f3f78aa94f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3446,7 +3446,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-200",
+    "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
     "uuid": "a53f9f9a-8fde-4de2-83a3-944e1c4556c1",
     "set_uuid": "a84ac914-c3f2-4d91-ac68-25433f0976bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3458,7 +3458,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-300",
+    "$ref": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
     "uuid": "896f2a2f-4d02-4104-ac33-a3705a9c61e3",
     "set_uuid": "a84ac914-c3f2-4d91-ac68-25433f0976bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3470,7 +3470,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-200",
+    "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
     "uuid": "1d628f99-7c9c-423d-a470-a260d84d0d8d",
     "set_uuid": "a84ac914-c3f2-4d91-ac68-25433f0976bb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3481,7 +3481,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-800",
+    "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
     "uuid": "681fc141-b235-4cde-9c3a-f0033943d772",
     "set_uuid": "604bcb2d-f04e-436e-a520-3f58cddd4660",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3492,7 +3492,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-900",
+    "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
     "uuid": "0ee2957b-c401-4106-8ff3-9de9fa544a03",
     "set_uuid": "604bcb2d-f04e-436e-a520-3f58cddd4660",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3503,7 +3503,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-800",
+    "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
     "uuid": "ef836f5b-c6b9-4e6b-a671-e979dc53c407",
     "set_uuid": "604bcb2d-f04e-436e-a520-3f58cddd4660",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3515,7 +3515,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-900",
+    "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
     "uuid": "8cec4a84-3eea-45d6-ae1b-64907be7da78",
     "set_uuid": "1bdf8cc5-f046-4054-a321-cafccbfe5d2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3527,7 +3527,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-800",
+    "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
     "uuid": "ce074ee2-a2a2-4da3-a99e-603524193d46",
     "set_uuid": "1bdf8cc5-f046-4054-a321-cafccbfe5d2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3539,7 +3539,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-900",
+    "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
     "uuid": "3fb6aa49-631f-489b-9dab-63a5712d72da",
     "set_uuid": "1bdf8cc5-f046-4054-a321-cafccbfe5d2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3551,7 +3551,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-200",
+    "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
     "uuid": "5d7cd7c1-66fa-49d4-923b-8cca2dcb4726",
     "set_uuid": "c95ee642-363a-430b-909e-b1dc4c345cf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3563,7 +3563,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-300",
+    "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
     "uuid": "c098c385-7fce-4f16-b1d1-54a86c608e64",
     "set_uuid": "c95ee642-363a-430b-909e-b1dc4c345cf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3575,7 +3575,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-200",
+    "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
     "uuid": "8a6b560b-50b2-4dbf-900b-0ed63233df8b",
     "set_uuid": "c95ee642-363a-430b-909e-b1dc4c345cf4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3586,7 +3586,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-800",
+    "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
     "uuid": "7fe7c804-7e6b-48ac-b1fa-b88874e0a330",
     "set_uuid": "80de3f87-9fea-40a2-94f6-05b88e4a4e11",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3597,7 +3597,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-700",
+    "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
     "uuid": "870f90ab-7f3e-41b6-9c11-59e9c4ff82c6",
     "set_uuid": "80de3f87-9fea-40a2-94f6-05b88e4a4e11",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3608,7 +3608,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-800",
+    "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
     "uuid": "834d0a71-9060-4ce0-8e25-8b062ef89b19",
     "set_uuid": "80de3f87-9fea-40a2-94f6-05b88e4a4e11",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3620,7 +3620,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-900",
+    "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
     "uuid": "be1d8187-effc-430f-ac31-3904cf83a6d6",
     "set_uuid": "7c2185c4-323c-4ea7-bcec-d550458f821f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3632,7 +3632,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-800",
+    "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
     "uuid": "9a727140-328d-430f-9b10-8965eebe77d1",
     "set_uuid": "7c2185c4-323c-4ea7-bcec-d550458f821f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3644,7 +3644,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-900",
+    "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
     "uuid": "e2f2ef18-aabf-44fd-b074-d94f75862f3d",
     "set_uuid": "7c2185c4-323c-4ea7-bcec-d550458f821f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3656,7 +3656,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-200",
+    "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
     "uuid": "7623166b-5320-40eb-8a5f-2cd12f17bdb2",
     "set_uuid": "32797d40-d482-4503-9a05-1bcdd58f5aad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3668,7 +3668,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-300",
+    "$ref": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
     "uuid": "73620c8b-3943-46c0-acb8-d517e7e6081e",
     "set_uuid": "32797d40-d482-4503-9a05-1bcdd58f5aad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3680,7 +3680,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-200",
+    "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
     "uuid": "0acaf55e-7e99-45f9-b99b-e461fa78a481",
     "set_uuid": "32797d40-d482-4503-9a05-1bcdd58f5aad",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3691,7 +3691,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-700",
+    "$ref": "ad52345b-0360-4819-9fe8-b6e07249810d",
     "uuid": "2b0a6584-db41-43b9-ba39-39171548c01a",
     "set_uuid": "ce6db8f0-4fb9-4a7d-9f4a-1b9244bf1ffc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3702,7 +3702,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-800",
+    "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
     "uuid": "736e4768-7944-40ec-a412-4cd36299e03d",
     "set_uuid": "ce6db8f0-4fb9-4a7d-9f4a-1b9244bf1ffc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3713,7 +3713,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-700",
+    "$ref": "ad52345b-0360-4819-9fe8-b6e07249810d",
     "uuid": "15de4533-1a59-4a9f-899f-004a429471c7",
     "set_uuid": "ce6db8f0-4fb9-4a7d-9f4a-1b9244bf1ffc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3725,7 +3725,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-900",
+    "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
     "uuid": "13d332e4-45b0-4549-a1a3-a608034960a1",
     "set_uuid": "0c7a05f8-e309-4f57-bc88-2ecdca589e16",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3737,7 +3737,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-800",
+    "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
     "uuid": "a6e04390-003e-4565-bf96-e0fb8a791cb9",
     "set_uuid": "0c7a05f8-e309-4f57-bc88-2ecdca589e16",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3749,7 +3749,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-900",
+    "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
     "uuid": "e0bb7dad-7f1b-4b6e-b2fe-99f8b14f3240",
     "set_uuid": "0c7a05f8-e309-4f57-bc88-2ecdca589e16",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3761,7 +3761,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-200",
+    "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
     "uuid": "c80f665a-801e-45c8-b59b-8b9b47ebb356",
     "set_uuid": "56878e94-5ba9-4c5b-9f21-9e8200789008",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3773,7 +3773,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-300",
+    "$ref": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
     "uuid": "6f596774-e326-4d80-bf1d-23f7ad1f4ccb",
     "set_uuid": "56878e94-5ba9-4c5b-9f21-9e8200789008",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3785,7 +3785,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-200",
+    "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
     "uuid": "ec3dddb5-3944-493c-b5c8-f08c3272dc06",
     "set_uuid": "56878e94-5ba9-4c5b-9f21-9e8200789008",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3796,7 +3796,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-800",
+    "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
     "uuid": "35f96ec6-0eae-4c55-aa54-134f03feda7d",
     "set_uuid": "3f2c02a7-454c-4c72-a35a-16987c8417f9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3807,7 +3807,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-900",
+    "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
     "uuid": "f7d55707-b9db-4711-b93f-dcc03932516c",
     "set_uuid": "3f2c02a7-454c-4c72-a35a-16987c8417f9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3818,7 +3818,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-800",
+    "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
     "uuid": "7e749788-d92d-4ad5-b4d2-446e77c5a041",
     "set_uuid": "3f2c02a7-454c-4c72-a35a-16987c8417f9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3828,7 +3828,7 @@
       "property": "static-black-focus-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black",
+    "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
     "uuid": "c6b8275b-f44e-43b4-b763-82dda94d963c"
   },
   {
@@ -3836,7 +3836,7 @@
       "property": "static-black-text-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black",
+    "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
     "uuid": "9b7919b5-764c-4f93-b4c7-39d8bf7f2b51"
   },
   {
@@ -3844,7 +3844,7 @@
       "property": "static-black-track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-300",
+    "$ref": "16a871e1-d9df-42bb-8889-99059d70e82e",
     "uuid": "c6d40ce0-bcee-4b56-9e63-a51ee1579ef0"
   },
   {
@@ -3852,7 +3852,7 @@
       "property": "static-black-track-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-900",
+    "$ref": "c0a331f9-53e3-4c72-b5e3-139d730a1752",
     "uuid": "0599d3b0-4d9e-4a12-ae0e-8f60e3533ab9"
   },
   {
@@ -3860,7 +3860,7 @@
       "property": "static-white-focus-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "white",
+    "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
     "uuid": "1dd6dc5b-47a2-41eb-80fc-f06293ae8e13"
   },
   {
@@ -3868,7 +3868,7 @@
       "property": "static-white-text-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "white",
+    "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
     "uuid": "13ee65f0-4bb9-4213-905d-92c1b788a702"
   },
   {
@@ -3876,7 +3876,7 @@
       "property": "static-white-track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-300",
+    "$ref": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
     "uuid": "23791534-8963-4ff8-bfb4-15108da47103"
   },
   {
@@ -3884,7 +3884,7 @@
       "property": "static-white-track-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-900",
+    "$ref": "c5c823c6-1911-4e0e-ba2f-5105f467e108",
     "uuid": "a1cbc282-1376-48d1-b8bb-92f10aef7c6f"
   },
   {
@@ -3892,7 +3892,7 @@
       "property": "title-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "a7e9c20c-ab9b-46de-bf6a-c8fec9a8986b"
   },
   {
@@ -3900,7 +3900,7 @@
       "property": "track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-300",
+    "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
     "uuid": "6f2bb13a-8579-495c-8fe3-0046b1f99b01"
   },
   {
@@ -3910,7 +3910,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-900",
+    "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
     "uuid": "e763acbc-2c17-46c5-8484-1d8536e7ef10",
     "set_uuid": "d997ddfd-36d9-4229-b6d1-b6ae8b8b37ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3922,7 +3922,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-800",
+    "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
     "uuid": "6beacbfc-6d61-4567-86fe-39771550cf20",
     "set_uuid": "d997ddfd-36d9-4229-b6d1-b6ae8b8b37ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3934,7 +3934,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-900",
+    "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
     "uuid": "50eb3d20-ab84-4541-8807-551391016b54",
     "set_uuid": "d997ddfd-36d9-4229-b6d1-b6ae8b8b37ee",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3946,7 +3946,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-200",
+    "$ref": "7720aa32-deea-454b-a593-f1234e638565",
     "uuid": "aa7d44fd-6c77-43dc-8981-4200356fd02a",
     "set_uuid": "ca18e828-3005-4361-9012-3e9d5c75c00f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3958,7 +3958,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-300",
+    "$ref": "47de7f9a-3e02-4824-b667-ad499729c9ff",
     "uuid": "5e5d9ba8-df94-43e1-ad40-f78312925ec5",
     "set_uuid": "ca18e828-3005-4361-9012-3e9d5c75c00f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3970,7 +3970,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-200",
+    "$ref": "7720aa32-deea-454b-a593-f1234e638565",
     "uuid": "4e874813-4ebc-4855-bcb3-83024a6d1ba2",
     "set_uuid": "ca18e828-3005-4361-9012-3e9d5c75c00f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3981,7 +3981,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-800",
+    "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
     "uuid": "2c31e5bc-cf23-42d6-85e8-9947e305d1ff",
     "set_uuid": "b36c23ca-94a9-4268-b63b-a40490756bb3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -3992,7 +3992,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-900",
+    "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
     "uuid": "04c6819d-5049-4e18-bb83-95239fa3d8c2",
     "set_uuid": "b36c23ca-94a9-4268-b63b-a40490756bb3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4003,7 +4003,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-800",
+    "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
     "uuid": "bc700351-a33c-4164-9ba7-3f86733ebe54",
     "set_uuid": "b36c23ca-94a9-4268-b63b-a40490756bb3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4015,7 +4015,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-400",
+    "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
     "uuid": "f8e435de-1630-4628-8b6d-128987d66ddc",
     "set_uuid": "04478af1-761c-4f12-b57a-5537d42f3d07",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4027,7 +4027,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-1100",
+    "$ref": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
     "uuid": "61c5e375-bff3-479f-8c32-2d2a5edb906c",
     "set_uuid": "04478af1-761c-4f12-b57a-5537d42f3d07",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4039,7 +4039,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-400",
+    "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
     "uuid": "ff49d6b0-4f39-4cbb-a580-db03b0579a71",
     "set_uuid": "04478af1-761c-4f12-b57a-5537d42f3d07",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4051,7 +4051,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-200",
+    "$ref": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
     "uuid": "5d5cfc7a-e6f4-4d6d-a39b-359350ddd280",
     "set_uuid": "6d867baa-c461-4ff9-9560-680b42750961",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4063,7 +4063,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-300",
+    "$ref": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
     "uuid": "fcb0fe04-3498-4cfa-964d-5134bbcc74c6",
     "set_uuid": "6d867baa-c461-4ff9-9560-680b42750961",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4075,7 +4075,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-200",
+    "$ref": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
     "uuid": "a238d434-3d0b-48fe-a413-a07e9229cdda",
     "set_uuid": "6d867baa-c461-4ff9-9560-680b42750961",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4086,7 +4086,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-600",
+    "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
     "uuid": "73e40884-6d55-4a56-a376-bd788e615754",
     "set_uuid": "d0362576-7efc-4910-a671-b87695571050",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4097,7 +4097,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-1100",
+    "$ref": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
     "uuid": "4a2ebbb5-b8b7-43a0-9d64-4974bb382a8b",
     "set_uuid": "d0362576-7efc-4910-a671-b87695571050",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4108,7 +4108,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-600",
+    "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
     "uuid": "c14eedf9-0f34-4a38-9b89-7c9b5f3e0af6",
     "set_uuid": "d0362576-7efc-4910-a671-b87695571050",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -4118,7 +4118,7 @@
       "property": "stack-item-selected-background-color-highlight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-background-color-default",
+    "$ref": "e05251ac-d64a-4157-9b20-224f0392269e",
     "uuid": "beaff99a-634a-4ce8-b2f4-54c63202d45b"
   }
 ]

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -6,7 +6,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-25",
+    "$ref": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
     "uuid": "166159cc-9353-4d22-90f0-64718533d73a",
     "set_uuid": "1f180759-7dbe-4ac3-80f6-78433659d52c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -18,7 +18,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "dac0d761-d8c1-4b1f-bfbe-766651122ecf",
     "set_uuid": "1f180759-7dbe-4ac3-80f6-78433659d52c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -30,7 +30,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-25",
+    "$ref": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
     "uuid": "e242c2e1-54db-40c5-98ee-abebdcd59f4d",
     "set_uuid": "1f180759-7dbe-4ac3-80f6-78433659d52c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -41,7 +41,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-25",
+    "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
     "uuid": "bae79ea7-2b3e-4d43-af42-7deab67acc7c"
   },
   {
@@ -51,7 +51,7 @@
       "state": "disabled"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "opacity-disabled",
+    "$ref": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74",
     "uuid": "84d25d1b-f9e4-4a9e-8cd0-92367ff00637"
   },
   {
@@ -60,7 +60,7 @@
       "property": "gripper-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "5a46c025-32b4-4bda-bab0-5ab0fb69ca8e"
   },
   {
@@ -69,7 +69,7 @@
       "property": "gripper-color-drag"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "16431c28-23e4-4077-bcfa-138f90583282"
   },
   {
@@ -78,7 +78,7 @@
       "property": "background-loading-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "6022f845-b182-493f-bdae-f86f6336efaa"
   },
   {
@@ -87,7 +87,7 @@
       "property": "background-well-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "c9c0e684-6b6c-4314-9b5b-7ba5e3333071"
   },
   {
@@ -97,7 +97,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-600",
+    "$ref": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
     "uuid": "622c6e86-dea6-416d-9f13-bb6ef112d3cb",
     "set_uuid": "bcf484d9-dd6c-4dbe-a648-fc54b3cedcd7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -109,7 +109,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-600",
+    "$ref": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
     "uuid": "81c0608b-c977-490e-b8d7-830d0676fdad",
     "set_uuid": "bcf484d9-dd6c-4dbe-a648-fc54b3cedcd7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -121,7 +121,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-600",
+    "$ref": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
     "uuid": "5dd9406f-9b36-43f1-8b35-b1bb7f2a4c8d",
     "set_uuid": "bcf484d9-dd6c-4dbe-a648-fc54b3cedcd7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -141,7 +141,7 @@
       "property": "color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "bfd387b8-0ce0-45ff-8d66-fc5de2f4900c"
   },
   {
@@ -150,7 +150,7 @@
       "property": "pagination-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-600",
+    "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
     "uuid": "f8cefe70-db2c-489e-bbbe-964050e96ab6"
   },
   {
@@ -159,7 +159,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-1000",
+    "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
     "uuid": "70fc4674-0f09-48f5-8850-48b4b38c2f01"
   },
   {
@@ -177,7 +177,7 @@
       "property": "drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-color",
+    "$ref": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
     "uuid": "97dfaf7f-ac2d-4517-84cc-6f692f712fc5",
     "deprecated": "unknown",
     "deprecated_comment": "Express does not need a separate design for Color loupe and Color handle components",
@@ -189,7 +189,7 @@
       "property": "inner-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black",
+    "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
     "uuid": "0c93f310-d7c6-474b-8f07-0e8e76e2756e"
   },
   {
@@ -207,7 +207,7 @@
       "property": "outer-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black",
+    "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
     "uuid": "e4733356-090e-4bb7-b32d-ab9df30fb785"
   },
   {
@@ -216,7 +216,7 @@
       "property": "outer-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "color-handle-inner-border-opacity",
+    "$ref": "72b473c6-ec9b-4830-a0f8-48b80070e7b8",
     "uuid": "0a0eff89-7e7d-4b7f-bcfa-a85e33e5798a"
   },
   {
@@ -225,7 +225,7 @@
       "property": "drop-shadow-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-elevated-blur",
+    "$ref": "f3487a86-3aea-4527-8b5c-287c0bddad6c",
     "uuid": "86caa027-9e9e-4a5f-aa38-058f0a96bc9d",
     "deprecated": "unknown"
   },
@@ -235,7 +235,7 @@
       "property": "drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-elevated-color",
+    "$ref": "e475981f-97af-479c-859b-7619dd87c448",
     "uuid": "918b8089-d89f-45d2-8c9c-f3f13f81b0b9",
     "deprecated": "unknown",
     "deprecated_comment": "Use `drop-shadow-elevated-color` instead",
@@ -247,7 +247,7 @@
       "property": "drop-shadow-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-elevated-y",
+    "$ref": "45f313a5-1749-4b95-b5e3-20944adbea84",
     "uuid": "c9af5d60-11b1-4fc3-972e-6a607120657b",
     "deprecated": "unknown"
   },
@@ -257,7 +257,7 @@
       "property": "inner-border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-200",
+    "$ref": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
     "uuid": "d2c4cb48-8a90-461d-95bc-d882ba01472b"
   },
   {
@@ -266,7 +266,7 @@
       "property": "outer-border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "white",
+    "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
     "uuid": "4e1d1cc5-736e-4e82-9054-5c1a74ac1aca"
   },
   {
@@ -275,7 +275,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-1000",
+    "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
     "uuid": "0c85e7fa-f950-436c-a68a-dd7fb8dfac9e"
   },
   {
@@ -293,7 +293,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-1000",
+    "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
     "uuid": "a60c3946-dff7-4245-bdcd-b61445066e48"
   },
   {
@@ -311,7 +311,7 @@
       "property": "background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-visual-color",
+    "$ref": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
     "uuid": "866f3613-c12f-4475-87b1-ad86ef2ce153"
   },
   {
@@ -338,7 +338,7 @@
       "property": "drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-black-300",
+    "$ref": "16a871e1-d9df-42bb-8889-99059d70e82e",
     "uuid": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0"
   },
   {
@@ -347,7 +347,7 @@
       "property": "shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "floating-action-button-drop-shadow-color",
+    "$ref": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0",
     "uuid": "f843b1b7-4b2f-496e-a679-b0372e49d575",
     "deprecated": "unknown",
     "deprecated_comment": "Use `floating-action-button-drop-shadow-color` instead",
@@ -361,7 +361,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "f4d97d6a-c1f3-4ef5-b7e5-8fbee1365a83",
     "set_uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -374,7 +374,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "9b9e8b32-46b8-470d-85b9-352c00e90138",
     "set_uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -387,7 +387,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "ae0fb15e-c8a2-42c4-b973-0fb523003b79",
     "set_uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -400,7 +400,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "211d6540-cf9d-4d80-815b-885844283fa6",
     "set_uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -413,7 +413,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "0e2c2900-180c-443a-86ff-49170166e616",
     "set_uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -426,7 +426,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "5924d0c5-6938-4660-8be3-9374bb3e5b0c",
     "set_uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -439,7 +439,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "d609bd79-ab48-4a7a-95b1-da5a88ac5338",
     "set_uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -452,7 +452,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "7ccdd9e8-3677-4de8-b9df-19efa80d88c0",
     "set_uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -465,7 +465,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "e31108a0-1b8a-4d5e-b579-592a01619bd0",
     "set_uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -478,7 +478,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "857e82a6-537e-4534-9084-353c5401f567",
     "set_uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -491,7 +491,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "f68ff159-e886-4519-b95e-e93879a2f535",
     "set_uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -504,7 +504,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "1329d684-6ac9-4f46-9bbc-046e2de5276e",
     "set_uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -517,7 +517,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "dd044387-57b9-4867-90fa-b3c4c4a62e5c",
     "set_uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -530,7 +530,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "ae9dc785-2406-407e-ab47-d42d6fbf65f6",
     "set_uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -543,7 +543,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "e9b046ee-408e-4781-a2cd-1d321bde4529",
     "set_uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -555,7 +555,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "84a7cd5e-bb2b-4bb5-bb5f-f5839ae3a761",
     "set_uuid": "bcddb17f-3fbc-40f2-b24e-7673225a2097",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -567,7 +567,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "f783b8cb-d31f-46c2-b550-990639752510",
     "set_uuid": "bcddb17f-3fbc-40f2-b24e-7673225a2097",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -579,7 +579,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "35fcf7b1-7140-4522-8410-48547aaf6fd6",
     "set_uuid": "bcddb17f-3fbc-40f2-b24e-7673225a2097",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -590,7 +590,7 @@
       "property": "square-light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "white",
+    "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
     "uuid": "c7e50676-3f61-49c3-a35f-2532fdb02360"
   },
   {
@@ -600,7 +600,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "transparent-white-25",
+    "$ref": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
     "uuid": "66da6f53-5446-43c1-bbe0-73b46763fde1",
     "set_uuid": "a06ca705-47c8-414b-8768-f49a0b5997c2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -612,7 +612,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "825dc035-7b1c-4ddd-b1a9-be1546dae7e3",
     "set_uuid": "a06ca705-47c8-414b-8768-f49a0b5997c2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -624,7 +624,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "92133ef4-9b81-4fbd-9736-8b83078ef053",
     "set_uuid": "a06ca705-47c8-414b-8768-f49a0b5997c2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -671,7 +671,7 @@
       "component": "select-box"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "4bbb81b1-09fb-4ebe-80b5-cebb75c13839"
   },
   {
@@ -681,7 +681,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "c99360a4-de28-48e6-80ad-93adb714d388"
   },
   {
@@ -691,7 +691,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "022a6244-ce6c-4c3f-82a1-e2f5118d3c5e"
   },
   {
@@ -701,7 +701,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "a0251da6-7517-4712-85a1-29ca7f16ef91"
   },
   {
@@ -710,7 +710,7 @@
       "component": "stack-item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "128c4963-471a-44e3-9fb5-328d92d0266d"
   },
   {
@@ -719,7 +719,7 @@
       "component": "stack-item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-300",
+    "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
     "uuid": "1ad58d16-66da-44ae-829e-9ee1ff56a857"
   },
   {
@@ -728,7 +728,7 @@
       "component": "stack-item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-background-color-default",
+    "$ref": "e05251ac-d64a-4157-9b20-224f0392269e",
     "uuid": "95685612-09b7-477f-9c13-06eb58abe5c8"
   },
   {
@@ -737,7 +737,7 @@
       "component": "stack-item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "a1bcd6c6-ef3e-42e4-8d88-2fafe2b318da"
   },
   {
@@ -746,7 +746,7 @@
       "component": "stack-item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-200",
+    "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
     "uuid": "93f433f2-2d0b-4225-8b39-b10000808360"
   },
   {
@@ -755,7 +755,7 @@
       "property": "gripper-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-500",
+    "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
     "uuid": "71840c7b-acdd-45b9-a228-5091591f5405"
   },
   {
@@ -764,7 +764,7 @@
       "property": "gripper-color-drag"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "69e2d0b3-6807-4e46-9f8a-72bf49439f36"
   },
   {
@@ -773,7 +773,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-1000",
+    "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
     "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48"
   },
   {
@@ -791,7 +791,7 @@
       "component": "swatch"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black",
+    "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
     "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535"
   },
   {
@@ -809,7 +809,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-1000",
+    "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
     "uuid": "08b8d06a-5475-47bf-ad2e-9f52ee07345a"
   },
   {
@@ -827,7 +827,7 @@
       "component": "table"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "44aedb76-5483-4ac3-a6f5-8cf71c2bd376"
   },
   {
@@ -845,7 +845,7 @@
       "component": "table"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-background-color-default",
+    "$ref": "6b40c677-e046-4a49-b421-8a4451844512",
     "uuid": "b7537f50-bd49-44b6-a171-19943d443d24"
   },
   {
@@ -854,7 +854,7 @@
       "component": "table"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-background-color-selected-default",
+    "$ref": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc",
     "uuid": "8578067a-6ce0-4059-84ad-4688c71df156"
   },
   {
@@ -899,7 +899,7 @@
       "property": "border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "5bd226f1-0a6b-42bc-80af-4a9dde99e9e9"
   },
   {
@@ -918,7 +918,7 @@
       "state": "disabled"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "opacity-disabled",
+    "$ref": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74",
     "uuid": "92418bcd-5f0f-4f26-9a96-51f8c9e871bf"
   },
   {
@@ -928,7 +928,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "39d26185-da40-47b5-b4b3-e47689129256"
   },
   {
@@ -937,7 +937,7 @@
       "component": "tree-view"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-background-color-default",
+    "$ref": "6b40c677-e046-4a49-b421-8a4451844512",
     "uuid": "65854450-ed1a-49ea-ab29-d257b8a0569e"
   },
   {
@@ -946,7 +946,7 @@
       "component": "tree-view"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "8f19994d-f49a-42ea-97bd-98ab1d76d02d"
   },
   {
@@ -955,7 +955,7 @@
       "component": "tree-view"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-100",
+    "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
     "uuid": "c325ed8f-8248-40c3-a0f0-efba57638f24"
   }
 ]

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -6,7 +6,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-200",
+    "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
     "uuid": "5f164d93-6efe-4abf-8f4c-9cb5f91bf26c",
     "set_uuid": "ce4c7cf5-e97a-439b-9724-9623a8f6ada3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -18,7 +18,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-300",
+    "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
     "uuid": "29c9205e-d39d-419a-b6e1-4e0544a3ca7c",
     "set_uuid": "ce4c7cf5-e97a-439b-9724-9623a8f6ada3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -30,7 +30,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-200",
+    "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
     "uuid": "2bfc538f-30ae-4e45-92ef-bb7ad72f1396",
     "set_uuid": "ce4c7cf5-e97a-439b-9724-9623a8f6ada3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -43,7 +43,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "f53f030b-755f-46ca-b411-7d62f4eb901e",
     "set_uuid": "bc640c2f-c039-4aee-b1b6-a0f743364612",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -56,7 +56,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "1bac9a3f-4bc8-4a4d-8dfd-53c542b1d1d8",
     "set_uuid": "bc640c2f-c039-4aee-b1b6-a0f743364612",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -69,7 +69,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "a306b28e-f698-427d-a576-439b2ab378fc",
     "set_uuid": "bc640c2f-c039-4aee-b1b6-a0f743364612",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -82,7 +82,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1100",
+    "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
     "uuid": "2d2a2756-332e-4d78-9385-e50fd8b5edcf",
     "set_uuid": "f76a1c6d-3b8b-4bf5-940e-bd39ad6ef789",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -95,7 +95,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1000",
+    "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
     "uuid": "b775d1a5-2951-4d51-9a48-265f46e8edc3",
     "set_uuid": "f76a1c6d-3b8b-4bf5-940e-bd39ad6ef789",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -108,7 +108,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1100",
+    "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
     "uuid": "c32c7711-0889-4f62-afe6-4b744166a66e",
     "set_uuid": "f76a1c6d-3b8b-4bf5-940e-bd39ad6ef789",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -121,7 +121,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1000",
+    "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
     "uuid": "d5f07e5a-b59b-4613-9eab-eae3a74c67f2",
     "set_uuid": "a63a3883-74a7-4bb0-96fc-2c716548e60d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -134,7 +134,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "17dd2bcd-e66f-4c86-8335-47bd3828a2cf",
     "set_uuid": "a63a3883-74a7-4bb0-96fc-2c716548e60d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -147,7 +147,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1000",
+    "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
     "uuid": "95cd46ba-7b1f-4ae4-86c1-1957c007a6a2",
     "set_uuid": "a63a3883-74a7-4bb0-96fc-2c716548e60d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -159,7 +159,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-200",
+    "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
     "uuid": "40166e04-505e-47ed-b039-0a3827895c36",
     "set_uuid": "d74c00ca-a11f-4e2a-a3a4-71cd9d4d8ba6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -171,7 +171,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-400",
+    "$ref": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c",
     "uuid": "8da7787f-2d39-4801-a5ea-1b3e69d505a6",
     "set_uuid": "d74c00ca-a11f-4e2a-a3a4-71cd9d4d8ba6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -183,7 +183,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-200",
+    "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
     "uuid": "2f1fba9a-25b3-4ac7-aaee-7d6da1292da8",
     "set_uuid": "d74c00ca-a11f-4e2a-a3a4-71cd9d4d8ba6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -196,7 +196,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-800",
+    "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
     "uuid": "59038eb6-5b6f-4fa7-8a5d-9bf78db26fa9",
     "set_uuid": "3e70443e-6765-4ee2-a271-84fb4eba66a6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -209,7 +209,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-700",
+    "$ref": "6f87ea74-5734-40c1-ab34-b284e0f75b1b",
     "uuid": "bd6c966d-0b33-4f68-9b84-9e7ae0082805",
     "set_uuid": "3e70443e-6765-4ee2-a271-84fb4eba66a6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -222,7 +222,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-800",
+    "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
     "uuid": "afdc8658-f6a4-4205-af17-553c04cca24d",
     "set_uuid": "3e70443e-6765-4ee2-a271-84fb4eba66a6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -235,7 +235,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-1000",
+    "$ref": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
     "uuid": "16f958d5-8128-4774-b3ec-3ba5dd41f4fa",
     "set_uuid": "9a01c0c0-e702-4081-ae56-2adbd00bbcf7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -248,7 +248,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-900",
+    "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
     "uuid": "ac16c318-bf3a-49f7-a696-a7aaf8eb4335",
     "set_uuid": "9a01c0c0-e702-4081-ae56-2adbd00bbcf7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -261,7 +261,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-1000",
+    "$ref": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
     "uuid": "b2474c42-cecc-4f91-b3e9-a0855a79d5ed",
     "set_uuid": "9a01c0c0-e702-4081-ae56-2adbd00bbcf7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -274,7 +274,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-900",
+    "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
     "uuid": "5821a2cf-320d-4947-8289-2537eeef3154",
     "set_uuid": "aa1651a3-d002-42d0-8d22-8400c02ad368",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -287,7 +287,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-800",
+    "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
     "uuid": "00757309-91b4-4a6a-9897-32db62d9e94b",
     "set_uuid": "aa1651a3-d002-42d0-8d22-8400c02ad368",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -300,7 +300,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "brown-900",
+    "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
     "uuid": "bffb9e2b-565a-4774-8f57-ef03768b4176",
     "set_uuid": "aa1651a3-d002-42d0-8d22-8400c02ad368",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -312,7 +312,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-100",
+    "$ref": "cfa877de-79f8-493f-898d-ceb70a12f64e",
     "uuid": "a5bfd666-a843-4b14-9b7e-1f392a34c4ba",
     "set_uuid": "4a588efb-726f-4122-8991-200fdeed9455",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -324,7 +324,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-400",
+    "$ref": "e8b68c0f-5e9f-47c0-b844-35032c46aeee",
     "uuid": "88437eca-ac07-4a83-930a-10861a8ed839",
     "set_uuid": "4a588efb-726f-4122-8991-200fdeed9455",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -336,7 +336,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-100",
+    "$ref": "cfa877de-79f8-493f-898d-ceb70a12f64e",
     "uuid": "2b519299-a5c9-47d9-bf52-51ce26410073",
     "set_uuid": "4a588efb-726f-4122-8991-200fdeed9455",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -349,7 +349,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-700",
+    "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
     "uuid": "347e56ff-3c87-49ca-b5c3-b359f33a0203",
     "set_uuid": "8d25cc1e-0ce5-42f7-81ad-0f4f968f3d4d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -362,7 +362,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-900",
+    "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
     "uuid": "c7a01756-b63e-4f18-b700-26b3f183e2c8",
     "set_uuid": "8d25cc1e-0ce5-42f7-81ad-0f4f968f3d4d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -375,7 +375,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-700",
+    "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
     "uuid": "c3f8622e-4ee4-4a68-be5d-c7b9f583c686",
     "set_uuid": "8d25cc1e-0ce5-42f7-81ad-0f4f968f3d4d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -388,7 +388,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-900",
+    "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
     "uuid": "4d42768e-6c50-4b41-bfa9-f626119d92b0",
     "set_uuid": "d5688ac1-3726-4b14-8879-01aef1831def",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -401,7 +401,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-1100",
+    "$ref": "bd5d2127-7c7e-428c-bded-4638ab7094a5",
     "uuid": "a16feeab-27da-4d04-af0b-2a45cc14982c",
     "set_uuid": "d5688ac1-3726-4b14-8879-01aef1831def",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -414,7 +414,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-900",
+    "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
     "uuid": "f9fa057e-58f4-472f-8ab7-6bae7d1d27eb",
     "set_uuid": "d5688ac1-3726-4b14-8879-01aef1831def",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -427,7 +427,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-800",
+    "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
     "uuid": "00213ade-1251-4e7f-9020-08d3f46bb3a6",
     "set_uuid": "e24e9976-ef3d-4356-8b9c-68fdf3e38d4e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -440,7 +440,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-1000",
+    "$ref": "2184d450-2711-4e31-bb52-ee71e4fee3a5",
     "uuid": "44a0a5c5-7131-42c4-859d-fa9541dff287",
     "set_uuid": "e24e9976-ef3d-4356-8b9c-68fdf3e38d4e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -453,7 +453,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "celery-800",
+    "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
     "uuid": "a32205e0-b208-4539-9fe4-5eb2d7464d91",
     "set_uuid": "e24e9976-ef3d-4356-8b9c-68fdf3e38d4e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -465,7 +465,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-200",
+    "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
     "uuid": "0b1869d0-6aca-4e20-904f-954153bb4b73",
     "set_uuid": "3ab68956-d853-4296-8db8-b37fa6ec76d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -477,7 +477,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-400",
+    "$ref": "dba5cb03-a980-48bd-8b35-99dd063763e0",
     "uuid": "cad79edb-8add-4b83-ad3e-fcbed050e037",
     "set_uuid": "3ab68956-d853-4296-8db8-b37fa6ec76d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -489,7 +489,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-200",
+    "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
     "uuid": "ec1c5d08-dd5e-40f5-adee-06ffecb36ed6",
     "set_uuid": "3ab68956-d853-4296-8db8-b37fa6ec76d2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -502,7 +502,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-600",
+    "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
     "uuid": "ded3802a-2b38-405d-a437-193bf1e061a0",
     "set_uuid": "622815df-4c22-4cf3-8263-177c21df6c24",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -515,7 +515,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-1000",
+    "$ref": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
     "uuid": "a407df08-a00b-421a-b999-d37097debc26",
     "set_uuid": "622815df-4c22-4cf3-8263-177c21df6c24",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -528,7 +528,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-600",
+    "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
     "uuid": "6bfd7aea-dfd9-47ee-9f18-e4431886e1cf",
     "set_uuid": "622815df-4c22-4cf3-8263-177c21df6c24",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -541,7 +541,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-800",
+    "$ref": "9131b099-6865-4e54-b364-acb3891737f1",
     "uuid": "dc16f7b1-8b33-42d8-a292-f6efbd3d9f43",
     "set_uuid": "2ac6e8b0-030d-4c4c-b8dc-1daa101789f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -554,7 +554,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-1200",
+    "$ref": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb",
     "uuid": "a8dcf645-ae32-4870-90bf-4d802837cf08",
     "set_uuid": "2ac6e8b0-030d-4c4c-b8dc-1daa101789f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -567,7 +567,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-800",
+    "$ref": "9131b099-6865-4e54-b364-acb3891737f1",
     "uuid": "d00300aa-5990-483d-8218-229169e9cd74",
     "set_uuid": "2ac6e8b0-030d-4c4c-b8dc-1daa101789f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -580,7 +580,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-700",
+    "$ref": "f50abb60-7047-4e92-a48c-627d98eb85d3",
     "uuid": "b263dc42-bcc1-4073-a230-81707fe7f388",
     "set_uuid": "3b0fc446-0362-4856-a4ca-633262498b29",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -593,7 +593,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-1100",
+    "$ref": "20c271df-6e71-4082-b953-d8bf938ff286",
     "uuid": "a63751a9-4d3d-4dfb-9028-3aaecf11df47",
     "set_uuid": "3b0fc446-0362-4856-a4ca-633262498b29",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -606,7 +606,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "chartreuse-700",
+    "$ref": "f50abb60-7047-4e92-a48c-627d98eb85d3",
     "uuid": "6d3438e5-cc32-4c26-960d-434b24dbb1e0",
     "set_uuid": "3b0fc446-0362-4856-a4ca-633262498b29",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -618,7 +618,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-200",
+    "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
     "uuid": "a522f597-1ed4-445c-94c4-a594bc50f9ce",
     "set_uuid": "174d3eef-4447-4e96-93a8-c125b455e1dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -630,7 +630,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-300",
+    "$ref": "3527fc94-a410-4933-bbb7-bedecd37e477",
     "uuid": "cb5eed01-b2f0-4410-8a71-2bf361d61fcc",
     "set_uuid": "174d3eef-4447-4e96-93a8-c125b455e1dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -642,7 +642,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-200",
+    "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
     "uuid": "61eaba25-d605-412f-ae11-5f36fd0061c8",
     "set_uuid": "174d3eef-4447-4e96-93a8-c125b455e1dd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -654,7 +654,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-800",
+    "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
     "uuid": "fcf4219b-fa42-4693-ba34-fc5f46bfcde8"
   },
   {
@@ -664,7 +664,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-1000",
+    "$ref": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38",
     "uuid": "6cb36abc-7d86-4df0-a96d-36a4308a8ebd"
   },
   {
@@ -674,7 +674,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cinnamon-900",
+    "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
     "uuid": "a91d68ae-30ac-496b-9558-39272e9926c4"
   },
   {
@@ -684,7 +684,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-100",
+    "$ref": "ba6486c3-b48d-4d4e-952e-c179db5671df",
     "uuid": "ac6d3cc6-dab7-400c-82d4-bd0876d241b2",
     "set_uuid": "4a867e32-dac2-404e-a80f-2e5595685056",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -696,7 +696,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-400",
+    "$ref": "61be07be-d428-4fe9-8e79-96df63980556",
     "uuid": "a5fd0ad9-999f-469d-b224-b60e06313cdb",
     "set_uuid": "4a867e32-dac2-404e-a80f-2e5595685056",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -708,7 +708,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-100",
+    "$ref": "ba6486c3-b48d-4d4e-952e-c179db5671df",
     "uuid": "b85aef89-a234-4386-9c46-22e2caa3b4f6",
     "set_uuid": "4a867e32-dac2-404e-a80f-2e5595685056",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -720,7 +720,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-800",
+    "$ref": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
     "uuid": "2855caf0-9b6d-4d45-bdb8-30aab37a237c"
   },
   {
@@ -730,7 +730,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-1000",
+    "$ref": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f",
     "uuid": "c6ae865c-1938-4eec-b89c-7f793dc3f049"
   },
   {
@@ -740,7 +740,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cyan-900",
+    "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
     "uuid": "2f68ac4a-be55-4fc7-b96e-987bdb5956ca"
   },
   {
@@ -749,7 +749,7 @@
       "component": "icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-400",
+    "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
     "uuid": "12c9d145-7357-449e-a99a-1154dd5be026"
   },
   {
@@ -758,7 +758,7 @@
       "component": "icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "fa5b0690-6ecd-4a3e-8675-ab6445df8946"
   },
   {
@@ -767,7 +767,7 @@
       "property": "color-fuchsia-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-200",
+    "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
     "uuid": "707601ab-a624-4466-9ce3-b52552b777a2"
   },
   {
@@ -778,7 +778,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-900",
+    "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
     "uuid": "0aedb32f-f3d7-4fa9-82d2-aee9ca727cfe",
     "set_uuid": "299e2985-3d4e-4ced-97d9-7a81bf4ac644",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -791,7 +791,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-700",
+    "$ref": "1149f4f6-5cd0-4792-9dad-189c2a75a542",
     "uuid": "ec2b1658-d174-49c9-a36a-7f80d97a1ee8",
     "set_uuid": "299e2985-3d4e-4ced-97d9-7a81bf4ac644",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -804,7 +804,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-900",
+    "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
     "uuid": "75b0d002-84b7-4c75-8c74-3b1ff15ff10a",
     "set_uuid": "299e2985-3d4e-4ced-97d9-7a81bf4ac644",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -817,7 +817,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-1100",
+    "$ref": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
     "uuid": "0610e1fa-387f-4018-bbb2-bda7b30c74a3",
     "set_uuid": "f5992aa9-60d7-4e8f-8d53-31d2040e10c7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -830,7 +830,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-900",
+    "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
     "uuid": "6964ef24-8178-4513-8d9a-5240973622fb",
     "set_uuid": "f5992aa9-60d7-4e8f-8d53-31d2040e10c7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -843,7 +843,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-1100",
+    "$ref": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
     "uuid": "625728db-30ec-41d7-9f6f-0ce9c0201c66",
     "set_uuid": "f5992aa9-60d7-4e8f-8d53-31d2040e10c7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -856,7 +856,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-1000",
+    "$ref": "0f412425-de6f-48f1-9d0f-0310d933d244",
     "uuid": "fd2f3488-d5bb-4f36-8799-a0168ae8ca5c",
     "set_uuid": "8a42d5e3-9a1d-4f97-af00-72e6cb127d84",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -869,7 +869,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-800",
+    "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
     "uuid": "0a66c0d9-0a0a-4f0d-9bb3-cbdb2bc12842",
     "set_uuid": "8a42d5e3-9a1d-4f97-af00-72e6cb127d84",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -882,7 +882,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "fuchsia-1000",
+    "$ref": "0f412425-de6f-48f1-9d0f-0310d933d244",
     "uuid": "53acea92-bc9f-4c41-93b9-e18cde613305",
     "set_uuid": "8a42d5e3-9a1d-4f97-af00-72e6cb127d84",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -894,7 +894,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-100",
+    "$ref": "7c7c0136-2623-468d-a12f-678d21973613",
     "uuid": "7941dc68-44bb-49d5-80ca-3c6952d2acb2",
     "set_uuid": "834b138e-265e-4313-acda-ea005b1836c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -906,7 +906,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-400",
+    "$ref": "6673709d-2154-4189-ad4f-e6867ecfe744",
     "uuid": "176c986b-8658-4b3e-b559-4080f4fd7834",
     "set_uuid": "834b138e-265e-4313-acda-ea005b1836c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -918,7 +918,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-100",
+    "$ref": "7c7c0136-2623-468d-a12f-678d21973613",
     "uuid": "3231780c-e233-4a60-b063-1c3a383669a3",
     "set_uuid": "834b138e-265e-4313-acda-ea005b1836c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -930,7 +930,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-800",
+    "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
     "uuid": "a0717159-cc62-4ba1-b1f1-a69dfb88c6ee"
   },
   {
@@ -940,7 +940,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1000",
+    "$ref": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
     "uuid": "c0acc956-e9de-469b-8919-aa0d8b762bb3"
   },
   {
@@ -950,7 +950,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-900",
+    "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
     "uuid": "9a667090-665d-47b2-b000-5a9f4fe26fcf"
   },
   {
@@ -960,7 +960,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-200",
+    "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
     "uuid": "1c49aee1-a8a2-41ae-b709-7e2d1fbc2705",
     "set_uuid": "81f2bf23-d0a9-4c59-b250-706a7aed4158",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -972,7 +972,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-100",
+    "$ref": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e",
     "uuid": "85432c93-7c00-435b-8298-2ba817cb58bd",
     "set_uuid": "81f2bf23-d0a9-4c59-b250-706a7aed4158",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -984,7 +984,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-200",
+    "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
     "uuid": "67cfb253-49f0-4a14-a83c-140324ef5bc0",
     "set_uuid": "81f2bf23-d0a9-4c59-b250-706a7aed4158",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -997,7 +997,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-900",
+    "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
     "uuid": "b6c15610-dc9a-4b7c-9391-247a0f4b56ff",
     "set_uuid": "e1c92878-e06a-4692-b1f3-d0130be745a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1010,7 +1010,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-700",
+    "$ref": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac",
     "uuid": "2e4457c1-e637-4f22-909d-643dd535b5fd",
     "set_uuid": "e1c92878-e06a-4692-b1f3-d0130be745a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1023,7 +1023,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-900",
+    "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
     "uuid": "05f75802-5062-422a-8a39-f7e8f71ce17e",
     "set_uuid": "e1c92878-e06a-4692-b1f3-d0130be745a0",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1036,7 +1036,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-1100",
+    "$ref": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
     "uuid": "ff60b02b-f205-48be-80c0-a362f7b72e27",
     "set_uuid": "0cfba473-9739-40cf-84a2-6fa2e9a82a31",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1049,7 +1049,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-900",
+    "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
     "uuid": "f21187bf-8dbe-4eee-9ce9-c76d08517a6c",
     "set_uuid": "0cfba473-9739-40cf-84a2-6fa2e9a82a31",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1062,7 +1062,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-1100",
+    "$ref": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
     "uuid": "1f2e8832-16e1-4030-a5ef-16f5b5c663d0",
     "set_uuid": "0cfba473-9739-40cf-84a2-6fa2e9a82a31",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1075,7 +1075,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-1000",
+    "$ref": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
     "uuid": "d6a54fc4-c4d9-403a-ba71-f525d36586ec",
     "set_uuid": "3baf7277-0033-4db2-b125-99be7010048b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1088,7 +1088,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-800",
+    "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
     "uuid": "fc9ef846-e264-498c-9b7a-be9a9164f3d3",
     "set_uuid": "3baf7277-0033-4db2-b125-99be7010048b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1101,7 +1101,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "indigo-1000",
+    "$ref": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
     "uuid": "735472d9-0220-4e7e-a06b-9f3504cad201",
     "set_uuid": "3baf7277-0033-4db2-b125-99be7010048b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1112,7 +1112,7 @@
       "property": "color-inverse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-50",
+    "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
     "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
     "deprecated": "unknown"
   },
@@ -1122,7 +1122,7 @@
       "property": "color-inverse-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-50",
+    "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
     "uuid": "ba10ab97-0c09-4d07-ab7b-050258169d52"
   },
   {
@@ -1131,7 +1131,7 @@
       "property": "color-magenta-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-200",
+    "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
     "uuid": "2cf7dea9-034c-48a8-8946-d059320ced08"
   },
   {
@@ -1142,7 +1142,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-900",
+    "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
     "uuid": "3fb3630d-e7a3-4807-93c1-c5da4a8f642b",
     "set_uuid": "df96212d-b4bf-4fbc-8599-a5a6096f510d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1155,7 +1155,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-700",
+    "$ref": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9",
     "uuid": "7b3f5848-6a8c-47fe-aacd-ad2f1af53306",
     "set_uuid": "df96212d-b4bf-4fbc-8599-a5a6096f510d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1168,7 +1168,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-900",
+    "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
     "uuid": "d0802b2a-faba-4530-8f50-dc22e6962d44",
     "set_uuid": "df96212d-b4bf-4fbc-8599-a5a6096f510d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1181,7 +1181,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-1100",
+    "$ref": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
     "uuid": "31aa02cb-2f5f-4803-bf5d-4e97816472be",
     "set_uuid": "070dba44-39f3-41f0-9b8a-082cc593ebbe",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1194,7 +1194,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-900",
+    "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
     "uuid": "042aa474-5cf0-4cdc-a75d-19eac80a0ade",
     "set_uuid": "070dba44-39f3-41f0-9b8a-082cc593ebbe",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1207,7 +1207,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-1100",
+    "$ref": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
     "uuid": "ddfb3e51-e724-48b4-aecc-dcfe000eec11",
     "set_uuid": "070dba44-39f3-41f0-9b8a-082cc593ebbe",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1220,7 +1220,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-1000",
+    "$ref": "66f59c7d-f12b-4b8b-a472-c196deec527c",
     "uuid": "b81fb79d-69dc-4bde-b3d6-661a7719a6e8",
     "set_uuid": "8f1e3cb4-fcfb-415c-a353-67f3abaf0db9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1233,7 +1233,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-800",
+    "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
     "uuid": "23dc0d7b-fb23-460a-b9f1-7a9a7496c107",
     "set_uuid": "8f1e3cb4-fcfb-415c-a353-67f3abaf0db9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1246,7 +1246,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "magenta-1000",
+    "$ref": "66f59c7d-f12b-4b8b-a472-c196deec527c",
     "uuid": "3e368eed-b2f7-4e9e-9935-421ef0f86f9f",
     "set_uuid": "8f1e3cb4-fcfb-415c-a353-67f3abaf0db9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1258,7 +1258,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-200",
+    "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
     "uuid": "3ceff0a2-fca9-4d73-82a8-f5098c511e17",
     "set_uuid": "90a3c087-153b-4aaf-ad6c-77300d42fde5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1270,7 +1270,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-300",
+    "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
     "uuid": "73e28358-35bb-4643-a1b8-ae3fd3de206f",
     "set_uuid": "90a3c087-153b-4aaf-ad6c-77300d42fde5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1282,7 +1282,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-200",
+    "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
     "uuid": "a6f69b6d-496f-40bb-96a5-f04efa4ce8bc",
     "set_uuid": "90a3c087-153b-4aaf-ad6c-77300d42fde5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1295,7 +1295,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-700",
+    "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
     "uuid": "d035f399-5154-4f0e-b5aa-434644e19f4b",
     "set_uuid": "a7e402be-9ca8-491c-8a37-0d10c36ae45d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1308,7 +1308,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-900",
+    "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
     "uuid": "1ea9d171-f3ba-40fd-bd0b-1e0ebaf68f01",
     "set_uuid": "a7e402be-9ca8-491c-8a37-0d10c36ae45d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1321,7 +1321,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-700",
+    "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
     "uuid": "41b694b3-5805-4ee7-aca0-88527dc6120b",
     "set_uuid": "a7e402be-9ca8-491c-8a37-0d10c36ae45d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1334,7 +1334,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-900",
+    "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
     "uuid": "cb36fbb9-e88f-4965-a67d-8a12f10fb445",
     "set_uuid": "3c418011-0596-4f28-ae20-26ade2e73e95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1347,7 +1347,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1100",
+    "$ref": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
     "uuid": "4534a7d3-b2b0-4e94-8366-030ac144031c",
     "set_uuid": "3c418011-0596-4f28-ae20-26ade2e73e95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1360,7 +1360,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-900",
+    "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
     "uuid": "b00737a5-c111-42fe-9378-47a79139e11a",
     "set_uuid": "3c418011-0596-4f28-ae20-26ade2e73e95",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1373,7 +1373,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-800",
+    "$ref": "bed559d1-c097-40ad-8d3a-2866198832c2",
     "uuid": "726e95d7-f687-4e9c-b050-2e54cc1b0b77",
     "set_uuid": "37aee2f6-f672-421f-b92b-b489adb4f3b9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1386,7 +1386,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1000",
+    "$ref": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
     "uuid": "d35dd0cd-49b0-4430-9fe6-9dcf0e9e5874",
     "set_uuid": "37aee2f6-f672-421f-b92b-b489adb4f3b9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1399,7 +1399,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-800",
+    "$ref": "bed559d1-c097-40ad-8d3a-2866198832c2",
     "uuid": "1c3bc51c-edf8-4c2b-af93-44d7ffeb46b2",
     "set_uuid": "37aee2f6-f672-421f-b92b-b489adb4f3b9",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1410,7 +1410,7 @@
       "property": "color-pink-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-200",
+    "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
     "uuid": "46d11573-718e-4e38-8493-f3a37a5e7d32"
   },
   {
@@ -1421,7 +1421,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-800",
+    "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
     "uuid": "abd32483-3555-4d1e-831b-9799db14d39c",
     "set_uuid": "7ad2203f-7595-4c14-b634-2bd5afac55f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1434,7 +1434,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-700",
+    "$ref": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9",
     "uuid": "4a4d6a11-1343-40c7-b7d3-d25d6f1d4ed3",
     "set_uuid": "7ad2203f-7595-4c14-b634-2bd5afac55f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1447,7 +1447,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-800",
+    "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
     "uuid": "1e0b6862-10cd-4860-9bf7-9cbce71e7f81",
     "set_uuid": "7ad2203f-7595-4c14-b634-2bd5afac55f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1460,7 +1460,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-1000",
+    "$ref": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
     "uuid": "f3b7c0ba-eb0f-46af-bf89-9e1f46afa937",
     "set_uuid": "7044ccda-e69a-4fac-b726-351773fa58f5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1473,7 +1473,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-900",
+    "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
     "uuid": "b4ead77c-aec3-4dc5-85c4-ab0e62231232",
     "set_uuid": "7044ccda-e69a-4fac-b726-351773fa58f5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1486,7 +1486,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-1000",
+    "$ref": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
     "uuid": "c31819e9-6bf1-4048-94bc-ee6f04b82474",
     "set_uuid": "7044ccda-e69a-4fac-b726-351773fa58f5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1499,7 +1499,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-900",
+    "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
     "uuid": "c516dfa3-8921-47d6-99fe-976e3d93adef",
     "set_uuid": "daa99344-9af2-4084-a361-6b8aaa85d2f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1512,7 +1512,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-800",
+    "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
     "uuid": "88bf5d43-7655-43e6-8844-a94f4696bde0",
     "set_uuid": "daa99344-9af2-4084-a361-6b8aaa85d2f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1525,7 +1525,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "pink-900",
+    "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
     "uuid": "8a64d036-a935-442a-b596-5d4d0fd001a9",
     "set_uuid": "daa99344-9af2-4084-a361-6b8aaa85d2f6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1537,7 +1537,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-content-color-default",
+    "$ref": "43ca4c0d-7803-4e8e-b444-26fe70d5304c",
     "uuid": "d143f2f2-e0d8-4eb3-b06c-86233321fb61"
   },
   {
@@ -1547,7 +1547,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-content-color-down",
+    "$ref": "cf169d95-e427-4665-a983-c24727dbfa60",
     "uuid": "83223069-7a05-4b61-b1ec-2af8e712e0a2"
   },
   {
@@ -1557,7 +1557,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-content-color-hover",
+    "$ref": "d236bdc5-037b-4838-8401-8a0d5136936c",
     "uuid": "2a3d8ce3-6294-41b2-ad19-c6b9b6ed7e10"
   },
   {
@@ -1566,7 +1566,7 @@
       "property": "color-purple-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-200",
+    "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
     "uuid": "5a9cdf9a-09a5-42bc-a0bf-6f187c6832c5"
   },
   {
@@ -1577,7 +1577,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-900",
+    "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
     "uuid": "7543b9c6-aea2-4dc9-ad2d-204d6f1d2185",
     "set_uuid": "eb6fd090-430f-463d-9371-1c560fb3c2d5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1590,7 +1590,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-700",
+    "$ref": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e",
     "uuid": "50b28c39-4b4e-43dc-b742-e85a892e843a",
     "set_uuid": "eb6fd090-430f-463d-9371-1c560fb3c2d5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1603,7 +1603,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-900",
+    "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
     "uuid": "1b6ce540-0839-4ba2-bf98-51fb499113a4",
     "set_uuid": "eb6fd090-430f-463d-9371-1c560fb3c2d5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1616,7 +1616,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-1100",
+    "$ref": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
     "uuid": "fbec43d7-90e6-424d-8f77-5a39ef739d7a",
     "set_uuid": "1d630c63-d443-4207-8da9-8a4fa27ebc2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1629,7 +1629,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-900",
+    "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
     "uuid": "0ff09a0f-33db-40ee-9b36-ed7db52aafbd",
     "set_uuid": "1d630c63-d443-4207-8da9-8a4fa27ebc2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1642,7 +1642,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-1100",
+    "$ref": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
     "uuid": "bf3e3302-4798-4b35-a37b-0d5fcd89b556",
     "set_uuid": "1d630c63-d443-4207-8da9-8a4fa27ebc2f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1655,7 +1655,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-1000",
+    "$ref": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
     "uuid": "740f2726-16e3-4011-8d2c-aaf504be8f14",
     "set_uuid": "5bb2c6bb-a798-4560-ae51-e229630dbcc1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1668,7 +1668,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-800",
+    "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
     "uuid": "2e9e7c94-5454-41d9-95e3-8e1e91c41f14",
     "set_uuid": "5bb2c6bb-a798-4560-ae51-e229630dbcc1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1681,7 +1681,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "purple-1000",
+    "$ref": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
     "uuid": "ec923982-6694-44bc-8f75-ebe1c76ba09a",
     "set_uuid": "5bb2c6bb-a798-4560-ae51-e229630dbcc1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1693,7 +1693,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-200",
+    "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
     "uuid": "c6872759-ff54-48ef-8513-d752ec12f8ca",
     "set_uuid": "2406da90-f230-4e70-8acc-22ed8078721d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1705,7 +1705,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-300",
+    "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
     "uuid": "1fbda732-e276-4dec-8ec7-faeff6cba3a7",
     "set_uuid": "2406da90-f230-4e70-8acc-22ed8078721d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1717,7 +1717,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-200",
+    "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
     "uuid": "12859f90-c49c-4508-bc0d-df4d9512c864",
     "set_uuid": "2406da90-f230-4e70-8acc-22ed8078721d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1730,7 +1730,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-900",
+    "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
     "uuid": "89656cae-d490-4b9f-93eb-75912b29ecf5",
     "set_uuid": "f7a6c17f-70c1-401d-99a6-400a720c173b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1743,7 +1743,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-700",
+    "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
     "uuid": "a60f2744-ad15-4cf7-b9dc-89ca307ed444",
     "set_uuid": "f7a6c17f-70c1-401d-99a6-400a720c173b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1756,7 +1756,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-900",
+    "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
     "uuid": "16bbb033-224a-43e6-881c-bd29ffd70d1b",
     "set_uuid": "f7a6c17f-70c1-401d-99a6-400a720c173b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1769,7 +1769,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1100",
+    "$ref": "5485c698-0ea9-47d7-b81d-43f0647c4078",
     "uuid": "e92b61d2-7c99-44ba-bc4b-94bf9cff3623",
     "set_uuid": "2633f970-1550-4389-aa5e-e26bef70a222",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1782,7 +1782,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-900",
+    "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
     "uuid": "d44cbe6f-b3e1-4048-b26c-c98e9be970f5",
     "set_uuid": "2633f970-1550-4389-aa5e-e26bef70a222",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1795,7 +1795,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1100",
+    "$ref": "5485c698-0ea9-47d7-b81d-43f0647c4078",
     "uuid": "02527b17-485a-4a59-b62e-5aa8bfca7df7",
     "set_uuid": "2633f970-1550-4389-aa5e-e26bef70a222",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1808,7 +1808,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1000",
+    "$ref": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
     "uuid": "5015c992-9d52-4e30-a4cc-e605a0c99545",
     "set_uuid": "8f3bfc49-c036-4196-9014-2ecee9db1c3f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1821,7 +1821,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-800",
+    "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
     "uuid": "362d9053-52d9-478a-aec9-b56fd805826a",
     "set_uuid": "8f3bfc49-c036-4196-9014-2ecee9db1c3f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1834,7 +1834,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1000",
+    "$ref": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
     "uuid": "ece07052-dff3-483e-a6b8-1d12b0d94d8a",
     "set_uuid": "8f3bfc49-c036-4196-9014-2ecee9db1c3f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1846,7 +1846,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-200",
+    "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
     "uuid": "975fa979-d134-4d4b-8a27-e50307925ec4",
     "set_uuid": "18971672-bcfa-4a48-afa3-197a50d3ac33",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1858,7 +1858,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-400",
+    "$ref": "63882463-c739-495b-b164-317ebcf97e35",
     "uuid": "39ff1a28-8c57-490f-8cf7-eb63fd3b7ebb",
     "set_uuid": "18971672-bcfa-4a48-afa3-197a50d3ac33",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1870,7 +1870,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-200",
+    "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
     "uuid": "bc3ce9f1-cde9-4609-b4ab-c78a15ac064c",
     "set_uuid": "18971672-bcfa-4a48-afa3-197a50d3ac33",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1882,7 +1882,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-800",
+    "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
     "uuid": "aca36c2e-6dda-4b5e-a6e1-8db1bbb9e448"
   },
   {
@@ -1892,7 +1892,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-1000",
+    "$ref": "487ae86b-24c7-4587-87b0-008fca574e84",
     "uuid": "3d4610d5-0870-4af3-8878-483218d43f92"
   },
   {
@@ -1902,7 +1902,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "seafoam-900",
+    "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
     "uuid": "cdc09dab-b4cc-4034-843b-98afcc36caf0"
   },
   {
@@ -1912,7 +1912,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-200",
+    "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
     "uuid": "98f6376e-01b0-4646-afe1-b52c33700db9",
     "set_uuid": "cdd3116b-9441-40be-bb20-368aec509ffd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1924,7 +1924,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-400",
+    "$ref": "2ac14b55-357e-43a0-85f3-c41a8f3697c8",
     "uuid": "a2c48afa-59de-43af-8ec4-2c573948ae52",
     "set_uuid": "cdd3116b-9441-40be-bb20-368aec509ffd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1936,7 +1936,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-200",
+    "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
     "uuid": "b2e8e8ac-001a-4a4e-bcc9-9508ba954ece",
     "set_uuid": "cdd3116b-9441-40be-bb20-368aec509ffd",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1949,7 +1949,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-700",
+    "$ref": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
     "uuid": "be16b346-ec55-4aa1-9767-0cb139dd361c",
     "set_uuid": "696a03e3-12c5-4af8-acaf-90246dd7b3df",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1962,7 +1962,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-800",
+    "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
     "uuid": "839005ad-8e22-4e1b-a83b-1fe5be08acb2",
     "set_uuid": "696a03e3-12c5-4af8-acaf-90246dd7b3df",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1975,7 +1975,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-700",
+    "$ref": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
     "uuid": "928c1a80-e248-4e00-aed8-5ddf764a5d22",
     "set_uuid": "696a03e3-12c5-4af8-acaf-90246dd7b3df",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -1988,7 +1988,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-900",
+    "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
     "uuid": "b44c8584-eec0-4cc4-b3d3-62df9b1877d9",
     "set_uuid": "07de191f-8b9c-40a0-ac40-434a2865702b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2001,7 +2001,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-1000",
+    "$ref": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86",
     "uuid": "44ddf65f-494c-4329-b17e-c791c7cfe779",
     "set_uuid": "07de191f-8b9c-40a0-ac40-434a2865702b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2014,7 +2014,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-900",
+    "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
     "uuid": "dc071b6f-788a-4a83-b1c0-17ae536c01e7",
     "set_uuid": "07de191f-8b9c-40a0-ac40-434a2865702b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2027,7 +2027,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-800",
+    "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
     "uuid": "74b17dd6-9b4b-43a9-9c7f-4c8edc72afc9",
     "set_uuid": "fdaf49d9-5470-44b4-9c5a-0470ff539079",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2040,7 +2040,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-900",
+    "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
     "uuid": "a6b610b6-915d-4c40-85ee-9b9fee0b5bd3",
     "set_uuid": "fdaf49d9-5470-44b4-9c5a-0470ff539079",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2053,7 +2053,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "silver-800",
+    "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
     "uuid": "cd0a41af-19ed-48fc-b659-d34cb37d4cef",
     "set_uuid": "fdaf49d9-5470-44b4-9c5a-0470ff539079",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2065,7 +2065,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-200",
+    "$ref": "7720aa32-deea-454b-a593-f1234e638565",
     "uuid": "a6478f6c-3a60-42e3-98f7-5cabf91e09af",
     "set_uuid": "b7c72978-d28b-4aca-97d6-7897d2dae50e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2077,7 +2077,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-400",
+    "$ref": "1327ec82-3f65-4706-a664-11e46294ffd2",
     "uuid": "3d251526-b63d-412c-bb54-712d36c73e8e",
     "set_uuid": "b7c72978-d28b-4aca-97d6-7897d2dae50e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2089,7 +2089,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-200",
+    "$ref": "7720aa32-deea-454b-a593-f1234e638565",
     "uuid": "a5b3d3f5-785b-4969-9389-12c1f7b2f26d",
     "set_uuid": "b7c72978-d28b-4aca-97d6-7897d2dae50e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2102,7 +2102,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-700",
+    "$ref": "3cf57594-3174-4192-ab62-b854b1562748",
     "uuid": "9a65bd1c-3ddf-4294-83f4-04967372c3f5",
     "set_uuid": "eb0405dc-c3c4-42e4-9b05-892a1959a332",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2115,7 +2115,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-800",
+    "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
     "uuid": "9566904a-3610-4668-9fe4-71ece5a58398",
     "set_uuid": "eb0405dc-c3c4-42e4-9b05-892a1959a332",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2128,7 +2128,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-700",
+    "$ref": "3cf57594-3174-4192-ab62-b854b1562748",
     "uuid": "3c39dea2-cdc4-4042-a134-7197a60ba8dd",
     "set_uuid": "eb0405dc-c3c4-42e4-9b05-892a1959a332",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2141,7 +2141,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-900",
+    "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
     "uuid": "c87c8466-22c1-40cb-9e5e-d661cd6cdcae",
     "set_uuid": "1911e604-88a5-4a64-a85c-fbfbabff604f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2154,7 +2154,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-1000",
+    "$ref": "eba4bafc-0f66-4dd1-8007-d25121e79a4b",
     "uuid": "1bbe2749-ba61-4e00-871f-cb3c6decd07c",
     "set_uuid": "1911e604-88a5-4a64-a85c-fbfbabff604f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2167,7 +2167,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-900",
+    "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
     "uuid": "0c3db762-fa21-497c-9a32-007e41ab24d6",
     "set_uuid": "1911e604-88a5-4a64-a85c-fbfbabff604f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2180,7 +2180,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-800",
+    "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
     "uuid": "260edfe7-6958-4d5b-8489-9ab3ab681577",
     "set_uuid": "aeb90a17-af9e-4bd4-ba02-5147c78465c6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2193,7 +2193,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-900",
+    "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
     "uuid": "a727a9f5-8f36-4e50-b8a4-3383f309785f",
     "set_uuid": "aeb90a17-af9e-4bd4-ba02-5147c78465c6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2206,7 +2206,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "turquoise-800",
+    "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
     "uuid": "2aca1631-0249-47dc-aa3b-44a51f5ea220",
     "set_uuid": "aeb90a17-af9e-4bd4-ba02-5147c78465c6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2218,7 +2218,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-100",
+    "$ref": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
     "uuid": "3cf7a8f4-9238-4f9f-9c85-97dc38de69d1",
     "set_uuid": "ca1cbd2f-3434-471c-8897-d70f8950795f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2230,7 +2230,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-400",
+    "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
     "uuid": "0dd236ab-7af8-418e-88dd-0cb45cf5da13",
     "set_uuid": "ca1cbd2f-3434-471c-8897-d70f8950795f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2242,7 +2242,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-100",
+    "$ref": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
     "uuid": "5a5e15ab-e73b-4997-be67-39534d98e823",
     "set_uuid": "ca1cbd2f-3434-471c-8897-d70f8950795f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2255,7 +2255,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-400",
+    "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
     "uuid": "59cd6057-b3d8-4bdf-b752-7df17c2c4a95",
     "set_uuid": "8b1b13d9-4645-4512-a671-e51bd8250978",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2268,7 +2268,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-1200",
+    "$ref": "af877bd7-9943-454e-b83e-5597e381190a",
     "uuid": "5ebf8291-23f8-4806-865d-4ebab38ff03c",
     "set_uuid": "8b1b13d9-4645-4512-a671-e51bd8250978",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2281,7 +2281,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-400",
+    "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
     "uuid": "fc16cbe3-7cf3-4744-a571-5bd2bdcef29e",
     "set_uuid": "8b1b13d9-4645-4512-a671-e51bd8250978",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2294,7 +2294,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-600",
+    "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
     "uuid": "94b9cfb2-1934-4ee5-88c8-0bf75c226dd3",
     "set_uuid": "8d9c55fd-9bfd-4ae6-b178-95fd648b02a7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2307,7 +2307,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-1400",
+    "$ref": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce",
     "uuid": "f92ad869-5610-46a4-8314-bee58a039d0d",
     "set_uuid": "8d9c55fd-9bfd-4ae6-b178-95fd648b02a7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2320,7 +2320,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-600",
+    "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
     "uuid": "24f49675-e169-4996-9993-c4a8941e8fab",
     "set_uuid": "8d9c55fd-9bfd-4ae6-b178-95fd648b02a7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2333,7 +2333,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-500",
+    "$ref": "8f90e008-a466-4477-ab93-1a55a644f52e",
     "uuid": "7d52f667-63c9-4ab9-b92c-10f7f6412632",
     "set_uuid": "5aa44700-fee8-46bc-9ef5-3c751f661479",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2346,7 +2346,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-1300",
+    "$ref": "b2558f6d-b45c-4662-a4a9-e34acd060c1d",
     "uuid": "4f50d025-f259-4130-bb6c-6fc30474e99d",
     "set_uuid": "5aa44700-fee8-46bc-9ef5-3c751f661479",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -2359,7 +2359,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "yellow-500",
+    "$ref": "8f90e008-a466-4477-ab93-1a55a644f52e",
     "uuid": "f4edf76c-b3f4-4455-b1d5-e222fa79b146",
     "set_uuid": "5aa44700-fee8-46bc-9ef5-3c751f661479",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -215,7 +215,7 @@
       "property": "bottom-to-text-regular-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-bottom-to-text-extra-large",
+    "$ref": "3f045028-2598-426a-91bd-443549a4c5f1",
     "uuid": "8c199212-a745-414c-8f6b-22d2445ade3c",
     "deprecated": "unknown"
   },
@@ -225,7 +225,7 @@
       "property": "bottom-to-text-regular-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-bottom-to-text-large",
+    "$ref": "036e6eac-cf81-4563-b4ea-f9610de674a8",
     "uuid": "f484838e-1f0c-4125-9298-beb4ddc0fd53",
     "deprecated": "unknown"
   },
@@ -235,7 +235,7 @@
       "property": "bottom-to-text-regular-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-bottom-to-text-medium",
+    "$ref": "071af591-5387-4a04-b00a-3451bb1f102d",
     "uuid": "2d6fa243-5f7e-41a8-840b-27a6432f54bc",
     "deprecated": "unknown"
   },
@@ -245,7 +245,7 @@
       "property": "bottom-to-text-regular-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-bottom-to-text-small",
+    "$ref": "13a9d984-2e46-4319-a466-d59fce44fef3",
     "uuid": "d64620dc-dd4a-447a-8491-d9e144ec8828",
     "deprecated": "unknown"
   },
@@ -1051,7 +1051,7 @@
       "property": "top-to-text-regular-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-top-to-text-extra-large",
+    "$ref": "346cdddd-d063-42bf-960a-c38e5cdcf862",
     "uuid": "9289aae4-ddaa-4a43-8f00-973dea8350f2",
     "deprecated": "unknown"
   },
@@ -1061,7 +1061,7 @@
       "property": "top-to-text-regular-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-top-to-text-large",
+    "$ref": "dd578daf-93a2-48f0-9df2-e67095cf5d7a",
     "uuid": "2021d787-ddaa-470a-a25d-8a57f67b7359",
     "deprecated": "unknown"
   },
@@ -1071,7 +1071,7 @@
       "property": "top-to-text-regular-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-top-to-text-medium",
+    "$ref": "9a60996d-f55e-47b5-a966-a10e297e4bd7",
     "uuid": "48db5aeb-6752-4267-89c7-48ed84692ec8",
     "deprecated": "unknown"
   },
@@ -1081,7 +1081,7 @@
       "property": "top-to-text-regular-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accordion-top-to-text-small",
+    "$ref": "bbaac303-b17e-48d5-8cad-9342c51d5c80",
     "uuid": "4f6e49d2-9ab8-4548-aae4-eed45a4003b9",
     "deprecated": "unknown"
   },
@@ -1241,7 +1241,7 @@
       "property": "bottom-to-content-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "3116a00c-0ad3-4ae6-9fbb-f9b5624a2708",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
@@ -1253,7 +1253,7 @@
       "property": "close-button-to-counter"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "text-to-control-50",
+    "$ref": "f9da434a-7742-4d38-ad52-05dec8d09cfa",
     "uuid": "bc54e89f-6740-4004-891e-c515f8f79693",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token group-gap-extra-small instead.",
@@ -1265,7 +1265,7 @@
       "property": "counter-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "66540ddb-ec74-487f-8e09-a37b436694b5"
   },
   {
@@ -1274,7 +1274,7 @@
       "property": "edge-to-content-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "a9fc8786-060e-4663-9381-211621240b2f",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token banner-padding-horizontal-compact instead.",
@@ -1286,7 +1286,7 @@
       "property": "height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-400",
+    "$ref": "b00a338c-f297-486a-94c8-cbfa8f6392c2",
     "uuid": "e67822de-d0cd-4b49-8e90-6c43523bb4dd"
   },
   {
@@ -1295,7 +1295,7 @@
       "property": "label-to-action-group-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "72e276ce-d6ee-4bcf-9955-91c833b8b2cd",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token banner-gap-horizontal instead.",
@@ -1316,7 +1316,7 @@
       "property": "top-to-content-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "cfa41a43-8fb2-4c3b-a2df-f8658c87b31b",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
@@ -1328,7 +1328,7 @@
       "property": "top-to-item-counter"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-300",
+    "$ref": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
     "uuid": "73f82d09-7927-461c-b7d7-ab0bc6b3e3f9",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
@@ -1638,7 +1638,7 @@
       "property": "to-bottom-text"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "alert-banner-bottom-to-text",
+    "$ref": "848a9c0d-eba9-4258-83fd-80e114fac05a",
     "uuid": "e2bd6435-6fbd-4030-9ff5-b034438b8d8a",
     "deprecated": "unknown",
     "deprecated_comment": "Introduced as an error. Use alert-banner-bottom-to-text instead",
@@ -1650,7 +1650,7 @@
       "property": "to-top-text"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "alert-banner-top-to-text",
+    "$ref": "db0461aa-d466-4a49-8f6d-f3b65659abb5",
     "uuid": "8fefedaf-6e95-4a14-a8ba-08381f57bfeb",
     "deprecated": "unknown",
     "deprecated_comment": "Introduced as an error. Use alert-banner-top-to-text instead",
@@ -1662,7 +1662,7 @@
       "property": "to-top-workflow-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "alert-banner-top-to-workflow-icon",
+    "$ref": "8ab5ed06-52be-4cbc-8922-35483e361488",
     "uuid": "42b40d65-eed4-432e-8ede-74d89905d131",
     "deprecated": "unknown",
     "deprecated_comment": "Introduced as an error. Use alert-banner-top-to-workflow-icon instead",
@@ -1789,7 +1789,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-m",
+    "$ref": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
     "uuid": "eda300de-5f0a-42e9-9880-9244a45d4e7d",
     "set_uuid": "6c94683e-1c66-4e07-84e4-7a8b6d7b069d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -1801,7 +1801,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "e969f730-9eea-4a35-8981-2804d660c23e",
     "set_uuid": "6c94683e-1c66-4e07-84e4-7a8b6d7b069d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -1812,7 +1812,7 @@
       "property": "description-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "alert-dialog-description-font-size",
+    "$ref": "6c94683e-1c66-4e07-84e4-7a8b6d7b069d",
     "uuid": "9dc42d1a-b87d-4a5d-a5a3-6afd4d5bd599",
     "deprecated": "unknown",
     "deprecated_comment": "Replace with alert-dialog-description-font-size",
@@ -1843,7 +1843,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xxl",
+    "$ref": "d4c4db99-70f2-4c79-8595-4d23407de068",
     "uuid": "749fa425-de12-464d-a1e2-80eb135d3ea6",
     "set_uuid": "5b046013-d264-4f71-b609-7dd2057571ff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -1855,7 +1855,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xl",
+    "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
     "uuid": "c84328d2-578b-4a36-9065-6c6a9e1d311f",
     "set_uuid": "5b046013-d264-4f71-b609-7dd2057571ff",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -1866,7 +1866,7 @@
       "property": "title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "alert-dialog-title-font-size",
+    "$ref": "5b046013-d264-4f71-b609-7dd2057571ff",
     "uuid": "9b7ce1fc-ea8a-4d7b-a926-0accbd6b1197",
     "deprecated": "unknown",
     "deprecated_comment": "Replace with alert-dialog-title-font-size",
@@ -2148,7 +2148,7 @@
       "property": "border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "border-width-100",
+    "$ref": "b5525080-28e7-4eb7-aee9-fb2c71a16f68",
     "uuid": "2d4cd3ad-cc2c-4ad5-9475-c73882c5201e"
   },
   {
@@ -2157,7 +2157,7 @@
       "property": "size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-100",
+    "$ref": "6f799e9e-1e37-4d9d-b88d-3969ca707213",
     "uuid": "1c869018-8c56-4c10-acea-7fc6e838aa09"
   },
   {
@@ -2166,7 +2166,7 @@
       "property": "size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-200",
+    "$ref": "ad82e875-4243-4665-93b9-91aef258b164",
     "uuid": "590ef940-55ea-4690-a403-e4b47a185a64"
   },
   {
@@ -2175,7 +2175,7 @@
       "property": "size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-300",
+    "$ref": "3c458169-051a-473d-9b68-af84803a74e6",
     "uuid": "5e60d980-21db-4bbd-b321-a20808571411"
   },
   {
@@ -2184,7 +2184,7 @@
       "property": "size-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-400",
+    "$ref": "f1ebef6a-9cf7-4aa6-9dcf-2bfd6387a97e",
     "uuid": "80e446ee-0091-4c6e-9158-e15fbc6207a4"
   },
   {
@@ -2193,7 +2193,7 @@
       "property": "size-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-50",
+    "$ref": "bf2b8540-8b70-4c36-8e02-7deeb66d532e",
     "uuid": "d55ab204-ee6c-47e3-a21b-25543c8fc36b"
   },
   {
@@ -2202,7 +2202,7 @@
       "property": "size-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-500",
+    "$ref": "b05bc8a7-3937-4e31-97eb-4514bdb31f9f",
     "uuid": "4bf63b03-931b-47ce-bb1a-4bd4e2cd82c1"
   },
   {
@@ -2211,7 +2211,7 @@
       "property": "size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "avatar-size-75",
+    "$ref": "88990423-8f5c-486b-9c7d-969db3d82cbb",
     "uuid": "420c8327-fa41-4919-9e01-4d58178d739b"
   },
   {
@@ -2877,7 +2877,7 @@
       "property": "bottom-to-text"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-bottom-to-text-200",
+    "$ref": "36742697-2320-4bc0-8a29-ad98e342349f",
     "uuid": "f0e6a20d-8c2d-4aa3-9060-b6ca66aa7943",
     "deprecated": "unknown"
   },
@@ -2887,7 +2887,7 @@
       "property": "bottom-to-text-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-bottom-to-text-100",
+    "$ref": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
     "uuid": "70a356be-c304-4bb4-a9df-97806931f089",
     "deprecated": "unknown"
   },
@@ -2938,7 +2938,7 @@
       "property": "height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-200",
+    "$ref": "a8f083cd-131e-4375-b948-3ef5c520cb42",
     "uuid": "2d39863c-6987-413c-90d8-07fcc506a0d4",
     "deprecated": "unknown"
   },
@@ -2948,7 +2948,7 @@
       "property": "height-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-100",
+    "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
     "uuid": "8393f599-37e8-484a-a1c6-0934ce15a507",
     "deprecated": "unknown"
   },
@@ -2982,7 +2982,7 @@
       "property": "separator-icon-to-bottom-text-multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-separator-to-bottom-text-multiline",
+    "$ref": "c5749cb5-6950-4aef-80f0-8445451370a7",
     "uuid": "56dd2fd0-c7a3-4f2c-bda9-8e6ba6d99e6c",
     "deprecated": "unknown"
   },
@@ -3022,7 +3022,7 @@
       "property": "start-edge-to-text"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-start-edge-to-text-large",
+    "$ref": "6833c05d-b5bd-49af-8dc7-8ef2ce52584a",
     "uuid": "a0542dab-98fb-45d8-b4a0-79cfd2cc4f1c",
     "deprecated": "unknown",
     "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-start-edge-to-text-large.",
@@ -3255,7 +3255,7 @@
       "property": "top-to-separator-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-top-to-separator-large",
+    "$ref": "f5a2b688-0ddd-4423-a958-6ef4bad42809",
     "uuid": "15e56281-5fc1-4b59-b815-fc333231e364",
     "deprecated": "unknown",
     "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-large.",
@@ -3267,7 +3267,7 @@
       "property": "top-to-separator-icon-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-top-to-separator-medium",
+    "$ref": "e7f97e3d-129e-4971-bc78-5f184710d716",
     "uuid": "a63e8df1-124f-4f3e-9e1b-ba422b8d8257",
     "deprecated": "unknown",
     "deprecated_comment": "Use a sized token instead, e.g., breadcrumbs-top-to-separator-medium.",
@@ -3280,7 +3280,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-top-to-separator-multiline",
+    "$ref": "5b042e52-ddce-4e17-84c0-faf86049a945",
     "uuid": "6b310160-ab2e-40fd-9216-21ddcb36b575",
     "set_uuid": "3acadfab-ddd5-4eac-85de-b6c573dae071",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -3293,7 +3293,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-separator-icon-to-bottom-text-multiline",
+    "$ref": "56dd2fd0-c7a3-4f2c-bda9-8e6ba6d99e6c",
     "uuid": "eb3b2566-6fc1-4a2c-a8cf-e40af3d34715",
     "set_uuid": "3acadfab-ddd5-4eac-85de-b6c573dae071",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -3395,7 +3395,7 @@
       "property": "top-to-text"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-200",
+    "$ref": "306b871f-cbfa-49a2-a74b-dd120bbff503",
     "uuid": "d084038e-bc31-43be-99ee-13cf727eaf9d",
     "deprecated": "unknown"
   },
@@ -3405,7 +3405,7 @@
       "property": "top-to-text-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-100",
+    "$ref": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
     "uuid": "b19547e2-bd8f-435d-b726-4f2ce6a83984",
     "deprecated": "unknown"
   },
@@ -3456,7 +3456,7 @@
       "property": "top-to-truncated-menu-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-top-to-truncated-menu",
+    "$ref": "751734bd-1c58-4222-bbd8-8b2349f2fbd2",
     "uuid": "e0aba287-799f-4621-97cb-563352002a20",
     "deprecated": "unknown"
   },
@@ -3507,7 +3507,7 @@
       "property": "truncated-menu-to-separator-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "breadcrumbs-truncated-menu-to-separator",
+    "$ref": "963bd7ed-cfc9-4a93-a8a6-a2340ec6479f",
     "uuid": "1fe2a3df-3179-4c4a-8d1f-de41297b6d74",
     "deprecated": "unknown"
   },
@@ -3571,7 +3571,7 @@
       "property": "description-to-footer"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "248d1f30-c0d3-49bb-a5b7-0860cc75ee85",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token container-padding-medium instead.",
@@ -3763,7 +3763,7 @@
       "property": "header-to-description"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "e874d2cd-6ad6-4d1c-8103-789945f10294",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token text-gap-medium instead. May require refactor",
@@ -3902,7 +3902,7 @@
       "property": "minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "card-minimum-width-default",
+    "$ref": "3a11949c-f1ac-490b-8416-f4883402d105",
     "uuid": "55db9f3d-621d-4d23-b3d0-c0f2b0f3f9b0",
     "deprecated": "unknown",
     "deprecated_comment": "This token has been deprecated, use card-minimum-width-default instead.",
@@ -4725,7 +4725,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-m",
+    "$ref": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
     "uuid": "4b88a0d5-2d07-4e63-afa6-cdd611f0a8c1",
     "set_uuid": "f4f305ae-e0da-48ec-9dab-c33cdd11b80f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -4737,7 +4737,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "73959c3d-afc2-4f6e-bd34-0399bf3b5b73",
     "set_uuid": "f4f305ae-e0da-48ec-9dab-c33cdd11b80f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -4748,7 +4748,7 @@
       "property": "body-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "coach-mark-body-font-size",
+    "$ref": "f4f305ae-e0da-48ec-9dab-c33cdd11b80f",
     "uuid": "eba9f466-deda-48d5-a120-14419d5a670f",
     "deprecated": "unknown",
     "deprecated_comment": "Replace with coach-mark-body-font-size",
@@ -4761,7 +4761,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-400",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
     "uuid": "d5a3e2c7-f717-4436-91a3-3ab34aebd48e",
     "set_uuid": "aba07ab5-e655-4a1c-9704-7850bafefae8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -4776,7 +4776,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "11fb0ab2-d6a0-4da8-9c83-c1f6b918406a",
     "set_uuid": "aba07ab5-e655-4a1c-9704-7850bafefae8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -4887,7 +4887,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "06ae2458-8490-4741-8a02-97f60cc01592",
     "set_uuid": "b8a50488-10c4-4b9e-8e3f-7cfdaea6b4a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -4899,7 +4899,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-xs",
+    "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
     "uuid": "4f8c99a5-0942-41b0-ac41-923ea9ca2bf2",
     "set_uuid": "b8a50488-10c4-4b9e-8e3f-7cfdaea6b4a8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -4910,7 +4910,7 @@
       "property": "pagination-body-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "coach-mark-pagination-body-font-size",
+    "$ref": "b8a50488-10c4-4b9e-8e3f-7cfdaea6b4a8",
     "uuid": "df8bc8ae-b6fa-4414-93b7-c89d8097fe11",
     "deprecated": "unknown",
     "deprecated_comment": "Replace with coach-mark-pagination-body-font-size",
@@ -4953,7 +4953,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-m",
+    "$ref": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
     "uuid": "5b132698-4ee2-40e4-83c0-9ad80f36f5fd",
     "set_uuid": "5ede1ea6-2643-489b-bd30-7165f5afe323",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -4965,7 +4965,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-s",
+    "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
     "uuid": "45855bc5-3b86-49a9-b443-7be9aa763c4e",
     "set_uuid": "5ede1ea6-2643-489b-bd30-7165f5afe323",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -4976,7 +4976,7 @@
       "property": "title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "coach-mark-title-font-size",
+    "$ref": "5ede1ea6-2643-489b-bd30-7165f5afe323",
     "uuid": "331604db-3f28-472e-810d-9010ed2c8e33",
     "deprecated": "unknown",
     "deprecated_comment": "Replace with coach-mark-title-font-size",
@@ -5012,7 +5012,7 @@
       "property": "cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "code-size-l",
+    "$ref": "b7010f1a-c994-4b19-b273-3f609fe4be2b",
     "uuid": "15e8593b-1b86-40e0-ae88-fcc587e24373"
   },
   {
@@ -5021,7 +5021,7 @@
       "property": "cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "code-size-m",
+    "$ref": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3",
     "uuid": "69436fba-18a7-4a28-b6c5-683a8838917c"
   },
   {
@@ -5030,7 +5030,7 @@
       "property": "cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "code-size-s",
+    "$ref": "efa9311b-27c5-45ea-93a7-bef6f9370179",
     "uuid": "80c3d9ab-39d1-4329-a88f-bb84c3afd17f"
   },
   {
@@ -5039,7 +5039,7 @@
       "property": "cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "code-size-xl",
+    "$ref": "7879adbc-6c38-4d29-9a90-a4ad91c75b90",
     "uuid": "a2e258a0-21f6-44d7-9bfe-0052620e5ac2"
   },
   {
@@ -5048,7 +5048,7 @@
       "property": "cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "code-size-xs",
+    "$ref": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7",
     "uuid": "6b577e2a-09c0-42bb-8b94-42034df63036"
   },
   {
@@ -5147,7 +5147,7 @@
       "property": "border-rounding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-medium-size-small",
+    "$ref": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
     "uuid": "ab656bf4-8814-42fa-9036-b1e67159e4e1"
   },
   {
@@ -5156,7 +5156,7 @@
       "property": "border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "border-width-100",
+    "$ref": "b5525080-28e7-4eb7-aee9-fb2c71a16f68",
     "uuid": "78fff16d-d6fe-4a74-98bc-97c56e352250"
   },
   {
@@ -5261,7 +5261,7 @@
       "property": "border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "border-width-200",
+    "$ref": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
     "uuid": "8ec9adae-0093-42f4-bd1b-6f3b2279996b"
   },
   {
@@ -5392,7 +5392,7 @@
       "property": "outer-border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "border-width-200",
+    "$ref": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
     "uuid": "51cd5039-1319-451a-b13f-bb3a218238a5"
   },
   {
@@ -5410,7 +5410,7 @@
       "property": "border-rounding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-medium-size-small",
+    "$ref": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
     "uuid": "991541a2-df44-4f32-90a5-de698adf5db3"
   },
   {
@@ -5563,7 +5563,7 @@
       "property": "visual-to-field-button-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "combo-box-visual-to-field-button",
+    "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "4a4ee415-1f25-4d36-928c-5ece0ce4abcc",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
@@ -5575,7 +5575,7 @@
       "property": "visual-to-field-button-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "combo-box-visual-to-field-button",
+    "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "356c4912-69c7-4a95-956b-c1aa78cb02cb",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
@@ -5587,7 +5587,7 @@
       "property": "visual-to-field-button-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "combo-box-visual-to-field-button",
+    "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "c5a4baf2-effe-4d9a-92f3-b4ead5440d36",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
@@ -5599,7 +5599,7 @@
       "property": "visual-to-field-button-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "combo-box-visual-to-field-button",
+    "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "292cbbe1-1ba4-4369-9768-2051c07e6406",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
@@ -5611,7 +5611,7 @@
       "property": "visual-to-field-button-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "combo-box-visual-to-field-button",
+    "$ref": "6c3c7201-2f5b-455a-bcbf-5e3d783887bf",
     "uuid": "5d054a3e-e4bb-4ca3-b84a-51b3d7fa2cb8",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with combo-box-visual-to-field-button",
@@ -5624,7 +5624,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "393e9a11-77f6-42a7-973b-34c673ad8afb",
     "set_uuid": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -5636,7 +5636,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-xs",
+    "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
     "uuid": "1d817b1e-7916-4443-b04d-aa232b089f67",
     "set_uuid": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -5647,7 +5647,7 @@
       "property": "body-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "contextual-help-body-font-size",
+    "$ref": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
     "uuid": "e458fa68-ab9c-4441-a7d5-a02f42df1cae",
     "deprecated": "unknown"
   },
@@ -5667,7 +5667,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-m",
+    "$ref": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
     "uuid": "16ee4dfd-afbe-482b-943e-03e2614037dd",
     "set_uuid": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -5679,7 +5679,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-s",
+    "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
     "uuid": "965f0854-0f3c-4d6e-9e21-54542ecf1a17",
     "set_uuid": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -5690,7 +5690,7 @@
       "property": "title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "contextual-help-title-font-size",
+    "$ref": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
     "uuid": "5358fd6c-d9a0-4caa-a85e-af82ed82efaf",
     "deprecated": "unknown"
   },
@@ -6309,7 +6309,7 @@
       "property": "body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-medium-body-font-size",
+    "$ref": "22f5b08c-2b86-447d-be0b-ed03841dbcfb",
     "uuid": "644593be-82da-4ae4-ae57-fabebd4513ca"
   },
   {
@@ -6318,7 +6318,7 @@
       "property": "body-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-zone-body-font-size",
+    "$ref": "644593be-82da-4ae4-ae57-fabebd4513ca",
     "uuid": "bb3fee51-24cc-4643-9f22-fa1592ab2457",
     "deprecated": "unknown",
     "deprecated_comment": "Use drop-zone-body-font-size instead",
@@ -6354,7 +6354,7 @@
       "property": "cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-medium-cjk-title-font-size",
+    "$ref": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f",
     "uuid": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75"
   },
   {
@@ -6363,7 +6363,7 @@
       "property": "cjk-title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-zone-cjk-title-font-size",
+    "$ref": "56fc89be-658e-4c5c-9b8e-7ac6f7d7db75",
     "uuid": "013387e8-8925-4bb4-a8ee-94420141fde9",
     "deprecated": "unknown",
     "deprecated_comment": "Use drop-zone-cjk-title-font-size instead",
@@ -6375,7 +6375,7 @@
       "property": "content-maximum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-maximum-width",
+    "$ref": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
     "uuid": "b8d0db71-9a25-46fc-b77a-037fcf86be8e",
     "deprecated": "unknown"
   },
@@ -6385,7 +6385,7 @@
       "property": "title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-medium-title-font-size",
+    "$ref": "5a575423-6129-4fcf-93f0-d3eb44096dd5",
     "uuid": "07564dd0-3628-42e1-8a29-253448a8c75f"
   },
   {
@@ -6394,7 +6394,7 @@
       "property": "title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-zone-title-font-size",
+    "$ref": "07564dd0-3628-42e1-8a29-253448a8c75f",
     "uuid": "edc68bfe-7ad3-4a12-81fa-ded8fb6fc2e3",
     "deprecated": "unknown",
     "deprecated_comment": "Use drop-zone-title-font-size instead",
@@ -6949,7 +6949,7 @@
       "property": "top-to-workflow-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-workflow-icon-300",
+    "$ref": "955bbeaf-dc4e-460b-8957-d145d4b6fc3e",
     "uuid": "bec914a9-5905-40ac-bd61-a727016c1228",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with component-top-to-workflow-icon-300",
@@ -6961,7 +6961,7 @@
       "property": "top-to-workflow-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-workflow-icon-200",
+    "$ref": "81bfcc6f-348b-4728-bfdc-10f2f181b041",
     "uuid": "54cae12b-5f21-47b4-a964-6033bd025975",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with component-top-to-workflow-icon-200",
@@ -6973,7 +6973,7 @@
       "property": "top-to-workflow-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-workflow-icon-100",
+    "$ref": "2b17325c-eec1-43e2-9a31-957adf67e44d",
     "uuid": "d159b313-4def-493a-adcf-398e2d1fce9f",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with component-top-to-workflow-icon-100",
@@ -6985,7 +6985,7 @@
       "property": "top-to-workflow-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-workflow-icon-75",
+    "$ref": "3b07cd46-add6-4cd9-b3f8-626f113905dd",
     "uuid": "91cb19ef-63fc-4d98-a61e-a5f55951f656",
     "deprecated": "unknown",
     "deprecated_comment": "Replaced with component-top-to-workflow-icon-75",
@@ -6997,7 +6997,7 @@
       "property": "body-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-large-body-font-size",
+    "$ref": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
     "uuid": "4140710f-ae31-4ae3-b8b6-2d3eb6a1ae78",
     "deprecated": "unknown",
     "deprecated_comment": "Use illustrated-message-medium-body-font-size instead",
@@ -7009,7 +7009,7 @@
       "property": "cjk-title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-large-cjk-title-font-size",
+    "$ref": "44509721-b85a-4c57-8850-d52322e0afef",
     "uuid": "e77279df-bc62-441a-8a30-5faa41d0df10",
     "deprecated": "unknown",
     "deprecated_comment": "Use illustrated-message-medium-cjk-title-font-size instead",
@@ -7031,7 +7031,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "0208e74a-4a86-42e4-a5d0-f931715c293b",
     "set_uuid": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7043,7 +7043,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-xs",
+    "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
     "uuid": "f4956b2c-dfda-4449-850b-36cf3a82ea09",
     "set_uuid": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7055,7 +7055,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-cjk-size-xxl",
+    "$ref": "abbc512e-fdce-4025-9d08-5a71692cf523",
     "uuid": "1929c819-5333-43ad-ba6c-fcf236270251",
     "set_uuid": "44509721-b85a-4c57-8850-d52322e0afef",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7067,7 +7067,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-cjk-size-xl",
+    "$ref": "99472fda-7d17-45d5-b2ba-0c79a45d628f",
     "uuid": "e3c5a7ed-94f9-4938-9b92-b411e971af20",
     "set_uuid": "44509721-b85a-4c57-8850-d52322e0afef",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7079,7 +7079,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xxl",
+    "$ref": "d4c4db99-70f2-4c79-8595-4d23407de068",
     "uuid": "abfe147d-04dd-45bd-8e86-eae6249e1745",
     "set_uuid": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7091,7 +7091,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xl",
+    "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
     "uuid": "05104cea-7882-4f80-a994-3e072d29eec2",
     "set_uuid": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7102,7 +7102,7 @@
       "property": "maximum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-vertical-maximum-width",
+    "$ref": "95c055b0-f688-4405-8426-1b2302e32ebd",
     "uuid": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
     "deprecated": "unknown"
   },
@@ -7113,7 +7113,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "ca0d9e22-35a8-4ae5-99ee-29cce3ffa0bd",
     "set_uuid": "22f5b08c-2b86-447d-be0b-ed03841dbcfb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7125,7 +7125,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-xs",
+    "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
     "uuid": "32b359dc-b489-4476-afbd-1c04e6b0ff0e",
     "set_uuid": "22f5b08c-2b86-447d-be0b-ed03841dbcfb",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7137,7 +7137,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-cjk-size-xl",
+    "$ref": "99472fda-7d17-45d5-b2ba-0c79a45d628f",
     "uuid": "ee763c7d-b98f-4f2e-9fc4-764cfa2ac53f",
     "set_uuid": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7149,7 +7149,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-cjk-size-l",
+    "$ref": "2fcf237b-6988-4c31-a806-f4176b94c2a8",
     "uuid": "1cb0c913-f4ec-478c-b92d-4c9d78875362",
     "set_uuid": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7161,7 +7161,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xl",
+    "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
     "uuid": "8e2d1a48-937c-4493-9624-5ca8383f74bd",
     "set_uuid": "5a575423-6129-4fcf-93f0-d3eb44096dd5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7173,7 +7173,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-l",
+    "$ref": "0fb9e5ec-e5b7-41e0-8ef4-db9e4e33e060",
     "uuid": "65961091-abdb-4155-9887-4aebe857c4fd",
     "set_uuid": "5a575423-6129-4fcf-93f0-d3eb44096dd5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7184,7 +7184,7 @@
       "property": "small-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-xs",
+    "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
     "uuid": "fad078e5-1791-4003-994d-3567162d8233"
   },
   {
@@ -7194,7 +7194,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-cjk-size-m",
+    "$ref": "d1bccaa7-731f-4df2-a4c3-9dbec33145fd",
     "uuid": "9a6cf390-ca10-4242-a7d4-da4c9acc4058",
     "set_uuid": "e5e7d4e3-39c7-4184-b590-cc4abf2f60fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7206,7 +7206,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-cjk-size-s",
+    "$ref": "a134fab9-7606-453d-a64f-fd2daa989283",
     "uuid": "a144455d-6bb3-43d4-828c-6b6f67ae9c51",
     "set_uuid": "e5e7d4e3-39c7-4184-b590-cc4abf2f60fc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7218,7 +7218,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-m",
+    "$ref": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
     "uuid": "f21da7b8-ba19-43e0-96e5-f9e60476ef6e",
     "set_uuid": "2164a3c7-b90d-4072-8f72-f364d07edb38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7230,7 +7230,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-s",
+    "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
     "uuid": "ef8d0abb-9652-4db3-8f1d-506c03e5e115",
     "set_uuid": "2164a3c7-b90d-4072-8f72-f364d07edb38",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -7241,7 +7241,7 @@
       "property": "title-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "illustrated-message-large-title-font-size",
+    "$ref": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
     "uuid": "365ec548-431b-4e1e-9f9d-7b04d337f001",
     "deprecated": "unknown",
     "deprecated_comment": "Use illustrated-message-medium-title-font-size instead",
@@ -7413,7 +7413,7 @@
       "property": "inner-edge-to-disclosure-icon-stacked-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large",
+    "$ref": "391e1e67-1677-4f60-a09a-3b49bacd01f5",
     "uuid": "c47499c1-b89f-49a7-bbb5-17e83e4b306e",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token accessory-item-padding-extra-large instead. Not present in S2 specs. May require refactor",
@@ -7425,7 +7425,7 @@
       "property": "inner-edge-to-disclosure-icon-stacked-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-large",
+    "$ref": "acc9c48a-f461-48ff-9f69-0224c4feabc6",
     "uuid": "710ebe58-f0d8-4d6b-8974-0be1f2f48dc4",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token accessory-item-padding-large instead. Not present in S2 specs. May require refactor",
@@ -7437,7 +7437,7 @@
       "property": "inner-edge-to-disclosure-icon-stacked-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-medium",
+    "$ref": "a87d68bb-4249-43cd-947d-bd061baba0ef",
     "uuid": "3dd5babb-5026-4f28-89ae-bfe687673f31",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token accessory-item-padding-medium instead. Not present in S2 specs. May require refactor",
@@ -7449,7 +7449,7 @@
       "property": "inner-edge-to-disclosure-icon-stacked-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "in-field-button-outer-edge-to-disclosure-icon-stacked-small",
+    "$ref": "9890df35-2d45-4767-9cbe-ee745d09d990",
     "uuid": "6c1330a4-1c89-45a7-b2b1-8cbcaf20b9ab",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token accessory-item-padding-small instead. Not present in S2 specs. May require refactor",
@@ -7933,7 +7933,7 @@
       "property": "item-bottom-corner-radius"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-medium-default",
+    "$ref": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6",
     "uuid": "57821e37-d39e-49d5-b978-4ece3747e531"
   },
   {
@@ -7942,7 +7942,7 @@
       "property": "item-top-corner-radius"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-medium-default",
+    "$ref": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6",
     "uuid": "6e4611f7-f202-4003-94b4-587d48d07e32"
   },
   {
@@ -8120,7 +8120,7 @@
       "property": "item-label-to-description"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "menu-item-label-to-description-medium",
+    "$ref": "608fd592-fff8-435e-88e2-846bd34cc235",
     "uuid": "628cf42f-eb40-49b0-b110-3340421d4502",
     "deprecated": "unknown"
   },
@@ -8595,7 +8595,7 @@
       "component": "meter"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "meter-width",
+    "$ref": "986cf4b8-bb3b-4752-83b9-3001d6d6ffac",
     "uuid": "2633d29d-8a14-48e8-977c-bdb9a53b3bd5",
     "deprecated": "unknown",
     "deprecated_comment": "Token renamed, use `meter-width`",
@@ -8971,7 +8971,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "opacity-checkerboard-square-size-medium",
+    "$ref": "a0410857-1be2-4bb8-9b31-a4db7f771485",
     "uuid": "9ddf2e73-ad74-46d7-a79d-fe961b06dbbd",
     "set_uuid": "d847973c-89b2-4454-9dd8-44fb671e9408",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -8986,7 +8986,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "opacity-checkerboard-square-size-medium",
+    "$ref": "a0410857-1be2-4bb8-9b31-a4db7f771485",
     "uuid": "879360e9-a7b0-47e0-bc4a-931a12877014",
     "set_uuid": "d847973c-89b2-4454-9dd8-44fb671e9408",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -9048,7 +9048,7 @@
       "property": "border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "border-width-100",
+    "$ref": "b5525080-28e7-4eb7-aee9-fb2c71a16f68",
     "uuid": "69c28762-f456-4641-b6ce-7cb295e3a27d"
   },
   {
@@ -9068,7 +9068,7 @@
       "property": "end-edge-to-disclousure-icon-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "picker-end-edge-to-disclosure-icon-quiet",
+    "$ref": "03da68d8-cd87-4e29-9aaf-ab467594ec2b",
     "uuid": "c8bd227d-c72b-4f6a-9d93-0b595821dee0",
     "deprecated": "unknown",
     "deprecated_comment": "Use `picker-end-edge-to-disclosure-icon-quiet` instead",
@@ -9209,7 +9209,7 @@
       "property": "edge-to-content-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "2a3bd47e-fde5-41d3-a585-f970bdefaf07",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token popover-padding instead.",
@@ -9239,7 +9239,7 @@
       "property": "top-to-content-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "popover-edge-to-content-area",
+    "$ref": "2a3bd47e-fde5-41d3-a585-f970bdefaf07",
     "uuid": "f97488e8-b1c1-442e-b98c-0ae6cff0b774",
     "deprecated": "unknown",
     "deprecated_comment": "Introduced as an error. Use popover-edge-to-content-area instead",
@@ -9746,7 +9746,7 @@
       "property": "bottom-to-content-area-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "360ab235-93bf-482c-9ff1-387d69f018e1",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
@@ -9770,7 +9770,7 @@
       "property": "edge-to-content-area-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "a2ad2062-a115-4abb-859b-f9d307b44744",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
@@ -9782,7 +9782,7 @@
       "property": "height-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-100",
+    "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
     "uuid": "d7f24ef9-eb71-45e8-96a1-7e48ddc56964"
   },
   {
@@ -9791,7 +9791,7 @@
       "property": "height-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-75",
+    "$ref": "fbdf2291-b332-4436-9e57-430c0a81d526",
     "uuid": "7e0c3f30-31f5-4fa2-b353-a739c904d796"
   },
   {
@@ -9864,7 +9864,7 @@
       "property": "top-to-content-area-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "8cf415d3-57f2-41c6-a175-40c75b58a79e",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
@@ -9903,7 +9903,7 @@
       "property": "item-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-100",
+    "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
     "uuid": "4aaef8d2-aa58-46b8-837c-15d794cfcdb5"
   },
   {
@@ -9921,7 +9921,7 @@
       "property": "selection-border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "border-width-200",
+    "$ref": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
     "uuid": "10f93760-7b09-4a4e-8cc2-33783e571926"
   },
   {
@@ -10886,7 +10886,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "side-navigation-second-level-with-icon-edge-to-text",
+    "$ref": "e09f8f4b-9384-49ad-88e9-f8b3fc966b1e",
     "uuid": "d254c910-2939-48ce-8547-08cfb346a0db",
     "set_uuid": "54cd1b31-fdef-4b15-a236-eb18e8468a65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -10901,7 +10901,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "side-navigation-second-level-with-icon-edge-to-text",
+    "$ref": "e09f8f4b-9384-49ad-88e9-f8b3fc966b1e",
     "uuid": "7d4cd9bd-bfaf-4ad7-9c3b-19f7913f0825",
     "set_uuid": "54cd1b31-fdef-4b15-a236-eb18e8468a65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -10916,7 +10916,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "side-navigation-third-level-with-icon-edge-to-text",
+    "$ref": "50359a00-5714-4f4f-accc-b9debc6de08f",
     "uuid": "f1d90f18-e114-477f-88ca-548c5ddbc287",
     "set_uuid": "ea2417cb-8f92-44ef-9f0c-00046c43fc69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -10931,7 +10931,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "side-navigation-third-level-with-icon-edge-to-text",
+    "$ref": "50359a00-5714-4f4f-accc-b9debc6de08f",
     "uuid": "f82ab001-808a-4528-bf4a-be27645a28fc",
     "set_uuid": "ea2417cb-8f92-44ef-9f0c-00046c43fc69",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -12385,7 +12385,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-m",
+    "$ref": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
     "uuid": "84aa108a-3c23-494f-b9c0-da64acdbeb79",
     "set_uuid": "3f6ab646-b255-4e0f-9911-cd2fb41fbaa4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -12397,7 +12397,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "body-size-s",
+    "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
     "uuid": "f33e2125-0424-4329-bf60-ec42a15c36bc",
     "set_uuid": "3f6ab646-b255-4e0f-9911-cd2fb41fbaa4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -12445,7 +12445,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xxl",
+    "$ref": "d4c4db99-70f2-4c79-8595-4d23407de068",
     "uuid": "d4e81ac4-8855-4ac4-b28f-ad054f74e517",
     "set_uuid": "670ecc3e-b844-4958-ba2f-998b72d39de2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -12457,7 +12457,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-xl",
+    "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
     "uuid": "02c75ba4-2c9f-45f3-8e74-c9a1065142ac",
     "set_uuid": "670ecc3e-b844-4958-ba2f-998b72d39de2",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json"
@@ -12522,7 +12522,7 @@
       "property": "title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "title-size-s",
+    "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
     "uuid": "ce8278ea-da1b-4a42-bf7d-4018c9e9d18e"
   },
   {
@@ -12672,7 +12672,7 @@
       "property": "text-to-visual-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "text-to-visual-100",
+    "$ref": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
     "uuid": "752a84f5-cbb7-4d18-85ca-fc913a061bb5",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-gap-medium instead.",
@@ -12684,7 +12684,7 @@
       "property": "text-to-visual-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "text-to-visual-200",
+    "$ref": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
     "uuid": "d3e53f14-b91e-4d10-8508-17360ae5620e",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-gap-large instead.",
@@ -12696,7 +12696,7 @@
       "property": "text-to-visual-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "text-to-visual-300",
+    "$ref": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
     "uuid": "ee780be7-b32c-4da8-a6bc-fc0897799537",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-gap-extra-large instead.",
@@ -12708,7 +12708,7 @@
       "property": "text-to-visual-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "text-to-visual-75",
+    "$ref": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
     "uuid": "ea98b9b0-20b5-4f19-aa4f-375559b1362a",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token base-gap-small instead.",
@@ -13910,7 +13910,7 @@
       "property": "compact-height-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-300",
+    "$ref": "0cc8906e-a9a2-4995-a6c2-920cb5f2b83c",
     "uuid": "49130d66-edfb-48bd-8648-96c47f40a884"
   },
   {
@@ -13919,7 +13919,7 @@
       "property": "compact-height-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-200",
+    "$ref": "a8f083cd-131e-4375-b948-3ef5c520cb42",
     "uuid": "6d781a0e-e03d-4750-ae4f-67a29d731702"
   },
   {
@@ -13928,7 +13928,7 @@
       "property": "compact-height-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-100",
+    "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
     "uuid": "e8c7c826-548d-4037-b064-3cf699675d35"
   },
   {
@@ -13937,7 +13937,7 @@
       "property": "compact-height-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-75",
+    "$ref": "fbdf2291-b332-4436-9e57-430c0a81d526",
     "uuid": "25f7d9a5-9464-4447-97d9-97839b371f96"
   },
   {
@@ -14066,7 +14066,7 @@
       "property": "height-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-500",
+    "$ref": "752a9a44-712b-429b-8161-91f7eaad8377",
     "uuid": "42ed814c-5044-4c70-b82f-b49f8226241e"
   },
   {
@@ -14075,7 +14075,7 @@
       "property": "height-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-400",
+    "$ref": "b00a338c-f297-486a-94c8-cbfa8f6392c2",
     "uuid": "8abd0b0e-fd6d-4064-9d0e-1ab998fcb0ce"
   },
   {
@@ -14084,7 +14084,7 @@
       "property": "height-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-300",
+    "$ref": "0cc8906e-a9a2-4995-a6c2-920cb5f2b83c",
     "uuid": "5d2288f4-f383-47fa-baca-0168cb46750a"
   },
   {
@@ -14093,7 +14093,7 @@
       "property": "height-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-200",
+    "$ref": "a8f083cd-131e-4375-b948-3ef5c520cb42",
     "uuid": "7b31cf38-5bac-4f79-a4f1-172a4ea66e10"
   },
   {
@@ -15394,7 +15394,7 @@
       "property": "row-bottom-to-text-extra-large-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-bottom-to-text-300",
+    "$ref": "e731e2e4-c3bf-4dff-aca0-04201e7e17ed",
     "uuid": "effa3e3c-eb5b-4c0a-aca9-81331e6a08ac",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -15407,7 +15407,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-extra-large",
+    "$ref": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a",
     "uuid": "d13d2f2e-9425-403d-a95f-889d67f03425",
     "set_uuid": "72d2def7-a752-4b02-b476-0d58cf74dae3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15422,7 +15422,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-extra-large",
+    "$ref": "dfd0bc13-5c80-4156-bf21-ef87c7c6b29a",
     "uuid": "c9ac99be-86c3-4f6c-a2a5-3487041bc95e",
     "set_uuid": "72d2def7-a752-4b02-b476-0d58cf74dae3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15496,7 +15496,7 @@
       "property": "row-bottom-to-text-large-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-bottom-to-text-200",
+    "$ref": "36742697-2320-4bc0-8a29-ad98e342349f",
     "uuid": "15e21448-3174-4565-aed7-ab84aa30d7ac",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -15509,7 +15509,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-large",
+    "$ref": "dfe63537-564b-4f23-ac78-39a08adeaf0b",
     "uuid": "775139b2-3fb4-4019-8a3e-2377211ed0ec",
     "set_uuid": "47db1bbb-aaf2-4d31-bb52-7f260a1a069d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15524,7 +15524,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-large",
+    "$ref": "dfe63537-564b-4f23-ac78-39a08adeaf0b",
     "uuid": "151bf172-2889-4c98-8f15-5b6cdcb30d4b",
     "set_uuid": "47db1bbb-aaf2-4d31-bb52-7f260a1a069d",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15598,7 +15598,7 @@
       "property": "row-bottom-to-text-medium-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-bottom-to-text-100",
+    "$ref": "79d44793-6b19-44a7-a0bd-9f2e8431b9cd",
     "uuid": "d9d8fee2-9e0f-4c2b-8059-f9badb3b6482",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -15611,7 +15611,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-medium",
+    "$ref": "0a40f436-9f58-4c9d-9a63-77c61adba6e2",
     "uuid": "c66ff3f2-3661-464c-b722-151f72d03f2a",
     "set_uuid": "18cd494e-f66e-4825-86fb-d35262cf7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15626,7 +15626,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-medium",
+    "$ref": "0a40f436-9f58-4c9d-9a63-77c61adba6e2",
     "uuid": "e80339a8-22c4-4b53-9a4a-a4456f6cab3f",
     "set_uuid": "18cd494e-f66e-4825-86fb-d35262cf7881",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15700,7 +15700,7 @@
       "property": "row-bottom-to-text-small-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-bottom-to-text-75",
+    "$ref": "861fff6a-7163-495d-bcb1-caa87693fb55",
     "uuid": "5eb79adf-f94c-4bf8-9ec9-279f49ce5331",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -15713,7 +15713,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-small",
+    "$ref": "6353bfab-c0fa-4cfd-bf93-11c01df2f236",
     "uuid": "90ae4c5b-a49d-40ad-8dd8-b25720c13f79",
     "set_uuid": "539bf649-6bee-4fd1-b0b8-cdcf53ca17c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15728,7 +15728,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-bottom-to-text-small",
+    "$ref": "6353bfab-c0fa-4cfd-bf93-11c01df2f236",
     "uuid": "d3147ee6-dc34-46e2-8379-02d9690ff80a",
     "set_uuid": "539bf649-6bee-4fd1-b0b8-cdcf53ca17c5",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15833,7 +15833,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-extra-large",
+    "$ref": "e9908164-5b47-4098-8de3-028cd93eaa0b",
     "uuid": "9b775e1f-9348-431d-9ba8-bffb19bcbf85",
     "set_uuid": "8819d918-2f76-4980-bf68-4d6b0d12b56a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15848,7 +15848,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-extra-large",
+    "$ref": "e9908164-5b47-4098-8de3-028cd93eaa0b",
     "uuid": "2171aee7-d013-459e-a13f-33075090cbe3",
     "set_uuid": "8819d918-2f76-4980-bf68-4d6b0d12b56a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15953,7 +15953,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-large",
+    "$ref": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70",
     "uuid": "559b9fc0-389e-4e2f-985c-8741f218850a",
     "set_uuid": "b801c82b-6ad6-47aa-a6ee-fae3f07fcc2b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -15968,7 +15968,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-large",
+    "$ref": "9fd50cd5-077e-4d5a-82f5-0c6639f63e70",
     "uuid": "2e16e4ef-fec6-41fb-9d96-bc6bb6c88f69",
     "set_uuid": "b801c82b-6ad6-47aa-a6ee-fae3f07fcc2b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16073,7 +16073,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-medium",
+    "$ref": "4ca4c4bf-85eb-41f7-9348-6408b408275e",
     "uuid": "2c8f9b97-f4df-48c2-ab1a-82373d335b83",
     "set_uuid": "30dfc19e-9751-4dab-a6c3-d3480af57dfc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16088,7 +16088,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-medium",
+    "$ref": "4ca4c4bf-85eb-41f7-9348-6408b408275e",
     "uuid": "36505a4f-01b6-4b83-adf1-592818eb2c0d",
     "set_uuid": "30dfc19e-9751-4dab-a6c3-d3480af57dfc",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16193,7 +16193,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-small",
+    "$ref": "300645bd-1253-44a2-970e-33a2a028eb4f",
     "uuid": "4435c143-a75a-47c1-a629-3574b70247a3",
     "set_uuid": "614a4d4a-48dc-4b3f-8920-e033dc4db28c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16208,7 +16208,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-checkbox-to-top-small",
+    "$ref": "300645bd-1253-44a2-970e-33a2a028eb4f",
     "uuid": "a63aa24e-c956-4af5-bf4f-4c5d44bd1e16",
     "set_uuid": "614a4d4a-48dc-4b3f-8920-e033dc4db28c",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16276,7 +16276,7 @@
       "property": "row-height-extra-large-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-300",
+    "$ref": "0cc8906e-a9a2-4995-a6c2-920cb5f2b83c",
     "uuid": "dcc5dd06-bb3d-46d3-adf2-133e5be942b7"
   },
   {
@@ -16286,7 +16286,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-extra-large",
+    "$ref": "34dfc670-7333-40fc-96e0-93a466273634",
     "uuid": "face2717-9c2c-4e18-9632-4e4a595b1fc7",
     "set_uuid": "e65de693-2b8c-4c70-955d-2e6a64059ca4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16301,7 +16301,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-extra-large",
+    "$ref": "34dfc670-7333-40fc-96e0-93a466273634",
     "uuid": "b7753c9a-8854-4927-89dd-80d47bff5fa5",
     "set_uuid": "e65de693-2b8c-4c70-955d-2e6a64059ca4",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16363,7 +16363,7 @@
       "property": "row-height-large-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-200",
+    "$ref": "a8f083cd-131e-4375-b948-3ef5c520cb42",
     "uuid": "d576b4aa-e3df-4aa9-8260-fecfe6517bde"
   },
   {
@@ -16373,7 +16373,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-large",
+    "$ref": "9e54ecf6-8a66-468c-8c8c-cd79ae9a6ecd",
     "uuid": "3b22a4c7-525c-4482-9e58-19cbe46d318b",
     "set_uuid": "02c1f806-f32d-4b95-a790-dbc50cd57f0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16388,7 +16388,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-large",
+    "$ref": "9e54ecf6-8a66-468c-8c8c-cd79ae9a6ecd",
     "uuid": "b92bc058-27ea-4e86-a1a2-e5dbae3c2ee8",
     "set_uuid": "02c1f806-f32d-4b95-a790-dbc50cd57f0e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16450,7 +16450,7 @@
       "property": "row-height-medium-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-100",
+    "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
     "uuid": "b4b86a59-041d-451c-a0be-cc82e997a1d2"
   },
   {
@@ -16460,7 +16460,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-medium",
+    "$ref": "e4365ada-fe16-4c16-af28-eb9bcbb15756",
     "uuid": "1dc88a25-18bc-491a-ab02-2c1ec36f4c1e",
     "set_uuid": "6c3fec1e-6a96-400f-8188-cd2fd6f5039a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16475,7 +16475,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-medium",
+    "$ref": "e4365ada-fe16-4c16-af28-eb9bcbb15756",
     "uuid": "72e6564c-2acf-4f77-80d9-b21d2d55a580",
     "set_uuid": "6c3fec1e-6a96-400f-8188-cd2fd6f5039a",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16537,7 +16537,7 @@
       "property": "row-height-small-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-height-75",
+    "$ref": "fbdf2291-b332-4436-9e57-430c0a81d526",
     "uuid": "a6dfc911-50fe-46dd-a7a3-cec3b115006a"
   },
   {
@@ -16547,7 +16547,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-small",
+    "$ref": "a9bf30e6-0ca8-44af-8f97-149917c9f8c2",
     "uuid": "fd53964b-cf4a-4cdf-b088-418364b1c518",
     "set_uuid": "f8519e64-027c-4724-b5f3-772ee266ba78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16562,7 +16562,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-height-small",
+    "$ref": "a9bf30e6-0ca8-44af-8f97-149917c9f8c2",
     "uuid": "cdbb999d-c2a9-4325-9689-bede2ad3559a",
     "set_uuid": "f8519e64-027c-4724-b5f3-772ee266ba78",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16630,7 +16630,7 @@
       "property": "row-top-to-text-extra-large-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-300",
+    "$ref": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
     "uuid": "2e8eff8c-60fa-4e0f-ae40-7b9f9b3679d6",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -16643,7 +16643,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-extra-large",
+    "$ref": "cf9418b9-a5ff-47ee-b19d-b933629f3072",
     "uuid": "03555438-78f5-429a-a0dd-c6777dc36372",
     "set_uuid": "b7562d01-f178-4ab0-bef4-e1f8e5f0f901",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16658,7 +16658,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-extra-large",
+    "$ref": "cf9418b9-a5ff-47ee-b19d-b933629f3072",
     "uuid": "c381a3c4-e0a3-4e86-b279-f51ee6e9e532",
     "set_uuid": "b7562d01-f178-4ab0-bef4-e1f8e5f0f901",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16732,7 +16732,7 @@
       "property": "row-top-to-text-large-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-200",
+    "$ref": "306b871f-cbfa-49a2-a74b-dd120bbff503",
     "uuid": "14437ed2-c60b-40ba-91e6-bed5353fc544",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -16745,7 +16745,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-large",
+    "$ref": "de73e367-5c1a-4532-bd93-644f066fa2f3",
     "uuid": "2ed03fb3-fed4-41d4-8a14-f7446bb76486",
     "set_uuid": "5be48be9-1157-411c-8357-b48451ee195e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16760,7 +16760,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-large",
+    "$ref": "de73e367-5c1a-4532-bd93-644f066fa2f3",
     "uuid": "0108018e-6146-45c9-b032-e3d44dfb8d84",
     "set_uuid": "5be48be9-1157-411c-8357-b48451ee195e",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16834,7 +16834,7 @@
       "property": "row-top-to-text-medium-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-100",
+    "$ref": "46ca4b6d-c739-478b-9862-41e5d2f5db9b",
     "uuid": "02c5faff-dbb4-4633-ae57-413b3666dfca",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -16847,7 +16847,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-medium",
+    "$ref": "6f81b550-82ce-436f-9e33-93a247eaae54",
     "uuid": "8e1448f8-5806-4629-8131-4e8422b26870",
     "set_uuid": "40e31948-a58c-41f8-968b-2eaf58a1832f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16862,7 +16862,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-medium",
+    "$ref": "6f81b550-82ce-436f-9e33-93a247eaae54",
     "uuid": "7df1dc32-b96d-41e3-a372-9bcaec7c2ccb",
     "set_uuid": "40e31948-a58c-41f8-968b-2eaf58a1832f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16936,7 +16936,7 @@
       "property": "row-top-to-text-small-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "component-top-to-text-75",
+    "$ref": "1a76668b-c733-4ec0-ae84-774f4e6e861a",
     "uuid": "b7e7808a-16c6-481a-9257-9c1dc4e13b62",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token table-item-padding-compact instead. Refactor may be necessary",
@@ -16949,7 +16949,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-small",
+    "$ref": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba",
     "uuid": "5e5a6837-34c9-4f01-8769-b66c3f602d1f",
     "set_uuid": "116a4042-45aa-41d3-8964-b9f9cdfb5e0f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -16964,7 +16964,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-row-top-to-text-small",
+    "$ref": "c1be9ecb-be3e-4ed3-9e74-46d299b69fba",
     "uuid": "98014297-14dc-4547-944a-8951c7f6f253",
     "set_uuid": "116a4042-45aa-41d3-8964-b9f9cdfb5e0f",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17165,7 +17165,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-extra-large",
+    "$ref": "65180f74-078a-48db-aea1-e095d37f9e00",
     "uuid": "17c4c578-d3e1-44c0-bd21-ee4df5cb2027",
     "set_uuid": "bfbef5d5-293c-4366-aef3-58e44a06500b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17180,7 +17180,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-extra-large",
+    "$ref": "65180f74-078a-48db-aea1-e095d37f9e00",
     "uuid": "b60c33b8-acc1-4af1-b30f-b467054ee417",
     "set_uuid": "bfbef5d5-293c-4366-aef3-58e44a06500b",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17285,7 +17285,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-large",
+    "$ref": "bea15b38-2401-4051-9c87-c0dc347e7d1d",
     "uuid": "de6e6ae5-eae6-4f7a-89be-176674176242",
     "set_uuid": "00499404-08ab-4a8a-9939-035374dfe2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17300,7 +17300,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-large",
+    "$ref": "bea15b38-2401-4051-9c87-c0dc347e7d1d",
     "uuid": "fc7efe7c-ef97-424f-89c2-2211daf44b4a",
     "set_uuid": "00499404-08ab-4a8a-9939-035374dfe2f3",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17405,7 +17405,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-medium",
+    "$ref": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd",
     "uuid": "12a6fd11-d3a5-4d72-9942-89d828d1d256",
     "set_uuid": "d51b5484-2bae-48f1-890a-fc90198ea480",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17420,7 +17420,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-medium",
+    "$ref": "fa53e899-0a50-41a1-bf3b-ebb70df69dbd",
     "uuid": "75af7a67-e0ae-4f41-9c70-09babbc587d1",
     "set_uuid": "d51b5484-2bae-48f1-890a-fc90198ea480",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17525,7 +17525,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-small",
+    "$ref": "6db35635-76fd-4ef3-9a44-c0b6354550ca",
     "uuid": "db98283d-1f25-4323-9f3a-0555b9670ba6",
     "set_uuid": "3d54e517-3d92-4adb-83e4-8f1cccc63673",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -17540,7 +17540,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "table-thumbnail-to-top-minimum-small",
+    "$ref": "6db35635-76fd-4ef3-9a44-c0b6354550ca",
     "uuid": "e25b14a7-cb9e-406b-bab6-b27575f00a52",
     "set_uuid": "3d54e517-3d92-4adb-83e4-8f1cccc63673",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -18368,7 +18368,7 @@
       "property": "corner-radius"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-75",
+    "$ref": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20",
     "uuid": "13681294-e3c6-4898-a17e-943932a53c08"
   },
   {
@@ -18696,7 +18696,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "2be8bfb1-7a0c-452d-9532-ea2eda408b82"
   },
   {
@@ -18705,7 +18705,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "c03b6bc7-76b6-4533-883e-881438de975f"
   },
   {
@@ -18714,7 +18714,7 @@
       "property": "cjk-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-font-family",
+    "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
     "uuid": "6fa83674-af7c-4656-8b33-d3312534ee53"
   },
   {
@@ -18723,7 +18723,7 @@
       "property": "cjk-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "f421339b-fc3b-4d4e-86b4-65a63584131b"
   },
   {
@@ -18732,7 +18732,7 @@
       "property": "cjk-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "57a5eaba-935d-47e5-9cc4-cc1da6a330de"
   },
   {
@@ -18741,7 +18741,7 @@
       "property": "cjk-line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-line-height-100",
+    "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
     "uuid": "999ba22a-87b6-45fe-9e89-9911f34ea330"
   },
   {
@@ -18750,7 +18750,7 @@
       "property": "cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "2fcf237b-6988-4c31-a806-f4176b94c2a8"
   },
   {
@@ -18759,7 +18759,7 @@
       "property": "cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "d1bccaa7-731f-4df2-a4c3-9dbec33145fd"
   },
   {
@@ -18768,7 +18768,7 @@
       "property": "cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "a134fab9-7606-453d-a64f-fd2daa989283"
   },
   {
@@ -18777,7 +18777,7 @@
       "property": "cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "99472fda-7d17-45d5-b2ba-0c79a45d628f"
   },
   {
@@ -18786,7 +18786,7 @@
       "property": "cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-50",
+    "$ref": "c6074b73-d460-439d-9401-498f52c88340",
     "uuid": "f5966933-93a3-4615-a19b-b94d6a0367da"
   },
   {
@@ -18795,7 +18795,7 @@
       "property": "cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "abbc512e-fdce-4025-9d08-5a71692cf523"
   },
   {
@@ -18804,7 +18804,7 @@
       "property": "cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-500",
+    "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
     "uuid": "223b1966-4dbb-4e89-b508-9191ffedc97c"
   },
   {
@@ -18813,7 +18813,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "55c1dcc1-f296-47eb-989b-ae5e22748869"
   },
   {
@@ -18822,7 +18822,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "ba6356fb-cada-4786-9306-71b940e61ca8"
   },
   {
@@ -18831,7 +18831,7 @@
       "property": "cjk-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "85e5ba03-3f0a-4245-a26c-ac9c3df23d1b"
   },
   {
@@ -18840,7 +18840,7 @@
       "property": "cjk-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "93e5a426-7229-46ee-89f6-a84f7084592b"
   },
   {
@@ -18849,7 +18849,7 @@
       "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "line-height-100",
+    "$ref": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
     "uuid": "e1397d35-0c23-410c-a213-65db1eb4887f"
   },
   {
@@ -18876,7 +18876,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "98fd5c98-b53d-49f0-bce1-705b53ae9ae4"
   },
   {
@@ -18885,7 +18885,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "4fe9b508-ff74-4819-8188-e080d814d9ef"
   },
   {
@@ -18894,7 +18894,7 @@
       "property": "sans-serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "sans-serif-font-family",
+    "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
     "uuid": "9a65d2f0-87c0-404b-9965-6e4b00efeda8"
   },
   {
@@ -18903,7 +18903,7 @@
       "property": "sans-serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "faa965d6-42c0-40f9-802e-ff0ea69d740d"
   },
   {
@@ -18912,7 +18912,7 @@
       "property": "sans-serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "58a27a2e-58c6-42dc-b860-1a8458966da4"
   },
   {
@@ -18921,7 +18921,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "39c10c1e-56c1-4a94-b5b9-a91a2db92050"
   },
   {
@@ -18930,7 +18930,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "ab0482d5-ff9a-4c50-876b-ed5accf067a4"
   },
   {
@@ -18939,7 +18939,7 @@
       "property": "sans-serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "871928bc-14ac-465d-b245-c39bcf265a72"
   },
   {
@@ -18948,7 +18948,7 @@
       "property": "sans-serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "ace1f3cb-629c-4172-b64f-a8b1f5afbdcc"
   },
   {
@@ -18957,7 +18957,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "cf6281f7-00ef-437e-b89b-d6d774818f0b"
   },
   {
@@ -18966,7 +18966,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "3abd6cd1-42f5-4b4b-9732-bb826fe0a740"
   },
   {
@@ -18975,7 +18975,7 @@
       "property": "serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "serif-font-family",
+    "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
     "uuid": "b3098f42-d73e-4228-a4f9-9be4b0c46ce8"
   },
   {
@@ -18984,7 +18984,7 @@
       "property": "serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "70955f1b-4124-432e-bd9d-c5b42c890195"
   },
   {
@@ -18993,7 +18993,7 @@
       "property": "serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "23cf3a6f-911c-4e64-8952-7412bc7f4629"
   },
   {
@@ -19002,7 +19002,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "6359f577-d462-456b-a748-ceecb893b4a2"
   },
   {
@@ -19011,7 +19011,7 @@
       "component": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "c2a2882b-f048-4580-96c8-76556fccc87c"
   },
   {
@@ -19020,7 +19020,7 @@
       "property": "serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "6d2f0e78-e527-41c7-8843-af89a9790da6"
   },
   {
@@ -19029,7 +19029,7 @@
       "property": "serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "a0367ebf-8cc8-4aa0-80c4-ccf4a03644a3"
   },
   {
@@ -19038,7 +19038,7 @@
       "property": "size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "0fb9e5ec-e5b7-41e0-8ef4-db9e4e33e060"
   },
   {
@@ -19047,7 +19047,7 @@
       "property": "size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "6d63a369-4261-44a4-bf8d-a567dffa8ef6"
   },
   {
@@ -19056,7 +19056,7 @@
       "property": "size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "0babc342-b506-495d-aaf1-20fe9e571e1b"
   },
   {
@@ -19065,7 +19065,7 @@
       "property": "size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "b5aaaa50-721b-4b41-ad90-345cd995f69e"
   },
   {
@@ -19074,7 +19074,7 @@
       "property": "size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "68dac9e8-9b07-4453-8cb2-24ed349d2134"
   },
   {
@@ -19083,7 +19083,7 @@
       "property": "size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-500",
+    "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
     "uuid": "d4c4db99-70f2-4c79-8595-4d23407de068"
   },
   {
@@ -19092,7 +19092,7 @@
       "property": "size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-600",
+    "$ref": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
     "uuid": "56152e6a-3058-4467-86a1-34fa2b6f75b2"
   },
   {
@@ -19589,7 +19589,7 @@
       "property": "item-to-item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "tree-view-item-to-item-default",
+    "$ref": "7d44a2b5-0aa6-4770-81da-8dbd87013906",
     "uuid": "9a04f19a-9e2a-43b9-9b1f-3385aef214ac",
     "deprecated": "unknown",
     "deprecated_comment": "This token has been deprecated, use tree-view-item-to-item-default instead.",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -174,7 +174,7 @@
       "property": "banner-gap-horizontal"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-400",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
     "uuid": "c0571c46-5946-4896-bcbf-270560de5385",
     "description": "Spacing between child elements for banner components"
   },
@@ -183,7 +183,7 @@
       "property": "banner-gap-vertical"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "312ebac2-32a0-47a8-9c4e-e366b2232228",
     "description": "Spacing between child elements for banner components"
   },
@@ -192,7 +192,7 @@
       "property": "banner-padding-horizontal"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "eb386242-21c6-437b-8125-e6d4394dd9c5",
     "description": "Horizontal internal spacing for banner components"
   },
@@ -201,7 +201,7 @@
       "property": "banner-padding-horizontal-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "7f237198-3842-49bc-aa79-e723fbe6c78e",
     "description": "Horizontal internal spacing for banner components (compact density)"
   },
@@ -210,7 +210,7 @@
       "property": "banner-padding-vertical"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "64fa4ab7-be93-4420-8cdc-a6ef91499852",
     "description": "Vertical internal spacing for banner components"
   },
@@ -345,7 +345,7 @@
       "property": "base-padding-horizontal-uniform-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-2x-large",
+    "$ref": "51761a5c-200d-467d-a575-3722f825edb9",
     "uuid": "9c571815-ef7f-4baa-9c7f-32a6f89052b7",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-large size"
   },
@@ -354,7 +354,7 @@
       "property": "base-padding-horizontal-uniform-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-2x-small",
+    "$ref": "c5f12db9-a471-4678-9828-e9b3d80f550d",
     "uuid": "af1d798e-4235-44a3-a327-1779c134b72b",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at 2x-small size"
   },
@@ -363,7 +363,7 @@
       "property": "base-padding-horizontal-uniform-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-extra-large",
+    "$ref": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc",
     "uuid": "54f547dc-cb51-4eb2-91ff-b0f7b383f072",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-large size"
   },
@@ -372,7 +372,7 @@
       "property": "base-padding-horizontal-uniform-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-extra-small",
+    "$ref": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47",
     "uuid": "337ce5da-d735-4930-a9c8-9fecf4dcb9b0",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at extra-small size"
   },
@@ -381,7 +381,7 @@
       "property": "base-padding-horizontal-uniform-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-large",
+    "$ref": "cc707192-e70f-4965-8582-55fa97d02184",
     "uuid": "1006824d-539b-408e-afd6-1e77779b9d21",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at large size"
   },
@@ -390,7 +390,7 @@
       "property": "base-padding-horizontal-uniform-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-medium",
+    "$ref": "5741f832-f012-45bc-9e87-6e07ab2cb87f",
     "uuid": "a982f1e2-0545-4ca3-8104-32208ea9e152",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at medium size"
   },
@@ -399,7 +399,7 @@
       "property": "base-padding-horizontal-uniform-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "base-padding-vertical-small",
+    "$ref": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d",
     "uuid": "3c42cb65-d84e-4cfd-bf17-e9f21ce17b7e",
     "description": "Horizontal internal spacing with uniform dimensions for base UI elements at small size"
   },
@@ -2240,7 +2240,7 @@
       "property": "container-gap-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-500",
+    "$ref": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
     "uuid": "4b6cd7dd-2b7c-4fec-935e-8ea88de4c412",
     "description": "Spacing between child elements for containers at 2x-large size"
   },
@@ -2249,7 +2249,7 @@
       "property": "container-gap-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-85",
+    "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
     "uuid": "b83df7f2-8811-4bad-b012-213e430e2aaf",
     "description": "Spacing between child elements for containers at 2x-small size"
   },
@@ -2258,7 +2258,7 @@
       "property": "container-gap-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-400",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
     "uuid": "c9c7652f-0332-417f-8520-e2202d7a08dc",
     "description": "Spacing between child elements for containers at extra-large size"
   },
@@ -2267,7 +2267,7 @@
       "property": "container-gap-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "9c79efdc-ab56-4f2e-b44d-5641d2480964",
     "description": "Spacing between child elements for containers at extra-small size"
   },
@@ -2276,7 +2276,7 @@
       "property": "container-gap-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-350",
+    "$ref": "b352f0f0-5843-4c65-8357-625b938ccaa0",
     "uuid": "236385bb-9e50-484c-912d-a71fe33924f4",
     "description": "Spacing between child elements for containers at large size"
   },
@@ -2285,7 +2285,7 @@
       "property": "container-gap-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "06d1563b-7d67-400a-bcfa-bc320c2b7a28",
     "description": "Spacing between child elements for containers at medium size"
   },
@@ -2294,7 +2294,7 @@
       "property": "container-gap-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "bd1948af-f4eb-46ed-9ab5-cbd93b5e0935",
     "description": "Spacing between child elements for containers at small size"
   },
@@ -2303,7 +2303,7 @@
       "property": "container-padding-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-500",
+    "$ref": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
     "uuid": "3801295f-e52b-412a-baf4-0b8e20449333",
     "description": "Internal spacing for containers at 2x-large size"
   },
@@ -2312,7 +2312,7 @@
       "property": "container-padding-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-85",
+    "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
     "uuid": "f0d9117a-5606-4e49-a81f-f89938b34ca4",
     "description": "Internal spacing for containers at 2x-small size"
   },
@@ -2321,7 +2321,7 @@
       "property": "container-padding-3x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-600",
+    "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",
     "uuid": "e595caf6-37f9-4f84-b81b-dd44ed0d6431",
     "description": "Internal spacing for containers at 3x-large size"
   },
@@ -2330,7 +2330,7 @@
       "property": "container-padding-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-400",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
     "uuid": "2e855806-0f65-4df0-9d8f-74428daa358d",
     "description": "Internal spacing for containers at extra-large size"
   },
@@ -2339,7 +2339,7 @@
       "property": "container-padding-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "9fcd2823-9a13-44c0-a613-7dbe272b99a9",
     "description": "Internal spacing for containers at extra-small size"
   },
@@ -2348,7 +2348,7 @@
       "property": "container-padding-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-350",
+    "$ref": "b352f0f0-5843-4c65-8357-625b938ccaa0",
     "uuid": "4cf528c8-fc7a-447b-ae4d-38b744ec1b0f",
     "description": "Internal spacing for containers at large size"
   },
@@ -2357,7 +2357,7 @@
       "property": "container-padding-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "81e5f983-4ca0-4d45-89f0-4accd78d7946",
     "description": "Internal spacing for containers at medium size"
   },
@@ -2366,7 +2366,7 @@
       "property": "container-padding-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "4c8d7d30-f0fb-4306-b78a-09ec0f2ffd97",
     "description": "Internal spacing for containers at small size"
   },
@@ -2464,7 +2464,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-800",
+    "$ref": "8fc023ca-8aec-40fe-9130-087aa035bac7",
     "uuid": "d639a0b5-16b4-4d75-ab37-d87815c7b500"
   },
   {
@@ -2472,7 +2472,7 @@
       "property": "corner-radius-full"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-1000",
+    "$ref": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b",
     "uuid": "4853520b-bda3-45d1-bd20-8508cac08847"
   },
   {
@@ -2481,7 +2481,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-700",
+    "$ref": "cb6b72ed-a9a1-4113-b147-1ef369fe6269",
     "uuid": "29981aef-aea6-4cde-849f-4bc67e320ea7"
   },
   {
@@ -2490,7 +2490,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-500",
+    "$ref": "ada2ea1d-1728-411a-8aae-a198ce390a25",
     "uuid": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6"
   },
   {
@@ -2498,7 +2498,7 @@
       "property": "corner-radius-medium-size-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-700",
+    "$ref": "cb6b72ed-a9a1-4113-b147-1ef369fe6269",
     "uuid": "81752b3e-488a-4273-abb5-4ba8b7f278d9"
   },
   {
@@ -2506,7 +2506,7 @@
       "property": "corner-radius-medium-size-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-300",
+    "$ref": "154642d7-c23d-44fd-9d79-b719ef32922e",
     "uuid": "d0e02d98-e93f-4f81-8d81-8f95e06ad360"
   },
   {
@@ -2514,7 +2514,7 @@
       "property": "corner-radius-medium-size-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-600",
+    "$ref": "abc0f309-3bd2-4800-af12-b27386e86617",
     "uuid": "ede17e00-83ef-40c5-a1d0-a46372d3fc90"
   },
   {
@@ -2522,7 +2522,7 @@
       "property": "corner-radius-medium-size-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-500",
+    "$ref": "ada2ea1d-1728-411a-8aae-a198ce390a25",
     "uuid": "67fb5355-6d7c-4e4e-a4cb-cdba10a85d84"
   },
   {
@@ -2530,7 +2530,7 @@
       "property": "corner-radius-medium-size-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-400",
+    "$ref": "690db7ae-cae8-49bb-8777-b4f1829b2f0b",
     "uuid": "892bc9de-16b2-4c51-9c18-b239e52ffd14"
   },
   {
@@ -2538,7 +2538,7 @@
       "property": "corner-radius-none"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-0",
+    "$ref": "bb9d8350-b1fb-4496-9c22-6ec9647ff117",
     "uuid": "7a11b308-bed2-4b6f-bb4a-c9ae4ef8e03d"
   },
   {
@@ -2547,7 +2547,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-100",
+    "$ref": "bf24d15e-ad86-4b6a-a9e0-e8fd49a5ae30",
     "uuid": "b4971f86-aeea-42c9-9ba7-a74cf4d1a545"
   },
   {
@@ -2555,7 +2555,7 @@
       "property": "corner-radius-small-size-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-300",
+    "$ref": "154642d7-c23d-44fd-9d79-b719ef32922e",
     "uuid": "d59337d1-4cec-43c0-821e-06a56745cbcc"
   },
   {
@@ -2563,7 +2563,7 @@
       "property": "corner-radius-small-size-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-200",
+    "$ref": "52ad01be-f512-4fa3-ae67-8c6cef70810c",
     "uuid": "f4f0bfc9-ce6d-473f-8dda-c9f21fb8a7b7"
   },
   {
@@ -2571,7 +2571,7 @@
       "property": "corner-radius-small-size-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-100",
+    "$ref": "bf24d15e-ad86-4b6a-a9e0-e8fd49a5ae30",
     "uuid": "a62a43dd-cb2a-4e18-bb94-7a9518668400"
   },
   {
@@ -2579,7 +2579,7 @@
       "property": "corner-radius-small-size-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "corner-radius-75",
+    "$ref": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20",
     "uuid": "3d39e5de-0800-4629-ae1a-99a34706a772"
   },
   {
@@ -2787,7 +2787,7 @@
       "property": "drop-shadow-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-blur-100",
+    "$ref": "025e39f4-dfe7-4a8a-beb5-bd0577f72eac",
     "uuid": "ac20a6da-31a7-4c8b-b361-0ad820cd8429",
     "deprecated": "unknown"
   },
@@ -2820,7 +2820,7 @@
       "property": "drop-shadow-dragged-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-blur-300",
+    "$ref": "34812e0c-7ccf-49c2-884a-6fecd45f7c5a",
     "uuid": "f6015252-21fb-48f9-aadb-5ad050e3d590"
   },
   {
@@ -2828,7 +2828,7 @@
       "property": "drop-shadow-dragged-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-x-300",
+    "$ref": "cb6d74fe-cc32-47ff-bf8b-74597643a8a6",
     "uuid": "be5c80b4-5769-491b-9550-fcf94f0c762e"
   },
   {
@@ -2836,7 +2836,7 @@
       "property": "drop-shadow-dragged-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-y-300",
+    "$ref": "5d09089b-c0c5-4122-a3be-3e989562acda",
     "uuid": "ff8d4fda-72fa-4256-b2c8-f22a9d3e644f"
   },
   {
@@ -2844,7 +2844,7 @@
       "property": "drop-shadow-elevated-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-blur-200",
+    "$ref": "2b08d425-ecf2-4891-83cd-005a2d5e76ce",
     "uuid": "f3487a86-3aea-4527-8b5c-287c0bddad6c"
   },
   {
@@ -2852,7 +2852,7 @@
       "property": "drop-shadow-elevated-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-x-200",
+    "$ref": "0c76c925-4d29-49a3-b882-e946bd7fe9f1",
     "uuid": "59324423-4428-40d7-a227-5f75aeb38312"
   },
   {
@@ -2860,7 +2860,7 @@
       "property": "drop-shadow-elevated-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-y-200",
+    "$ref": "d2d0320a-6984-4b3f-8f5d-ccb88892a26c",
     "uuid": "45f313a5-1749-4b95-b5e3-20944adbea84"
   },
   {
@@ -2868,7 +2868,7 @@
       "property": "drop-shadow-emphasized-default-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-blur-100",
+    "$ref": "025e39f4-dfe7-4a8a-beb5-bd0577f72eac",
     "uuid": "57920fe8-72ad-48d2-aa9b-feec4c989106"
   },
   {
@@ -2876,7 +2876,7 @@
       "property": "drop-shadow-emphasized-default-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-x-100",
+    "$ref": "751d636e-efb5-411e-a5b8-06b11439cc90",
     "uuid": "5b611aa8-9db2-495d-a119-3385eee62442"
   },
   {
@@ -2884,7 +2884,7 @@
       "property": "drop-shadow-emphasized-default-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-y-100",
+    "$ref": "ed1f46fd-a586-46a5-8cc1-d843a57e2cc2",
     "uuid": "02949dd5-0596-44bc-8b63-dcc7d2ba628b"
   },
   {
@@ -2892,7 +2892,7 @@
       "property": "drop-shadow-emphasized-hover-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-blur-200",
+    "$ref": "2b08d425-ecf2-4891-83cd-005a2d5e76ce",
     "uuid": "5f6674e8-ef00-490a-800d-3b946059bae2"
   },
   {
@@ -2900,7 +2900,7 @@
       "property": "drop-shadow-emphasized-hover-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-x-200",
+    "$ref": "0c76c925-4d29-49a3-b882-e946bd7fe9f1",
     "uuid": "d86f7c89-92a6-4bad-83b0-43953472ce7f"
   },
   {
@@ -2908,7 +2908,7 @@
       "property": "drop-shadow-emphasized-hover-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-y-200",
+    "$ref": "d2d0320a-6984-4b3f-8f5d-ccb88892a26c",
     "uuid": "da17e314-f3e9-4d49-9362-533eb65c0f7b"
   },
   {
@@ -2916,7 +2916,7 @@
       "property": "drop-shadow-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-x-100",
+    "$ref": "751d636e-efb5-411e-a5b8-06b11439cc90",
     "uuid": "81415747-aa3f-4ef3-b0bc-7c33f07a4316",
     "deprecated": "unknown"
   },
@@ -2949,7 +2949,7 @@
       "property": "drop-shadow-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "drop-shadow-y-100",
+    "$ref": "ed1f46fd-a586-46a5-8cc1-d843a57e2cc2",
     "uuid": "c530129f-248c-4e36-ba7f-05d6d6a53962",
     "deprecated": "unknown"
   },
@@ -2982,7 +2982,7 @@
       "property": "drop-target-dash-gap"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-85",
+    "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
     "uuid": "5582026a-22e6-4e0e-9a21-2a7a43b026a6",
     "description": "Dash gap spacing for drop targets"
   },
@@ -2991,7 +2991,7 @@
       "property": "drop-target-dash-length"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "24cd8175-3dc5-46ae-b1af-01632787fcd8",
     "description": "Dash length for drop targets"
   },
@@ -4503,7 +4503,7 @@
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "field-width-small",
+    "$ref": "d316d676-b4cf-4d16-b89c-63ef1d969861",
     "uuid": "096ddcb7-5afd-416f-9a11-4275556c4b52",
     "set_uuid": "ad37a519-be52-492e-a816-03ed7608fe65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -4517,7 +4517,7 @@
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "field-width-small",
+    "$ref": "d316d676-b4cf-4d16-b89c-63ef1d969861",
     "uuid": "08c2390a-353b-4e6b-b025-dbaeaa5fdff2",
     "set_uuid": "ad37a519-be52-492e-a816-03ed7608fe65",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -4530,7 +4530,7 @@
       "property": "field-width-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "field-default-width-extra-large",
+    "$ref": "5ab58f4b-2493-499a-ab97-f7533de2c5fa",
     "uuid": "a903b595-ffe8-43ae-af9b-7b6577191dc5",
     "deprecated": "unknown",
     "deprecated_comment": "This token has been deprecated, use field-default-width-extra-large instead.",
@@ -4541,7 +4541,7 @@
       "property": "field-width-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "field-default-width-large",
+    "$ref": "4b7418ca-2384-4470-bfca-d8f742681740",
     "uuid": "cc43e053-1255-403f-aaf5-2182f5438592",
     "deprecated": "unknown",
     "deprecated_comment": "This token has been deprecated, use field-default-width-large instead.",
@@ -4552,7 +4552,7 @@
       "property": "field-width-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "field-default-width-medium",
+    "$ref": "7e5eb477-85b4-46c3-a5eb-ac986b3298e2",
     "uuid": "935927d3-b25e-468a-999a-938643901e50",
     "deprecated": "unknown",
     "deprecated_comment": "This token has been deprecated, use field-default-width-medium instead.",
@@ -4563,7 +4563,7 @@
       "property": "field-width-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "field-default-width-small",
+    "$ref": "2fe6f129-a722-46ca-9f87-2cebcd2faa38",
     "uuid": "d316d676-b4cf-4d16-b89c-63ef1d969861",
     "deprecated": "unknown",
     "deprecated_comment": "This token has been deprecated, use field-default-width-small instead.",
@@ -4593,7 +4593,7 @@
       "property": "focus-ring-gap"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-50",
+    "$ref": "1b06f6e2-d9be-4934-b3da-bed75986d104",
     "uuid": "fb035d45-e63b-4cd4-b220-675a52e99399",
     "description": "Spacing between child elements for focus indicators"
   },
@@ -4650,7 +4650,7 @@
       "property": "group-gap-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-50",
+    "$ref": "1b06f6e2-d9be-4934-b3da-bed75986d104",
     "uuid": "0f93a6a8-0128-4ee3-81a1-53216e069acc",
     "description": "Spacing between child elements (compact density)"
   },
@@ -4659,7 +4659,7 @@
       "property": "group-gap-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "89e74f93-9124-41a8-96b0-0fcc5ce9ab08",
     "description": "Spacing between child elements at extra-large size"
   },
@@ -4668,7 +4668,7 @@
       "property": "group-gap-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "c3ada312-da94-4779-bbf0-0fde3beb8121",
     "description": "Spacing between child elements at extra-small size"
   },
@@ -4677,7 +4677,7 @@
       "property": "group-gap-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "fd40a531-eee6-48b2-8212-a33d012a2173",
     "description": "Spacing between child elements at large size"
   },
@@ -4686,7 +4686,7 @@
       "property": "group-gap-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "6f2ccc0b-42ff-4f1a-a789-527427440d13",
     "description": "Spacing between child elements at medium size"
   },
@@ -4695,7 +4695,7 @@
       "property": "group-gap-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-85",
+    "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
     "uuid": "ce1865aa-9f33-492a-80c6-981fd503d70c",
     "description": "Spacing between child elements at small size"
   },
@@ -4714,7 +4714,7 @@
       "property": "list-gap-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-50",
+    "$ref": "1b06f6e2-d9be-4934-b3da-bed75986d104",
     "uuid": "a66810ec-1839-4ca3-8036-d552a71b1511",
     "description": "Spacing between child elements for list structures (compact density)"
   },
@@ -4723,7 +4723,7 @@
       "property": "list-gap-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "b7e1af59-753e-4059-8f46-8d862f631ad8",
     "description": "Spacing between child elements for list structures (regular density)"
   },
@@ -4732,7 +4732,7 @@
       "property": "list-gap-spacious"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "2a22e67c-5c2b-452b-8d51-b0396677898c",
     "description": "Spacing between child elements for list structures (spacious density)"
   },
@@ -4741,7 +4741,7 @@
       "property": "list-indent-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-400",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
     "uuid": "c5c94124-c16d-46f1-a22a-acf1378846bc",
     "description": "Indentation for list structures at large size"
   },
@@ -4750,7 +4750,7 @@
       "property": "list-indent-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "9af302c3-7cf8-4b03-b6d1-4af5e641d67f",
     "description": "Indentation for list structures at medium size"
   },
@@ -4759,7 +4759,7 @@
       "property": "list-item-gap-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "3cd1e483-969b-492c-8d44-d29348c981a5",
     "description": "Spacing between child elements for list structures items at medium size"
   },
@@ -4768,7 +4768,7 @@
       "property": "list-item-gap-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-50",
+    "$ref": "1b06f6e2-d9be-4934-b3da-bed75986d104",
     "uuid": "a8a20ecd-480e-4681-8639-c44d6dcb0658",
     "description": "Spacing between child elements for list structures items at small size"
   },
@@ -4777,7 +4777,7 @@
       "property": "list-item-padding-horizontal"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-85",
+    "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
     "uuid": "2147f873-8f42-4821-9654-9db2b1adc2f9",
     "description": "Horizontal internal spacing for list structures items"
   },
@@ -4786,7 +4786,7 @@
       "property": "list-item-padding-vertical-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-75",
+    "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",
     "uuid": "6207cc71-4b5d-4ada-ad9d-07ec0d51487c",
     "description": "Vertical internal spacing for list structures items (regular density)"
   },
@@ -4795,7 +4795,7 @@
       "property": "list-item-padding-vertical-spacious"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "71a2a059-e5d7-4965-a4c0-5ed1fee74c6a",
     "description": "Vertical internal spacing for list structures items (spacious density)"
   },
@@ -4916,7 +4916,7 @@
       "property": "popover-gap"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "6bae40ba-3b57-4e4b-a8a7-4044cd729068",
     "description": "Spacing between child elements for popover components"
   },
@@ -4925,7 +4925,7 @@
       "property": "popover-padding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "c872da51-317e-44cf-aef8-2f5f9fb77ae8",
     "description": "Internal spacing for popover components"
   },
@@ -5130,7 +5130,7 @@
       "property": "tab-gap-horizontal-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-600",
+    "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",
     "uuid": "0c958750-2c96-453b-9464-f041ac126749",
     "description": "Spacing between child elements for tab components at extra-large size"
   },
@@ -5139,7 +5139,7 @@
       "property": "tab-gap-horizontal-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-500",
+    "$ref": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
     "uuid": "8932b4cf-300f-4377-bbda-7fc02011cd37",
     "description": "Spacing between child elements for tab components at large size"
   },
@@ -5148,7 +5148,7 @@
       "property": "tab-gap-horizontal-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-400",
+    "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
     "uuid": "7a5f3049-0c20-4ff8-84ea-d161e58546fb",
     "description": "Spacing between child elements for tab components at medium size"
   },
@@ -5157,7 +5157,7 @@
       "property": "tab-gap-horizontal-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-350",
+    "$ref": "b352f0f0-5843-4c65-8357-625b938ccaa0",
     "uuid": "a41aaa58-77af-476e-9050-4f4864c8c3f9",
     "description": "Spacing between child elements for tab components at small size"
   },
@@ -5166,7 +5166,7 @@
       "property": "table-item-padding-compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-100",
+    "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
     "uuid": "42473d6e-5f40-46c7-9bbc-302e355ae6ae",
     "description": "Internal spacing for table structures items (compact density)"
   },
@@ -5175,7 +5175,7 @@
       "property": "table-item-padding-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-200",
+    "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
     "uuid": "15ffb38e-341b-4c47-a6b3-c197e05afffe",
     "description": "Internal spacing for table structures items (regular density)"
   },
@@ -5184,7 +5184,7 @@
       "property": "table-item-padding-spacious"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-300",
+    "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
     "uuid": "a775a186-802e-4256-947c-7fda3ac53caa",
     "description": "Internal spacing for table structures items (spacious density)"
   },
@@ -5593,7 +5593,7 @@
       "property": "window-to-edge"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "spacing-600",
+    "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",
     "uuid": "a3e53161-c38a-4ee0-88c2-4a36fd530e51",
     "deprecated": "unknown",
     "deprecated_comment": "Use semantic token container-padding-3x-large instead.",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -4,7 +4,7 @@
       "property": "accent-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-100",
+    "$ref": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
     "uuid": "2e080bb5-6f2c-4fd9-96a2-bf9fc19d2649"
   },
   {
@@ -12,7 +12,7 @@
       "property": "accent-color-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1000",
+    "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
     "uuid": "9bf3fa2f-75d3-44d3-ae30-d88893665366"
   },
   {
@@ -20,7 +20,7 @@
       "property": "accent-color-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1100",
+    "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
     "uuid": "f7f853a5-f091-4a7e-8aea-68d060c840f0"
   },
   {
@@ -28,7 +28,7 @@
       "property": "accent-color-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1200",
+    "$ref": "5c04481e-664e-4e9a-8da9-841e349167f5",
     "uuid": "7c141cdb-1e5e-468a-ba48-0df01b275402"
   },
   {
@@ -36,7 +36,7 @@
       "property": "accent-color-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1300",
+    "$ref": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
     "uuid": "f7307eba-e311-41a8-bb50-0b1e96833dfa"
   },
   {
@@ -44,7 +44,7 @@
       "property": "accent-color-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1400",
+    "$ref": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
     "uuid": "06585cf4-a924-49b2-b6c8-f0e80b57c576"
   },
   {
@@ -52,7 +52,7 @@
       "property": "accent-color-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1500",
+    "$ref": "be3d8c39-72f3-4134-b009-4aa30fb01883",
     "uuid": "c43d9991-8929-4b1c-8631-670eef6bde83"
   },
   {
@@ -60,7 +60,7 @@
       "property": "accent-color-1600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1600",
+    "$ref": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
     "uuid": "4b70c929-f48d-403d-9607-5963203433dc"
   },
   {
@@ -68,7 +68,7 @@
       "property": "accent-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-200",
+    "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
     "uuid": "cf583998-4dfd-4222-a554-8e05ed7fb5d6"
   },
   {
@@ -76,7 +76,7 @@
       "property": "accent-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-300",
+    "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
     "uuid": "ea67f054-1f42-427e-a768-beb8d21de2a3"
   },
   {
@@ -84,7 +84,7 @@
       "property": "accent-color-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-400",
+    "$ref": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
     "uuid": "a249e4b1-e6f9-4ef3-96c6-1559059839a7"
   },
   {
@@ -92,7 +92,7 @@
       "property": "accent-color-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-500",
+    "$ref": "1350b184-da3d-4920-bfa1-b42ba88761b2",
     "uuid": "c1c0e6fb-ce21-49d7-91bb-73ce873aa69f"
   },
   {
@@ -100,7 +100,7 @@
       "property": "accent-color-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-600",
+    "$ref": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
     "uuid": "5a2000be-5640-4389-a128-b2c164ad2253"
   },
   {
@@ -108,7 +108,7 @@
       "property": "accent-color-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-700",
+    "$ref": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
     "uuid": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae"
   },
   {
@@ -116,7 +116,7 @@
       "property": "accent-color-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "87a2c8f0-54fd-4939-8f42-3124fde1e49e"
   },
   {
@@ -124,7 +124,7 @@
       "property": "accent-color-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54"
   },
   {
@@ -134,7 +134,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-200",
+    "$ref": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
     "uuid": "97293b77-c21d-4ba1-bd2c-5d1de37d75eb",
     "set_uuid": "14e7dcde-b29d-42ba-8a90-327ada3af3e7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -146,7 +146,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-300",
+    "$ref": "ea67f054-1f42-427e-a768-beb8d21de2a3",
     "uuid": "c120499e-98c4-442d-971f-31dee8d16c4d",
     "set_uuid": "14e7dcde-b29d-42ba-8a90-327ada3af3e7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -158,7 +158,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "accent-color-200",
+    "$ref": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
     "uuid": "5c9c8a1c-c4ac-45e5-ba5f-b08edd9f4297",
     "set_uuid": "14e7dcde-b29d-42ba-8a90-327ada3af3e7",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -168,7 +168,7 @@
       "property": "icon-color-informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-visual-color",
+    "$ref": "60aa72d2-3b00-4eea-973d-265a55d3095a",
     "uuid": "2296b0de-6231-4f89-9992-499b67c6879c"
   },
   {
@@ -176,7 +176,7 @@
       "property": "icon-color-negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-visual-color",
+    "$ref": "23cea5fe-acb5-4460-add7-3512aaceeb35",
     "uuid": "adf2a3f0-d1cd-4b53-8a9c-47ab9cb7bb0f"
   },
   {
@@ -184,7 +184,7 @@
       "property": "icon-color-neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "neutral-visual-color",
+    "$ref": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
     "uuid": "29f5b73c-e8e8-4162-b9af-5a8e327baab8"
   },
   {
@@ -192,7 +192,7 @@
       "property": "icon-color-notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-visual-color",
+    "$ref": "da827479-f058-4117-9cd3-90cbe525d05d",
     "uuid": "4bdb8681-f7a1-4bbe-b788-a64c6f9df6ea"
   },
   {
@@ -200,7 +200,7 @@
       "property": "icon-color-positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-visual-color",
+    "$ref": "d439dfad-437a-4929-8d0d-9b9290dcb843",
     "uuid": "02f093b3-ab51-42e7-8f6e-26bc7c7cba63"
   },
   {
@@ -208,7 +208,7 @@
       "property": "informative-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-100",
+    "$ref": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
     "uuid": "b9fc8b82-275a-49fe-98d7-95f136b48772"
   },
   {
@@ -216,7 +216,7 @@
       "property": "informative-color-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1000",
+    "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
     "uuid": "6b609325-2bcf-491a-ad38-1409025caae0"
   },
   {
@@ -224,7 +224,7 @@
       "property": "informative-color-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1100",
+    "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
     "uuid": "7bf54313-58b6-4581-b5ac-a2e51df4a9ed"
   },
   {
@@ -232,7 +232,7 @@
       "property": "informative-color-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1200",
+    "$ref": "5c04481e-664e-4e9a-8da9-841e349167f5",
     "uuid": "4504d6a9-87f7-48ea-94a0-d075f28bbcff"
   },
   {
@@ -240,7 +240,7 @@
       "property": "informative-color-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1300",
+    "$ref": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
     "uuid": "f7a736c2-db44-4668-90a8-c27778ae9892"
   },
   {
@@ -248,7 +248,7 @@
       "property": "informative-color-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1400",
+    "$ref": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
     "uuid": "b178b13b-93ee-422c-af98-3bf89105754b"
   },
   {
@@ -256,7 +256,7 @@
       "property": "informative-color-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1500",
+    "$ref": "be3d8c39-72f3-4134-b009-4aa30fb01883",
     "uuid": "beeee44c-dc6b-4892-949e-67f069fc4a94"
   },
   {
@@ -264,7 +264,7 @@
       "property": "informative-color-1600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-1600",
+    "$ref": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
     "uuid": "68aa069d-d8a6-413a-b330-0ec6af905e6d"
   },
   {
@@ -272,7 +272,7 @@
       "property": "informative-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-200",
+    "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
     "uuid": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c"
   },
   {
@@ -280,7 +280,7 @@
       "property": "informative-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-300",
+    "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
     "uuid": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a"
   },
   {
@@ -288,7 +288,7 @@
       "property": "informative-color-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-400",
+    "$ref": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
     "uuid": "46f3f214-5211-452b-8dc0-ffb7e9f9712b"
   },
   {
@@ -296,7 +296,7 @@
       "property": "informative-color-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-500",
+    "$ref": "1350b184-da3d-4920-bfa1-b42ba88761b2",
     "uuid": "546f860f-4e17-455a-a6eb-f7a6a3b37128"
   },
   {
@@ -304,7 +304,7 @@
       "property": "informative-color-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-600",
+    "$ref": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
     "uuid": "79a0fe09-63fb-4c96-a3bf-a8e126e7838c"
   },
   {
@@ -312,7 +312,7 @@
       "property": "informative-color-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-700",
+    "$ref": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
     "uuid": "04a018bd-229c-47da-99e9-d338d05f0fb6"
   },
   {
@@ -320,7 +320,7 @@
       "property": "informative-color-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-800",
+    "$ref": "85be576c-6810-4971-9748-e558384b903d",
     "uuid": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f"
   },
   {
@@ -328,7 +328,7 @@
       "property": "informative-color-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "blue-900",
+    "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
     "uuid": "41b73196-0bc1-493e-9b5d-49f608914f5a"
   },
   {
@@ -338,7 +338,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-200",
+    "$ref": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
     "uuid": "62dfb07f-5eee-451c-9c77-745d8f714766",
     "set_uuid": "beaee709-482e-4678-99d5-585da056f5c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -350,7 +350,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-300",
+    "$ref": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a",
     "uuid": "4cbe010f-0608-47e3-bf27-c7da70a70b9e",
     "set_uuid": "beaee709-482e-4678-99d5-585da056f5c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -362,7 +362,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "informative-color-200",
+    "$ref": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
     "uuid": "71ebebf0-95e7-45f7-9f6f-d14ef51cf4f0",
     "set_uuid": "beaee709-482e-4678-99d5-585da056f5c8",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -372,7 +372,7 @@
       "property": "negative-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-100",
+    "$ref": "921d4bb8-f5b0-4955-a495-294864cf4ca5",
     "uuid": "c37f795e-e338-4220-b0ab-5cf899f114c0"
   },
   {
@@ -380,7 +380,7 @@
       "property": "negative-color-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1000",
+    "$ref": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
     "uuid": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2"
   },
   {
@@ -388,7 +388,7 @@
       "property": "negative-color-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1100",
+    "$ref": "5485c698-0ea9-47d7-b81d-43f0647c4078",
     "uuid": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489"
   },
   {
@@ -396,7 +396,7 @@
       "property": "negative-color-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1200",
+    "$ref": "403564fd-fda3-4ef5-a68e-96c6f5a93a93",
     "uuid": "1b24f4e8-224c-41f9-b0eb-6a01e9261598"
   },
   {
@@ -404,7 +404,7 @@
       "property": "negative-color-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1300",
+    "$ref": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849",
     "uuid": "fa641bdd-0714-4ae4-9a8f-8d829a9977e5"
   },
   {
@@ -412,7 +412,7 @@
       "property": "negative-color-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1400",
+    "$ref": "590136e1-3127-4540-9689-05b1161bd4c2",
     "uuid": "58824d04-e2c0-4f0c-a3d7-9b88a01bf28d"
   },
   {
@@ -420,7 +420,7 @@
       "property": "negative-color-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1500",
+    "$ref": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e",
     "uuid": "b4c1f747-e665-43bb-a1a9-1bf9f252471d"
   },
   {
@@ -428,7 +428,7 @@
       "property": "negative-color-1600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-1600",
+    "$ref": "e042de3e-9b82-4229-880d-e1e4b1af80b7",
     "uuid": "62beb7ee-c347-4cd7-a84b-40c84fcbc135"
   },
   {
@@ -436,7 +436,7 @@
       "property": "negative-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-200",
+    "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
     "uuid": "14919f0c-a40f-48d1-adfd-55826de8e600"
   },
   {
@@ -444,7 +444,7 @@
       "property": "negative-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-300",
+    "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
     "uuid": "53486ec0-79f7-4853-ad5b-dacc5a904f8a"
   },
   {
@@ -452,7 +452,7 @@
       "property": "negative-color-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-400",
+    "$ref": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5",
     "uuid": "de87c624-7f43-406e-8cdf-584343a55edc"
   },
   {
@@ -460,7 +460,7 @@
       "property": "negative-color-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-500",
+    "$ref": "33e7f73d-be80-4961-bcd7-6088fddadf44",
     "uuid": "67d09223-03a0-444a-95b6-645a2d66f8c7"
   },
   {
@@ -468,7 +468,7 @@
       "property": "negative-color-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-600",
+    "$ref": "2bad908f-065a-45fb-9a75-6f3ae0da19a4",
     "uuid": "4a0c11a4-4e77-43e0-a2cd-9931ac51d87d"
   },
   {
@@ -476,7 +476,7 @@
       "property": "negative-color-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-700",
+    "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
     "uuid": "b7d5d2db-0282-436b-8cb0-873e891b22a6"
   },
   {
@@ -484,7 +484,7 @@
       "property": "negative-color-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-800",
+    "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
     "uuid": "d858b481-8970-4547-aed1-b6388c36aba4"
   },
   {
@@ -492,7 +492,7 @@
       "property": "negative-color-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "red-900",
+    "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
     "uuid": "0b469d2e-7c66-4188-b6bf-bbc379f75538"
   },
   {
@@ -501,7 +501,7 @@
       "state": "default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-subtle-background-color-default",
+    "$ref": "30fa3891-135b-405a-bf0f-3cc17f711079",
     "uuid": "a553db3e-a051-4023-87eb-da6545b983b2",
     "deprecated": "unknown"
   },
@@ -511,7 +511,7 @@
       "state": "down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-300",
+    "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "1eea917c-52e7-4295-b0e1-d33c2e73a137",
     "deprecated": "unknown"
   },
@@ -521,7 +521,7 @@
       "state": "hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-300",
+    "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "9513cf13-8537-443f-81ce-f9d88292ba32",
     "deprecated": "unknown"
   },
@@ -531,7 +531,7 @@
       "state": "key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-300",
+    "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "4b6aaf76-e0ab-4be0-81c0-d5f64cacee88",
     "deprecated": "unknown"
   },
@@ -542,7 +542,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-200",
+    "$ref": "14919f0c-a40f-48d1-adfd-55826de8e600",
     "uuid": "8e9429cf-4c89-47be-bc6e-eeecc632aeb1",
     "set_uuid": "30fa3891-135b-405a-bf0f-3cc17f711079",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -554,7 +554,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-300",
+    "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
     "uuid": "c7575b76-8035-4037-8bd5-e8bdb82bddc3",
     "set_uuid": "30fa3891-135b-405a-bf0f-3cc17f711079",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -566,7 +566,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "negative-color-200",
+    "$ref": "14919f0c-a40f-48d1-adfd-55826de8e600",
     "uuid": "ea3ceaa2-235b-4c55-88b2-c0d744434d83",
     "set_uuid": "30fa3891-135b-405a-bf0f-3cc17f711079",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -576,7 +576,7 @@
       "property": "notice-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-100",
+    "$ref": "b31d8010-6701-4a59-8f7e-3ae680755c17",
     "uuid": "d0382c45-0cf7-4c3b-89fb-3536459cbc31"
   },
   {
@@ -584,7 +584,7 @@
       "property": "notice-color-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1000",
+    "$ref": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
     "uuid": "d6fdcf63-c135-48a0-a767-e8f1e93e8190"
   },
   {
@@ -592,7 +592,7 @@
       "property": "notice-color-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1100",
+    "$ref": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
     "uuid": "c30c4ce0-ed40-44eb-ae0b-3549523d5bc9"
   },
   {
@@ -600,7 +600,7 @@
       "property": "notice-color-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1200",
+    "$ref": "cdffa59a-a440-4e1b-a9f4-c45755f954b8",
     "uuid": "7e22e4fe-bd28-4dac-b518-e35ec6900da3"
   },
   {
@@ -608,7 +608,7 @@
       "property": "notice-color-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1300",
+    "$ref": "322a161e-bbda-4369-b4ec-6140ccbb01c4",
     "uuid": "197c8ecc-3d6a-46e5-82f2-c315a52169fb"
   },
   {
@@ -616,7 +616,7 @@
       "property": "notice-color-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1400",
+    "$ref": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb",
     "uuid": "4eccc44a-1cd5-4d9e-8627-18f7a363d3c8"
   },
   {
@@ -624,7 +624,7 @@
       "property": "notice-color-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1500",
+    "$ref": "dae987e5-c3ee-405b-83a9-3d9e054f95b1",
     "uuid": "3da89d37-cf33-4408-b316-05bb61c25759"
   },
   {
@@ -632,7 +632,7 @@
       "property": "notice-color-1600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-1600",
+    "$ref": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3",
     "uuid": "67e534f5-5421-493c-9324-624f0fd491f3"
   },
   {
@@ -640,7 +640,7 @@
       "property": "notice-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-200",
+    "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
     "uuid": "b9218264-6bd0-4fee-8ab7-346428c9bbaa"
   },
   {
@@ -648,7 +648,7 @@
       "property": "notice-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-300",
+    "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
     "uuid": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd"
   },
   {
@@ -656,7 +656,7 @@
       "property": "notice-color-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-400",
+    "$ref": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3",
     "uuid": "77535709-6e67-4d7c-aaeb-d2dea1918430"
   },
   {
@@ -664,7 +664,7 @@
       "property": "notice-color-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-500",
+    "$ref": "9e3e4263-9515-4937-b33f-3af341e57073",
     "uuid": "ab679012-b7cb-4f24-b401-b02e523d7c99"
   },
   {
@@ -672,7 +672,7 @@
       "property": "notice-color-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-600",
+    "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
     "uuid": "716af828-c64d-465d-8476-d142892ca59c"
   },
   {
@@ -680,7 +680,7 @@
       "property": "notice-color-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-700",
+    "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
     "uuid": "adb5159c-654f-4b9a-a101-3afa90328c42"
   },
   {
@@ -688,7 +688,7 @@
       "property": "notice-color-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-800",
+    "$ref": "bed559d1-c097-40ad-8d3a-2866198832c2",
     "uuid": "a83cdd4d-b8a9-42af-98c4-459f721abbff"
   },
   {
@@ -696,7 +696,7 @@
       "property": "notice-color-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "orange-900",
+    "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
     "uuid": "df87ca09-ff38-485e-90f7-6d9cbfbb6714"
   },
   {
@@ -706,7 +706,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-200",
+    "$ref": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
     "uuid": "f0799e87-dbb2-4e71-8253-65f45eddc078",
     "set_uuid": "8a357a16-a337-4edd-b73f-e09d7a6d45f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -718,7 +718,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-300",
+    "$ref": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd",
     "uuid": "c9bfd62b-95c7-47d3-bace-ce3f2bfaade8",
     "set_uuid": "8a357a16-a337-4edd-b73f-e09d7a6d45f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -730,7 +730,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "notice-color-200",
+    "$ref": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
     "uuid": "163958bd-7303-4328-ad3c-b04f8dacaf32",
     "set_uuid": "8a357a16-a337-4edd-b73f-e09d7a6d45f1",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -740,7 +740,7 @@
       "property": "positive-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-100",
+    "$ref": "7c7c0136-2623-468d-a12f-678d21973613",
     "uuid": "09503086-ccd2-4dfb-9bc1-6b86cf595976"
   },
   {
@@ -748,7 +748,7 @@
       "property": "positive-color-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1000",
+    "$ref": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
     "uuid": "82d9fc42-d750-43d2-b227-b8df29abaca4"
   },
   {
@@ -756,7 +756,7 @@
       "property": "positive-color-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1100",
+    "$ref": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc",
     "uuid": "05f42672-455e-421c-8a7e-cb187355d23d"
   },
   {
@@ -764,7 +764,7 @@
       "property": "positive-color-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1200",
+    "$ref": "365a47c9-43c8-45a4-8cb8-07c552aca28b",
     "uuid": "c4f84a4a-cfc4-42a6-81d4-11f27e1b38eb"
   },
   {
@@ -772,7 +772,7 @@
       "property": "positive-color-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1300",
+    "$ref": "6668c6c5-b66e-4c83-a95a-37fde594296b",
     "uuid": "7d2d9fe7-5498-4f73-be6a-3a4ac91b6e15"
   },
   {
@@ -780,7 +780,7 @@
       "property": "positive-color-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1400",
+    "$ref": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9",
     "uuid": "eb2fdab7-ea9e-42a3-a3d1-f9beec0c7b66"
   },
   {
@@ -788,7 +788,7 @@
       "property": "positive-color-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1500",
+    "$ref": "54ef3b06-ac50-4176-af22-86d0c73d5d13",
     "uuid": "2381ba55-11ff-4ef0-a770-dfd402650d5d"
   },
   {
@@ -796,7 +796,7 @@
       "property": "positive-color-1600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-1600",
+    "$ref": "2d45aad7-eb31-46f9-a73f-69498e466a29",
     "uuid": "de206438-991f-4580-8aa1-1488acb03a09"
   },
   {
@@ -804,7 +804,7 @@
       "property": "positive-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-200",
+    "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
     "uuid": "00a2adcc-7b8a-4e94-97d2-51a647016265"
   },
   {
@@ -812,7 +812,7 @@
       "property": "positive-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-300",
+    "$ref": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
     "uuid": "2c75e63f-e628-487d-a143-e03de065d5ee"
   },
   {
@@ -820,7 +820,7 @@
       "property": "positive-color-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-400",
+    "$ref": "6673709d-2154-4189-ad4f-e6867ecfe744",
     "uuid": "906a05ca-0b2f-4ada-9e71-507d9f0653be"
   },
   {
@@ -828,7 +828,7 @@
       "property": "positive-color-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-500",
+    "$ref": "a63a12c8-2526-49b0-a918-543af6deb103",
     "uuid": "b2e94182-57ae-479d-ab91-717edc0ec3f6"
   },
   {
@@ -836,7 +836,7 @@
       "property": "positive-color-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-600",
+    "$ref": "26b0bdde-2ea0-456c-8ade-a521e8799613",
     "uuid": "d3a018bf-0abe-4031-8c38-80a94b0d62ae"
   },
   {
@@ -844,7 +844,7 @@
       "property": "positive-color-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-700",
+    "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
     "uuid": "ffdde321-5c1d-489e-8a0f-afc582248594"
   },
   {
@@ -852,7 +852,7 @@
       "property": "positive-color-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-800",
+    "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
     "uuid": "ee02d9d5-b840-44af-be8a-0f10086e8f7e"
   },
   {
@@ -860,7 +860,7 @@
       "property": "positive-color-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "green-900",
+    "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
     "uuid": "1cd86108-ff79-4ccf-911e-8de9986c9053"
   },
   {
@@ -870,7 +870,7 @@
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-200",
+    "$ref": "00a2adcc-7b8a-4e94-97d2-51a647016265",
     "uuid": "57a1aa8f-5c06-4ff6-8d1c-0e278a433ebf",
     "set_uuid": "a412cbb3-bcee-40d3-af69-99ead9be1954",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -882,7 +882,7 @@
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-300",
+    "$ref": "2c75e63f-e628-487d-a143-e03de065d5ee",
     "uuid": "c7644c81-1b2c-40ee-b3a6-b25e88fc34ea",
     "set_uuid": "a412cbb3-bcee-40d3-af69-99ead9be1954",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"
@@ -894,7 +894,7 @@
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "positive-color-200",
+    "$ref": "00a2adcc-7b8a-4e94-97d2-51a647016265",
     "uuid": "531be3e1-ddfa-4d3b-9a7f-73d7f0e38cd9",
     "set_uuid": "a412cbb3-bcee-40d3-af69-99ead9be1954",
     "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json"

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -13,7 +13,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "3e90be19-62fd-4e53-abf9-4c697baba5da"
   },
   {
@@ -22,7 +22,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "0d8ada2f-272d-4f76-bf37-095e0b48cdae"
   },
   {
@@ -31,7 +31,7 @@
       "property": "cjk-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-font-family",
+    "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
     "uuid": "06d5790c-21e9-4135-843d-05007b046677"
   },
   {
@@ -40,7 +40,7 @@
       "property": "cjk-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "41389b62-c449-485b-bfa8-1659bacc8c42"
   },
   {
@@ -49,7 +49,7 @@
       "property": "cjk-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "a754c16b-2f0c-485f-813d-d472ee650660"
   },
   {
@@ -58,7 +58,7 @@
       "property": "cjk-line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-line-height-200",
+    "$ref": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
     "uuid": "2106b188-8520-4261-968b-2eb2928857f9"
   },
   {
@@ -66,7 +66,7 @@
       "property": "body-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "9f0e0ddb-a4d2-416e-a425-8d71527f77b2"
   },
   {
@@ -74,7 +74,7 @@
       "property": "body-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "7e01bc65-5823-456f-a830-9848a96ad85a"
   },
   {
@@ -82,7 +82,7 @@
       "property": "body-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "081aa502-e2f1-4bc8-8fb2-a00dcd4236dd"
   },
   {
@@ -90,7 +90,7 @@
       "property": "body-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "25d65a6e-e8e1-4849-848a-984373fd9cf9"
   },
   {
@@ -98,7 +98,7 @@
       "property": "body-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-50",
+    "$ref": "c6074b73-d460-439d-9401-498f52c88340",
     "uuid": "ba73926d-2ef4-4d7b-86c2-9044aa1cdf95"
   },
   {
@@ -106,7 +106,7 @@
       "property": "body-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "9aab03eb-c0c1-462c-aa7c-88c93b06f714"
   },
   {
@@ -114,7 +114,7 @@
       "property": "body-cjk-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-25",
+    "$ref": "73ef03ac-5b7b-4182-8991-0bb62006d276",
     "uuid": "218f04ed-0679-4090-b1ad-76ef062dd07c"
   },
   {
@@ -122,7 +122,7 @@
       "property": "body-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-500",
+    "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
     "uuid": "71a41f9e-73da-4632-8877-7af7acf4db03"
   },
   {
@@ -131,7 +131,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "f792aac0-62f2-47e3-b6ac-158ae009d9c3"
   },
   {
@@ -140,7 +140,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "54020791-a975-4e5d-a905-8bffcc9d2d93"
   },
   {
@@ -149,7 +149,7 @@
       "property": "cjk-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "11fe09ad-92eb-4d7d-8872-467cdd69659b"
   },
   {
@@ -158,7 +158,7 @@
       "property": "cjk-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "d79de2c4-ca7c-4316-ac44-fee1a66983d7"
   },
   {
@@ -167,7 +167,7 @@
       "property": "color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "a7218010-91c1-4f20-8072-7b1801593014"
   },
   {
@@ -176,7 +176,7 @@
       "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "line-height-200",
+    "$ref": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97",
     "uuid": "39accad7-3de1-4850-9773-4e0ff8080049"
   },
   {
@@ -194,7 +194,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "717c067c-55d1-4927-ad9c-8784769f581d"
   },
   {
@@ -203,7 +203,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "5640ac73-a482-4787-9ab2-035b57a87833"
   },
   {
@@ -212,7 +212,7 @@
       "property": "sans-serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "sans-serif-font-family",
+    "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
     "uuid": "32c3d84f-2b0d-4ccd-ba3c-b8475d82550b"
   },
   {
@@ -221,7 +221,7 @@
       "property": "sans-serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "e1da0eff-7482-46a0-8190-4c54c6b1e1dd"
   },
   {
@@ -230,7 +230,7 @@
       "property": "sans-serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "6813005d-9df4-459b-9fab-b2a054c32c31"
   },
   {
@@ -239,7 +239,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "b87e6738-af38-49be-9945-f3a307ce7b6f"
   },
   {
@@ -248,7 +248,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "421dc907-5862-4ed5-95f4-41d654b2fdc0"
   },
   {
@@ -257,7 +257,7 @@
       "property": "sans-serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b36db31f-eaaa-4310-9f54-f7b509d5f571"
   },
   {
@@ -266,7 +266,7 @@
       "property": "sans-serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "633953a9-c61b-44cc-9dee-aebece97ccbc"
   },
   {
@@ -275,7 +275,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "c817210d-2b1a-4648-bff3-33fa212491f1"
   },
   {
@@ -284,7 +284,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "be2a8ff3-6117-4235-bcb8-72257b75d622"
   },
   {
@@ -293,7 +293,7 @@
       "property": "serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "serif-font-family",
+    "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
     "uuid": "20df8bd4-5a61-4614-aa86-5b76c5976860"
   },
   {
@@ -302,7 +302,7 @@
       "property": "serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "d317d387-9bc8-4258-a79a-a0dd4e22d952"
   },
   {
@@ -311,7 +311,7 @@
       "property": "serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "f049ba7a-c52f-4d39-b38e-911b2b91d031"
   },
   {
@@ -320,7 +320,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "b940bdc8-d373-4bd0-8620-d6c04134698b"
   },
   {
@@ -329,7 +329,7 @@
       "component": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "a87b77ff-5b27-47e0-a7df-f15092fb783e"
   },
   {
@@ -338,7 +338,7 @@
       "property": "serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c8b531d1-949e-4492-9897-450a477983ce"
   },
   {
@@ -347,7 +347,7 @@
       "property": "serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "be263571-bd6b-4383-bdf9-3cdf80248b6a"
   },
   {
@@ -356,7 +356,7 @@
       "property": "size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "884b74cb-d247-491d-acb9-d3dc84bfd9a6"
   },
   {
@@ -365,7 +365,7 @@
       "property": "size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "4f7f6878-5304-48d3-8a42-5bb452c2163b"
   },
   {
@@ -374,7 +374,7 @@
       "property": "size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e"
   },
   {
@@ -383,7 +383,7 @@
       "property": "size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "3927604f-eaf3-4605-aa34-80b7bc88ac0f"
   },
   {
@@ -392,7 +392,7 @@
       "property": "size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "25e93322-8f0b-45f8-ae9a-18668251f064"
   },
   {
@@ -401,7 +401,7 @@
       "property": "size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-500",
+    "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
     "uuid": "4d0d4ed9-af14-4d88-98f1-9237f65e192a"
   },
   {
@@ -409,7 +409,7 @@
       "property": "body-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-50",
+    "$ref": "c6074b73-d460-439d-9401-498f52c88340",
     "uuid": "3aa79ac7-9e78-4413-b500-b8d1937705cb"
   },
   {
@@ -418,7 +418,7 @@
       "property": "size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-600",
+    "$ref": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
     "uuid": "e0b8ceea-3404-4c4b-9145-fe5d445020fe"
   },
   {
@@ -442,7 +442,7 @@
       "property": "cjk-letter-spacing"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "letter-spacing",
+    "$ref": "d8caf3aa-1261-411f-b383-18f87334c117",
     "uuid": "12e27721-35f5-4d03-95f3-3fc9e1cf50e4"
   },
   {
@@ -467,7 +467,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "f892e676-5218-4dc9-870b-c9d2df6f3152"
   },
   {
@@ -476,7 +476,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "61f8b443-95fa-46fd-8876-b4d7a2244af9"
   },
   {
@@ -485,7 +485,7 @@
       "property": "cjk-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "code-font-family",
+    "$ref": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1",
     "uuid": "322cb744-5837-4d0a-94a8-3c885d54568d"
   },
   {
@@ -494,7 +494,7 @@
       "property": "cjk-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b26477bc-8bf1-41aa-b849-cfde54e27780"
   },
   {
@@ -503,7 +503,7 @@
       "property": "cjk-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "8455f34c-0c79-4699-aa7c-c77d28bfa617"
   },
   {
@@ -512,7 +512,7 @@
       "property": "cjk-line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-line-height-200",
+    "$ref": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
     "uuid": "35580910-cb91-44df-9613-7b2e40a75a7c"
   },
   {
@@ -521,7 +521,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "38006d42-4f02-46ff-917f-6c0163525642"
   },
   {
@@ -530,7 +530,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "8ed5c5e0-ff72-4937-98fd-fd09f1fab288"
   },
   {
@@ -539,7 +539,7 @@
       "property": "cjk-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "a30c9a18-1a49-4b16-87a0-e882c81dd1bd"
   },
   {
@@ -548,7 +548,7 @@
       "property": "cjk-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "ed73f5fc-5b7a-4414-8f1c-325e7944a9e1"
   },
   {
@@ -557,7 +557,7 @@
       "property": "color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-800",
+    "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
     "uuid": "851aebc5-5aa2-42ae-9032-59a5c9e8db5f"
   },
   {
@@ -566,7 +566,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "9d3151ad-4a37-4eeb-aadd-7389ccb09345"
   },
   {
@@ -575,7 +575,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "948436ba-23d7-4eec-a3fe-ef5829ccadb0"
   },
   {
@@ -593,7 +593,7 @@
       "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b98a9c39-7d39-4b6d-ad35-46c8b1725c0c"
   },
   {
@@ -602,7 +602,7 @@
       "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "bf02dd59-4b3c-435a-b33b-49fff22674a3"
   },
   {
@@ -611,7 +611,7 @@
       "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "line-height-200",
+    "$ref": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97",
     "uuid": "0d33b30d-96d6-4b5a-90d2-2a708bdae623"
   },
   {
@@ -620,7 +620,7 @@
       "property": "size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "b7010f1a-c994-4b19-b273-3f609fe4be2b"
   },
   {
@@ -629,7 +629,7 @@
       "property": "size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3"
   },
   {
@@ -638,7 +638,7 @@
       "property": "size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "efa9311b-27c5-45ea-93a7-bef6f9370179"
   },
   {
@@ -647,7 +647,7 @@
       "property": "size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "7879adbc-6c38-4d29-9a90-a4ad91c75b90"
   },
   {
@@ -656,7 +656,7 @@
       "property": "size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7"
   },
   {
@@ -665,7 +665,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "83d53fe1-372f-46ba-b8e0-f90ca2e59647"
   },
   {
@@ -674,7 +674,7 @@
       "component": "code"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "4d5f1937-552d-44a4-be8e-2edafefa46aa"
   },
   {
@@ -683,7 +683,7 @@
       "property": "strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "dac3d8d5-3005-4fa6-b71a-6679470176cf"
   },
   {
@@ -692,7 +692,7 @@
       "property": "strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "48d2b9b8-beac-4185-827d-0c552e47663f"
   },
   {
@@ -910,7 +910,7 @@
       "property": "default-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "sans-serif-font-family",
+    "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
     "uuid": "45d43d4e-a4e4-4c5f-94ec-644a81300eb0"
   },
   {
@@ -927,7 +927,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "3dca0579-91c4-4f60-a2a6-25f16eb673b3"
   },
   {
@@ -936,7 +936,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "aa70fa2d-87ee-4e67-b230-85f400ddd7d1"
   },
   {
@@ -945,7 +945,7 @@
       "property": "cjk-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-font-family",
+    "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
     "uuid": "6cc647ab-1474-4094-974d-d079d7ef7565"
   },
   {
@@ -954,7 +954,7 @@
       "property": "cjk-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "4d2a9b37-101b-4025-95d6-aba18b701a58"
   },
   {
@@ -963,7 +963,7 @@
       "property": "cjk-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "9b11f80a-7600-4a6b-a366-218ba320a5cc"
   },
   {
@@ -972,7 +972,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c7b1b312-cd81-4c65-8a67-017f91aee40b",
     "deprecated": "unknown"
   },
@@ -982,7 +982,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "279d9a16-279f-4788-b5b0-af825a4b5d40",
     "deprecated": "unknown"
   },
@@ -992,7 +992,7 @@
       "property": "cjk-light-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "4cc06d86-326e-4b6f-a751-99445bb1d131",
     "deprecated": "unknown"
   },
@@ -1002,7 +1002,7 @@
       "property": "cjk-light-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "light-font-weight",
+    "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "3b531775-a1fd-4a40-b169-7c42b8c6de38",
     "deprecated": "unknown"
   },
@@ -1012,7 +1012,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "1d4235ff-c183-4d6c-8277-9783e3e1ce7a",
     "deprecated": "unknown"
   },
@@ -1022,7 +1022,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "0bc51146-a3e5-48c4-8324-4490b9d30f4d",
     "deprecated": "unknown"
   },
@@ -1032,7 +1032,7 @@
       "property": "cjk-light-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "ec87fefe-f35f-41a0-9be1-6d076f0db230",
     "deprecated": "unknown"
   },
@@ -1042,7 +1042,7 @@
       "property": "cjk-light-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "91231878-73dc-46ce-a277-1d14e0e36842",
     "deprecated": "unknown"
   },
@@ -1052,7 +1052,7 @@
       "property": "cjk-line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-line-height-100",
+    "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
     "uuid": "93434006-5ed7-4656-96b7-8f355a1f07b2"
   },
   {
@@ -1061,7 +1061,7 @@
       "property": "cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "92399d83-aa71-4207-b533-4fe69e6271e2"
   },
   {
@@ -1070,7 +1070,7 @@
       "property": "cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "236c73fb-d3bc-4390-8682-dd06fbd92d23"
   },
   {
@@ -1079,7 +1079,7 @@
       "property": "cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-50",
+    "$ref": "c6074b73-d460-439d-9401-498f52c88340",
     "uuid": "8eb0f29f-71a1-4aa5-a3ed-98a373baf620"
   },
   {
@@ -1088,7 +1088,7 @@
       "property": "cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "533265d4-7304-4688-b2fb-379a086b20bf"
   },
   {
@@ -1097,7 +1097,7 @@
       "property": "cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-25",
+    "$ref": "73ef03ac-5b7b-4182-8991-0bb62006d276",
     "uuid": "e6d8e8ae-d9a3-42fb-b4c7-f2e893b926f1"
   },
   {
@@ -1106,7 +1106,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "75a3a4ec-2b57-4a49-b3bd-84b41a3cd314"
   },
   {
@@ -1115,7 +1115,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "a7007c07-15a4-4671-bd3b-7406f4b374bb"
   },
   {
@@ -1124,7 +1124,7 @@
       "property": "cjk-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "653358fc-5ee4-4e97-affc-c56896d370c0"
   },
   {
@@ -1133,7 +1133,7 @@
       "property": "cjk-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "ef2997f3-276c-4662-8644-9514590114f4"
   },
   {
@@ -1142,7 +1142,7 @@
       "property": "color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-600",
+    "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
     "uuid": "5f6b9d7a-2433-44fa-8de5-1fb40137e334"
   },
   {
@@ -1161,7 +1161,7 @@
       "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "line-height-100",
+    "$ref": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
     "uuid": "4ca9965a-24f9-454e-b0a7-dd5a0c5ae170"
   },
   {
@@ -1188,7 +1188,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "5c7dcef1-514e-4d43-b2ef-76639e214b8c"
   },
   {
@@ -1197,7 +1197,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "6ca600be-010a-4aaa-a815-e5bfdbe36b21"
   },
   {
@@ -1206,7 +1206,7 @@
       "property": "sans-serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "sans-serif-font-family",
+    "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
     "uuid": "34101c26-b4cd-43aa-bddd-0758d21fef01"
   },
   {
@@ -1215,7 +1215,7 @@
       "property": "sans-serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "21a9500c-f9a4-4ff3-9eb5-6da81bf314f6"
   },
   {
@@ -1224,7 +1224,7 @@
       "property": "sans-serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "medium-font-weight",
+    "$ref": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
     "uuid": "d06a4346-ec24-4922-8985-4b8a05e0bfc6"
   },
   {
@@ -1233,7 +1233,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "fc6098a2-3263-433c-8378-ba609629ef53",
     "deprecated": "unknown"
   },
@@ -1243,7 +1243,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "64972012-5050-41d0-9c9b-269b533a58b7",
     "deprecated": "unknown"
   },
@@ -1253,7 +1253,7 @@
       "property": "sans-serif-light-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "a6b7c26e-3ff5-4241-b9cc-3026604fe30e",
     "deprecated": "unknown"
   },
@@ -1263,7 +1263,7 @@
       "property": "sans-serif-light-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "cf8f93e2-2b79-4a4c-bb31-313e013148e3",
     "deprecated": "unknown"
   },
@@ -1273,7 +1273,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "b7364639-2686-4e12-9ede-d6543d0d0d6d",
     "deprecated": "unknown"
   },
@@ -1283,7 +1283,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "53f16a1c-9d44-4384-9a7e-88a2c4319486",
     "deprecated": "unknown"
   },
@@ -1293,7 +1293,7 @@
       "property": "sans-serif-light-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c1966f09-1c6e-4fe0-89ad-8fb8e847e3ba",
     "deprecated": "unknown"
   },
@@ -1303,7 +1303,7 @@
       "property": "sans-serif-light-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "4f0f95d3-098a-4852-bd21-785f5bf054b5",
     "deprecated": "unknown"
   },
@@ -1313,7 +1313,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "82d04795-da5f-4868-a90d-980f5376a878"
   },
   {
@@ -1322,7 +1322,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "c57f8682-52d2-43fa-a306-a588a13ead6b"
   },
   {
@@ -1331,7 +1331,7 @@
       "property": "sans-serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c56642f3-043c-4738-bed0-61b324221f4e"
   },
   {
@@ -1340,7 +1340,7 @@
       "property": "sans-serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "a150e66c-daf4-4c71-a2e2-577600878988"
   },
   {
@@ -1359,7 +1359,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "cfaf6a70-3eb5-4887-bae6-8ae41c094192"
   },
   {
@@ -1368,7 +1368,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "medium-font-weight",
+    "$ref": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
     "uuid": "247b2004-e0bc-42b9-ba83-6edbe417c4cb"
   },
   {
@@ -1377,7 +1377,7 @@
       "property": "serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "serif-font-family",
+    "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
     "uuid": "365c6166-e17d-40bd-841e-495aa9c6acd7"
   },
   {
@@ -1386,7 +1386,7 @@
       "property": "serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "524c5101-f745-47e6-b233-62cd005850f8"
   },
   {
@@ -1395,7 +1395,7 @@
       "property": "serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "medium-font-weight",
+    "$ref": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
     "uuid": "87ef8843-f44e-4526-80cd-9635f3e0261e"
   },
   {
@@ -1404,7 +1404,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "320bcd8e-2bb8-4e9e-9b1d-4838b2966857",
     "deprecated": "unknown"
   },
@@ -1414,7 +1414,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "3d27f76e-b068-4f06-bea8-ee31fcbc49b2",
     "deprecated": "unknown"
   },
@@ -1424,7 +1424,7 @@
       "property": "serif-light-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "f6478d1d-5dcf-43eb-a4fc-498479b29aa7",
     "deprecated": "unknown"
   },
@@ -1434,7 +1434,7 @@
       "property": "serif-light-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "2a15a805-fd08-4f8e-82e6-9264ef8937cb",
     "deprecated": "unknown"
   },
@@ -1444,7 +1444,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "42d2049f-cda2-4ae4-8d0a-41f7789f768b",
     "deprecated": "unknown"
   },
@@ -1454,7 +1454,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "1c524d85-9fca-433c-b5c4-5eaa456cc3a2",
     "deprecated": "unknown"
   },
@@ -1464,7 +1464,7 @@
       "property": "serif-light-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "7a878a3f-b663-41ee-8357-6e62f2e51d80",
     "deprecated": "unknown"
   },
@@ -1474,7 +1474,7 @@
       "property": "serif-light-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "fc5df058-f678-4dc8-953f-e2738798ee2b",
     "deprecated": "unknown"
   },
@@ -1484,7 +1484,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "7fdffa4e-4370-45cf-aab0-316561a56a24"
   },
   {
@@ -1493,7 +1493,7 @@
       "component": "detail"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "863cf841-7b83-4f66-a01f-12dccd47fee6"
   },
   {
@@ -1502,7 +1502,7 @@
       "property": "serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "3b2124e3-e50b-4ab7-8340-f97b1f8fef1e"
   },
   {
@@ -1511,7 +1511,7 @@
       "property": "serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "d737931b-f63c-4874-8fa5-872b95048727"
   },
   {
@@ -1530,7 +1530,7 @@
       "property": "size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "613da587-5c48-4efa-abb5-36378c1e81f0"
   },
   {
@@ -1539,7 +1539,7 @@
       "property": "size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "07840554-1ec1-4823-b119-474ec9cc31f0"
   },
   {
@@ -1548,7 +1548,7 @@
       "property": "size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-75",
+    "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
     "uuid": "585e1bec-ee93-4983-b0bb-3a1f6ec28218"
   },
   {
@@ -1557,7 +1557,7 @@
       "property": "size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "ab476eec-b592-4890-af8f-74de808cb87f"
   },
   {
@@ -1566,7 +1566,7 @@
       "property": "size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-50",
+    "$ref": "c6074b73-d460-439d-9401-498f52c88340",
     "uuid": "b33a59b4-1ec2-4f09-8cb3-9bfd09d7c695"
   },
   {
@@ -1979,7 +1979,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "05c74b28-3051-498c-874a-5dc523bc27e5"
   },
   {
@@ -1988,7 +1988,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "d854afd2-290a-40ae-a627-c4cdabeb546a"
   },
   {
@@ -1997,7 +1997,7 @@
       "property": "cjk-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-font-family",
+    "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
     "uuid": "b6652ee5-466f-4117-a77c-a93a40f2a791"
   },
   {
@@ -2006,7 +2006,7 @@
       "property": "cjk-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c93b39df-82e9-4e87-920f-1747e5d48e8e"
   },
   {
@@ -2014,7 +2014,7 @@
       "property": "heading-cjk-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "bd54516c-2fda-4421-ab62-720c3a887a34"
   },
   {
@@ -2023,7 +2023,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "aef21944-3dac-4b2d-ba7b-0a4df3f406bb"
   },
   {
@@ -2032,7 +2032,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "9315971c-6e83-42c8-9c24-d1bc6fa5e106"
   },
   {
@@ -2041,7 +2041,7 @@
       "property": "cjk-heavy-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b2f50ba2-e694-47ba-b81a-ea8fc813247e"
   },
   {
@@ -2050,7 +2050,7 @@
       "property": "cjk-heavy-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "73c20d2f-1227-46bc-8548-102358405b0b"
   },
   {
@@ -2059,7 +2059,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "619a15ba-f74e-4ff4-a604-312b810f1a50"
   },
   {
@@ -2068,7 +2068,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "a0f680fa-2453-4bcc-b06c-9ff82de50c0c"
   },
   {
@@ -2077,7 +2077,7 @@
       "property": "cjk-heavy-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "26817f91-2742-4170-aa01-1e1e67ef01e8"
   },
   {
@@ -2086,7 +2086,7 @@
       "property": "cjk-heavy-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "b7d2203c-c651-493e-80c2-b71b7c7c2692"
   },
   {
@@ -2095,7 +2095,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "dac03eec-6910-4176-bfca-33f8a57cf3d7",
     "deprecated": "unknown"
   },
@@ -2105,7 +2105,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "aea9787b-ee0b-40cc-9089-5973e52b18bd",
     "deprecated": "unknown"
   },
@@ -2115,7 +2115,7 @@
       "property": "cjk-light-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b5704c75-2914-4268-9023-7f7452e826c1",
     "deprecated": "unknown"
   },
@@ -2125,7 +2125,7 @@
       "property": "cjk-light-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "light-font-weight",
+    "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "9da0ba4c-b4e3-4052-8b2e-d2fde714bb9d",
     "deprecated": "unknown"
   },
@@ -2135,7 +2135,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "9136e25e-563b-4485-bad7-41809d5317de",
     "deprecated": "unknown"
   },
@@ -2145,7 +2145,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "83cc347c-7a1a-4665-9de4-cf19903f1043",
     "deprecated": "unknown"
   },
@@ -2155,7 +2155,7 @@
       "property": "cjk-light-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "be854057-43b1-40ce-bdc7-69960cd7638c",
     "deprecated": "unknown"
   },
@@ -2165,7 +2165,7 @@
       "property": "cjk-light-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "5ca91bc2-215b-4cbb-b966-80bfffd569ad",
     "deprecated": "unknown"
   },
@@ -2175,7 +2175,7 @@
       "property": "cjk-line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "cjk-line-height-100",
+    "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
     "uuid": "3e038db9-c5f7-4b8b-b1af-31075a31e0cc"
   },
   {
@@ -2184,7 +2184,7 @@
       "property": "cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-600",
+    "$ref": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
     "uuid": "f57ffe02-2e41-46f3-a0ac-1feb63bdd748"
   },
   {
@@ -2193,7 +2193,7 @@
       "property": "cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "43f45659-314b-45aa-9886-1beb096fc4ce"
   },
   {
@@ -2202,7 +2202,7 @@
       "property": "cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "c1242a8c-ca10-40d0-8fc4-67bbbce8fc5f"
   },
   {
@@ -2211,7 +2211,7 @@
       "property": "cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-800",
+    "$ref": "d46d987e-44dd-4113-81b3-1b28c0f5cfe6",
     "uuid": "43535e5f-607e-43f4-bd37-8230b1f7993f"
   },
   {
@@ -2220,7 +2220,7 @@
       "property": "cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-200",
+    "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
     "uuid": "132688a7-917d-44b9-a34f-a7135599b299"
   },
   {
@@ -2229,7 +2229,7 @@
       "property": "cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-1000",
+    "$ref": "200d964e-b6f4-4011-a40d-33b1bfb7aa68",
     "uuid": "fbf59302-1ad2-4327-bfde-d638a0ca2429"
   },
   {
@@ -2238,7 +2238,7 @@
       "property": "cjk-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "bddd6a96-c280-47ca-8858-20df055e488d",
     "deprecated": "unknown"
   },
@@ -2248,7 +2248,7 @@
       "property": "cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-1200",
+    "$ref": "dbd67b04-f114-4549-8e36-223b7d7007c7",
     "uuid": "5a44e177-2478-4bb0-9212-ba2df64c8b00"
   },
   {
@@ -2256,7 +2256,7 @@
       "property": "heading-cjk-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-1400",
+    "$ref": "21c1f04f-3a63-4bf8-9f60-e9afa0e672a2",
     "uuid": "3b954e15-341a-40f4-a47e-9abd2813fec4"
   },
   {
@@ -2265,7 +2265,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "22934d4d-4952-40a7-a5e5-256a7a3c9371"
   },
   {
@@ -2274,7 +2274,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "0080a817-b26f-42f1-84c4-5ed1ac08c12c"
   },
   {
@@ -2283,7 +2283,7 @@
       "property": "cjk-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "4f061165-0e86-46b9-83c3-c95eeb8ff956"
   },
   {
@@ -2292,7 +2292,7 @@
       "property": "cjk-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "eaf179aa-4514-4206-b3e2-a99b7d4d2029"
   },
   {
@@ -2301,7 +2301,7 @@
       "property": "color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "gray-900",
+    "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
     "uuid": "60300cd2-9b30-4ee3-b7a1-b8dae00270d9"
   },
   {
@@ -2310,7 +2310,7 @@
       "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "line-height-100",
+    "$ref": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
     "uuid": "64f28fe4-20f7-48cb-baeb-ff1898573727"
   },
   {
@@ -2337,7 +2337,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "2f17833a-28a4-4152-8999-12b077557797"
   },
   {
@@ -2345,7 +2345,7 @@
       "property": "heading-sans-serif-emphasized-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "e4a183fd-53c5-4dbb-afd1-6308e2e74f80"
   },
   {
@@ -2354,7 +2354,7 @@
       "property": "sans-serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "sans-serif-font-family",
+    "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
     "uuid": "234d7b9d-bddc-4988-8be5-ef5e41e08185"
   },
   {
@@ -2363,7 +2363,7 @@
       "property": "sans-serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "561d905e-7f44-43da-b2b4-26e12551ef6d"
   },
   {
@@ -2371,7 +2371,7 @@
       "property": "heading-sans-serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "extra-bold-font-weight",
+    "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
     "uuid": "1d4d09b4-021a-48e8-a724-bfecc13df325"
   },
   {
@@ -2380,7 +2380,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "924c338f-7141-490a-a842-ad632c26160c"
   },
   {
@@ -2389,7 +2389,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "a7cb3274-e48e-435b-a066-32027ac19e84"
   },
   {
@@ -2398,7 +2398,7 @@
       "property": "sans-serif-heavy-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "0c4cdd06-8180-40b1-9b1f-d7d973a7b772"
   },
   {
@@ -2407,7 +2407,7 @@
       "property": "sans-serif-heavy-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "ef13b8f0-f686-492d-990f-691ec91ebb96"
   },
   {
@@ -2416,7 +2416,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "c20ea22a-c34d-4c7c-a816-75b533e28c92"
   },
   {
@@ -2425,7 +2425,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "8779e773-7b37-4eb0-ae7a-2ba0104ad9d5"
   },
   {
@@ -2434,7 +2434,7 @@
       "property": "sans-serif-heavy-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "86775b10-5682-49fb-9d38-6bdb857da801"
   },
   {
@@ -2443,7 +2443,7 @@
       "property": "sans-serif-heavy-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "2104c3c2-d834-436a-a26d-508056f1013d"
   },
   {
@@ -2452,7 +2452,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "5f88eb81-7052-4c21-9896-f14cb09f0e70",
     "deprecated": "unknown"
   },
@@ -2462,7 +2462,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "light-font-weight",
+    "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "e882ea46-8f0a-4313-84f5-85bb8d9f1f5e",
     "deprecated": "unknown"
   },
@@ -2472,7 +2472,7 @@
       "property": "sans-serif-light-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "c5551fd5-4ee2-4c93-b91f-9ed295fa63a4",
     "deprecated": "unknown"
   },
@@ -2482,7 +2482,7 @@
       "property": "sans-serif-light-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "light-font-weight",
+    "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
     "uuid": "ff84a748-5923-451d-967c-a346d2dee46c",
     "deprecated": "unknown"
   },
@@ -2492,7 +2492,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "bc5d65e0-e13a-424c-a260-9268a0dee66c",
     "deprecated": "unknown"
   },
@@ -2502,7 +2502,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "c297a503-fc3c-4939-8c5a-6611b9b04719",
     "deprecated": "unknown"
   },
@@ -2512,7 +2512,7 @@
       "property": "sans-serif-light-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "67271ca0-c9fd-4047-a615-6314d7333f7a",
     "deprecated": "unknown"
   },
@@ -2522,7 +2522,7 @@
       "property": "sans-serif-light-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "75437f9a-7ee8-4194-b4b3-0746be097396",
     "deprecated": "unknown"
   },
@@ -2532,7 +2532,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "f692d35f-1b11-43d1-ad29-967436b90928"
   },
   {
@@ -2541,7 +2541,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "9d834e30-53c1-4cea-9e17-2326038cb6cb"
   },
   {
@@ -2550,7 +2550,7 @@
       "property": "sans-serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "2117cb6e-67f7-4509-b4fb-e9e442b6dc0e"
   },
   {
@@ -2559,7 +2559,7 @@
       "property": "sans-serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "79275989-91ed-408a-b884-a31d9f8bac26"
   },
   {
@@ -2568,7 +2568,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "fe694554-832d-457d-a320-f02629f9c441"
   },
   {
@@ -2576,7 +2576,7 @@
       "property": "heading-serif-emphasized-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "a0983216-b0c5-4a3f-97dc-96ee711acb1f"
   },
   {
@@ -2585,7 +2585,7 @@
       "property": "serif-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "serif-font-family",
+    "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
     "uuid": "f2430818-41b5-439a-8347-6b384e78d141"
   },
   {
@@ -2594,7 +2594,7 @@
       "property": "serif-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "938f3684-44c6-4ae2-935a-b88921fcd7fe"
   },
   {
@@ -2602,7 +2602,7 @@
       "property": "heading-serif-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "350aa193-9996-49c8-b5e4-54d4f7bef3c2"
   },
   {
@@ -2611,7 +2611,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "a18ac621-eade-4224-9660-3e9a080219ec"
   },
   {
@@ -2620,7 +2620,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "82e9d579-8918-4114-bafa-3a9757556f84"
   },
   {
@@ -2629,7 +2629,7 @@
       "property": "serif-heavy-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "14532cb8-6c88-46ce-886b-96fac971e7b9"
   },
   {
@@ -2638,7 +2638,7 @@
       "property": "serif-heavy-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "6b74c5ea-6bf4-46bb-bee1-3841606f1500"
   },
   {
@@ -2647,7 +2647,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "adf303e8-1e27-4aec-9bbc-5abe166358ec"
   },
   {
@@ -2656,7 +2656,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "2d8e76cd-f123-488d-893d-54a9f48f679e"
   },
   {
@@ -2665,7 +2665,7 @@
       "property": "serif-heavy-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "b2875bbe-b5cb-452f-b7d6-3dcb4fc59921"
   },
   {
@@ -2674,7 +2674,7 @@
       "property": "serif-heavy-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "af0010c7-5134-4fe4-bee1-bbb7dd31de3a"
   },
   {
@@ -2683,7 +2683,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "7bd831cd-3fe0-402b-a105-f65b8e8023e2",
     "deprecated": "unknown"
   },
@@ -2693,7 +2693,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "b5f79fde-07f7-4c07-897e-0bfdf27e2839",
     "deprecated": "unknown"
   },
@@ -2703,7 +2703,7 @@
       "property": "serif-light-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "5f30418a-aa76-434e-bca9-902d5be0d929",
     "deprecated": "unknown"
   },
@@ -2713,7 +2713,7 @@
       "property": "serif-light-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "regular-font-weight",
+    "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
     "uuid": "66958795-6459-4750-8c68-dc39ab383837",
     "deprecated": "unknown"
   },
@@ -2723,7 +2723,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "71c8e302-6bc1-4f45-b804-c847dd153d1b",
     "deprecated": "unknown"
   },
@@ -2733,7 +2733,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "98c61df3-057d-4345-881e-0c04628757f3",
     "deprecated": "unknown"
   },
@@ -2743,7 +2743,7 @@
       "property": "serif-light-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "73906871-24e5-48cc-9140-ec700c08d144",
     "deprecated": "unknown"
   },
@@ -2753,7 +2753,7 @@
       "property": "serif-light-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "bold-font-weight",
+    "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
     "uuid": "29ad1c96-62e4-4143-88e8-fc8e08913a52",
     "deprecated": "unknown"
   },
@@ -2763,7 +2763,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "italic-font-style",
+    "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
     "uuid": "da6e1593-9d2a-4fd8-8877-d30d6e1d1c07"
   },
   {
@@ -2772,7 +2772,7 @@
       "component": "heading"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "cd32f2b7-3e9f-47ae-ad34-2c7783dd5b2f"
   },
   {
@@ -2781,7 +2781,7 @@
       "property": "serif-strong-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "default-font-style",
+    "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
     "uuid": "2e0ef484-406a-4902-995d-9a3d5177ec12"
   },
   {
@@ -2790,7 +2790,7 @@
       "property": "serif-strong-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "black-font-weight",
+    "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
     "uuid": "6df0fb95-4aa0-4c67-896d-fa6aa3d34e95"
   },
   {
@@ -2799,7 +2799,7 @@
       "property": "size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-700",
+    "$ref": "c9a3ec61-f116-4298-be2d-6149d6eae889",
     "uuid": "336e434c-9026-4bb3-96b1-5bb44376b868"
   },
   {
@@ -2808,7 +2808,7 @@
       "property": "size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-500",
+    "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
     "uuid": "4cdcefe1-2006-4560-839f-5bdef6db8c1a"
   },
   {
@@ -2817,7 +2817,7 @@
       "property": "size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-400",
+    "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
     "uuid": "96673fee-b75c-4867-9041-48362af044bc"
   },
   {
@@ -2826,7 +2826,7 @@
       "property": "size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-900",
+    "$ref": "cf1791b4-dcc2-4620-a508-d95bbd44504b",
     "uuid": "94bb5ad9-503a-428a-a8ba-6cf3f70592ac"
   },
   {
@@ -2835,7 +2835,7 @@
       "property": "size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-300",
+    "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
     "uuid": "4f179af6-c31f-48f8-927c-a45150668ad3"
   },
   {
@@ -2844,7 +2844,7 @@
       "property": "size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-1100",
+    "$ref": "202a2c3e-5bfc-4871-9481-13c771bdc8dc",
     "uuid": "464e34cd-e768-4a38-a72b-cae1a4852ef3"
   },
   {
@@ -2853,7 +2853,7 @@
       "property": "size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-100",
+    "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
     "uuid": "82a831b4-b624-475b-b2be-4eb949e48626",
     "deprecated": "unknown"
   },
@@ -2863,7 +2863,7 @@
       "property": "size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-1300",
+    "$ref": "760d6969-7e0e-4744-b1c6-d89d3a02af8d",
     "uuid": "db884bf9-e7b5-420a-b408-bd9a4d6bb0a4"
   },
   {
@@ -2871,7 +2871,7 @@
       "property": "heading-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "$ref": "font-size-1500",
+    "$ref": "d59c0cd1-efb8-4f5b-9d5a-7ecbcd79f758",
     "uuid": "517d86cc-2e66-4cdc-8841-cb32db9e56f4"
   },
   {

--- a/packages/tokens/schemas/token-types/alias.json
+++ b/packages/tokens/schemas/token-types/alias.json
@@ -4,6 +4,7 @@
   "title": "Alias",
   "description": "A token that references another token. Accepts both the legacy value-form ('{name}') and the cascade canonical form ('$ref': '<uuid>').",
   "type": "object",
+  "required": ["$schema", "uuid"],
   "oneOf": [
     {
       "description": "Legacy format: alias target wrapped in curly braces, e.g. {blue-100}.",
@@ -40,7 +41,7 @@
     "description": {},
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
       "format": "uuid"
     },
     "set_uuid": {

--- a/packages/tokens/schemas/token-types/alias.json
+++ b/packages/tokens/schemas/token-types/alias.json
@@ -2,26 +2,66 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
   "title": "Alias",
-  "description": "A token that references another token.",
+  "description": "A token that references another token. Accepts both the legacy value-form ('{name}') and the cascade canonical form ('$ref': '<uuid>').",
   "type": "object",
-  "allOf": [
+  "oneOf": [
     {
-      "$ref": "token.json"
+      "description": "Legacy format: alias target wrapped in curly braces, e.g. {blue-100}.",
+      "required": ["value"],
+      "not": { "required": ["$ref"] },
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^\\{(\\w|-)*\\}$"
+        }
+      }
+    },
+    {
+      "description": "Cascade canonical format: alias target UUID (rename-proof, resolvable via uuid_index).",
+      "required": ["$ref"],
+      "not": { "required": ["value"] },
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     }
   ],
   "properties": {
     "$schema": {
       "const": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json"
     },
-    "value": {
-      "type": "string",
-      "pattern": "^\\{(\\w|-)*\\}$"
-    },
+    "name": {},
     "component": {},
     "private": {},
     "deprecated": {},
     "deprecated_comment": {},
     "description": {},
-    "uuid": {}
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$",
+      "format": "uuid"
+    },
+    "set_uuid": {
+      "type": "string",
+      "description": "Set-level UUID carried from the cascade migration (used by legacy-output to reconstruct the outer set UUID)."
+    },
+    "set_schema": {
+      "type": "string",
+      "description": "Set-level schema URL carried from the cascade migration."
+    },
+    "replaced_by": {
+      "oneOf": [
+        { "type": "string", "format": "uuid" },
+        {
+          "type": "array",
+          "items": { "type": "string", "format": "uuid" },
+          "minItems": 1
+        }
+      ]
+    },
+    "introduced": { "type": "string" },
+    "plannedRemoval": { "type": "string" }
   }
 }

--- a/packages/tokens/schemas/token-types/token.json
+++ b/packages/tokens/schemas/token-types/token.json
@@ -43,7 +43,11 @@
     "replaced_by": {
       "oneOf": [
         { "type": "string", "format": "uuid" },
-        { "type": "array", "items": { "type": "string", "format": "uuid" }, "minItems": 1 }
+        {
+          "type": "array",
+          "items": { "type": "string", "format": "uuid" },
+          "minItems": 1
+        }
       ],
       "description": "UUID(s) of the replacement token(s). Array form requires deprecated_comment."
     },
@@ -57,7 +61,7 @@
     },
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
       "format": "uuid"
     }
   },

--- a/packages/tokens/test/schemaValidators/alias.test.js
+++ b/packages/tokens/test/schemaValidators/alias.test.js
@@ -26,16 +26,58 @@ const validate = await ajv.compile(
   await readJSON("schemas/token-types/alias.json"),
 );
 
-test("Every token schema should validate against the definition", (t) => {
+const ALIAS_SCHEMA =
+  "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json";
+
+test("cascade $ref-only alias validates (oneOf cascade branch)", (t) => {
+  const alias = {
+    $schema: ALIAS_SCHEMA,
+    $ref: "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
+    uuid: "f24eb871-6419-4cef-88a2-cca8548ae31e",
+  };
+  const valid = validate(alias);
+  if (!valid) {
+    t.log("Validation errors:", validate.errors);
+  }
+  t.true(valid, "cascade alias with $ref and uuid must validate");
+});
+
+test("legacy value-form alias validates (oneOf legacy branch)", (t) => {
   const alias = {
     component: "swatch",
-    $schema:
-      "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    $schema: ALIAS_SCHEMA,
     value: "{gray-900}",
     uuid: "7da5157d-7f25-405b-8de0-f3669565fb48",
   };
-  if (!validate(alias)) {
-    console.log(validate.errors);
+  const valid = validate(alias);
+  if (!valid) {
+    t.log("Validation errors:", validate.errors);
   }
-  t.pass();
+  t.true(valid, "legacy alias with value:'{name}' and uuid must validate");
+});
+
+test("alias with both $ref and value is rejected by oneOf", (t) => {
+  const alias = {
+    $schema: ALIAS_SCHEMA,
+    $ref: "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
+    value: "{gray-900}",
+    uuid: "f24eb871-6419-4cef-88a2-cca8548ae31e",
+  };
+  t.false(
+    validate(alias),
+    "alias carrying both $ref and value must be rejected (oneOf not both)",
+  );
+});
+
+test("legacy value with illegal characters in braces is rejected", (t) => {
+  const alias = {
+    $schema: ALIAS_SCHEMA,
+    // Dots and slashes are not allowed inside {…} by the legacy pattern.
+    value: "{a.b}",
+    uuid: "7da5157d-7f25-405b-8de0-f3669565fb48",
+  };
+  t.false(
+    validate(alias),
+    "value:'{a.b}' violates the \\{(\\w|-)*\\} pattern and must be rejected",
+  );
 });

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -646,6 +646,7 @@ impl TokenGraph {
         // Rebuild the UUID index so override/alias resolution below cannot point
         // at tokens that were just filtered out.
         self.rebuild_uuid_index();
+        self.rebuild_legacy_name_index();
 
         // 2. overrides — typed, Platform layer, type-preserving.
         if let Some(overrides) = manifest.get("overrides").and_then(|v| v.as_array()) {
@@ -775,6 +776,8 @@ impl TokenGraph {
         &self,
         target: &str,
     ) -> Result<Vec<OverrideTargetMatch>, CoreError> {
+        // Query expression heuristic: UUIDs (hex+hyphens) and slugs (word chars+hyphens)
+        // never contain '=', so presence of '=' unambiguously signals a query expression.
         if target.contains('=') {
             let filter = query::parse(target)?;
             return Ok(query::filter(self, &filter)
@@ -812,6 +815,19 @@ impl TokenGraph {
                 self.uuid_index
                     .entry(u.clone())
                     .or_insert_with(|| key.clone());
+            }
+        }
+    }
+
+    fn rebuild_legacy_name_index(&mut self) {
+        self.legacy_name_index.clear();
+        for (key, rec) in &self.tokens {
+            if let Some(name_val) = rec.raw.get("name") {
+                if let Some(legacy_key) = extract_legacy_key(name_val) {
+                    self.legacy_name_index
+                        .entry(legacy_key)
+                        .or_insert_with(|| key.clone());
+                }
             }
         }
     }

--- a/sdk/core/src/graph.rs
+++ b/sdk/core/src/graph.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use crate::discovery::discover_json_files;
+use crate::naming::extract_legacy_key;
 use crate::query;
 use crate::CoreError;
 
@@ -100,8 +101,16 @@ pub struct TokenGraph {
     ///
     /// Required for cascade-format alias resolution: cascade token keys are
     /// `"<file>:<index>"` (guaranteed unique) rather than UUIDs, so `$ref`
-    /// targets that are plain UUID strings need this index to resolve.
+    /// targets that are UUID strings need this index to resolve.
     uuid_index: HashMap<String, String>,
+    /// Tertiary index: legacy human-readable name → primary key in `tokens`.
+    ///
+    /// Populated for cascade-format tokens (keyed `"<file>:<index>"`), where
+    /// the graph key is not the human-readable legacy name.  Allows inline
+    /// composite alias references that use `{legacy-name}` syntax to resolve
+    /// against cascade tokens.  Not needed for object-format tokens, which are
+    /// already keyed by their legacy slug, but harmlessly populated there too.
+    legacy_name_index: HashMap<String, String>,
 }
 
 impl TokenGraph {
@@ -281,9 +290,25 @@ impl TokenGraph {
                         .and_then(|v| v.as_str())
                         .map(str::to_string);
                     let alias_target = extract_alias_target(tok_obj);
-                    // Register UUID → key for alias resolution.
+                    // Register UUID → key for cascade alias resolution.
                     if let Some(u) = &uuid {
                         g.uuid_index.entry(u.clone()).or_insert_with(|| key.clone());
+                    }
+                    // Register set_uuid → key so that aliases pointing at the
+                    // set-level UUID (emitted by the forward migration when a
+                    // legacy alias targets a color-set or scale-set token) can
+                    // resolve.  `or_insert_with` keeps the first mode (stable).
+                    if let Some(su) = tok_obj.get("set_uuid").and_then(|v| v.as_str()) {
+                        g.uuid_index.entry(su.to_string()).or_insert_with(|| key.clone());
+                    }
+                    // Register legacy name → key so inline composite `{name}`
+                    // refs can resolve against cascade tokens (keyed file:index).
+                    if let Some(name_val) = tok_obj.get("name") {
+                        if let Some(legacy_key) = extract_legacy_key(name_val) {
+                            g.legacy_name_index
+                                .entry(legacy_key)
+                                .or_insert_with(|| key.clone());
+                        }
                     }
                     g.tokens.insert(
                         key.clone(),
@@ -383,6 +408,9 @@ impl TokenGraph {
     pub fn from_pairs(entries: Vec<(String, PathBuf, Value)>) -> Self {
         let mut tokens = HashMap::new();
         let mut uuid_index = HashMap::new();
+        // `from_pairs` uses the entry name as the graph key (object-format style),
+        // so no separate legacy_name_index entry is needed — tokens.get(name) works.
+        let legacy_name_index = HashMap::new();
         for (name, file, raw) in entries {
             let tok_obj = raw.as_object();
             let schema_url = tok_obj
@@ -416,6 +444,7 @@ impl TokenGraph {
             mode_sets: Vec::new(),
             components: Vec::new(),
             uuid_index,
+            legacy_name_index,
         }
     }
 
@@ -426,11 +455,21 @@ impl TokenGraph {
     pub fn from_records(records: Vec<TokenRecord>) -> Self {
         let mut tokens = HashMap::new();
         let mut uuid_index = HashMap::new();
+        let mut legacy_name_index = HashMap::new();
         for record in records {
             if let Some(u) = &record.uuid {
                 uuid_index
                     .entry(u.clone())
                     .or_insert_with(|| record.name.clone());
+            }
+            // Index by legacy name derived from the name object so that inline
+            // composite refs can resolve if this was a cascade-format token.
+            if let Some(name_val) = record.raw.get("name") {
+                if let Some(legacy_key) = extract_legacy_key(name_val) {
+                    legacy_name_index
+                        .entry(legacy_key)
+                        .or_insert_with(|| record.name.clone());
+                }
             }
             tokens.insert(record.name.clone(), record);
         }
@@ -439,6 +478,7 @@ impl TokenGraph {
             mode_sets: Vec::new(),
             components: Vec::new(),
             uuid_index,
+            legacy_name_index,
         }
     }
 
@@ -893,29 +933,61 @@ fn normalize_ref_target(s: &str) -> String {
         .to_string()
 }
 
+impl TokenGraph {
+    /// Resolve an alias target string to a `TokenRecord`, trying indexes in
+    /// priority order:
+    ///
+    /// 1. **UUID index** — cascade `$ref` stores the target's UUID (canonical).
+    /// 2. **Direct graph key** — legacy object-format tokens are keyed by slug.
+    /// 3. **Legacy name index** — inline composite `{name}` refs that reference
+    ///    cascade tokens by their human-readable name.
+    pub fn resolve_alias_key<'a>(&'a self, target: &str) -> Option<&'a TokenRecord> {
+        // 1. UUID → graph key (cascade format canonical path).
+        if let Some(k) = self.uuid_index.get(target) {
+            if let Some(rec) = self.tokens.get(k) {
+                return Some(rec);
+            }
+        }
+        // 2. Direct lookup — object-format tokens are keyed by their legacy slug.
+        if let Some(rec) = self.tokens.get(target) {
+            return Some(rec);
+        }
+        // 3. Legacy name → graph key (inline composite refs into cascade tokens).
+        if let Some(k) = self.legacy_name_index.get(target) {
+            return self.tokens.get(k);
+        }
+        None
+    }
+}
+
 impl TokenRecord {
     /// Follow alias edges until a non-alias or missing target.
     ///
-    /// For cascade tokens whose `$ref` targets a UUID, the graph key is
-    /// `"file:index"` rather than the UUID itself. The `uuid_index` is checked
-    /// as a fallback so UUID-based aliases resolve correctly.
+    /// Resolution priority per hop (via [`TokenGraph::resolve_alias_key`]):
+    /// 1. UUID index — canonical for cascade `$ref` targets.
+    /// 2. Direct graph key — legacy slug-keyed object-format tokens.
+    /// 3. Legacy name index — inline composite `{name}` refs into cascade tokens.
+    ///
+    /// Cycle detection keys on the *resolved graph key* of each hop (not the
+    /// raw alias string), so chains that mix UUID and name references to the
+    /// same token are correctly detected.
     pub fn resolve_leaf<'a>(&'a self, graph: &'a TokenGraph) -> &'a TokenRecord {
         let mut current = self;
+        // Seed with the starting token's graph key.
         let mut seen: Vec<&str> = vec![&self.name];
-        while let Some(target_name) = &current.alias_target {
-            let next = graph.tokens.get(target_name).or_else(|| {
-                graph
-                    .uuid_index
-                    .get(target_name)
-                    .and_then(|k| graph.tokens.get(k))
-            });
-            let Some(next) = next else {
+        loop {
+            let Some(target_name) = current.alias_target.as_deref() else {
                 break;
             };
-            if seen.contains(&target_name.as_str()) {
+            let Some(next) = graph.resolve_alias_key(target_name) else {
+                break;
+            };
+            // Use the resolved graph key, not the raw alias string, so that a
+            // UUID ref and a name ref to the same token are both detected.
+            if seen.contains(&next.name.as_str()) {
                 break;
             }
-            seen.push(target_name);
+            seen.push(&next.name);
             current = next;
         }
         current
@@ -1312,5 +1384,149 @@ mod tests {
         let outcome = g.apply_platform_manifest(&manifest).unwrap();
         assert_eq!(g.tokens.len(), before);
         assert!(outcome.mode_set_restrictions.is_empty());
+    }
+
+    // ── resolve_alias_key / resolve_leaf (UUID-first, cycle guard) ────────────
+
+    /// Helper: build a cascade-format graph from an array of token objects.
+    ///
+    /// Uses a temp file so cascade-format ingest (keyed file:index) is exercised.
+    fn cascade_graph_from(tokens: serde_json::Value) -> TokenGraph {
+        use std::io::Write;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(f, "{tokens}").unwrap();
+        // Keep `dir` alive until graph is loaded.
+        let g = TokenGraph::from_json_dir(dir.path()).unwrap();
+        g
+    }
+
+    #[test]
+    fn resolve_alias_key_uuid_first() {
+        // Two tokens: a leaf (palette value) and an alias pointing to it by UUID.
+        let uuid = "aaaaaaaa-0000-0000-0000-000000000001";
+        let g = cascade_graph_from(json!([
+            {
+                "name": { "property": "color", "colorFamily": "blue", "scaleIndex": 100 },
+                "$schema": "https://example.com/color.json",
+                "value": "rgb(0,0,255)",
+                "uuid": uuid
+            },
+            {
+                "name": { "property": "accent-background-color", "state": "default" },
+                "$schema": "https://example.com/alias.json",
+                "$ref": uuid,
+                "uuid": "aaaaaaaa-0000-0000-0000-000000000002"
+            }
+        ]));
+
+        // resolve_alias_key by UUID must find the leaf.
+        let leaf = g.resolve_alias_key(uuid).expect("UUID lookup must succeed");
+        assert_eq!(leaf.raw["value"], "rgb(0,0,255)");
+
+        // resolve_leaf on the alias must traverse to the value token.
+        let alias_key = g
+            .tokens
+            .iter()
+            .find(|(_, r)| r.alias_target.is_some())
+            .map(|(k, _)| k.clone())
+            .unwrap();
+        let alias_rec = g.tokens.get(&alias_key).unwrap();
+        let resolved = alias_rec.resolve_leaf(&g);
+        assert_eq!(resolved.raw["value"], "rgb(0,0,255)");
+    }
+
+    #[test]
+    fn legacy_name_index_resolves_cascade_token_by_name() {
+        // Cascade tokens are keyed file:index. resolve_alias_key must still find
+        // them when given their human-readable legacy name.
+        let g = cascade_graph_from(json!([
+            {
+                "name": { "property": "color", "colorFamily": "blue", "scaleIndex": 100 },
+                "$schema": "https://example.com/color.json",
+                "value": "rgb(0,0,255)",
+                "uuid": "bbbbbbbb-0000-0000-0000-000000000001"
+            }
+        ]));
+
+        // "blue-100" is the serialized legacy name for this token.
+        let rec = g
+            .resolve_alias_key("blue-100")
+            .expect("legacy name lookup must succeed");
+        assert_eq!(rec.raw["value"], "rgb(0,0,255)");
+    }
+
+    #[test]
+    fn dangling_uuid_ref_returns_self_without_panic() {
+        // An alias whose $ref UUID has no matching token must break the chain
+        // and return self (same behaviour as today for dangling name refs).
+        let g = cascade_graph_from(json!([
+            {
+                "name": { "property": "accent-background-color", "state": "default" },
+                "$schema": "https://example.com/alias.json",
+                "$ref": "00000000-dead-beef-0000-000000000000",
+                "uuid": "cccccccc-0000-0000-0000-000000000001"
+            }
+        ]));
+
+        let alias_key = g.tokens.keys().next().unwrap().clone();
+        let rec = g.tokens.get(&alias_key).unwrap();
+        // Must return self, not panic.
+        let resolved = rec.resolve_leaf(&g);
+        assert_eq!(resolved.name, rec.name, "dangling UUID ref must return self");
+    }
+
+    #[test]
+    fn cycle_guard_detects_mixed_uuid_and_name_chain() {
+        // Craft a two-token cycle where A refs B by UUID and B refs A by legacy
+        // slug, exercising the "key on resolved graph key" fix.
+        let uuid_a = "dddddddd-0000-0000-0000-000000000001";
+        let uuid_b = "dddddddd-0000-0000-0000-000000000002";
+
+        // Use object-format for B so it's keyed by slug (enabling name ref from A).
+        let tokens_dir = tempdir().unwrap();
+        // Token A: cascade format, refs B by UUID.
+        let cascade_path = tokens_dir.path().join("a.json");
+        std::fs::write(
+            &cascade_path,
+            serde_json::to_string(&json!([
+                {
+                    "name": { "property": "accent-background-color", "state": "default" },
+                    "$schema": "https://example.com/alias.json",
+                    "$ref": uuid_b,
+                    "uuid": uuid_a
+                }
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+        // Token B: object format (keyed by slug), refs A by legacy name.
+        let obj_path = tokens_dir.path().join("b.json");
+        std::fs::write(
+            &obj_path,
+            serde_json::to_string(&json!({
+                "accent-color-800": {
+                    "$schema": "https://example.com/alias.json",
+                    "$ref": "accent-background-color-default",
+                    "uuid": uuid_b
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let g = TokenGraph::from_json_dir(tokens_dir.path()).unwrap();
+
+        // Resolving from either token must terminate (not loop forever).
+        let rec_a = g.resolve_alias_key(uuid_a).unwrap();
+        let result_a = rec_a.resolve_leaf(&g);
+        // Result is one of the two tokens; the important thing is it terminates.
+        assert!(
+            result_a.uuid.as_deref() == Some(uuid_a)
+                || result_a.uuid.as_deref() == Some(uuid_b),
+            "cycle must terminate, got {:?}",
+            result_a.uuid
+        );
     }
 }

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -166,8 +166,11 @@ pub fn convert_dir(input_dir: &Path, output_dir: &Path) -> Result<LegacySummary,
 ///
 /// Used directly in tests; `convert_dir` calls this internally via `convert_array`.
 pub fn convert_token(token: &Map<String, Value>) -> Option<(String, Value)> {
+    // No uuid_to_name map available in this single-token API; any UUID $ref
+    // is wrapped verbatim.  Use convert_dir for full UUID→name resolution.
+    let empty: HashMap<String, String> = HashMap::new();
     let key = token.get("name").and_then(extract_legacy_key)?;
-    let entry = build_flat_entry(token);
+    let entry = build_flat_entry(token, &empty);
     Some((key, entry))
 }
 
@@ -485,13 +488,13 @@ fn convert_array(
         }
 
         let mut entry = if let Some(dim) = dim_keys.into_iter().next() {
-            let result = build_set_entry(&property, &tokens, dim, summary);
+            let result = build_set_entry(&property, &tokens, dim, summary, global_uuid_to_name);
             summary.sets_reconstructed += 1;
             result
         } else {
             // No mode set key → flat entry (use first token, base/default variant).
             summary.flat_tokens += 1;
-            build_flat_entry(tokens[0])
+            build_flat_entry(tokens[0], global_uuid_to_name)
         };
 
         // Convert cascade lifecycle fields to legacy format.
@@ -571,6 +574,7 @@ fn build_set_entry(
     tokens: &[&Map<String, Value>],
     dim_key: &str,
     _summary: &mut LegacySummary,
+    uuid_to_name: &HashMap<String, String>,
 ) -> Value {
     // Prefer the stored set_schema (written by migrate) so we can round-trip
     // schema types that share a mode set key (e.g. typography-scale vs scale-set).
@@ -621,7 +625,7 @@ fn build_set_entry(
         let Some(mode) = name_obj.get(dim_key).and_then(|v| v.as_str()) else {
             continue;
         };
-        let entry = build_mode_entry(tok, tokens);
+        let entry = build_mode_entry(tok, tokens, uuid_to_name);
         sets.insert(mode.to_string(), Value::Object(entry));
     }
     outer.insert("sets".into(), Value::Object(sets));
@@ -635,6 +639,7 @@ fn build_set_entry(
 fn build_mode_entry(
     tok: &Map<String, Value>,
     all_tokens: &[&Map<String, Value>],
+    uuid_to_name: &HashMap<String, String>,
 ) -> Map<String, Value> {
     let mut entry = Map::new();
 
@@ -643,7 +648,7 @@ fn build_mode_entry(
     }
 
     // Value / alias denormalization.
-    insert_value_or_ref(&mut entry, tok);
+    insert_value_or_ref(&mut entry, tok, uuid_to_name);
 
     if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
         entry.insert("uuid".into(), Value::String(uuid.to_string()));
@@ -664,7 +669,7 @@ fn build_mode_entry(
 }
 
 /// Build a flat legacy entry from a cascade token with no mode-set key.
-fn build_flat_entry(tok: &Map<String, Value>) -> Value {
+fn build_flat_entry(tok: &Map<String, Value>, uuid_to_name: &HashMap<String, String>) -> Value {
     let mut entry = Map::new();
 
     if let Some(schema) = tok.get("$schema").and_then(|v| v.as_str()) {
@@ -681,7 +686,7 @@ fn build_flat_entry(tok: &Map<String, Value>) -> Value {
         entry.insert("component".into(), Value::String(c.to_string()));
     }
 
-    insert_value_or_ref(&mut entry, tok);
+    insert_value_or_ref(&mut entry, tok, uuid_to_name);
 
     if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
         entry.insert("uuid".into(), Value::String(uuid.to_string()));
@@ -696,10 +701,21 @@ fn build_flat_entry(tok: &Map<String, Value>) -> Value {
     Value::Object(entry)
 }
 
-/// Denormalize `$ref: "foo"` → `value: "{foo}"`.
-fn insert_value_or_ref(out: &mut Map<String, Value>, src: &Map<String, Value>) {
+/// Denormalize `$ref: "<uuid-or-name>"` → `value: "{<name>}"`.
+///
+/// When `$ref` holds a UUID (cascade canonical form), looks it up in
+/// `uuid_to_name` to recover the human-readable legacy slug.  If the UUID is
+/// not found in the map (dangling or non-UUID `$ref`), the raw `$ref` value is
+/// wrapped verbatim so the output is still syntactically valid and the
+/// `roundtrip-verify` task will surface the discrepancy.
+fn insert_value_or_ref(
+    out: &mut Map<String, Value>,
+    src: &Map<String, Value>,
+    uuid_to_name: &HashMap<String, String>,
+) {
     if let Some(r) = src.get("$ref").and_then(|v| v.as_str()) {
-        out.insert("value".into(), Value::String(format!("{{{r}}}")));
+        let name = uuid_to_name.get(r).map(String::as_str).unwrap_or(r);
+        out.insert("value".into(), Value::String(format!("{{{name}}}")));
     } else if let Some(v) = src.get("value") {
         out.insert("value".into(), v.clone());
     }

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -616,12 +616,11 @@ fn build_set_entry(
             name_obj.insert(dim_key.to_string(), Value::String(mode.to_string()));
             Value::Object(name_obj)
         }
-        // String escape hatch: can't add dim_key to a string.
-        // Fall back to thin object so the set structure is preserved.
+        // String-valued base_name: produced when the sidecar carries a
+        // SPEC-017 string-name escape-hatch value rather than an object.
+        // Reconstruct a thin name object so the mode dimension can still
+        // be attached and the set structure is preserved.
         _ => {
-            // Reconstruct thin from outer (property field is embedded in base_name
-            // only when it is an Object; this branch handles the unreachable
-            // String case defensively).
             let property = base_name.as_str().unwrap_or("");
             let mut name_obj = Map::new();
             name_obj.insert("property".into(), Value::String(property.to_string()));

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -131,6 +131,12 @@ pub struct MigrateSummary {
     /// Number of sidecar slug entries that were overwritten by a later file
     /// (last-writer-wins collision count from `load_sidecar_names`).
     pub sidecar_slug_overrides: usize,
+    /// Alias `$ref` targets whose legacy name was not found in the UUID map.
+    ///
+    /// These fall back to writing the raw name string so SPEC-014 can detect
+    /// the dangling ref downstream.  A non-zero count indicates source tokens
+    /// that reference a target not present in the current migration run.
+    pub dangling_alias_refs: usize,
 }
 
 /// Summary statistics from an add-uuids run.
@@ -582,6 +588,7 @@ fn convert_set(
                 mode,
                 name_to_uuid,
                 &base_name,
+                &mut summary.dangling_alias_refs,
             ))
         })
         .collect()
@@ -598,6 +605,7 @@ fn build_set_entry(
     mode: &str,
     name_to_uuid: &HashMap<&str, &str>,
     base_name: &Value,
+    dangling: &mut usize,
 ) -> Value {
     let mut out = Map::new();
 
@@ -631,8 +639,8 @@ fn build_set_entry(
         out.insert("$schema".into(), Value::String(schema.to_string()));
     }
 
-    // Value or alias.
-    insert_value_or_ref(&mut out, entry);
+    // Value or alias (UUID-keyed $ref for aliases).
+    insert_value_or_ref(&mut out, entry, name_to_uuid, dangling);
 
     // UUID from entry (mode-level).
     if let Some(uuid) = entry.get("uuid").and_then(|v| v.as_str()) {
@@ -710,8 +718,8 @@ fn build_flat(
         }
     }
 
-    // Value or alias.
-    insert_value_or_ref(&mut out, token_obj);
+    // Value or alias (UUID-keyed $ref for aliases).
+    insert_value_or_ref(&mut out, token_obj, name_to_uuid, &mut summary.dangling_alias_refs);
 
     // UUID.
     if let Some(uuid) = token_obj.get("uuid").and_then(|v| v.as_str()) {
@@ -766,13 +774,30 @@ fn normalize_lifecycle_for_cascade(
 
 /// Insert `value` or `$ref` into the output map from a source object.
 ///
-/// Alias syntax `value: "{token-name}"` is normalized to `$ref: "token-name"`.
-fn insert_value_or_ref(out: &mut Map<String, Value>, src: &Map<String, Value>) {
+/// Alias syntax `value: "{token-name}"` is normalized to `$ref: "<uuid>"` by
+/// looking up the target name in `name_to_uuid`.  If the target name is not
+/// found (dangling alias in the source), the name string is used verbatim as a
+/// fallback and `dangling` is incremented — SPEC-014 will flag it downstream.
+///
+/// Non-alias `value` entries are copied unchanged.
+fn insert_value_or_ref(
+    out: &mut Map<String, Value>,
+    src: &Map<String, Value>,
+    name_to_uuid: &HashMap<&str, &str>,
+    dangling: &mut usize,
+) {
     if let Some(val) = src.get("value") {
         if let Some(s) = val.as_str() {
             if s.starts_with('{') && s.ends_with('}') && s.len() > 2 {
-                let target = s[1..s.len() - 1].to_string();
-                out.insert("$ref".into(), Value::String(target));
+                let target_name = &s[1..s.len() - 1];
+                let ref_value = if let Some(&uuid) = name_to_uuid.get(target_name) {
+                    uuid.to_string()
+                } else {
+                    // Dangling alias: target not in this migration run.
+                    *dangling += 1;
+                    target_name.to_string()
+                };
+                out.insert("$ref".into(), Value::String(ref_value));
                 return;
             }
         }

--- a/sdk/core/src/validate/rules/spec001.rs
+++ b/sdk/core/src/validate/rules/spec001.rs
@@ -28,7 +28,7 @@ impl ValidationRule for Rule {
             let Some(target) = &t.alias_target else {
                 continue;
             };
-            if !ctx.graph.tokens.contains_key(target) {
+            if ctx.graph.resolve_alias_key(target).is_none() {
                 out.push(Diagnostic {
                     file: t.file.clone(),
                     token: Some(t.name.clone()),

--- a/sdk/core/src/validate/rules/spec002.rs
+++ b/sdk/core/src/validate/rules/spec002.rs
@@ -28,7 +28,7 @@ impl ValidationRule for Rule {
             let Some(target_name) = &t.alias_target else {
                 continue;
             };
-            let Some(target) = ctx.graph.tokens.get(target_name) else {
+            let Some(target) = ctx.graph.resolve_alias_key(target_name) else {
                 continue;
             };
             let leaf = target.resolve_leaf(ctx.graph);

--- a/sdk/core/src/validate/rules/spec003.rs
+++ b/sdk/core/src/validate/rules/spec003.rs
@@ -44,7 +44,7 @@ impl ValidationRule for Rule {
                     break;
                 }
                 path.push(next_name.clone());
-                let Some(next) = ctx.graph.tokens.get(next_name.as_str()) else {
+                let Some(next) = ctx.graph.resolve_alias_key(next_name.as_str()) else {
                     break;
                 };
                 current = next;

--- a/sdk/core/src/validate/rules/spec015.rs
+++ b/sdk/core/src/validate/rules/spec015.rs
@@ -194,7 +194,7 @@ impl ValidationRule for Rule {
                     continue;
                 };
 
-                let Some(target_record) = ctx.graph.tokens.get(&target_name) else {
+                let Some(target_record) = ctx.graph.resolve_alias_key(&target_name) else {
                     // Missing target is SPEC-014's job, not ours.
                     continue;
                 };

--- a/sdk/core/src/validate/rules/spec042.rs
+++ b/sdk/core/src/validate/rules/spec042.rs
@@ -77,7 +77,7 @@ impl ValidationRule for Rule {
                     if hops >= 8 {
                         break; // depth guard; SPEC-003 enforces no true cycles
                     }
-                    let Some(target) = ctx.graph.tokens.get(target_name) else {
+                    let Some(target) = ctx.graph.resolve_alias_key(target_name) else {
                         break; // broken alias — SPEC-001 owns this diagnostic
                     };
                     resolved = target.schema_url.as_deref().unwrap_or("<missing schema>");


### PR DESCRIPTION
## Description

Cascade alias tokens previously stored their \`$ref\` as a bare kebab name string (e.g. \`$ref: "accent-color-900"\`). This was **both rename-fragile and silently broken**: cascade tokens are keyed \`file:index\` in the graph, so name-string refs never resolved through \`uuid_index\` or the primary token map — cascade alias chains were effectively dangling.

This PR makes cascade \`$ref\` the canonical, resolvable form by pointing it at the **target token's UUID**. The legacy \`packages/tokens/src\` package stays on the unchanged \`{name}\` curly-brace format; \`roundtrip-verify\` is clean.

## Related Issue

N/A — identified during MCP \`resolve_token\` debugging session.

## Motivation and Context

- **Rename-fragile:** a name change to \`accent-color-900\` would silently break all aliases pointing at it by name.
- **Currently broken:** cascade tokens are graph-keyed by \`file:index\`. \`resolve_leaf\` tries \`tokens.get("accent-color-900")\` (misses) then \`uuid_index.get("accent-color-900")\` (also misses — that index maps UUIDs, not names). So all cascade alias chains returned \`self\` as the leaf, skipping resolution entirely.
- **Consistent with the system:** \`diff.rs\` already pairs tokens by UUID first; \`replaced_by\` already uses UUIDs. \`$ref\` was the odd one out.

## How Has This Been Tested?

- All **476 existing + new tests** pass (\`cargo test --all\`)
- **4 new graph tests** covering UUID-first resolve, \`legacy_name_index\` lookup, dangling-UUID returns-self, and mixed-chain cycle guard
- **\`roundtrip-verify\`**: \`Roundtrip OK\` — legacy output is byte-semantically identical after the migration
- **Embedded snapshot tests** pass (\`materialize_token_src_contains_json_files\`, version parity)
- **Changeset linter**: 0 warnings, 0 errors
- **alias.json \`oneOf\` schema tests**: 4 new AVA assertions covering cascade \`\$ref\`-only, legacy \`value:"{name}"\`, both-fields rejection, and illegal-char rejection

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

### Key changes by file

| File | Change |
|---|---|
| \`sdk/core/src/graph.rs\` | Add \`resolve_alias_key\` (UUID→slug→legacy-name fallback); \`legacy_name_index\` (serialised name→graph key); index \`set_uuid\` for set-targeted aliases; fix cycle guard to key on resolved graph key |
| \`sdk/core/src/migrate.rs\` | Emit UUID \`$ref\` via \`global_name_to_uuid\`; add \`dangling_alias_refs\` counter |
| \`sdk/core/src/legacy.rs\` | Denormalize UUID \`$ref\` → \`{name}\` via \`global_uuid_to_name\` |
| \`sdk/core/src/validate/rules/spec001–003,015,042\` | Route alias-target lookups through \`resolve_alias_key\` |
| \`packages/design-data/tokens/*.tokens.json\` (8) | Regenerated — all \`$ref\` values are now UUIDs |
| \`packages/tokens/schemas/token-types/alias.json\` | Accept \`value: "{name}"\` (legacy) or \`$ref: "<uuid>"\` (cascade) via \`oneOf\`; add top-level \`required: ["$schema","uuid"]\`; clean up UUID regex; strengthen schema tests |
| \`packages/design-data-spec/schemas/token.schema.json\` | Document UUID as canonical cascade \`$ref\` form |
| \`packages/design-data-spec/spec/token-format.md\` | Activate the previously reserved UUID-alias direction with example |
| \`packages/design-data-spec/spec/cascade.md\` | Cross-reference UUID \`$ref\` form in §Alias resolution |
| \`.changeset/cascade-uuid-refs.md\` | Minor changeset for affected packages |