### PR TITLE
fix(changesets): replace Rust crate names with npm wrapper package in frontmatter

### DIFF
--- a/.changeset/cascade-uuid-refs.md
+++ b/.changeset/cascade-uuid-refs.md
@@ -1,7 +1,7 @@
 ---
 "@adobe/spectrum-design-data": minor
 "@adobe/design-data-spec": minor
-"design-data-core": minor
+"@adobe/design-data": minor
 ---
 Migrate cascade token `$ref` aliases from name strings to UUIDs.
 

--- a/.changeset/tui-ratatui-0-30-bump.md
+++ b/.changeset/tui-ratatui-0-30-bump.md
@@ -1,5 +1,5 @@
 ---
-"design-data-tui": minor
+"@adobe/design-data": minor
 ---
 Upgrade Ratatui ecosystem to unlock new widget crates for UX improvements.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Fix three changeset files that referenced Rust crate names (`design-data-core`, `design-data-tui`) in their frontmatter. Changesets only versions JS/pnpm workspace packages — the Rust crates are not workspace members. They ship via the `@adobe/design-data` CLI wrapper (`sdk/cli/package.json`), which is the correct frontmatter target per established project convention.

**Files fixed:**
- `.changeset/cascade-uuid-refs.md`: `"design-data-core": minor` → `"@adobe/design-data": minor`
- `.changeset/tui-ratatui-0-30-bump.md`: `"design-data-tui": minor` → `"@adobe/design-data": minor`

## Related Issue

Blocked Release workflow: https://github.com/adobe/spectrum-design-data/actions/runs/26919562682

## Motivation and Context

The Release workflow failed at "Create or update Version Packages PR" with:
```
🦋 error Found changeset cascade-uuid-refs for package design-data-core which is not in the workspace
```

`changeset version` aborts when a frontmatter key doesn't match a pnpm workspace package. The Rust crates (`design-data-core`, `design-data-tui`) are built and bundled into platform-specific npm packages, then re-exported through `@adobe/design-data` — that npm package is what changesets should bump.

Precedent established by `cascade-embed-source-of-truth.md` and `tui-v2-epic-1014.md`, both SDK changes, both correctly used `"@adobe/design-data"`.

## How Has This Been Tested?

Ran `pnpm exec changeset status` on the hotfix branch — no errors, `@adobe/design-data` correctly listed for minor bump alongside `@adobe/spectrum-design-data` and `@adobe/design-data-spec`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.