### PR TITLE
fix(workspace): add sdk/tui to pnpm workspace packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,8 @@ importers:
 
   sdk/npm/win32-x64: {}
 
+  sdk/tui: {}
+
   tools/changeset-linter:
     dependencies:
       chalk:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - "tools/*"
   - "sdk/cli"
   - "sdk/npm/*"
+  - "sdk/tui"


### PR DESCRIPTION
## Description

Add `sdk/tui` to `pnpm-workspace.yaml` and update the lockfile.

## Related Issue

Fixes the broken release CI (run [#26982685131](https://github.com/adobe/spectrum-design-data/actions/runs/26982685131)).

## Motivation and Context

PR #1107 landed the `tui-verify-skill-and-layout-tests` changeset, which bumps `@adobe/design-data-tui`, but `sdk/tui` was never added to `pnpm-workspace.yaml`. Changesets errors with _"Found changeset … for package @adobe/design-data-tui which is not in the workspace"_ every time the Changesets action tries to create the version PR, blocking all releases.

## How Has This Been Tested?

- `pnpm install` passes with the new workspace entry
- `pnpm changeset status` now lists `@adobe/design-data-tui` without error

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.