### PR TITLE
fix(design-data-agent-mcp): resolve design data via the workspace package

### DIFF
--- a/.changeset/fix-mcp-relative-path-anchoring.md
+++ b/.changeset/fix-mcp-relative-path-anchoring.md
@@ -1,0 +1,14 @@
+---
+"@adobe/design-data-agent-mcp": minor
+---
+
+Anchor relative `DESIGN_DATA_*` paths so MCP tools work when launched from a
+monorepo subdirectory (closes #1109).
+
+- **src/config.js**: resolve relative `DESIGN_DATA_PATH`, `DESIGN_DATA_COMPONENTS`,
+  `DESIGN_DATA_FIELDS`, `DESIGN_DATA_SCHEMAS`, and `DESIGN_DATA_EXCEPTIONS` against a
+  known root instead of the process CWD. Adds the `DESIGN_DATA_ROOT` env var (absolute
+  root, works under `npx`) and falls back to the server package root for in-repo runs.
+- **src/cli.js**: spawn the `design-data` CLI with `cwd` set to the resolved root so its
+  own tier/probe resolution anchors correctly.
+- **README.md**: document `DESIGN_DATA_ROOT` and the recommended config.

--- a/.changeset/fix-mcp-relative-path-anchoring.md
+++ b/.changeset/fix-mcp-relative-path-anchoring.md
@@ -2,17 +2,13 @@
 "@adobe/design-data-agent-mcp": minor
 ---
 
-Resolve design data paths independently of the working directory so MCP tools
-work when launched from a monorepo subdirectory (closes #1109).
+Anchor relative `DESIGN_DATA_*` paths so MCP tools work when launched from a
+monorepo subdirectory (closes #1109).
 
-- **package.json**: depend on `@adobe/spectrum-design-data` (`workspace:*`) so the
-  data package is linked into the server.
-- **src/config.js**: when no env override is set, resolve `tokens`/`components`/
-  `fields` from the `@adobe/spectrum-design-data` package via Node module
-  resolution (CWD-independent). Explicit `DESIGN_DATA_*` env overrides still win;
-  relative values are anchored to the new `DESIGN_DATA_ROOT` (or the server
-  package root when unset).
-- **src/cli.js**: spawn the `design-data` CLI with `cwd` set to the resolved root.
-- **moon.yml / .moon/workspace.yml**: register the project and add
-  `dependsOn: ["design-data"]` so moon orders tasks and syncs the dependency.
-- **README.md**: document the resolution precedence and `DESIGN_DATA_ROOT`.
+- **src/config.js**: resolve relative `DESIGN_DATA_PATH`, `DESIGN_DATA_COMPONENTS`,
+  `DESIGN_DATA_FIELDS`, `DESIGN_DATA_SCHEMAS`, and `DESIGN_DATA_EXCEPTIONS` against a
+  known root instead of the process CWD. Adds the `DESIGN_DATA_ROOT` env var (absolute
+  root, works under `npx`) and falls back to the server package root for in-repo runs.
+- **src/cli.js**: spawn the `design-data` CLI with `cwd` set to the resolved root so its
+  own tier/probe resolution anchors correctly.
+- **README.md**: document `DESIGN_DATA_ROOT` and the recommended config.

--- a/.changeset/fix-mcp-relative-path-anchoring.md
+++ b/.changeset/fix-mcp-relative-path-anchoring.md
@@ -2,13 +2,17 @@
 "@adobe/design-data-agent-mcp": minor
 ---
 
-Anchor relative `DESIGN_DATA_*` paths so MCP tools work when launched from a
-monorepo subdirectory (closes #1109).
+Resolve design data paths independently of the working directory so MCP tools
+work when launched from a monorepo subdirectory (closes #1109).
 
-- **src/config.js**: resolve relative `DESIGN_DATA_PATH`, `DESIGN_DATA_COMPONENTS`,
-  `DESIGN_DATA_FIELDS`, `DESIGN_DATA_SCHEMAS`, and `DESIGN_DATA_EXCEPTIONS` against a
-  known root instead of the process CWD. Adds the `DESIGN_DATA_ROOT` env var (absolute
-  root, works under `npx`) and falls back to the server package root for in-repo runs.
-- **src/cli.js**: spawn the `design-data` CLI with `cwd` set to the resolved root so its
-  own tier/probe resolution anchors correctly.
-- **README.md**: document `DESIGN_DATA_ROOT` and the recommended config.
+- **package.json**: depend on `@adobe/spectrum-design-data` (`workspace:*`) so the
+  data package is linked into the server.
+- **src/config.js**: when no env override is set, resolve `tokens`/`components`/
+  `fields` from the `@adobe/spectrum-design-data` package via Node module
+  resolution (CWD-independent). Explicit `DESIGN_DATA_*` env overrides still win;
+  relative values are anchored to the new `DESIGN_DATA_ROOT` (or the server
+  package root when unset).
+- **src/cli.js**: spawn the `design-data` CLI with `cwd` set to the resolved root.
+- **moon.yml / .moon/workspace.yml**: register the project and add
+  `dependsOn: ["design-data"]` so moon orders tasks and syncs the dependency.
+- **README.md**: document the resolution precedence and `DESIGN_DATA_ROOT`.

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,5 +1,16 @@
 export default {
-  "**/*.{js,jsx,ts,tsx,json,yml,yaml}": ["prettier --write"],
+  "**/*.{js,jsx,ts,tsx,json,yml,yaml}": (files) => {
+    // Exclude lockfiles: they are machine-generated and must not be reformatted
+    // by prettier (doing so produces a massive, churny diff). A bare
+    // `"!**/pnpm-lock.yaml": []` key does NOT exclude them from this glob —
+    // lint-staged matches each key independently — so filter them out here.
+    const lockfile = /(?:^|\/)(pnpm-lock\.yaml|package-lock\.json|yarn\.lock)$/;
+    const formatable = files.filter((file) => !lockfile.test(file));
+    if (formatable.length === 0) return [];
+    return [
+      `prettier --write ${formatable.map((f) => JSON.stringify(f)).join(" ")}`,
+    ];
+  },
   "**/*.md": (files) => {
     // Filter out changeset and CHANGELOG files - they need special handling
     // Skip 11ty page templates so YAML frontmatter (---) is not reformatted by remark
@@ -22,9 +33,6 @@ export default {
         `remark ${file} --use remark-frontmatter --use remark-gfm --use remark-github -o`,
     );
   },
-  "!**/pnpm-lock.yaml": [],
-  "!**/package-lock.json": [],
-  "!**/yarn.lock": [],
   ".changeset/*.md": (files) => {
     // Only run changeset linter on actual changeset files, not README.md
     const changesetFiles = files.filter((file) => !file.endsWith("README.md"));

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -20,6 +20,7 @@ projects:
   release-analyzer: "tools/release-analyzer"
   release-timeline: "docs/release-timeline"
   spectrum-design-data-mcp: "tools/spectrum-design-data-mcp"
+  design-data-agent-mcp: "tools/design-data-agent-mcp"
   s2-docs-mcp: "tools/s2-docs-mcp"
   component-options-editor: "tools/component-options-editor"
   token-naming-audit: "tools/token-naming-audit"

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -20,7 +20,6 @@ projects:
   release-analyzer: "tools/release-analyzer"
   release-timeline: "docs/release-timeline"
   spectrum-design-data-mcp: "tools/spectrum-design-data-mcp"
-  design-data-agent-mcp: "tools/design-data-agent-mcp"
   s2-docs-mcp: "tools/s2-docs-mcp"
   component-options-editor: "tools/component-options-editor"
   token-naming-audit: "tools/token-naming-audit"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,9 +574,6 @@ importers:
 
   tools/design-data-agent-mcp:
     dependencies:
-      '@adobe/spectrum-design-data':
-        specifier: workspace:*
-        version: link:../../packages/design-data
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,9 @@ importers:
 
   tools/design-data-agent-mcp:
     dependencies:
+      '@adobe/spectrum-design-data':
+        specifier: workspace:*
+        version: link:../../packages/design-data
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -47,14 +47,30 @@ node tools/design-data-agent-mcp/src/index.js
 
 ### Environment variables
 
-| Variable                 | Default       | Description                               |
-| ------------------------ | ------------- | ----------------------------------------- |
-| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary          |
-| `DESIGN_DATA_PATH`       | `.`           | Dataset root path                         |
-| `DESIGN_DATA_COMPONENTS` | —             | Override components directory             |
-| `DESIGN_DATA_FIELDS`     | —             | Override fields directory                 |
-| `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)     |
-| `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`) |
+| Variable                 | Default       | Description                                       |
+| ------------------------ | ------------- | ------------------------------------------------- |
+| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary                  |
+| `DESIGN_DATA_ROOT`       | —             | Absolute root that relative paths are anchored to |
+| `DESIGN_DATA_PATH`       | `.`           | Dataset root path                                 |
+| `DESIGN_DATA_COMPONENTS` | —             | Override components directory                     |
+| `DESIGN_DATA_FIELDS`     | —             | Override fields directory                         |
+| `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)             |
+| `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`)         |
+
+> **Relative paths and the working directory.** The MCP client launches this
+> server with the working directory inherited from wherever the editor was
+> opened — which may be a subdirectory of your repo (e.g. `sdk/`), not the repo
+> root. Relative `DESIGN_DATA_*` paths are therefore anchored to a known root
+> rather than the process CWD:
+>
+> 1. If `DESIGN_DATA_ROOT` is set (recommended), relative paths resolve against
+>    it. Set it to the absolute path of your repo root. This is the reliable
+>    option when the server is launched via `npx`.
+> 2. Otherwise, relative paths resolve against the server package's own location
+>    in the monorepo (only correct when running the server from inside the repo
+>    checkout).
+>
+> Absolute `DESIGN_DATA_*` paths are always used as-is.
 
 ### Example (Cursor `.cursor/mcp.json`)
 
@@ -65,9 +81,10 @@ node tools/design-data-agent-mcp/src/index.js
       "command": "npx",
       "args": ["-y", "@adobe/design-data-agent-mcp"],
       "env": {
-        "DESIGN_DATA_PATH": "./packages/tokens/src",
-        "DESIGN_DATA_COMPONENTS": "./packages/design-data/components",
-        "DESIGN_DATA_FIELDS": "./packages/design-data/fields"
+        "DESIGN_DATA_ROOT": "/abs/path/to/your/repo",
+        "DESIGN_DATA_PATH": "packages/design-data/tokens",
+        "DESIGN_DATA_COMPONENTS": "packages/design-data/components",
+        "DESIGN_DATA_FIELDS": "packages/design-data/fields"
       }
     }
   }

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -57,20 +57,28 @@ node tools/design-data-agent-mcp/src/index.js
 | `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)             |
 | `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`)         |
 
-> **Relative paths and the working directory.** The MCP client launches this
-> server with the working directory inherited from wherever the editor was
-> opened — which may be a subdirectory of your repo (e.g. `sdk/`), not the repo
-> root. Relative `DESIGN_DATA_*` paths are therefore anchored to a known root
-> rather than the process CWD:
+> **Path resolution.** The MCP client launches this server with the working
+> directory inherited from wherever the editor was opened — which may be a
+> subdirectory of your repo (e.g. `sdk/`), not the repo root. To stay independent
+> of that working directory, each data path is resolved in this order:
 >
-> 1. If `DESIGN_DATA_ROOT` is set (recommended), relative paths resolve against
->    it. Set it to the absolute path of your repo root. This is the reliable
->    option when the server is launched via `npx`.
-> 2. Otherwise, relative paths resolve against the server package's own location
->    in the monorepo (only correct when running the server from inside the repo
->    checkout).
+> 1. **Explicit env override.** If `DESIGN_DATA_PATH` / `DESIGN_DATA_COMPONENTS` /
+>    `DESIGN_DATA_FIELDS` is set, it is used. Relative values are anchored to
+>    `DESIGN_DATA_ROOT` (absolute, recommended when launching via `npx`) or, if
+>    that is unset, to the server package's own location in the monorepo. Absolute
+>    values are used as-is.
+> 2. **Resolved `@adobe/spectrum-design-data` package** (zero config). When no env
+>    override is set, the server resolves the installed `@adobe/spectrum-design-data`
+>    package via Node module resolution and reads its `tokens/`, `components/`, and
+>    `fields/` directories. In a pnpm workspace this follows the symlink to
+>    `packages/design-data`; when published it uses the installed dependency. This
+>    is independent of the working directory.
+> 3. **Fallback.** `dataPath` falls back to the (anchored) current directory; the
+>    component/field overrides fall back to the `design-data` binary's own
+>    discovery (including its embedded snapshot).
 >
-> Absolute `DESIGN_DATA_*` paths are always used as-is.
+> In a monorepo checkout you typically need no `DESIGN_DATA_*` env vars at all —
+> resolution via the workspace package handles it.
 
 ### Example (Cursor `.cursor/mcp.json`)
 

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -57,28 +57,20 @@ node tools/design-data-agent-mcp/src/index.js
 | `DESIGN_DATA_SCHEMAS`    | —             | Override schema path (for `validate`)             |
 | `DESIGN_DATA_EXCEPTIONS` | —             | Override exceptions path (for `validate`)         |
 
-> **Path resolution.** The MCP client launches this server with the working
-> directory inherited from wherever the editor was opened — which may be a
-> subdirectory of your repo (e.g. `sdk/`), not the repo root. To stay independent
-> of that working directory, each data path is resolved in this order:
+> **Relative paths and the working directory.** The MCP client launches this
+> server with the working directory inherited from wherever the editor was
+> opened — which may be a subdirectory of your repo (e.g. `sdk/`), not the repo
+> root. Relative `DESIGN_DATA_*` paths are therefore anchored to a known root
+> rather than the process CWD:
 >
-> 1. **Explicit env override.** If `DESIGN_DATA_PATH` / `DESIGN_DATA_COMPONENTS` /
->    `DESIGN_DATA_FIELDS` is set, it is used. Relative values are anchored to
->    `DESIGN_DATA_ROOT` (absolute, recommended when launching via `npx`) or, if
->    that is unset, to the server package's own location in the monorepo. Absolute
->    values are used as-is.
-> 2. **Resolved `@adobe/spectrum-design-data` package** (zero config). When no env
->    override is set, the server resolves the installed `@adobe/spectrum-design-data`
->    package via Node module resolution and reads its `tokens/`, `components/`, and
->    `fields/` directories. In a pnpm workspace this follows the symlink to
->    `packages/design-data`; when published it uses the installed dependency. This
->    is independent of the working directory.
-> 3. **Fallback.** `dataPath` falls back to the (anchored) current directory; the
->    component/field overrides fall back to the `design-data` binary's own
->    discovery (including its embedded snapshot).
+> 1. If `DESIGN_DATA_ROOT` is set (recommended), relative paths resolve against
+>    it. Set it to the absolute path of your repo root. This is the reliable
+>    option when the server is launched via `npx`.
+> 2. Otherwise, relative paths resolve against the server package's own location
+>    in the monorepo (only correct when running the server from inside the repo
+>    checkout).
 >
-> In a monorepo checkout you typically need no `DESIGN_DATA_*` env vars at all —
-> resolution via the workspace package handles it.
+> Absolute `DESIGN_DATA_*` paths are always used as-is.
 
 ### Example (Cursor `.cursor/mcp.json`)
 

--- a/tools/design-data-agent-mcp/moon.yml
+++ b/tools/design-data-agent-mcp/moon.yml
@@ -9,6 +9,11 @@
 # governing permissions and limitations under the License.
 $schema: "https://moonrepo.dev/schemas/project.json"
 layer: tool
+# The MCP server serves Spectrum design data, so it depends on the design-data
+# package. moon uses this for task ordering and (via
+# syncProjectWorkspaceDependencies) keeps the workspace dependency in package.json.
+dependsOn:
+  - "design-data"
 tasks:
   start:
     command: [node, src/index.js]

--- a/tools/design-data-agent-mcp/moon.yml
+++ b/tools/design-data-agent-mcp/moon.yml
@@ -9,11 +9,6 @@
 # governing permissions and limitations under the License.
 $schema: "https://moonrepo.dev/schemas/project.json"
 layer: tool
-# The MCP server serves Spectrum design data, so it depends on the design-data
-# package. moon uses this for task ordering and (via
-# syncProjectWorkspaceDependencies) keeps the workspace dependency in package.json.
-dependsOn:
-  - "design-data"
 tasks:
   start:
     command: [node, src/index.js]

--- a/tools/design-data-agent-mcp/package.json
+++ b/tools/design-data-agent-mcp/package.json
@@ -33,6 +33,7 @@
     "provenance": true
   },
   "dependencies": {
+    "@adobe/spectrum-design-data": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "devDependencies": {

--- a/tools/design-data-agent-mcp/package.json
+++ b/tools/design-data-agent-mcp/package.json
@@ -33,7 +33,6 @@
     "provenance": true
   },
   "dependencies": {
-    "@adobe/spectrum-design-data": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "devDependencies": {

--- a/tools/design-data-agent-mcp/src/cli.js
+++ b/tools/design-data-agent-mcp/src/cli.js
@@ -14,6 +14,10 @@ import { config } from "./config.js";
 export function runCli(args, { timeout = 10_000 } = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn(config.bin, args, {
+      // Anchor the CLI's working directory to the resolved data root so its own
+      // tier/probe logic (data_source::resolve, is_in_repo) resolves correctly
+      // even when Claude Code launched the server from a monorepo subdirectory.
+      cwd: config.dataRoot,
       // isolates CLI stdout from the MCP JSON-RPC stream on the parent's stdout
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/tools/design-data-agent-mcp/src/config.js
+++ b/tools/design-data-agent-mcp/src/config.js
@@ -8,11 +8,34 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
+import { fileURLToPath } from "url";
+import { isAbsolute, resolve } from "path";
+
+// The repo root relative to this file: src → package → tools → repo root.
+// Used as the self-anchoring fallback when DESIGN_DATA_ROOT is not provided
+// and the server is run from inside the monorepo checkout.
+const SERVER_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+// Claude Code launches the MCP server with the working directory inherited from
+// wherever the editor was opened (e.g. `sdk/`), not the repo root. Relative
+// DESIGN_DATA_* paths must therefore be anchored to a known root rather than the
+// process CWD. Prefer an explicit absolute DESIGN_DATA_ROOT (works even when the
+// server is launched via `npx` from the npm cache); fall back to SERVER_ROOT for
+// in-repo runs.
+const dataRoot = process.env.DESIGN_DATA_ROOT
+  ? resolve(process.env.DESIGN_DATA_ROOT)
+  : SERVER_ROOT;
+
+function anchorPath(p) {
+  return p && !isAbsolute(p) ? resolve(dataRoot, p) : p;
+}
+
 export const config = {
   bin: process.env.DESIGN_DATA_BIN ?? "design-data",
-  dataPath: process.env.DESIGN_DATA_PATH ?? ".",
-  schemaPath: process.env.DESIGN_DATA_SCHEMAS ?? null,
-  exceptionsPath: process.env.DESIGN_DATA_EXCEPTIONS ?? null,
-  componentsDir: process.env.DESIGN_DATA_COMPONENTS ?? null,
-  fieldsDir: process.env.DESIGN_DATA_FIELDS ?? null,
+  dataRoot,
+  dataPath: anchorPath(process.env.DESIGN_DATA_PATH ?? "."),
+  schemaPath: anchorPath(process.env.DESIGN_DATA_SCHEMAS ?? null),
+  exceptionsPath: anchorPath(process.env.DESIGN_DATA_EXCEPTIONS ?? null),
+  componentsDir: anchorPath(process.env.DESIGN_DATA_COMPONENTS ?? null),
+  fieldsDir: anchorPath(process.env.DESIGN_DATA_FIELDS ?? null),
 };

--- a/tools/design-data-agent-mcp/src/config.js
+++ b/tools/design-data-agent-mcp/src/config.js
@@ -51,6 +51,12 @@ function resolveDataPackageDir(subdir) {
 
 // Path precedence: explicit env override (anchored to dataRoot) wins, then the
 // resolved design-data package directory, then a final fallback.
+//
+// The fallback differs by field on purpose: `dataPath` is a required positional
+// CLI argument, so it falls back to the anchored current directory. `componentsDir`
+// and `fieldsDir` are optional `--components-dir`/`--fields-dir` flags, so they fall
+// back to `null` (flag omitted) and let the design-data binary's own discovery —
+// including its embedded snapshot — locate them.
 export const config = {
   bin: process.env.DESIGN_DATA_BIN ?? "design-data",
   dataRoot,

--- a/tools/design-data-agent-mcp/src/config.js
+++ b/tools/design-data-agent-mcp/src/config.js
@@ -8,8 +8,9 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
+import { createRequire } from "module";
 import { fileURLToPath } from "url";
-import { isAbsolute, resolve } from "path";
+import { dirname, isAbsolute, resolve } from "path";
 
 // The repo root relative to this file: src → package → tools → repo root.
 // Used as the self-anchoring fallback when DESIGN_DATA_ROOT is not provided
@@ -30,12 +31,41 @@ function anchorPath(p) {
   return p && !isAbsolute(p) ? resolve(dataRoot, p) : p;
 }
 
+// Locate a directory inside the @adobe/spectrum-design-data package via Node's
+// module resolution. In a pnpm workspace this resolves through the symlink to
+// `packages/design-data`; when published it resolves the installed dependency.
+// Either way it is independent of the process working directory, so it provides
+// a zero-config default that does not depend on where the server was launched.
+// Returns null when the package is not installed (e.g. a standalone CLI install
+// that relies on the design-data binary's embedded snapshot instead).
+function resolveDataPackageDir(subdir) {
+  try {
+    const pkgJson = createRequire(import.meta.url).resolve(
+      "@adobe/spectrum-design-data/package.json",
+    );
+    return resolve(dirname(pkgJson), subdir);
+  } catch {
+    return null;
+  }
+}
+
+// Path precedence: explicit env override (anchored to dataRoot) wins, then the
+// resolved design-data package directory, then a final fallback.
 export const config = {
   bin: process.env.DESIGN_DATA_BIN ?? "design-data",
   dataRoot,
-  dataPath: anchorPath(process.env.DESIGN_DATA_PATH ?? "."),
+  dataPath:
+    anchorPath(process.env.DESIGN_DATA_PATH) ??
+    resolveDataPackageDir("tokens") ??
+    anchorPath("."),
   schemaPath: anchorPath(process.env.DESIGN_DATA_SCHEMAS ?? null),
   exceptionsPath: anchorPath(process.env.DESIGN_DATA_EXCEPTIONS ?? null),
-  componentsDir: anchorPath(process.env.DESIGN_DATA_COMPONENTS ?? null),
-  fieldsDir: anchorPath(process.env.DESIGN_DATA_FIELDS ?? null),
+  componentsDir:
+    anchorPath(process.env.DESIGN_DATA_COMPONENTS) ??
+    resolveDataPackageDir("components") ??
+    null,
+  fieldsDir:
+    anchorPath(process.env.DESIGN_DATA_FIELDS) ??
+    resolveDataPackageDir("fields") ??
+    null,
 };

--- a/tools/design-data-agent-mcp/src/config.js
+++ b/tools/design-data-agent-mcp/src/config.js
@@ -8,9 +8,8 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { createRequire } from "module";
 import { fileURLToPath } from "url";
-import { dirname, isAbsolute, resolve } from "path";
+import { isAbsolute, resolve } from "path";
 
 // The repo root relative to this file: src → package → tools → repo root.
 // Used as the self-anchoring fallback when DESIGN_DATA_ROOT is not provided
@@ -31,41 +30,12 @@ function anchorPath(p) {
   return p && !isAbsolute(p) ? resolve(dataRoot, p) : p;
 }
 
-// Locate a directory inside the @adobe/spectrum-design-data package via Node's
-// module resolution. In a pnpm workspace this resolves through the symlink to
-// `packages/design-data`; when published it resolves the installed dependency.
-// Either way it is independent of the process working directory, so it provides
-// a zero-config default that does not depend on where the server was launched.
-// Returns null when the package is not installed (e.g. a standalone CLI install
-// that relies on the design-data binary's embedded snapshot instead).
-function resolveDataPackageDir(subdir) {
-  try {
-    const pkgJson = createRequire(import.meta.url).resolve(
-      "@adobe/spectrum-design-data/package.json",
-    );
-    return resolve(dirname(pkgJson), subdir);
-  } catch {
-    return null;
-  }
-}
-
-// Path precedence: explicit env override (anchored to dataRoot) wins, then the
-// resolved design-data package directory, then a final fallback.
 export const config = {
   bin: process.env.DESIGN_DATA_BIN ?? "design-data",
   dataRoot,
-  dataPath:
-    anchorPath(process.env.DESIGN_DATA_PATH) ??
-    resolveDataPackageDir("tokens") ??
-    anchorPath("."),
+  dataPath: anchorPath(process.env.DESIGN_DATA_PATH ?? "."),
   schemaPath: anchorPath(process.env.DESIGN_DATA_SCHEMAS ?? null),
   exceptionsPath: anchorPath(process.env.DESIGN_DATA_EXCEPTIONS ?? null),
-  componentsDir:
-    anchorPath(process.env.DESIGN_DATA_COMPONENTS) ??
-    resolveDataPackageDir("components") ??
-    null,
-  fieldsDir:
-    anchorPath(process.env.DESIGN_DATA_FIELDS) ??
-    resolveDataPackageDir("fields") ??
-    null,
+  componentsDir: anchorPath(process.env.DESIGN_DATA_COMPONENTS ?? null),
+  fieldsDir: anchorPath(process.env.DESIGN_DATA_FIELDS ?? null),
 };

--- a/tools/design-data-agent-mcp/test/config.test.js
+++ b/tools/design-data-agent-mcp/test/config.test.js
@@ -70,6 +70,21 @@ test.serial(
   },
 );
 
+test.serial(
+  "default dataPath ('.') resolves to dataRoot, not the process CWD",
+  async (t) => {
+    // Intentional behavior change: the old default of "." resolved against the
+    // process CWD (the bug behind #1109). The default now anchors to dataRoot so
+    // the dataset is found regardless of where the server was launched.
+    const root = resolve("/tmp/some-repo");
+    const config = await loadConfig({ DESIGN_DATA_ROOT: root });
+    t.is(config.dataPath, root);
+    t.is(config.dataPath, resolve(root, "."));
+    t.not(config.dataPath, resolve("."));
+    t.true(isAbsolute(config.dataPath));
+  },
+);
+
 test.serial("unset optional path fields stay null", async (t) => {
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),

--- a/tools/design-data-agent-mcp/test/config.test.js
+++ b/tools/design-data-agent-mcp/test/config.test.js
@@ -1,0 +1,96 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { isAbsolute, resolve } from "path";
+import { fileURLToPath } from "url";
+
+// `config` reads process.env at import time, so each case sets the environment
+// and then imports the module with a cache-busting query to force re-evaluation.
+const CONFIG_URL = new URL("../src/config.js", import.meta.url).href;
+let importCounter = 0;
+async function loadConfig(env) {
+  const keys = [
+    "DESIGN_DATA_BIN",
+    "DESIGN_DATA_ROOT",
+    "DESIGN_DATA_PATH",
+    "DESIGN_DATA_COMPONENTS",
+    "DESIGN_DATA_FIELDS",
+    "DESIGN_DATA_SCHEMAS",
+    "DESIGN_DATA_EXCEPTIONS",
+  ];
+  for (const key of keys) delete process.env[key];
+  Object.assign(process.env, env);
+  const mod = await import(`${CONFIG_URL}?case=${importCounter++}`);
+  return mod.config;
+}
+
+// Repo root relative to this test file: test → package → tools → repo root.
+const SERVER_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+test.serial(
+  "relative path is anchored to DESIGN_DATA_ROOT when set",
+  async (t) => {
+    const root = resolve("/tmp/some-repo");
+    const config = await loadConfig({
+      DESIGN_DATA_ROOT: root,
+      DESIGN_DATA_PATH: "packages/design-data/tokens",
+    });
+    t.is(config.dataRoot, root);
+    t.is(config.dataPath, resolve(root, "packages/design-data/tokens"));
+    t.true(isAbsolute(config.dataPath));
+  },
+);
+
+test.serial("absolute paths are returned unchanged", async (t) => {
+  const abs = resolve("/var/data/tokens");
+  const config = await loadConfig({
+    DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
+    DESIGN_DATA_PATH: abs,
+  });
+  t.is(config.dataPath, abs);
+});
+
+test.serial(
+  "relative path falls back to the server package root",
+  async (t) => {
+    const config = await loadConfig({
+      DESIGN_DATA_PATH: "packages/design-data/tokens",
+    });
+    t.is(config.dataRoot, SERVER_ROOT);
+    t.is(config.dataPath, resolve(SERVER_ROOT, "packages/design-data/tokens"));
+    t.true(isAbsolute(config.dataPath));
+  },
+);
+
+test.serial("unset optional path fields stay null", async (t) => {
+  const config = await loadConfig({
+    DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
+  });
+  t.is(config.componentsDir, null);
+  t.is(config.fieldsDir, null);
+  t.is(config.schemaPath, null);
+  t.is(config.exceptionsPath, null);
+});
+
+test.serial("all relative override dirs are anchored", async (t) => {
+  const root = resolve("/tmp/some-repo");
+  const config = await loadConfig({
+    DESIGN_DATA_ROOT: root,
+    DESIGN_DATA_COMPONENTS: "packages/design-data/components",
+    DESIGN_DATA_FIELDS: "packages/design-data/fields",
+    DESIGN_DATA_SCHEMAS: "schemas",
+    DESIGN_DATA_EXCEPTIONS: "exceptions.json",
+  });
+  t.is(config.componentsDir, resolve(root, "packages/design-data/components"));
+  t.is(config.fieldsDir, resolve(root, "packages/design-data/fields"));
+  t.is(config.schemaPath, resolve(root, "schemas"));
+  t.is(config.exceptionsPath, resolve(root, "exceptions.json"));
+});

--- a/tools/design-data-agent-mcp/test/config.test.js
+++ b/tools/design-data-agent-mcp/test/config.test.js
@@ -9,8 +9,7 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
-import { createRequire } from "module";
-import { dirname, isAbsolute, resolve } from "path";
+import { isAbsolute, resolve } from "path";
 import { fileURLToPath } from "url";
 
 // `config` reads process.env at import time, so each case sets the environment
@@ -36,16 +35,8 @@ async function loadConfig(env) {
 // Repo root relative to this test file: test → package → tools → repo root.
 const SERVER_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 
-// The directory that @adobe/spectrum-design-data resolves to in this workspace,
-// used to assert the zero-config package-resolution behavior.
-const dataPkgDir = dirname(
-  createRequire(import.meta.url).resolve(
-    "@adobe/spectrum-design-data/package.json",
-  ),
-);
-
 test.serial(
-  "relative override is anchored to DESIGN_DATA_ROOT when set",
+  "relative path is anchored to DESIGN_DATA_ROOT when set",
   async (t) => {
     const root = resolve("/tmp/some-repo");
     const config = await loadConfig({
@@ -58,7 +49,7 @@ test.serial(
   },
 );
 
-test.serial("absolute overrides are returned unchanged", async (t) => {
+test.serial("absolute paths are returned unchanged", async (t) => {
   const abs = resolve("/var/data/tokens");
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
@@ -68,7 +59,7 @@ test.serial("absolute overrides are returned unchanged", async (t) => {
 });
 
 test.serial(
-  "relative override falls back to the server package root",
+  "relative path falls back to the server package root",
   async (t) => {
     const config = await loadConfig({
       DESIGN_DATA_PATH: "packages/design-data/tokens",
@@ -79,21 +70,12 @@ test.serial(
   },
 );
 
-test.serial(
-  "resolves data dirs from the @adobe/spectrum-design-data package with no env override",
-  async (t) => {
-    const config = await loadConfig({});
-    t.is(config.dataPath, resolve(dataPkgDir, "tokens"));
-    t.is(config.componentsDir, resolve(dataPkgDir, "components"));
-    t.is(config.fieldsDir, resolve(dataPkgDir, "fields"));
-    t.true(isAbsolute(config.dataPath));
-  },
-);
-
-test.serial("schema and exceptions paths stay null when unset", async (t) => {
+test.serial("unset optional path fields stay null", async (t) => {
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
   });
+  t.is(config.componentsDir, null);
+  t.is(config.fieldsDir, null);
   t.is(config.schemaPath, null);
   t.is(config.exceptionsPath, null);
 });

--- a/tools/design-data-agent-mcp/test/config.test.js
+++ b/tools/design-data-agent-mcp/test/config.test.js
@@ -9,7 +9,8 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
-import { isAbsolute, resolve } from "path";
+import { createRequire } from "module";
+import { dirname, isAbsolute, resolve } from "path";
 import { fileURLToPath } from "url";
 
 // `config` reads process.env at import time, so each case sets the environment
@@ -35,8 +36,16 @@ async function loadConfig(env) {
 // Repo root relative to this test file: test → package → tools → repo root.
 const SERVER_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 
+// The directory that @adobe/spectrum-design-data resolves to in this workspace,
+// used to assert the zero-config package-resolution behavior.
+const dataPkgDir = dirname(
+  createRequire(import.meta.url).resolve(
+    "@adobe/spectrum-design-data/package.json",
+  ),
+);
+
 test.serial(
-  "relative path is anchored to DESIGN_DATA_ROOT when set",
+  "relative override is anchored to DESIGN_DATA_ROOT when set",
   async (t) => {
     const root = resolve("/tmp/some-repo");
     const config = await loadConfig({
@@ -49,7 +58,7 @@ test.serial(
   },
 );
 
-test.serial("absolute paths are returned unchanged", async (t) => {
+test.serial("absolute overrides are returned unchanged", async (t) => {
   const abs = resolve("/var/data/tokens");
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
@@ -59,7 +68,7 @@ test.serial("absolute paths are returned unchanged", async (t) => {
 });
 
 test.serial(
-  "relative path falls back to the server package root",
+  "relative override falls back to the server package root",
   async (t) => {
     const config = await loadConfig({
       DESIGN_DATA_PATH: "packages/design-data/tokens",
@@ -71,26 +80,24 @@ test.serial(
 );
 
 test.serial(
-  "default dataPath ('.') resolves to dataRoot, not the process CWD",
+  "resolves data dirs from the @adobe/spectrum-design-data package with no env override",
   async (t) => {
-    // Intentional behavior change: the old default of "." resolved against the
-    // process CWD (the bug behind #1109). The default now anchors to dataRoot so
-    // the dataset is found regardless of where the server was launched.
-    const root = resolve("/tmp/some-repo");
-    const config = await loadConfig({ DESIGN_DATA_ROOT: root });
-    t.is(config.dataPath, root);
-    t.is(config.dataPath, resolve(root, "."));
-    t.not(config.dataPath, resolve("."));
+    // Zero-config default: independent of the process working directory, the
+    // dataset dirs resolve through the installed/symlinked design-data package
+    // rather than the (old, buggy) CWD-relative "." default behind #1109.
+    const config = await loadConfig({});
+    t.is(config.dataPath, resolve(dataPkgDir, "tokens"));
+    t.is(config.componentsDir, resolve(dataPkgDir, "components"));
+    t.is(config.fieldsDir, resolve(dataPkgDir, "fields"));
     t.true(isAbsolute(config.dataPath));
+    t.not(config.dataPath, resolve("."));
   },
 );
 
-test.serial("unset optional path fields stay null", async (t) => {
+test.serial("schema and exceptions paths stay null when unset", async (t) => {
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
   });
-  t.is(config.componentsDir, null);
-  t.is(config.fieldsDir, null);
   t.is(config.schemaPath, null);
   t.is(config.exceptionsPath, null);
 });

--- a/tools/design-data-agent-mcp/test/config.test.js
+++ b/tools/design-data-agent-mcp/test/config.test.js
@@ -9,7 +9,8 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
-import { isAbsolute, resolve } from "path";
+import { createRequire } from "module";
+import { dirname, isAbsolute, resolve } from "path";
 import { fileURLToPath } from "url";
 
 // `config` reads process.env at import time, so each case sets the environment
@@ -35,8 +36,16 @@ async function loadConfig(env) {
 // Repo root relative to this test file: test → package → tools → repo root.
 const SERVER_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 
+// The directory that @adobe/spectrum-design-data resolves to in this workspace,
+// used to assert the zero-config package-resolution behavior.
+const dataPkgDir = dirname(
+  createRequire(import.meta.url).resolve(
+    "@adobe/spectrum-design-data/package.json",
+  ),
+);
+
 test.serial(
-  "relative path is anchored to DESIGN_DATA_ROOT when set",
+  "relative override is anchored to DESIGN_DATA_ROOT when set",
   async (t) => {
     const root = resolve("/tmp/some-repo");
     const config = await loadConfig({
@@ -49,7 +58,7 @@ test.serial(
   },
 );
 
-test.serial("absolute paths are returned unchanged", async (t) => {
+test.serial("absolute overrides are returned unchanged", async (t) => {
   const abs = resolve("/var/data/tokens");
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
@@ -59,7 +68,7 @@ test.serial("absolute paths are returned unchanged", async (t) => {
 });
 
 test.serial(
-  "relative path falls back to the server package root",
+  "relative override falls back to the server package root",
   async (t) => {
     const config = await loadConfig({
       DESIGN_DATA_PATH: "packages/design-data/tokens",
@@ -70,12 +79,21 @@ test.serial(
   },
 );
 
-test.serial("unset optional path fields stay null", async (t) => {
+test.serial(
+  "resolves data dirs from the @adobe/spectrum-design-data package with no env override",
+  async (t) => {
+    const config = await loadConfig({});
+    t.is(config.dataPath, resolve(dataPkgDir, "tokens"));
+    t.is(config.componentsDir, resolve(dataPkgDir, "components"));
+    t.is(config.fieldsDir, resolve(dataPkgDir, "fields"));
+    t.true(isAbsolute(config.dataPath));
+  },
+);
+
+test.serial("schema and exceptions paths stay null when unset", async (t) => {
   const config = await loadConfig({
     DESIGN_DATA_ROOT: resolve("/tmp/some-repo"),
   });
-  t.is(config.componentsDir, null);
-  t.is(config.fieldsDir, null);
   t.is(config.schemaPath, null);
   t.is(config.exceptionsPath, null);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The `primer`, `resolve_token`, `query_tokens`, `validate_usage`, and authoring tools failed with `path does not exist: packages/design-data/tokens` when the MCP server was launched from a monorepo subdirectory (e.g. `sdk/`). The server inherits its working directory from wherever the editor was opened, so relative `DESIGN_DATA_*` env paths resolved against the wrong CWD.

This connects the MCP server to the design data package the way other workspace consumers do (e.g. `packages/component-schemas`), so the common case needs no configuration and is independent of the working directory:

- **`package.json`**: declare `@adobe/spectrum-design-data` (`workspace:*`) as a dependency, so pnpm links the data package into the server.
- **`src/config.js`**: when no env override is set, resolve the `tokens/`, `components/`, and `fields/` directories from the `@adobe/spectrum-design-data` package via Node module resolution (`createRequire(import.meta.url).resolve(...)`). In a pnpm workspace this follows the symlink to `packages/design-data`; when published it uses the installed dependency. This is CWD-independent. Explicit `DESIGN_DATA_*` env overrides still win and, when relative, are anchored to the new `DESIGN_DATA_ROOT` (or the server package root when unset). Absolute paths pass through unchanged.
- **`src/cli.js`**: spawn the `design-data` CLI with `cwd` set to the resolved root so the binary's own tier/probe logic (`data_source::resolve`, `is_in_repo`) anchors correctly too.
- **`moon.yml` / `.moon/workspace.yml`**: register the project and add `dependsOn: ["design-data"]` so moon orders tasks correctly and (via `syncProjectWorkspaceDependencies`) keeps the workspace dependency in `package.json`.
- **`README.md`**: document the resolution precedence and `DESIGN_DATA_ROOT`.
- **`test/config.test.js`**: AVA tests for the resolution precedence (env-override anchoring, absolute passthrough, server-root fallback, zero-config package resolution, null schema/exceptions, and override-dir anchoring).
- **`.lintstagedrc.js`**: fix a pre-existing bug where the `"!**/pnpm-lock.yaml"` negation keys did not actually exclude lockfiles from the prettier task (lint-staged matches each key independently), causing pre-commit to reformat `pnpm-lock.yaml` into a huge diff. Lockfiles are now filtered out within the prettier task.

### Resolution precedence

1. Explicit `DESIGN_DATA_*` env override (relative values anchored to `DESIGN_DATA_ROOT`, else the server package root; absolute used as-is).
2. The resolved `@adobe/spectrum-design-data` package directory (zero config, CWD-independent).
3. Fallback: anchored current directory for `dataPath`; the `design-data` binary's own discovery (including its embedded snapshot) for the component/field dirs.

### Design note

The issue's preferred Option A (`new URL('../../..', import.meta.url)` self-anchoring) only works when the server runs from inside the monorepo; since the real `.mcp.json` launches via `npx`, the package lives in the npm cache and self-anchoring resolves to a `node_modules/` dir, not the repo. Resolving through the workspace package (with `DESIGN_DATA_ROOT` for explicit relative overrides) is robust across both in-repo and `npx` launches.

Adding the workspace dependency changes the root `pnpm-lock.yaml`, which expands moon's "affected" set to the full task graph. That previously surfaced a pre-existing cascade↔legacy `renamed` drift in `tokens:verifyLegacyRoundtrip`; that drift is now fixed on `main` by #1123 (which also added a `tokens:verifyLegacyOutput` guard), so this PR's full-graph CI runs clean.

## Related Issue

Closes #1109

## Motivation and Context

Without this, the MCP token tools are unusable whenever Claude Code / Cursor is opened in a subdirectory of the repo, which is a common workflow. Wiring the server to the data package via the workspace makes the default zero-config and aligns it with how the rest of the monorepo connects packages.

## How Has This Been Tested?

- `pnpm exec ava` in `tools/design-data-agent-mcp` — all 17 tests pass (existing suite + config resolution/precedence tests).
- Manual: with no env vars, `config.dataPath`/`componentsDir`/`fieldsDir` resolve to `packages/design-data/{tokens,components,fields}` even when run from `sdk/`; env overrides anchored to `DESIGN_DATA_ROOT` still take precedence.
- `moon project design-data-agent-mcp` confirms the project is registered and depends on `design-data`.
- `changeset-linter check --fail-on-warnings` — valid. Pre-commit hook now leaves `pnpm-lock.yaml` untouched (no `--no-verify` needed).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a80587d-fada-4e54-9a4a-09a0e6aff8f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a80587d-fada-4e54-9a4a-09a0e6aff8f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

