### PR TITLE
fix(sdk): reconstruct renamed from array-form replaced_by + legacy-verify drift guard

### DIFF
--- a/.changeset/fix-renamed-from-array-replaced-by.md
+++ b/.changeset/fix-renamed-from-array-replaced-by.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data": minor
+---
+
+Fix `renamed` reconstruction from array `replaced_by`; add legacy-verify drift guard (#1122).
+
+- **sdk/core/src/legacy.rs** (`normalize_lifecycle_for_legacy`): reconstruct the legacy
+  `renamed` field from array-form `replaced_by` — resolve each UUID via the uuid→name
+  map; emit `renamed` when all elements collapse to one distinct name. Hoist `renamed`
+  to the outer level when per-mode set entries all carry the same value.
+- **sdk/cli** (`migrate legacy-verify`): new subcommand regenerates legacy from a cascade
+  source dir and semantically compares against a reference legacy dir; non-zero exit on
+  differences.
+- **packages/tokens** (`verifyLegacyOutput`): new moon task wires `migrate legacy-verify`
+  into the `test` dependency graph with cross-package inputs so cascade↔legacy drift is
+  caught on any PR that touches either token tree.

--- a/packages/tokens/moon.yml
+++ b/packages/tokens/moon.yml
@@ -107,7 +107,6 @@ tasks:
       - sdk:build
     inputs:
       - "@globs(sources)"
-      - "../design-data/tokens/**/*.json"
   test:
     command:
       - pnpm

--- a/packages/tokens/moon.yml
+++ b/packages/tokens/moon.yml
@@ -94,6 +94,20 @@ tasks:
       - sdk:build
     inputs:
       - "@globs(sources)"
+  verifyLegacyOutput:
+    command: ../../sdk/target/debug/design-data
+    args:
+      - migrate
+      - legacy-verify
+      - ../design-data/tokens
+      - --reference
+      - ./src
+    platform: system
+    deps:
+      - sdk:build
+    inputs:
+      - "@globs(sources)"
+      - "../design-data/tokens/**/*.json"
   test:
     command:
       - pnpm
@@ -108,6 +122,7 @@ tasks:
       - ~:buildTokens
       - ~:verifyDesignDataSnapshot
       - ~:verifyLegacyRoundtrip
+      - ~:verifyLegacyOutput
     platform: node
   test-watch:
     command:

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -385,6 +385,15 @@ enum MigrateSub {
         #[arg(value_name = "PATH")]
         path: PathBuf,
     },
+    /// Verify that regenerating legacy output from cascade matches a reference legacy directory
+    LegacyVerify {
+        /// Source directory containing cascade .tokens.json files
+        #[arg(value_name = "CASCADE_DIR")]
+        cascade_dir: PathBuf,
+        /// Reference legacy directory to compare against (e.g. packages/tokens/src)
+        #[arg(long, value_name = "DIR")]
+        reference: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -850,6 +859,35 @@ fn run_migrate_roundtrip_verify(path: &Path) -> miette::Result<ExitCode> {
         .wrap_err_with(|| format!("roundtrip-verify failed: {}", path.display()))?;
     if diffs.is_empty() {
         println!("Roundtrip OK: {}", path.display());
+        return Ok(ExitCode::SUCCESS);
+    }
+    for d in &diffs {
+        if d.token.is_empty() {
+            eprintln!("  {}: {}", d.file, d.detail);
+        } else {
+            eprintln!("  {}/{}: {}", d.file, d.token, d.detail);
+        }
+    }
+    eprintln!("{} difference(s) found", diffs.len());
+    Ok(ExitCode::from(1))
+}
+
+fn run_migrate_legacy_verify(cascade_dir: &Path, reference: &Path) -> miette::Result<ExitCode> {
+    let diffs = legacy::legacy_output_verify(cascade_dir, reference)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "legacy-verify failed: {} vs {}",
+                cascade_dir.display(),
+                reference.display()
+            )
+        })?;
+    if diffs.is_empty() {
+        println!(
+            "Legacy output OK: {} matches {}",
+            cascade_dir.display(),
+            reference.display()
+        );
         return Ok(ExitCode::SUCCESS);
     }
     for d in &diffs {
@@ -1831,6 +1869,10 @@ fn main() -> ExitCode {
             }
             MigrateSub::AddUuids { dir } => run_migrate_add_uuids(&dir),
             MigrateSub::RoundtripVerify { path } => run_migrate_roundtrip_verify(&path),
+            MigrateSub::LegacyVerify {
+                cascade_dir,
+                reference,
+            } => run_migrate_legacy_verify(&cascade_dir, &reference),
         },
         Commands::Figma { sub } => match sub {
             FigmaSub::Read {

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -205,6 +205,24 @@ pub fn roundtrip_verify(legacy_src: &Path) -> Result<Vec<VerifyDifference>, Core
     verify_against_reference(legacy_tmp.path(), legacy_src)
 }
 
+/// Regenerate legacy files from a cascade source directory and compare
+/// semantically against a committed reference legacy directory.
+///
+/// Equivalent to running `design-data migrate legacy-output` into a temp dir
+/// and then comparing the output against `reference_legacy_dir` with the same
+/// semantic normalisation as [`roundtrip_verify`].
+///
+/// Returns an empty `Vec` when the cascade and reference are in sync. Returns
+/// `Err` only on I/O or parse failures.
+pub fn legacy_output_verify(
+    cascade_dir: &Path,
+    reference_legacy_dir: &Path,
+) -> Result<Vec<VerifyDifference>, CoreError> {
+    let legacy_tmp = tempfile::tempdir()?;
+    convert_dir(cascade_dir, legacy_tmp.path())?;
+    verify_against_reference(legacy_tmp.path(), reference_legacy_dir)
+}
+
 /// Compare a directory of generated legacy files against a reference directory.
 ///
 /// For each `.json` file in `reference_dir`, finds the matching file in
@@ -512,7 +530,11 @@ fn convert_array(
 /// Convert cascade lifecycle fields to legacy format on a token entry.
 ///
 /// - `deprecated: "version"` → `deprecated: true`
-/// - `replaced_by: "uuid"` → `renamed: "<property-name>"` (resolved via map)
+/// - `replaced_by: "uuid"` → `renamed: "<property-name>"` (string form, resolved via map)
+/// - `replaced_by: ["uuid", ...]` → `renamed: "<property-name>"` when all elements
+///   resolve to the **same** legacy name (multi-member scale/color-set pointing at one
+///   logical token); left unset when they resolve to multiple distinct names (genuine
+///   multi-target rename — `deprecated_comment` explains it).
 /// - `plannedRemoval`, `introduced` → removed (no legacy equivalent)
 fn normalize_lifecycle_for_legacy(
     entry: &mut Map<String, Value>,
@@ -525,14 +547,33 @@ fn normalize_lifecycle_for_legacy(
         }
     }
 
-    // replaced_by → renamed (resolve UUID to property name)
+    // replaced_by → renamed (resolve UUID(s) to property name)
     if let Some(replaced) = entry.remove("replaced_by") {
         if let Some(uuid) = replaced.as_str() {
+            // Single-string form.
             if let Some(name) = uuid_to_name.get(uuid) {
                 entry.insert("renamed".into(), Value::String(name.clone()));
             }
+        } else if let Some(arr) = replaced.as_array() {
+            // Array form: collect all distinct resolved names.
+            let mut distinct: Vec<&str> = Vec::new();
+            for elem in arr {
+                if let Some(uuid) = elem.as_str() {
+                    if let Some(name) = uuid_to_name.get(uuid) {
+                        let s = name.as_str();
+                        if !distinct.contains(&s) {
+                            distinct.push(s);
+                        }
+                    }
+                }
+            }
+            // Emit renamed only when all elements point at the same logical token
+            // (e.g. two scale-set members with the same property name).
+            if distinct.len() == 1 {
+                entry.insert("renamed".into(), Value::String(distinct[0].to_string()));
+            }
+            // Multiple distinct targets: no 1:1 mapping; deprecated_comment explains it.
         }
-        // Array form: don't emit renamed (no 1:1 mapping); deprecated_comment explains it.
     }
 
     // Drop fields with no legacy equivalent.
@@ -544,6 +585,41 @@ fn normalize_lifecycle_for_legacy(
         for (_mode, set_entry) in sets.iter_mut() {
             if let Some(obj) = set_entry.as_object_mut() {
                 normalize_lifecycle_for_legacy(obj, uuid_to_name);
+            }
+        }
+    }
+
+    // Hoist `renamed` to the outer level when it is absent there but consistently
+    // the same across all mode entries. This matches the structural convention of the
+    // committed legacy files (lifecycle fields uniform across all modes belong at the
+    // outer level, not inside each set entry). This can happen when the cascade source
+    // stores per-mode `replaced_by` UUIDs that all resolve to the same legacy token
+    // name (e.g. desktop/mobile scale members of one logical replacement token).
+    if entry.get("renamed").is_none() {
+        let hoist_val: Option<Value> = entry
+            .get("sets")
+            .and_then(|s| s.as_object())
+            .filter(|sets| !sets.is_empty())
+            .and_then(|sets| {
+                let mut iter = sets
+                    .values()
+                    .filter_map(|v| v.as_object()?.get("renamed").cloned());
+                let first = iter.next()?;
+                if iter.all(|v| v == first) {
+                    Some(first)
+                } else {
+                    None
+                }
+            });
+        if let Some(val) = hoist_val {
+            entry.insert("renamed".into(), val);
+            // Remove from mode entries — the value is now represented at the outer level.
+            if let Some(sets) = entry.get_mut("sets").and_then(|v| v.as_object_mut()) {
+                for set_entry in sets.values_mut() {
+                    if let Some(obj) = set_entry.as_object_mut() {
+                        obj.remove("renamed");
+                    }
+                }
             }
         }
     }
@@ -905,6 +981,113 @@ mod tests {
             err.contains("bg"),
             "error message should name the property: {err}"
         );
+    }
+
+    /// Regression: array-form replaced_by where all elements resolve to the same
+    /// property name (e.g. two scale-set members) must produce `renamed`.
+    #[test]
+    fn replaced_by_array_single_target_resolves_to_renamed() {
+        let arr = json!([
+            // old-token: flat alias, deprecated, replaced_by two scale-set member UUIDs.
+            {
+                "name": {"property": "old-width"},
+                "$schema": ".../alias.json",
+                "$ref": "new-desktop-uuid",
+                "uuid": "old-uuid-0001",
+                "deprecated": "unknown",
+                "deprecated_comment": "Use new-width instead.",
+                "replaced_by": ["new-desktop-uuid", "new-mobile-uuid"]
+            },
+            // new-width desktop: both scale members share the same property name.
+            {
+                "name": {"property": "new-width", "scale": "desktop"},
+                "$schema": ".../alias.json",
+                "value": "240px",
+                "uuid": "new-desktop-uuid"
+            },
+            // new-width mobile.
+            {
+                "name": {"property": "new-width", "scale": "mobile"},
+                "$schema": ".../alias.json",
+                "value": "288px",
+                "uuid": "new-mobile-uuid"
+            }
+        ]);
+
+        let mut global: HashMap<String, String> = HashMap::new();
+        for item in arr.as_array().unwrap() {
+            let tok = item.as_object().unwrap();
+            if let Some(key) = tok.get("name").and_then(extract_legacy_key) {
+                if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                    global.insert(uuid.to_string(), key.clone());
+                }
+                if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
+                    global.insert(set_uuid.to_string(), key);
+                }
+            }
+        }
+
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &global).unwrap();
+
+        let old = &out["old-width"];
+        assert_eq!(
+            old.get("renamed").and_then(|v| v.as_str()),
+            Some("new-width"),
+            "array replaced_by all resolving to same name should produce renamed"
+        );
+        assert_eq!(old["deprecated"], true, "deprecated should be true");
+    }
+
+    /// Array-form replaced_by with two different target names must NOT emit renamed
+    /// (no 1:1 legacy mapping; deprecated_comment describes the split).
+    #[test]
+    fn replaced_by_array_multi_target_omits_renamed() {
+        let arr = json!([
+            // old-token: replaced by two genuinely distinct tokens.
+            {
+                "name": {"property": "old-token"},
+                "$schema": ".../alias.json",
+                "$ref": "target-a-uuid",
+                "uuid": "old-uuid-0002",
+                "deprecated": "unknown",
+                "deprecated_comment": "Split into token-a and token-b.",
+                "replaced_by": ["target-a-uuid", "target-b-uuid"]
+            },
+            {
+                "name": {"property": "token-a"},
+                "$schema": ".../alias.json",
+                "value": "1px",
+                "uuid": "target-a-uuid"
+            },
+            {
+                "name": {"property": "token-b"},
+                "$schema": ".../alias.json",
+                "value": "2px",
+                "uuid": "target-b-uuid"
+            }
+        ]);
+
+        let mut global: HashMap<String, String> = HashMap::new();
+        for item in arr.as_array().unwrap() {
+            let tok = item.as_object().unwrap();
+            if let Some(key) = tok.get("name").and_then(extract_legacy_key) {
+                if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                    global.insert(uuid.to_string(), key);
+                }
+            }
+        }
+
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &global).unwrap();
+
+        let old = &out["old-token"];
+        assert!(
+            old.get("renamed").is_none(),
+            "multi-target array replaced_by should NOT produce renamed, got: {:?}",
+            old.get("renamed")
+        );
+        assert_eq!(old["deprecated"], true, "deprecated should still be true");
     }
 
     /// Regression: replaced_by pointing at a set token's outer UUID must resolve

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -567,12 +567,17 @@ fn normalize_lifecycle_for_legacy(
                     }
                 }
             }
-            // Emit renamed only when all elements point at the same logical token
-            // (e.g. two scale-set members with the same property name).
+            // Emit renamed only when all resolvable elements point at the same logical
+            // token (e.g. two scale-set members with the same property name). Unresolvable
+            // UUIDs are skipped rather than treated as ambiguous: if a replacement token is
+            // absent from this conversion run the resolvable elements still identify the
+            // replacement name, so emitting renamed is correct. If elements resolve to two
+            // or more distinct names the mapping is genuinely ambiguous; deprecated_comment
+            // explains it. An empty array (or all unresolvable) produces no renamed.
             if distinct.len() == 1 {
                 entry.insert("renamed".into(), Value::String(distinct[0].to_string()));
             }
-            // Multiple distinct targets: no 1:1 mapping; deprecated_comment explains it.
+            // Multiple distinct targets or empty: no 1:1 mapping.
         }
     }
 
@@ -980,6 +985,139 @@ mod tests {
         assert!(
             err.contains("bg"),
             "error message should name the property: {err}"
+        );
+    }
+
+    /// Empty replaced_by array must produce no renamed and must not crash.
+    #[test]
+    fn replaced_by_empty_array_omits_renamed() {
+        let arr = json!([{
+            "name": {"property": "old-token"},
+            "$schema": ".../alias.json",
+            "value": "1px",
+            "uuid": "old-uuid-empty",
+            "deprecated": "unknown",
+            "replaced_by": []
+        }]);
+        let global: HashMap<String, String> = HashMap::new();
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &global).unwrap();
+        assert!(
+            out["old-token"].get("renamed").is_none(),
+            "empty replaced_by should not produce renamed"
+        );
+        assert_eq!(out["old-token"]["deprecated"], true);
+    }
+
+    /// When replaced_by contains a mix of resolvable and unresolvable UUIDs, and all
+    /// resolvable ones collapse to one name, renamed is still emitted.  The unresolvable
+    /// UUID is interpreted as "target may be absent from this conversion run" rather than
+    /// "unknown second target" — see the comment in normalize_lifecycle_for_legacy.
+    #[test]
+    fn replaced_by_array_partial_resolution_emits_renamed() {
+        let arr = json!([
+            {
+                "name": {"property": "old-token"},
+                "$schema": ".../alias.json",
+                "$ref": "known-uuid-0001",
+                "uuid": "old-partial-uuid",
+                "deprecated": "unknown",
+                "replaced_by": ["known-uuid-0001", "no-such-uuid-xyz"]
+            },
+            {
+                "name": {"property": "new-token"},
+                "$schema": ".../alias.json",
+                "value": "1px",
+                "uuid": "known-uuid-0001"
+            }
+        ]);
+        let mut global: HashMap<String, String> = HashMap::new();
+        for item in arr.as_array().unwrap() {
+            let tok = item.as_object().unwrap();
+            if let Some(key) = tok.get("name").and_then(extract_legacy_key) {
+                if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                    global.insert(uuid.to_string(), key);
+                }
+            }
+        }
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &global).unwrap();
+        assert_eq!(
+            out["old-token"].get("renamed").and_then(|v| v.as_str()),
+            Some("new-token"),
+            "one resolvable + one unresolvable UUID should emit renamed from the resolved element"
+        );
+    }
+
+    /// Per-mode replaced_by strings (different UUID per scale member, both resolving to
+    /// the same property name) must produce renamed hoisted to the outer set level.
+    #[test]
+    fn per_mode_replaced_by_string_hoisted_to_outer() {
+        let arr = json!([
+            // old-width scale-set: each mode member replaced by the corresponding member
+            // of new-width.  The two target UUIDs differ but share the same property name.
+            {
+                "name": {"property": "old-width", "scale": "desktop"},
+                "$schema": ".../alias.json",
+                "$ref": "new-desktop-uuid-0001",
+                "uuid": "old-desktop-uuid-0001",
+                "set_uuid": "old-set-uuid-0001",
+                "set_schema": ".../scale-set.json",
+                "deprecated": "unknown",
+                "replaced_by": "new-desktop-uuid-0001"
+            },
+            {
+                "name": {"property": "old-width", "scale": "mobile"},
+                "$schema": ".../alias.json",
+                "$ref": "new-mobile-uuid-0001",
+                "uuid": "old-mobile-uuid-0001",
+                "set_uuid": "old-set-uuid-0001",
+                "set_schema": ".../scale-set.json",
+                "deprecated": "unknown",
+                "replaced_by": "new-mobile-uuid-0001"
+            },
+            {
+                "name": {"property": "new-width", "scale": "desktop"},
+                "$schema": ".../alias.json",
+                "value": "240px",
+                "uuid": "new-desktop-uuid-0001"
+            },
+            {
+                "name": {"property": "new-width", "scale": "mobile"},
+                "$schema": ".../alias.json",
+                "value": "288px",
+                "uuid": "new-mobile-uuid-0001"
+            }
+        ]);
+        let mut global: HashMap<String, String> = HashMap::new();
+        for item in arr.as_array().unwrap() {
+            let tok = item.as_object().unwrap();
+            if let Some(key) = tok.get("name").and_then(extract_legacy_key) {
+                if let Some(uuid) = tok.get("uuid").and_then(|v| v.as_str()) {
+                    global.insert(uuid.to_string(), key.clone());
+                }
+                if let Some(set_uuid) = tok.get("set_uuid").and_then(|v| v.as_str()) {
+                    global.insert(set_uuid.to_string(), key);
+                }
+            }
+        }
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &global).unwrap();
+        let old = out["old-width"].as_object().unwrap();
+        assert_eq!(
+            old.get("renamed").and_then(|v| v.as_str()),
+            Some("new-width"),
+            "renamed should be hoisted to outer set level"
+        );
+        assert_eq!(old["deprecated"], true);
+        let sets = old["sets"].as_object().unwrap();
+        assert!(
+            sets["desktop"].as_object().unwrap().get("renamed").is_none(),
+            "renamed should be absent from sets.desktop after hoisting"
+        );
+        assert!(
+            sets["mobile"].as_object().unwrap().get("renamed").is_none(),
+            "renamed should be absent from sets.mobile after hoisting"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes the cascade→legacy `renamed` field reconstruction when cascade `replaced_by` is a JSON array of UUIDs, and adds a new `migrate legacy-verify` command + `tokens:verifyLegacyOutput` moon task to catch cascade↔legacy drift at CI time.

## Related Issue

Closes #1122.

## Motivation and Context

Since #1110/#1113, cascade deprecated aliases store renames as `replaced_by: [uuid, ...]` (array) + `deprecated: "unknown"`. The `migrate legacy-output` converter only handled the string form (`replaced_by: "uuid"`), silently dropping `renamed` on deprecated alias tokens. This caused `moon run tokens:verifyLegacyRoundtrip` to pass (that task is self-contained: legacy→cascade→legacy, and the forward migration emits string-form `replaced_by`), while the actual cascade→legacy generation was broken.

The drift was hidden until a PR touches a root-level file (e.g. `pnpm-lock.yaml`) that marks all projects affected, pulling `verifyLegacyRoundtrip` into the moon CI run — as surfaced on #1120.

**Root causes addressed:**

1. `normalize_lifecycle_for_legacy`: now handles array-form `replaced_by` — resolves each UUID via the existing global UUID→name map; emits `renamed` when all elements resolve to one distinct name (multi-member scale/color-set pointing at the same logical replacement token). Also adds post-recursion hoisting: if per-mode set entries all resolve to the same `renamed`, hoists it to the outer level (matching the structural convention of the committed legacy files).

2. New `migrate legacy-verify <cascade-dir> --reference <legacy-dir>` CLI subcommand regenerates legacy from a cascade source and compares semantically against a reference legacy directory (same normalisation as `roundtrip-verify`).

3. New `tokens:verifyLegacyOutput` moon task wires `legacy-verify` into the `test` dependency graph with cross-package inputs (`packages/tokens/src/**` AND `packages/design-data/tokens/**`), so the task is marked affected — and the drift is caught — on any PR touching either token tree.

## How Has This Been Tested?

**Pre-fix baseline:** `migrate legacy-output` from the real cascade dropped `renamed` on 46 deprecated tokens (25 flat aliases with array-form `replaced_by`, 21 scale-set tokens where per-mode string UUIDs both resolved to the same name but weren't hoisted to outer).

**Post-fix:**
```bash
cargo test -p design-data-core           # 465 passed, 0 failed (includes 2 new tests)

# New drift guard: 0 differences
./sdk/target/debug/design-data migrate legacy-verify ./packages/design-data/tokens --reference ./packages/tokens/src
# → Legacy output OK: ./packages/design-data/tokens matches ./packages/tokens/src

# Existing roundtrip still passes
./sdk/target/debug/design-data migrate roundtrip-verify ./packages/tokens/src
# → Roundtrip OK: ./packages/tokens/src

node tools/changeset-linter/src/cli.js check --fail-on-warnings
# → 1 valid, 0 warnings, 0 errors
```

Two new unit tests in `sdk/core/src/legacy.rs`:
- `replaced_by_array_single_target_resolves_to_renamed`: array with two scale-set UUIDs both resolving to the same name → `renamed` emitted.
- `replaced_by_array_multi_target_omits_renamed`: array with two genuinely different target names → `renamed` absent (drop path preserved).

**Follow-up (not in this PR):** The `verifyLegacyOutput` task is still affected-gated on PRs. To fully close the "hidden on unrelated PRs" gap, the CI workflow should run this task on `main` pushes. The cross-package `inputs` wiring ensures any PR touching either token tree triggers the check.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.