### PR TITLE
test(tui): close COMMANDS <-> dispatch loop with Command enum

### DIFF
--- a/.changeset/tui-command-enum-sync.md
+++ b/.changeset/tui-command-enum-sync.md
@@ -1,0 +1,17 @@
+---
+"design-data-tui": minor
+---
+
+Route TUI palette dispatch through a `Command` enum and enforce
+COMMANDS <-> dispatch sync (closes #1096).
+
+- **sdk/tui/src/command.rs** (new): `Command` enum is the single source of truth for
+  palette commands, with `ALL`, `canonical`, `aliases`, and `parse`.
+- **sdk/tui/src/update_command.rs**: dispatch matches on `Command::parse`; `describe`/
+  `component` and `new`/`create` collapse into single arms via aliases.
+- **sdk/tui/src/update.rs**: Tab autocomplete derives from `Command::ALL`; removes the
+  hand-maintained `KNOWN_COMMANDS` const in `app_views.rs`.
+- **sdk/tui/src/logo.rs** / **help.rs**: surface the previously orphaned `:name` command
+  so COMMANDS, HELP_TEXT, and dispatch agree.
+- **sdk/tui/src/command.rs** (tests): bidirectional COMMANDS <-> `Command` checks plus
+  alias coverage, closing the loop left open by `commands_present_in_help_text` (#1094).

--- a/sdk/tui/src/app_views.rs
+++ b/sdk/tui/src/app_views.rs
@@ -33,11 +33,6 @@ use crate::wizard::{WizardScreen, WizardState};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-/// Command names for Tab autocomplete.
-pub(crate) const KNOWN_COMMANDS: &[&str] = &[
-    "find", "name", "new", "query", "resolve", "describe", "validate",
-];
-
 /// Max palette history entries persisted to disk.
 pub(crate) const HISTORY_CAP: usize = 200;
 

--- a/sdk/tui/src/command.rs
+++ b/sdk/tui/src/command.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! The enumerable set of `:cmd` palette commands (GH #1096).
+//!
+//! `Command` is the single source of truth for which palette commands exist. The
+//! dispatcher in `update_command.rs` matches on `Command::parse`, the Tab
+//! autocomplete in `update.rs` iterates `Command::ALL` canonical names, and the
+//! home-screen `COMMANDS` table in `logo.rs` is kept in lock-step by a
+//! bidirectional sync test (see the `tests` module below). Adding a variant here
+//! is the one place a new command is declared; everything else derives from it.
+
+/// A dispatchable palette command.
+///
+/// Each variant maps to exactly one canonical name (the string typed after `:`)
+/// and zero or more aliases. `parse` accepts either form; the rest of the code
+/// only reasons about variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Command {
+    Query,
+    Resolve,
+    Describe,
+    Validate,
+    New,
+    Find,
+    Name,
+}
+
+impl Command {
+    /// Every command variant, for exhaustive iteration in tests and autocomplete.
+    pub(crate) const ALL: &'static [Command] = &[
+        Command::Query,
+        Command::Resolve,
+        Command::Describe,
+        Command::Validate,
+        Command::New,
+        Command::Find,
+        Command::Name,
+    ];
+
+    /// The primary name typed after `:` (e.g. `Describe => "describe"`).
+    pub(crate) fn canonical(self) -> &'static str {
+        match self {
+            Command::Query => "query",
+            Command::Resolve => "resolve",
+            Command::Describe => "describe",
+            Command::Validate => "validate",
+            Command::New => "new",
+            Command::Find => "find",
+            Command::Name => "name",
+        }
+    }
+
+    /// Accepted alternate names that dispatch to the same variant.
+    pub(crate) fn aliases(self) -> &'static [&'static str] {
+        match self {
+            Command::Describe => &["component"],
+            Command::New => &["create"],
+            _ => &[],
+        }
+    }
+
+    /// Parse a command token (the part before the first space) into a variant.
+    ///
+    /// Matching is case-insensitive on the canonical name or any alias, mirroring
+    /// the lowercase normalization done by `handle_palette_submit`.
+    pub(crate) fn parse(cmd: &str) -> Option<Command> {
+        let cmd = cmd.to_lowercase();
+        Command::ALL.iter().copied().find(|c| {
+            c.canonical() == cmd || c.aliases().iter().any(|&a| a == cmd)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logo::COMMANDS;
+
+    /// Extract the command token from a `COMMANDS` entry name, e.g.
+    /// `":describe <component>" -> "describe"`. Returns `None` for non-palette
+    /// entries (global keys like `?` / `q` that don't start with `:`).
+    fn command_token(name: &str) -> Option<&str> {
+        let rest = name.strip_prefix(':')?;
+        Some(rest.split_whitespace().next().unwrap_or(rest))
+    }
+
+    /// Every `Command` variant must have exactly one matching `COMMANDS` entry.
+    ///
+    /// This closes the COMMANDS -> dispatch direction: a command that the
+    /// dispatcher handles but that nobody documents on the home screen fails here.
+    #[test]
+    fn every_command_has_a_commands_entry() {
+        for cmd in Command::ALL {
+            let matches = COMMANDS
+                .iter()
+                .filter(|(name, _)| command_token(name) == Some(cmd.canonical()))
+                .count();
+            assert_eq!(
+                matches, 1,
+                "Command::{cmd:?} (`{}`) must map to exactly one COMMANDS entry, found {matches}; \
+                 update logo.rs",
+                cmd.canonical()
+            );
+        }
+    }
+
+    /// Every palette entry in `COMMANDS` must parse to a `Command` variant.
+    ///
+    /// This closes the dispatch -> COMMANDS direction: a `:` entry documented on
+    /// the home screen but not handled by the dispatcher fails here.
+    #[test]
+    fn every_commands_entry_maps_to_a_command() {
+        for (name, _) in COMMANDS {
+            let Some(token) = command_token(name) else {
+                continue;
+            };
+            assert!(
+                Command::parse(token).is_some(),
+                "COMMANDS entry {name:?} (`{token}`) does not map to a Command variant; \
+                 add it to command.rs or remove it from logo.rs"
+            );
+        }
+    }
+
+    /// Aliases must parse and must not collide with any canonical name.
+    #[test]
+    fn aliases_parse_and_do_not_collide() {
+        for cmd in Command::ALL {
+            for &alias in cmd.aliases() {
+                assert_eq!(
+                    Command::parse(alias),
+                    Some(*cmd),
+                    "alias `{alias}` should parse to Command::{cmd:?}"
+                );
+                assert!(
+                    Command::ALL.iter().all(|c| c.canonical() != alias),
+                    "alias `{alias}` collides with a canonical command name"
+                );
+            }
+        }
+    }
+
+    /// `parse` is case-insensitive, matching the palette's lowercase normalization.
+    #[test]
+    fn parse_is_case_insensitive() {
+        assert_eq!(Command::parse("QUERY"), Some(Command::Query));
+        assert_eq!(Command::parse("Component"), Some(Command::Describe));
+        assert_eq!(Command::parse("bogus"), None);
+    }
+}

--- a/sdk/tui/src/command.rs
+++ b/sdk/tui/src/command.rs
@@ -17,65 +17,71 @@
 //! bidirectional sync test (see the `tests` module below). Adding a variant here
 //! is the one place a new command is declared; everything else derives from it.
 
-/// A dispatchable palette command.
+/// Declare the `Command` enum together with its `ALL` list, `canonical()` name,
+/// and `aliases()` from a single table.
 ///
-/// Each variant maps to exactly one canonical name (the string typed after `:`)
-/// and zero or more aliases. `parse` accepts either form; the rest of the code
-/// only reasons about variants.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Command {
-    Query,
-    Resolve,
-    Describe,
-    Validate,
-    New,
-    Find,
-    Name,
+/// Generating all four from one source makes drift impossible: a variant can't
+/// exist without an entry here, and that entry necessarily populates `ALL`,
+/// `canonical()`, and `aliases()`. This is the zero-dependency stand-in for what
+/// a `strum`-style derive would provide.
+macro_rules! define_commands {
+    ($(
+        $variant:ident => $canonical:literal $(| $alias:literal)*
+    ),+ $(,)?) => {
+        /// A dispatchable palette command.
+        ///
+        /// Each variant maps to exactly one canonical name (the string typed
+        /// after `:`) and zero or more aliases. `parse` accepts either form; the
+        /// rest of the code only reasons about variants.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub(crate) enum Command {
+            $($variant),+
+        }
+
+        impl Command {
+            /// Every command variant, for exhaustive iteration in tests and
+            /// autocomplete. Generated from the table, so it can never omit a
+            /// variant.
+            pub(crate) const ALL: &'static [Command] = &[$(Command::$variant),+];
+
+            /// The primary name typed after `:` (e.g. `Describe => "describe"`).
+            pub(crate) fn canonical(self) -> &'static str {
+                match self {
+                    $(Command::$variant => $canonical),+
+                }
+            }
+
+            /// Accepted alternate names that dispatch to the same variant.
+            pub(crate) fn aliases(self) -> &'static [&'static str] {
+                match self {
+                    $(Command::$variant => &[$($alias),*]),+
+                }
+            }
+        }
+    };
+}
+
+define_commands! {
+    Query => "query",
+    Resolve => "resolve",
+    Describe => "describe" | "component",
+    Validate => "validate",
+    New => "new" | "create",
+    Find => "find",
+    Name => "name",
 }
 
 impl Command {
-    /// Every command variant, for exhaustive iteration in tests and autocomplete.
-    pub(crate) const ALL: &'static [Command] = &[
-        Command::Query,
-        Command::Resolve,
-        Command::Describe,
-        Command::Validate,
-        Command::New,
-        Command::Find,
-        Command::Name,
-    ];
-
-    /// The primary name typed after `:` (e.g. `Describe => "describe"`).
-    pub(crate) fn canonical(self) -> &'static str {
-        match self {
-            Command::Query => "query",
-            Command::Resolve => "resolve",
-            Command::Describe => "describe",
-            Command::Validate => "validate",
-            Command::New => "new",
-            Command::Find => "find",
-            Command::Name => "name",
-        }
-    }
-
-    /// Accepted alternate names that dispatch to the same variant.
-    pub(crate) fn aliases(self) -> &'static [&'static str] {
-        match self {
-            Command::Describe => &["component"],
-            Command::New => &["create"],
-            _ => &[],
-        }
-    }
-
     /// Parse a command token (the part before the first space) into a variant.
     ///
     /// Matching is case-insensitive on the canonical name or any alias, mirroring
     /// the lowercase normalization done by `handle_palette_submit`.
     pub(crate) fn parse(cmd: &str) -> Option<Command> {
         let cmd = cmd.to_lowercase();
-        Command::ALL.iter().copied().find(|c| {
-            c.canonical() == cmd || c.aliases().iter().any(|&a| a == cmd)
-        })
+        Command::ALL
+            .iter()
+            .copied()
+            .find(|c| c.canonical() == cmd || c.aliases().iter().any(|&a| a == cmd))
     }
 }
 
@@ -87,6 +93,10 @@ mod tests {
     /// Extract the command token from a `COMMANDS` entry name, e.g.
     /// `":describe <component>" -> "describe"`. Returns `None` for non-palette
     /// entries (global keys like `?` / `q` that don't start with `:`).
+    ///
+    /// This relies on the convention that every palette command in `COMMANDS`
+    /// is written `:<name> [<args>]` and global keys are not. A future global key
+    /// with `:`-prefixed syntax would need this filter revisited.
     fn command_token(name: &str) -> Option<&str> {
         let rest = name.strip_prefix(':')?;
         Some(rest.split_whitespace().next().unwrap_or(rest))

--- a/sdk/tui/src/command.rs
+++ b/sdk/tui/src/command.rs
@@ -75,13 +75,13 @@ impl Command {
     /// Parse a command token (the part before the first space) into a variant.
     ///
     /// Matching is case-insensitive on the canonical name or any alias, mirroring
-    /// the lowercase normalization done by `handle_palette_submit`.
+    /// the lowercase normalization done by `handle_palette_submit`. All command
+    /// names are ASCII, so `eq_ignore_ascii_case` lets this stay allocation-free.
     pub(crate) fn parse(cmd: &str) -> Option<Command> {
-        let cmd = cmd.to_lowercase();
-        Command::ALL
-            .iter()
-            .copied()
-            .find(|c| c.canonical() == cmd || c.aliases().iter().any(|&a| a == cmd))
+        Command::ALL.iter().copied().find(|c| {
+            c.canonical().eq_ignore_ascii_case(cmd)
+                || c.aliases().iter().any(|&a| a.eq_ignore_ascii_case(cmd))
+        })
     }
 }
 

--- a/sdk/tui/src/help.rs
+++ b/sdk/tui/src/help.rs
@@ -29,6 +29,7 @@ COMMANDS
   :describe <component>   Inspect a component schema
   :validate               Validate all tokens against schemas
   :new [<intent>]         Open the token authoring wizard
+  :name [<intent>]        Open the token naming wizard
   :find                   Open the fuzzy-find token explorer
 
 QUERY / RESOLVE / VALIDATE VIEW

--- a/sdk/tui/src/lib.rs
+++ b/sdk/tui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod app;
 pub mod app_launch;
 pub mod app_views;
 pub(crate) mod clipboard;
+pub(crate) mod command;
 pub mod find;
 pub(crate) mod fuzzy;
 pub mod help;

--- a/sdk/tui/src/logo.rs
+++ b/sdk/tui/src/logo.rs
@@ -39,8 +39,10 @@ pub const LOGO: &str = r"                ████
 /// unicode-width if that ever changes.
 ///
 /// These entries should stay in sync with the `COMMANDS` section of `help.rs`
-/// and with the command dispatch in `update_command.rs`. A test in this module
-/// (`commands_present_in_help_text`) guards against silent drift.
+/// and with the command dispatch in `update_command.rs`. Two tests guard against
+/// silent drift: `commands_present_in_help_text` (COMMANDS subset of HELP_TEXT)
+/// and the bidirectional COMMANDS <-> `Command` enum check in `command.rs`
+/// (every `:` entry maps to a dispatchable variant and vice versa, GH #1096).
 pub const COMMANDS: &[(&str, &str)] = &[
     (":query <expr>", "Filter tokens  e.g. background-color/*"),
     (
@@ -50,6 +52,7 @@ pub const COMMANDS: &[(&str, &str)] = &[
     (":describe <component>", "Inspect a component schema"),
     (":validate", "Validate all tokens against schemas"),
     (":new [<intent>]", "Open the token authoring wizard"),
+    (":name [<intent>]", "Open the token naming wizard"),
     (":find", "Open fuzzy find"),
     ("?", "Toggle help"),
     ("q", "Quit"),

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -228,6 +228,9 @@ fn handle_palette_key(
         KeyCode::Tab if palette_cmd_mode => {
             let current = model.palette_input_value().to_string();
             if !current.contains(' ') {
+                // Canonical names only — aliases (e.g. `component`, `create`) are
+                // a dispatch-only convenience and are intentionally not offered by
+                // Tab completion, so `:comp<Tab>` does not expand to `component`.
                 let matches: Vec<&str> = Command::ALL
                     .iter()
                     .map(|c| c.canonical())

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -26,9 +26,10 @@ use tui_input::backend::crossterm::EventHandler;
 
 use crate::app::{
     move_table_selection, rect_contains, ActiveView, HitAction, Modal, PaletteMode, StatusMessage,
-    ValidateView, KNOWN_COMMANDS,
+    ValidateView,
 };
 use crate::clipboard::write_clipboard;
+use crate::command::Command;
 use crate::find::FindEvent;
 use crate::message::Message;
 use crate::model::Model;
@@ -227,10 +228,10 @@ fn handle_palette_key(
         KeyCode::Tab if palette_cmd_mode => {
             let current = model.palette_input_value().to_string();
             if !current.contains(' ') {
-                let matches: Vec<&str> = KNOWN_COMMANDS
+                let matches: Vec<&str> = Command::ALL
                     .iter()
-                    .copied()
-                    .filter(|&c| c.starts_with(current.as_str()))
+                    .map(|c| c.canonical())
+                    .filter(|c| c.starts_with(current.as_str()))
                     .collect();
                 match matches.len() {
                     0 => {}

--- a/sdk/tui/src/update_command.rs
+++ b/sdk/tui/src/update_command.rs
@@ -27,6 +27,7 @@ use crate::app::{
     DescribeView, DiagnosticRow, Modal, QueryRow, QueryView, ResolveView, ResolvedRow,
     StatusMessage, HISTORY_CAP,
 };
+use crate::command::Command;
 use crate::find::FindWizardState;
 use crate::message::Message;
 use crate::model::Model;
@@ -90,8 +91,8 @@ fn dispatch_command(
     rest: &str,
     ctx: &UpdateCtx<'_>,
 ) -> Task<Message> {
-    match cmd {
-        "query" => {
+    match Command::parse(cmd) {
+        Some(Command::Query) => {
             if rest.is_empty() {
                 model.status_message = Some(StatusMessage::error("query: expression required"));
                 return Task::none();
@@ -116,7 +117,7 @@ fn dispatch_command(
             }
             Task::none()
         }
-        "resolve" => {
+        Some(Command::Resolve) => {
             if rest.is_empty() {
                 model.status_message =
                     Some(StatusMessage::error("resolve: property=<name> required"));
@@ -143,7 +144,7 @@ fn dispatch_command(
             model.status_message = Some(StatusMessage::info(format!("{count} candidate(s)")));
             Task::none()
         }
-        "describe" | "component" => {
+        Some(Command::Describe) => {
             if rest.is_empty() {
                 model.status_message =
                     Some(StatusMessage::error("describe: component ID required"));
@@ -205,7 +206,7 @@ fn dispatch_command(
                 Message::DescribeDone(Box::new(result))
             })
         }
-        "validate" => {
+        Some(Command::Validate) => {
             let (Some(dataset_path), Some(registry)) =
                 (ctx.dataset_path, ctx.schema_registry.clone())
             else {
@@ -253,28 +254,28 @@ fn dispatch_command(
                 Message::ValidateDone(Box::new(result))
             })
         }
-        "find" => {
+        Some(Command::Find) => {
             let fs = FindWizardState::new_with_intent(rest.trim());
             model.open_modal(Modal::Find(Box::new(fs)));
             model.status_message = None;
             Task::none()
         }
-        "name" => {
+        Some(Command::Name) => {
             let mut ns = NamingWizardState::new_with_intent(rest.trim());
             ns.refresh_suggestions(ctx.graph);
             model.open_modal(Modal::Naming(Box::new(ns)));
             model.status_message = None;
             Task::none()
         }
-        "new" | "create" => {
+        Some(Command::New) => {
             let mut ws = WizardState::new_with_intent(rest.trim());
             ws.refresh_suggestions(ctx.graph);
             model.open_modal(Modal::Wizard(Box::new(ws)));
             model.status_message = None;
             Task::none()
         }
-        other => {
-            model.status_message = Some(StatusMessage::error(format!("unknown command: {other}")));
+        None => {
+            model.status_message = Some(StatusMessage::error(format!("unknown command: {cmd}")));
             Task::none()
         }
     }

--- a/sdk/tui/tests/snapshots/snapshots__home_view_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__home_view_80x24.snap
@@ -13,6 +13,7 @@ expression: rendered
   :describe <component>     Inspect a component schema
   :validate                 Validate all tokens against schemas
   :new [<intent>]           Open the token authoring wizard
+  :name [<intent>]          Open the token naming wizard
   :find                     Open fuzzy find
   ?                         Toggle help
   q                         Quit

--- a/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
@@ -13,10 +13,10 @@ expression: rendered
   :describe <component>     Inspect a component schema
   :validate                 Validate all tokens against schemas
   :new [<intent>]           Open the token authoring wizard
+  :name [<intent>]          Open the token naming wizard
   :find                     Open fuzzy find
   ?                         Toggle help
   q                         Quit
-
 
 
 

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -13,10 +13,10 @@ expression: rendered
   :desc│                                                                │
   :vali│                                                                │
   :new │                                                                │
+  :name│                                                                │
   :find│                                                                │
   ?    │                                                                │
   q    │                                                                │
-       │                                                                │
        │                                                                │
        │                                                                │
        │                                                                │


### PR DESCRIPTION
## Description

Routes the TUI palette command dispatch through a new `Command` enum that
serves as the single source of truth for which `:cmd` palette commands exist,
and adds the bidirectional `COMMANDS` <-> dispatch sync test requested in #1096.

- **`sdk/tui/src/command.rs`** (new): `Command` enum with `ALL`, `canonical()`,
  `aliases()`, and a case-insensitive `parse()`. Aliases (`component` -> `Describe`,
  `create` -> `New`) are now owned and discoverable on the enum.
- **`update_command.rs`**: `dispatch_command` matches on `Command::parse`; the
  `describe | component` and `new | create` string arms collapse into single arms.
- **`update.rs` / `app_views.rs`**: Tab autocomplete derives from `Command::ALL`,
  removing the hand-maintained `KNOWN_COMMANDS` const so it can no longer drift.
- **`logo.rs` / `help.rs`**: surface the previously orphaned `:name` command in
  `COMMANDS` and `HELP_TEXT` so all sources agree.
- **`command.rs` tests**: `every_command_has_a_commands_entry` and
  `every_commands_entry_maps_to_a_command` close the loop bidirectionally, plus
  alias and case-insensitivity coverage.

## Related Issue

Closes #1096 (refs #1094).

## Motivation and Context

PR #1094 added `commands_present_in_help_text`, which only asserts
`COMMANDS ⊆ HELP_TEXT` — it did not verify that every command is actually
dispatched, nor that dispatch references no phantom commands. That gap was held
open only by a doc comment because the flat `match` on string literals wasn't
introspectable from a test. #1096 tracked closing it once dispatch moved to an
enumerable set of variants. This PR performs that refactor and makes the
three-way sync (`COMMANDS` <-> `HELP_TEXT` <-> dispatch) fully test-enforced.
It also reconciles existing drift: `name` was dispatched/autocompleted but
undocumented, and `component`/`create` were dispatch-only aliases.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — all tests pass, including the new sync tests,
  autocomplete tests, render snapshots, and the budget (LOC) test.
- Regenerated the home/palette/wizard insta snapshots for the new `:name` row.
- `cargo clippy -p design-data-tui` — no new warnings from the changed code.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
