### PR TITLE
test(tui): fix dead_code warnings in tests/common helpers

### DIFF
--- a/sdk/tui/tests/common/mod.rs
+++ b/sdk/tui/tests/common/mod.rs
@@ -8,9 +8,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-use crossterm::event::{
-    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind,
-};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_tui::theme::Theme;
 use design_data_tui::{dispatch, update, Message, Model, Task, UpdateCtx, UpdateCtxBuilder};
@@ -27,16 +25,6 @@ pub fn key(code: KeyCode) -> KeyEvent {
         modifiers: KeyModifiers::NONE,
         kind: KeyEventKind::Press,
         state: KeyEventState::NONE,
-    }
-}
-
-/// Build a mouse event at the given terminal cell.
-pub fn mouse(kind: MouseEventKind, row: u16, col: u16) -> MouseEvent {
-    MouseEvent {
-        kind,
-        row,
-        column: col,
-        modifiers: KeyModifiers::NONE,
     }
 }
 
@@ -92,23 +80,6 @@ pub fn render_to_buffer(model: &mut Model, w: u16, h: u16) -> Buffer {
         .draw(|f| design_data_tui::draw(model, f, &Theme::terminal(), TEST_PRIMER))
         .unwrap();
     terminal.backend().buffer().clone()
-}
-
-/// Stringify a ratatui `Buffer` into a multi-line string for snapshot comparison.
-///
-/// Each row becomes a line (trailing spaces trimmed); rows are joined by `\n`.
-/// This is the canonical input for `insta::assert_snapshot!` in render tests.
-pub fn buffer_to_string(buf: &Buffer) -> String {
-    let area = buf.area();
-    (0..area.height)
-        .map(|row| {
-            let line: String = (0..area.width)
-                .map(|col| buf.cell((col, row)).map(|c| c.symbol()).unwrap_or(" "))
-                .collect();
-            line.trim_end().to_string()
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 // ── Builder convenience ───────────────────────────────────────────────────────
@@ -279,4 +250,10 @@ fn assert_emits_cmd_passes_on_task_cmd() {
 fn assert_emits_cmd_passes_on_batch_containing_cmd() {
     let task: Task<Message> = Task::batch(vec![Task::none(), Task::cmd(|| Message::Tick)]);
     assert_emits_cmd(&task, "Batch with Cmd should count as a side effect");
+}
+
+#[test]
+fn empty_graph_has_no_tokens() {
+    let graph = empty_graph();
+    assert!(graph.tokens.is_empty(), "empty_graph() should contain zero tokens");
 }

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -11,15 +11,25 @@
 //! M5 polish milestone tests: mouse, help overlay, palette history, theming.
 
 mod common;
-use common::{empty_graph, key, mouse, update_ctx};
+use common::{empty_graph, key, update_ctx};
 
-use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
+use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use design_data_tui::app::{
     ActiveView, DescribeView, HitAction, HitRegion, Modal, QueryRow, QueryView,
 };
 use design_data_tui::theme::Theme;
 use design_data_tui::{update, Message, Model};
 use ratatui::layout::Rect;
+
+/// Build a mouse event at the given terminal cell.
+fn mouse(kind: MouseEventKind, row: u16, col: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        row,
+        column: col,
+        modifiers: KeyModifiers::NONE,
+    }
+}
 
 // ── Help overlay ──────────────────────────────────────────────────────────────
 

--- a/sdk/tui/tests/snapshots.rs
+++ b/sdk/tui/tests/snapshots.rs
@@ -29,10 +29,7 @@ use common::{make_graph_with_tokens, render_to_buffer, update_ctx};
 use design_data_tui::{update, Message, Model};
 use ratatui::buffer::Buffer;
 
-/// Stringify a ratatui [`Buffer`] into a multi-line string for snapshot comparison.
-///
-/// Each row becomes a line (trailing spaces trimmed); rows are joined by `\n`.
-/// This is the canonical input for `insta::assert_snapshot!` in render tests.
+/// Stringify a ratatui [`Buffer`] into a trimmed multi-line string for `insta::assert_snapshot!`.
 fn buffer_to_string(buf: &Buffer) -> String {
     let area = buf.area();
     (0..area.height)

--- a/sdk/tui/tests/snapshots.rs
+++ b/sdk/tui/tests/snapshots.rs
@@ -24,9 +24,27 @@
 //! These tests use an 80×24 `TestBackend` (the canonical "terminal window").
 
 mod common;
-use common::{buffer_to_string, make_graph_with_tokens, render_to_buffer, update_ctx};
+use common::{make_graph_with_tokens, render_to_buffer, update_ctx};
 
 use design_data_tui::{update, Message, Model};
+use ratatui::buffer::Buffer;
+
+/// Stringify a ratatui [`Buffer`] into a multi-line string for snapshot comparison.
+///
+/// Each row becomes a line (trailing spaces trimmed); rows are joined by `\n`.
+/// This is the canonical input for `insta::assert_snapshot!` in render tests.
+fn buffer_to_string(buf: &Buffer) -> String {
+    let area = buf.area();
+    (0..area.height)
+        .map(|row| {
+            let line: String = (0..area.width)
+                .map(|col| buf.cell((col, row)).map(|c| c.symbol()).unwrap_or(" "))
+                .collect();
+            line.trim_end().to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 // ── Home / empty view ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

Eliminates ~40 duplicated `dead_code` warnings emitted on every `moon run sdk:test` build from `sdk/tui/tests/common/mod.rs`. No `#[allow]` attributes — each helper is fixed at source.

## Related Issue

Closes #1128

## Motivation and Context

`tests/common/mod.rs` is compiled independently into every integration-test binary. The `dead_code` lint runs per-binary, so helpers not used by a given binary are flagged — even if they are used by others. Every other helper in `common` already has a `#[test]` self-test in the same file, which makes it reachable everywhere. The three flagged helpers (`mouse`, `empty_graph`, `buffer_to_string`) were the only ones without one.

Fix strategy (no `#[allow]` attributes):

- **`mouse()`** — moved from `common/mod.rs` into `m5.rs`, its only consumer.
- **`buffer_to_string()`** — moved from `common/mod.rs` into `snapshots.rs`, its only consumer.
- **`empty_graph()`** — kept in `common` (used by 7+ binaries); a self-test added following the existing pattern for every other common helper.

## How Has This Been Tested?

`cargo test -p design-data-tui` — all 23 test binaries pass, zero `dead_code` warnings.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.