### PR TITLE
feat(mcp): migrate MCP servers and SKILL.md to in-process wasm (Phase C)

### DIFF
--- a/.changeset/fix-review-mcp-wasm-phase-c.md
+++ b/.changeset/fix-review-mcp-wasm-phase-c.md
@@ -1,0 +1,23 @@
+---
+"@adobe/design-data-mcp": minor
+"@adobe/design-data-agent-mcp": minor
+"@adobe/design-data-skill": minor
+---
+
+Fix review findings from Phase C MCP wasm migration.
+
+- **design-data-mcp**: replace hardcoded `indexed` field list with `getIndexedFields()`
+  wasm call (was missing `$schema`); cache `Dataset.embedded()`; extract
+  `scoreTokensByKeyword` helper; update suggest description to disclose keyword scoring.
+- **design-data-agent-mcp validate**: restore Layer-1 JSON-Schema validation via
+  `@adobe/design-data-js/validate`; expose `schema_path` input; document exceptions limit.
+- **design-data-agent-mcp diff**: fix filter to use camelCase `oldName`/`newName`;
+  extract `filterDiffByName` helper.
+- **design-data-agent-mcp authoring**: restore `schema_path` on `authoring_session_commit`
+  and wire it to Layer-1 validation in `commitSession`.
+- **design-data-skill SKILL.md**: fix `allowed-tools` to correct tool names; rewrite
+  body to use MCP tool descriptions instead of CLI `npx` commands.
+- **design-data-agent-mcp SKILL.md**: fix `allowed-tools` prefix to
+  `mcp__design-data-agent__`; rewrite body to use MCP tool descriptions.
+- **sdk/core query.rs**: expose `indexed_fields()` public accessor.
+- **sdk/wasm registry.rs**: add `getIndexedFields()` wasm export.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,6 +580,12 @@ importers:
 
   tools/design-data-agent-mcp:
     dependencies:
+      '@adobe/design-data-js':
+        specifier: workspace:*
+        version: link:../design-data-js
+      '@adobe/design-data-wasm':
+        specifier: workspace:*
+        version: link:../../sdk/wasm
       '@adobe/spectrum-design-data':
         specifier: workspace:*
         version: link:../../packages/design-data
@@ -596,6 +602,12 @@ importers:
       '@adobe/design-data-wasm':
         specifier: workspace:*
         version: link:../../sdk/wasm
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
     devDependencies:
       ava:
         specifier: ^6.1.2
@@ -603,6 +615,12 @@ importers:
 
   tools/design-data-mcp:
     dependencies:
+      '@adobe/design-data-wasm':
+        specifier: workspace:*
+        version: link:../../sdk/wasm
+      '@adobe/spectrum-design-data':
+        specifier: workspace:*
+        version: link:../../packages/design-data
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -33,6 +33,14 @@ pub(crate) const ALLOWED_KEYS: &[&str] = &[
     "$schema",
 ];
 
+/// Return the list of keys that may appear in filter expressions.
+///
+/// Exposed so that the wasm surface can return the canonical set dynamically
+/// rather than duplicating it in JavaScript.
+pub fn indexed_fields() -> &'static [&'static str] {
+    ALLOWED_KEYS
+}
+
 /// Keys resolved from `raw["name"][key]` (name-object fields).
 const NAME_OBJECT_KEYS: &[&str] = &[
     "property",
@@ -371,6 +379,21 @@ mod tests {
                 .map(|(name, raw)| (name.to_string(), PathBuf::from("test.json"), raw))
                 .collect(),
         )
+    }
+
+    // ── indexed_fields ──────────────────────────────────────────────────
+
+    #[test]
+    fn indexed_fields_contains_expected_keys() {
+        let fields = super::indexed_fields();
+        let expected = [
+            "property", "component", "variant", "state",
+            "colorScheme", "scale", "contrast", "uuid", "$schema",
+        ];
+        assert_eq!(fields.len(), expected.len());
+        for key in &expected {
+            assert!(fields.contains(key), "indexed_fields missing key: {key}");
+        }
     }
 
     // ── Parser tests ────────────────────────────────────────────────────

--- a/sdk/wasm/src/registry.rs
+++ b/sdk/wasm/src/registry.rs
@@ -68,6 +68,19 @@ pub fn get_advisory_fields() -> Vec<String> {
         .collect()
 }
 
+/// Return the list of field names that can be used as filter keys in query
+/// expressions (e.g. `"property"`, `"component"`, `"$schema"`).
+///
+/// This is the canonical set maintained in `design_data_core::query::ALLOWED_KEYS`,
+/// exposed here so callers do not need to hard-code it.
+#[wasm_bindgen(js_name = "getIndexedFields")]
+pub fn get_indexed_fields() -> Vec<String> {
+    design_data_core::query::indexed_fields()
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
 // ---------------------------------------------------------------------------
 // JSON-object helpers (mirror @adobe/design-system-registry contract)
 //

--- a/sdk/wasm/test/parity.test.js
+++ b/sdk/wasm/test/parity.test.js
@@ -60,7 +60,10 @@ test.before(async () => {
 test("Dataset.embedded() returns a dataset with a non-zero token count", (t) => {
   const ds = wasm.Dataset.embedded();
   t.truthy(ds);
-  t.true(ds.tokenCount() > 100, `Expected tokens > 100, got ${ds.tokenCount()}`);
+  t.true(
+    ds.tokenCount() > 100,
+    `Expected tokens > 100, got ${ds.tokenCount()}`,
+  );
 });
 
 test("Dataset.embedded() query returns results for known Spectrum tokens", (t) => {
@@ -116,6 +119,27 @@ test("getAdvisoryFields returns a non-empty string array", (t) => {
   t.true(Array.isArray(fields));
   t.true(fields.length > 0);
   t.true(fields.every((f) => typeof f === "string"));
+});
+
+test("getIndexedFields returns all 9 queryable filter keys", (t) => {
+  const fields = wasm.getIndexedFields();
+  t.true(Array.isArray(fields));
+  t.true(fields.every((f) => typeof f === "string"));
+  const expected = [
+    "property",
+    "component",
+    "variant",
+    "state",
+    "colorScheme",
+    "scale",
+    "contrast",
+    "uuid",
+    "$schema",
+  ];
+  t.is(fields.length, expected.length);
+  for (const key of expected) {
+    t.true(fields.includes(key), `getIndexedFields missing key: ${key}`);
+  }
 });
 
 // Registry JSON-object helpers — mirrors @adobe/design-system-registry API

--- a/tools/design-data-agent-mcp/package.json
+++ b/tools/design-data-agent-mcp/package.json
@@ -33,6 +33,8 @@
     "provenance": true
   },
   "dependencies": {
+    "@adobe/design-data-js": "workspace:*",
+    "@adobe/design-data-wasm": "workspace:*",
     "@adobe/spectrum-design-data": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1"
   },

--- a/tools/design-data-agent-mcp/skills/design-data/SKILL.md
+++ b/tools/design-data-agent-mcp/skills/design-data/SKILL.md
@@ -2,20 +2,22 @@
 name: design-data-agent
 description: >
   Validate, query, resolve, diff, and author spec-conformant design tokens and components using the
-  design-data CLI against a local dataset. Use when the user asks about design tokens, a design
+  design-data MCP tools against a local dataset. Use when the user asks about design tokens, a design
   system, token lookup, spec-conformance, drift detection, or token authoring on custom data.
 when_to_use: >
   Trigger on: design system, design tokens, spec-conformant, drift, validate tokens, token
   authoring, custom dataset, DESIGN_DATA_PATH, design-data validate, design-data diff,
   design-data write, product-context.json.
-allowed-tools: mcp__design-data__primer, mcp__design-data__query_tokens, mcp__design-data__resolve_token, mcp__design-data__describe_component, mcp__design-data__validate_usage, mcp__design-data__diff_datasets, mcp__design-data__write, mcp__design-data__start_authoring_session, mcp__design-data__authoring_session_step_intent, mcp__design-data__authoring_session_step_classification, mcp__design-data__authoring_session_step_values, mcp__design-data__authoring_session_commit, mcp__design-data__authoring_session_cancel, mcp__design-data__authoring_session_get, mcp__design-data__authoring_session_list
+allowed-tools: mcp__design-data-agent__primer, mcp__design-data-agent__query_tokens, mcp__design-data-agent__resolve_token, mcp__design-data-agent__describe_component, mcp__design-data-agent__validate_usage, mcp__design-data-agent__diff_datasets, mcp__design-data-agent__write, mcp__design-data-agent__start_authoring_session, mcp__design-data-agent__authoring_session_step_intent, mcp__design-data-agent__authoring_session_step_classification, mcp__design-data-agent__authoring_session_step_values, mcp__design-data-agent__authoring_session_commit, mcp__design-data-agent__authoring_session_cancel, mcp__design-data-agent__authoring_session_get, mcp__design-data-agent__authoring_session_list
 ---
 
 # design-data agent skill
 
-`design-data` is the reference CLI for the Spectrum Design Data specification. It validates, queries, resolves, and authors spec-conformant tokens and components from any dataset on the local filesystem.
+`@adobe/design-data-agent-mcp` provides in-process wasm tools for validating, querying,
+resolving, diffing, and authoring spec-conformant tokens and components from any dataset
+on the local filesystem.
 
-Set two path variables once and reference them throughout. The token dataset and the spec catalog (components, fields, dimensions) live in separate directories:
+Set two path variables once and reference them throughout:
 
 ```bash
 export DESIGN_DATA_PATH=./packages/design-data/tokens
@@ -26,145 +28,7 @@ For Spectrum tokens with zero setup (embedded snapshot), use the `design-data` s
 
 ## Bootstrap
 
-On first use, ensure the CLI is available:
-
-```
-npx @adobe/design-data --version
-```
-
-***
-
-## Session start — call `primer` first
-
-Call `primer` at the start of every session that touches design data. It returns the active dimensions, component list, taxonomy fields, and token count — structural context that scopes all subsequent lookups.
-
-```bash
-npx @adobe/design-data primer "$DESIGN_DATA_PATH" --format json \
-  --components-dir "$DESIGN_DATA_SPEC_PATH/components" \
-  --fields-dir     "$DESIGN_DATA_SPEC_PATH/fields"
-```
-
-Always pass `--components-dir` and `--fields-dir` explicitly. These directories live under `packages/design-data/`, alongside the token dataset. The CLI defaults probe those paths relative to CWD, so omitting the flags when running from an arbitrary directory (or with an absolute `DESIGN_DATA_PATH`) produces empty `components` and `taxonomyFields`.
-
-The payload includes `specVersion`, `manifest`, `components`, `taxonomyFields`, and `tokenCount`.
-
-***
-
-## Token lookup
-
-### Resolve a token to its literal value
-
-```bash
-npx @adobe/design-data resolve <property> "$DESIGN_DATA_PATH" --format json \
-  [--color-scheme light|dark] \
-  [--scale desktop|mobile] \
-  [--contrast regular|high]
-```
-
-Example:
-
-```bash
-npx @adobe/design-data resolve accent-background-color-default "$DESIGN_DATA_PATH" \
-  --format json --color-scheme dark --scale desktop
-```
-
-### Query tokens by filter expression
-
-```bash
-npx @adobe/design-data query "$DESIGN_DATA_PATH" --filter "<expr>" --format json
-```
-
-Valid filter keys: `property`, `component`, `variant`, `state`, `colorScheme`, `scale`, `contrast`, `uuid`, `$schema`. Any other key is a parse error. The dimension keys (`colorScheme`, `scale`, `contrast`) accept the same enum values as the `resolve` flags (`light`/`dark`, `desktop`/`mobile`, `regular`/`high`).
-
-Filter syntax examples:
-
-```
-property=background-color
-property=*background*
-component=button
-component=button,state=hover
-property=background-color|property=border-color
-$schema=https://spectrum.adobe.com/page/design-token/
-```
-
-> **Exit codes:** `0` = matches found; `1` = no matches (returns `[]` — not an error); `>1` = error.
-
-***
-
-## Component info
-
-```bash
-npx @adobe/design-data component <id> --components-dir "$DESIGN_DATA_SPEC_PATH/components"
-```
-
-Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`, and `tokenBindings`. Output is always JSON; there is no `--format` flag on this subcommand.
-
-Pass `--components-dir` explicitly for the same reason as `primer` — the default probes CWD-relative paths that won't resolve in agent contexts.
-
-Example:
-
-```bash
-npx @adobe/design-data component button --components-dir "$DESIGN_DATA_SPEC_PATH/components"
-```
-
-***
-
-## Validation
-
-```bash
-npx @adobe/design-data validate "$DESIGN_DATA_PATH" --format json \
-  [--schema-path <path>] \
-  [--exceptions-path <path>] \
-  [--strict]
-```
-
-Returns a `ValidationReport` object: `{ layer: 1|2, errors: [...], warnings: [...] }` where each diagnostic has `rule_id` (e.g. `"SPEC-002"`), `severity` (`"error"` | `"warning"`), and `message`. Layer 1 is schema validation; Layer 2 is cascade-rule validation. `--strict` treats warnings as errors.
-
-***
-
-## Dataset diff
-
-```bash
-npx @adobe/design-data diff <old-path> <new-path> --format json [--filter <expr>]
-```
-
-> **Exit codes:** `0` = no changes; `1` = differences found (returns JSON diff — not an error); `>1` = error.
-
-***
-
-## Product-layer authoring
-
-Write or update the product context document in the dataset:
-
-```bash
-npx @adobe/design-data write \
-  --output "$DESIGN_DATA_PATH/product-context.json" \
-  --rationale "Why these overrides exist"
-```
-
-Always pass `--output` with an explicit path inside the dataset. The default resolves relative to CWD, which is rarely correct in agent contexts.
-
-Generates a product-context scaffold at the output path (`specVersion`, `layer: "product"`, `rationale`, attribution metadata). Creates the file if absent; overwrites if it already exists. The confirmation string returned to stdout on success is a plain text message — not JSON.
-
-***
-
-## Gotchas
-
-* **Scale values:** `desktop` and `mobile` — not `medium`/`large`.
-* **Contrast values:** `regular` and `high` — not `standard`/`high`.
-* **`query` exit 1** means no matches and still emits `[]`. Only `>1` is an error.
-* **`diff` exit 1** means changes were found. The JSON diff is in stdout — still a success result.
-* **`--format json`** — always pass this in agent and script contexts; the CLI pretty-prints when stdout is a TTY.
-
-## When working in Cursor
-
-Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste this URL:
-
-```
-https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
-```
-
-For always-available tool access (higher context cost), add `@adobe/design-data-agent-mcp` to `.cursor/mcp.json`:
+Add `@adobe/design-data-agent-mcp` to your `.cursor/mcp.json`:
 
 ```json
 {
@@ -183,3 +47,122 @@ For always-available tool access (higher context cost), add `@adobe/design-data-
 ```
 
 Adjust paths to match your dataset layout.
+
+***
+
+## Session start — call `primer` first
+
+Call `primer` at the start of every session that touches design data. It returns the active
+dimensions, component list, taxonomy fields, and token count — structural context that scopes
+all subsequent lookups. No inputs required.
+
+***
+
+## Token lookup
+
+### Resolve a token to its literal value — `resolve_token`
+
+Required: `property` (string) — e.g. `"accent-background-color-default"`
+Optional: `colorScheme` (`"light"` or `"dark"`), `scale` (`"desktop"` or `"mobile"`),
+`contrast` (`"regular"` or `"high"`)
+
+### Query tokens by filter expression — `query_tokens`
+
+Required: `filter` (string)
+
+Valid filter keys: `property`, `component`, `variant`, `state`, `colorScheme`, `scale`,
+`contrast`, `uuid`, `$schema`.
+
+Filter syntax examples:
+
+```
+property=background-color
+property=*background*
+component=button
+component=button,state=hover
+property=background-color|property=border-color
+$schema=https://spectrum.adobe.com/page/design-token/
+```
+
+> **Exit codes:** `0` = matches found; empty array = no matches (not an error).
+
+***
+
+## Component info — `describe_component`
+
+Required: `id` (string) — kebab-case component ID, e.g. `button`, `action-button`
+
+Returns the component contract: `name`, `displayName`, `options`, `anatomy`, `states`,
+and `tokenBindings`.
+
+***
+
+## Validation — `validate_usage`
+
+Optional inputs:
+
+* `path` — dataset path (defaults to `DESIGN_DATA_PATH`)
+* `strict` (boolean) — treat warnings as errors
+* `schema_path` — override schemas directory (defaults to `@adobe/spectrum-tokens` schemas)
+
+Runs Layer-1 JSON-Schema structural validation and Layer-2 relational rules.
+Returns `{ valid, errors, warnings }`.
+
+> **Note:** `--exceptions-path` (SPEC-007 naming allowlist) is not supported in the
+> in-process path. Use the `design-data` CLI directly if you need exceptions support.
+
+***
+
+## Dataset diff — `diff_datasets`
+
+Required: `oldPath`, `newPath`
+Optional: `filter` (substring to narrow results by token name)
+
+Returns `{ renamed, deprecated, reverted, added, deleted, updated }`.
+
+***
+
+## Product-layer authoring — `write`
+
+Write or update the product context document in the dataset.
+
+Optional inputs: `output` (defaults to `$DESIGN_DATA_PATH/product-context.json`),
+`rationale` (string)
+
+***
+
+## Token authoring session
+
+Use the following tools in sequence to create a new token through the wizard:
+
+1. **`start_authoring_session`** — start a session (returns `session_id`)
+2. **`authoring_session_step_intent`** — provide natural-language intent; get token suggestions
+3. **`authoring_session_step_classification`** — set layer, property, name fields
+4. **`authoring_session_step_values`** — set mode-specific value rows
+5. **`authoring_session_commit`** — validate and write the token to disk
+6. **`authoring_session_cancel`** — cancel without writing
+
+Helper tools: `authoring_session_get` (inspect state), `authoring_session_list` (all active sessions).
+
+`authoring_session_commit` accepts an optional `schema_path` to override the schemas directory
+for Layer-1 JSON-Schema validation before writing.
+
+> **Note:** `authoring_session_step_intent` (NLP suggestion ranking) still delegates to the
+> `design-data` CLI because the NLP `suggest` API is not yet on the wasm surface.
+
+***
+
+## Gotchas
+
+* **Scale values:** `desktop` and `mobile` — not `medium`/`large`.
+* **Contrast values:** `regular` and `high` — not `standard`/`high`.
+* **`query_tokens` returns `[]`** when no tokens match — not an error.
+* **`diff_datasets` filter** matches by token name substring (case-insensitive).
+
+## When working in Cursor
+
+Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste this URL:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-mcp/skills/design-data
+```

--- a/tools/design-data-agent-mcp/skills/design-data/SKILL.md
+++ b/tools/design-data-agent-mcp/skills/design-data/SKILL.md
@@ -8,7 +8,7 @@ when_to_use: >
   Trigger on: design system, design tokens, spec-conformant, drift, validate tokens, token
   authoring, custom dataset, DESIGN_DATA_PATH, design-data validate, design-data diff,
   design-data write, product-context.json.
-allowed-tools: Bash(npx @adobe/design-data *)
+allowed-tools: mcp__design-data__primer, mcp__design-data__query_tokens, mcp__design-data__resolve_token, mcp__design-data__describe_component, mcp__design-data__validate_usage, mcp__design-data__diff_datasets, mcp__design-data__write, mcp__design-data__start_authoring_session, mcp__design-data__authoring_session_step_intent, mcp__design-data__authoring_session_step_classification, mcp__design-data__authoring_session_step_values, mcp__design-data__authoring_session_commit, mcp__design-data__authoring_session_cancel, mcp__design-data__authoring_session_get, mcp__design-data__authoring_session_list
 ---
 
 # design-data agent skill

--- a/tools/design-data-agent-mcp/src/tools/authoring.js
+++ b/tools/design-data-agent-mcp/src/tools/authoring.js
@@ -8,35 +8,40 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! MCP authoring-session tools (RFC #973 Q4).
-//!
-//! Each tool maps to one `design-data authoring-session` CLI subcommand.
-//! State is held on disk (one JSON file per session); the CLI is stateless.
+/**
+ * Authoring-session tools for design-data-agent-mcp.
+ *
+ * Most operations use @adobe/design-data-js (on-disk session store) and run
+ * fully in-process. The exception is authoring_session_step_intent, which still
+ * delegates to the CLI because the NLP `suggest` ranking is not yet on the wasm
+ * surface. When that API is added, step_intent can be migrated here too.
+ */
 
-import { runCli } from "../cli.js";
-import { config } from "../config.js";
-
-async function callCli(args) {
-  const { exitCode, stdout, stderr } = await runCli(args, { timeout: 30_000 });
-  if (exitCode !== 0)
-    throw new Error(stderr || `authoring-session exited ${exitCode}`);
-  return JSON.parse(stdout);
-}
+import {
+  startSession,
+  getSession,
+  listSessions,
+  stepClassification,
+  stepValues,
+  commitSession,
+  cancelSession,
+} from '@adobe/design-data-js/session';
+import { runCli } from '../cli.js';
+import { config } from '../config.js';
 
 export function createAuthoringTools() {
   return [
     {
-      name: "start_authoring_session",
+      name: 'start_authoring_session',
       description:
-        "Start a new token authoring session. Returns a session_id and the initial wizard state. " +
-        "The session persists across calls — use the returned session_id in subsequent steps.",
+        'Start a new token authoring session. Returns a session_id and the initial wizard state. ' +
+        'The session persists across calls — use the returned session_id in subsequent steps.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           dataset_path: {
-            type: "string",
-            description:
-              "Path to the token dataset directory. Defaults to DESIGN_DATA_PATH.",
+            type: 'string',
+            description: 'Path to the token dataset directory. Defaults to DESIGN_DATA_PATH.',
           },
         },
         additionalProperties: false,
@@ -45,25 +50,25 @@ export function createAuthoringTools() {
         const path = dataset_path ?? config.dataPath;
         if (!path) {
           throw new Error(
-            "dataset_path is required (or set DESIGN_DATA_PATH in the environment)",
+            'dataset_path is required (or set DESIGN_DATA_PATH in the environment)',
           );
         }
-        return callCli(["authoring-session", "start", path]);
+        return startSession(path);
       },
     },
 
     {
-      name: "authoring_session_step_intent",
+      name: 'authoring_session_step_intent',
       description:
-        "Update the intent for a session and get ranked existing-token suggestions. " +
-        "Returns suggestions and can_alias (true when a high-confidence match exists).",
+        'Update the intent for a session and get ranked existing-token suggestions. ' +
+        'Returns suggestions and can_alias (true when a high-confidence match exists).',
       inputSchema: {
-        type: "object",
-        required: ["session_id", "intent"],
+        type: 'object',
+        required: ['session_id', 'intent'],
         properties: {
-          session_id: { type: "string" },
+          session_id: { type: 'string' },
           intent: {
-            type: "string",
+            type: 'string',
             description:
               "Natural-language description of what the token is for, e.g. 'accent background color'.",
           },
@@ -71,102 +76,84 @@ export function createAuthoringTools() {
         additionalProperties: false,
       },
       async handler({ session_id, intent }) {
-        return callCli([
-          "authoring-session",
-          "step",
-          "intent",
-          "--session-id",
+        // step_intent requires NLP suggest ranking — still uses the CLI.
+        // Will be migrated when suggest is added to the wasm surface.
+        const { exitCode, stdout, stderr } = await runCli([
+          'authoring-session',
+          'step',
+          'intent',
+          '--session-id',
           session_id,
-          "--intent",
+          '--intent',
           intent,
-        ]);
+        ], { timeout: 30_000 });
+        if (exitCode !== 0) throw new Error(stderr || `authoring-session step intent exited ${exitCode}`);
+        return JSON.parse(stdout);
       },
     },
 
     {
-      name: "authoring_session_step_classification",
+      name: 'authoring_session_step_classification',
       description:
-        "Set the layer, property, and name-object fields for the token. " +
-        "name_fields is an array of {key, value} objects.",
+        'Set the layer, property, and name-object fields for the token. ' +
+        'name_fields is an array of {key, value} objects.',
       inputSchema: {
-        type: "object",
-        required: ["session_id", "layer", "property"],
+        type: 'object',
+        required: ['session_id', 'layer', 'property'],
         properties: {
-          session_id: { type: "string" },
+          session_id: { type: 'string' },
           layer: {
-            type: "string",
-            enum: ["foundation", "platform", "product"],
-            description: "Token layer.",
+            type: 'string',
+            enum: ['foundation', 'platform', 'product'],
+            description: 'Token layer.',
           },
-          property: {
-            type: "string",
-            description: "Token property, e.g. 'background-color'.",
-          },
+          property: { type: 'string', description: "Token property, e.g. 'background-color'." },
           name_fields: {
-            type: "array",
+            type: 'array',
             items: {
-              type: "object",
-              required: ["key", "value"],
+              type: 'object',
+              required: ['key', 'value'],
               properties: {
-                key: { type: "string" },
-                value: { type: "string" },
+                key: { type: 'string' },
+                value: { type: 'string' },
               },
             },
-            description: "Additional name-object fields beyond property.",
+            description: 'Additional name-object fields beyond property.',
           },
         },
         additionalProperties: false,
       },
       async handler({ session_id, layer, property, name_fields = [] }) {
-        const args = [
-          "authoring-session",
-          "step",
-          "classification",
-          "--session-id",
-          session_id,
-          "--layer",
-          layer,
-          "--property",
-          property,
-        ];
-        for (const { key, value } of name_fields) {
-          args.push("--name-field", `${key}=${value}`);
-        }
-        return callCli(args);
+        return stepClassification(session_id, { layer, property, nameFields: name_fields });
       },
     },
 
     {
-      name: "authoring_session_step_values",
+      name: 'authoring_session_step_values',
       description:
-        "Set the value rows for the token. Each row specifies mode conditions and either " +
-        "a literal value or an alias target. Most tokens need one row with empty mode_combo.",
+        'Set the value rows for the token. Each row specifies mode conditions and either ' +
+        'a literal value or an alias target. Most tokens need one row with empty mode_combo.',
       inputSchema: {
-        type: "object",
-        required: ["session_id", "rows"],
+        type: 'object',
+        required: ['session_id', 'rows'],
         properties: {
-          session_id: { type: "string" },
+          session_id: { type: 'string' },
           rows: {
-            type: "array",
+            type: 'array',
             description:
               "Value rows. Each: { mode_combo: [[key,val],...], kind: 'Literal'|'Alias', " +
-              "alias_target: string, literal: string }",
+              'alias_target: string, literal: string }',
             items: {
-              type: "object",
-              required: ["mode_combo", "kind", "alias_target", "literal"],
+              type: 'object',
+              required: ['mode_combo', 'kind', 'alias_target', 'literal'],
               properties: {
                 mode_combo: {
-                  type: "array",
-                  items: {
-                    type: "array",
-                    items: { type: "string" },
-                    minItems: 2,
-                    maxItems: 2,
-                  },
+                  type: 'array',
+                  items: { type: 'array', items: { type: 'string' }, minItems: 2, maxItems: 2 },
                 },
-                kind: { type: "string", enum: ["Literal", "Alias"] },
-                alias_target: { type: "string" },
-                literal: { type: "string" },
+                kind: { type: 'string', enum: ['Literal', 'Alias'] },
+                alias_target: { type: 'string' },
+                literal: { type: 'string' },
               },
             },
           },
@@ -174,139 +161,95 @@ export function createAuthoringTools() {
         additionalProperties: false,
       },
       async handler({ session_id, rows }) {
-        return callCli([
-          "authoring-session",
-          "step",
-          "values",
-          "--session-id",
-          session_id,
-          "--rows",
-          JSON.stringify(rows),
-        ]);
+        return stepValues(session_id, rows);
       },
     },
 
     {
-      name: "authoring_session_commit",
+      name: 'authoring_session_commit',
       description:
-        "Build and write the token to disk, then remove the session. " +
-        "Requires schema_url (the JSON Schema URL for the token type) and target (output file path).",
+        'Build and write the token to disk, then remove the session. ' +
+        'Requires schema_url (the JSON Schema URL for the token type) and target (output file path).',
       inputSchema: {
-        type: "object",
-        required: ["session_id", "schema_url", "target"],
+        type: 'object',
+        required: ['session_id', 'schema_url', 'target'],
         properties: {
-          session_id: { type: "string" },
+          session_id: { type: 'string' },
           schema_url: {
-            type: "string",
+            type: 'string',
             description:
-              "The $schema URL for the token type, e.g. https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+              'The $schema URL for the token type, e.g. https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json',
           },
           target: {
-            type: "string",
-            description:
-              "Target legacy JSON file to write to (created if absent, merged if present).",
+            type: 'string',
+            description: 'Target legacy JSON file to write to (created if absent, merged if present).',
           },
-          rationale: {
-            type: "string",
-            description: "Why this token is being created.",
-          },
+          rationale: { type: 'string', description: 'Why this token is being created.' },
           product_context: {
-            type: "string",
-            description: "Path to product-context.json for rationale capture.",
+            type: 'string',
+            description: 'Path to product-context.json for rationale capture.',
           },
           schema_path: {
-            type: "string",
-            description:
-              "Path to schemas directory. Defaults to packages/tokens/schemas relative to target.",
+            type: 'string',
+            description: 'Path to schemas directory. (Not used in JS implementation; no schema validation.)',
           },
           is_override: {
-            type: "boolean",
-            description:
-              "True when this token overrides an existing foundation/platform token.",
+            type: 'boolean',
+            description: 'True when this token overrides an existing foundation/platform token.',
           },
         },
         additionalProperties: false,
       },
-      async handler({
-        session_id,
-        schema_url,
-        target,
-        rationale = "",
-        product_context,
-        schema_path,
-        is_override = false,
-      }) {
-        const args = [
-          "authoring-session",
-          "commit",
-          "--session-id",
-          session_id,
-          "--schema-url",
-          schema_url,
-          "--target",
+      async handler({ session_id, schema_url, target, rationale = '', product_context, is_override = false }) {
+        return commitSession({
+          sessionId: session_id,
+          schemaUrl: schema_url,
           target,
-          "--rationale",
           rationale,
-        ];
-        if (product_context) args.push("--product-context", product_context);
-        if (schema_path) args.push("--schema-path", schema_path);
-        if (is_override) args.push("--is-override");
-        return callCli(args);
+          productContext: product_context,
+          isOverride: is_override,
+        });
       },
     },
 
     {
-      name: "authoring_session_cancel",
-      description: "Cancel a session and delete its on-disk file.",
+      name: 'authoring_session_cancel',
+      description: 'Cancel a session and delete its on-disk file.',
       inputSchema: {
-        type: "object",
-        required: ["session_id"],
-        properties: {
-          session_id: { type: "string" },
-        },
+        type: 'object',
+        required: ['session_id'],
+        properties: { session_id: { type: 'string' } },
         additionalProperties: false,
       },
       async handler({ session_id }) {
-        return callCli([
-          "authoring-session",
-          "cancel",
-          "--session-id",
-          session_id,
-        ]);
+        return cancelSession(session_id);
       },
     },
 
     {
-      name: "authoring_session_get",
-      description: "Get the current state of an authoring session.",
+      name: 'authoring_session_get',
+      description: 'Get the current state of an authoring session.',
       inputSchema: {
-        type: "object",
-        required: ["session_id"],
-        properties: {
-          session_id: { type: "string" },
-        },
+        type: 'object',
+        required: ['session_id'],
+        properties: { session_id: { type: 'string' } },
         additionalProperties: false,
       },
       async handler({ session_id }) {
-        return callCli([
-          "authoring-session",
-          "get",
-          "--session-id",
-          session_id,
-        ]);
+        return getSession(session_id);
       },
     },
 
     {
-      name: "authoring_session_list",
-      description: "List all active authoring sessions.",
+      name: 'authoring_session_list',
+      description: 'List all active authoring sessions.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {},
         additionalProperties: false,
       },
       async handler() {
-        return callCli(["authoring-session", "list"]);
+        return listSessions();
       },
     },
   ];

--- a/tools/design-data-agent-mcp/src/tools/authoring.js
+++ b/tools/design-data-agent-mcp/src/tools/authoring.js
@@ -25,23 +25,24 @@ import {
   stepValues,
   commitSession,
   cancelSession,
-} from '@adobe/design-data-js/session';
-import { runCli } from '../cli.js';
-import { config } from '../config.js';
+} from "@adobe/design-data-js/session";
+import { runCli } from "../cli.js";
+import { config } from "../config.js";
 
 export function createAuthoringTools() {
   return [
     {
-      name: 'start_authoring_session',
+      name: "start_authoring_session",
       description:
-        'Start a new token authoring session. Returns a session_id and the initial wizard state. ' +
-        'The session persists across calls — use the returned session_id in subsequent steps.',
+        "Start a new token authoring session. Returns a session_id and the initial wizard state. " +
+        "The session persists across calls — use the returned session_id in subsequent steps.",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
           dataset_path: {
-            type: 'string',
-            description: 'Path to the token dataset directory. Defaults to DESIGN_DATA_PATH.',
+            type: "string",
+            description:
+              "Path to the token dataset directory. Defaults to DESIGN_DATA_PATH.",
           },
         },
         additionalProperties: false,
@@ -50,7 +51,7 @@ export function createAuthoringTools() {
         const path = dataset_path ?? config.dataPath;
         if (!path) {
           throw new Error(
-            'dataset_path is required (or set DESIGN_DATA_PATH in the environment)',
+            "dataset_path is required (or set DESIGN_DATA_PATH in the environment)",
           );
         }
         return startSession(path);
@@ -58,17 +59,17 @@ export function createAuthoringTools() {
     },
 
     {
-      name: 'authoring_session_step_intent',
+      name: "authoring_session_step_intent",
       description:
-        'Update the intent for a session and get ranked existing-token suggestions. ' +
-        'Returns suggestions and can_alias (true when a high-confidence match exists).',
+        "Update the intent for a session and get ranked existing-token suggestions. " +
+        "Returns suggestions and can_alias (true when a high-confidence match exists).",
       inputSchema: {
-        type: 'object',
-        required: ['session_id', 'intent'],
+        type: "object",
+        required: ["session_id", "intent"],
         properties: {
-          session_id: { type: 'string' },
+          session_id: { type: "string" },
           intent: {
-            type: 'string',
+            type: "string",
             description:
               "Natural-language description of what the token is for, e.g. 'accent background color'.",
           },
@@ -78,82 +79,100 @@ export function createAuthoringTools() {
       async handler({ session_id, intent }) {
         // step_intent requires NLP suggest ranking — still uses the CLI.
         // Will be migrated when suggest is added to the wasm surface.
-        const { exitCode, stdout, stderr } = await runCli([
-          'authoring-session',
-          'step',
-          'intent',
-          '--session-id',
-          session_id,
-          '--intent',
-          intent,
-        ], { timeout: 30_000 });
-        if (exitCode !== 0) throw new Error(stderr || `authoring-session step intent exited ${exitCode}`);
+        const { exitCode, stdout, stderr } = await runCli(
+          [
+            "authoring-session",
+            "step",
+            "intent",
+            "--session-id",
+            session_id,
+            "--intent",
+            intent,
+          ],
+          { timeout: 30_000 },
+        );
+        if (exitCode !== 0)
+          throw new Error(
+            stderr || `authoring-session step intent exited ${exitCode}`,
+          );
         return JSON.parse(stdout);
       },
     },
 
     {
-      name: 'authoring_session_step_classification',
+      name: "authoring_session_step_classification",
       description:
-        'Set the layer, property, and name-object fields for the token. ' +
-        'name_fields is an array of {key, value} objects.',
+        "Set the layer, property, and name-object fields for the token. " +
+        "name_fields is an array of {key, value} objects.",
       inputSchema: {
-        type: 'object',
-        required: ['session_id', 'layer', 'property'],
+        type: "object",
+        required: ["session_id", "layer", "property"],
         properties: {
-          session_id: { type: 'string' },
+          session_id: { type: "string" },
           layer: {
-            type: 'string',
-            enum: ['foundation', 'platform', 'product'],
-            description: 'Token layer.',
+            type: "string",
+            enum: ["foundation", "platform", "product"],
+            description: "Token layer.",
           },
-          property: { type: 'string', description: "Token property, e.g. 'background-color'." },
+          property: {
+            type: "string",
+            description: "Token property, e.g. 'background-color'.",
+          },
           name_fields: {
-            type: 'array',
+            type: "array",
             items: {
-              type: 'object',
-              required: ['key', 'value'],
+              type: "object",
+              required: ["key", "value"],
               properties: {
-                key: { type: 'string' },
-                value: { type: 'string' },
+                key: { type: "string" },
+                value: { type: "string" },
               },
             },
-            description: 'Additional name-object fields beyond property.',
+            description: "Additional name-object fields beyond property.",
           },
         },
         additionalProperties: false,
       },
       async handler({ session_id, layer, property, name_fields = [] }) {
-        return stepClassification(session_id, { layer, property, nameFields: name_fields });
+        return stepClassification(session_id, {
+          layer,
+          property,
+          nameFields: name_fields,
+        });
       },
     },
 
     {
-      name: 'authoring_session_step_values',
+      name: "authoring_session_step_values",
       description:
-        'Set the value rows for the token. Each row specifies mode conditions and either ' +
-        'a literal value or an alias target. Most tokens need one row with empty mode_combo.',
+        "Set the value rows for the token. Each row specifies mode conditions and either " +
+        "a literal value or an alias target. Most tokens need one row with empty mode_combo.",
       inputSchema: {
-        type: 'object',
-        required: ['session_id', 'rows'],
+        type: "object",
+        required: ["session_id", "rows"],
         properties: {
-          session_id: { type: 'string' },
+          session_id: { type: "string" },
           rows: {
-            type: 'array',
+            type: "array",
             description:
               "Value rows. Each: { mode_combo: [[key,val],...], kind: 'Literal'|'Alias', " +
-              'alias_target: string, literal: string }',
+              "alias_target: string, literal: string }",
             items: {
-              type: 'object',
-              required: ['mode_combo', 'kind', 'alias_target', 'literal'],
+              type: "object",
+              required: ["mode_combo", "kind", "alias_target", "literal"],
               properties: {
                 mode_combo: {
-                  type: 'array',
-                  items: { type: 'array', items: { type: 'string' }, minItems: 2, maxItems: 2 },
+                  type: "array",
+                  items: {
+                    type: "array",
+                    items: { type: "string" },
+                    minItems: 2,
+                    maxItems: 2,
+                  },
                 },
-                kind: { type: 'string', enum: ['Literal', 'Alias'] },
-                alias_target: { type: 'string' },
-                literal: { type: 'string' },
+                kind: { type: "string", enum: ["Literal", "Alias"] },
+                alias_target: { type: "string" },
+                literal: { type: "string" },
               },
             },
           },
@@ -166,59 +185,76 @@ export function createAuthoringTools() {
     },
 
     {
-      name: 'authoring_session_commit',
+      name: "authoring_session_commit",
       description:
-        'Build and write the token to disk, then remove the session. ' +
-        'Requires schema_url (the JSON Schema URL for the token type) and target (output file path).',
+        "Build and write the token to disk, then remove the session. " +
+        "Requires schema_url (the JSON Schema URL for the token type) and target (output file path).",
       inputSchema: {
-        type: 'object',
-        required: ['session_id', 'schema_url', 'target'],
+        type: "object",
+        required: ["session_id", "schema_url", "target"],
         properties: {
-          session_id: { type: 'string' },
+          session_id: { type: "string" },
           schema_url: {
-            type: 'string',
+            type: "string",
             description:
-              'The $schema URL for the token type, e.g. https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json',
+              "The $schema URL for the token type, e.g. https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
           },
           target: {
-            type: 'string',
-            description: 'Target legacy JSON file to write to (created if absent, merged if present).',
+            type: "string",
+            description:
+              "Target legacy JSON file to write to (created if absent, merged if present).",
           },
-          rationale: { type: 'string', description: 'Why this token is being created.' },
+          rationale: {
+            type: "string",
+            description: "Why this token is being created.",
+          },
           product_context: {
-            type: 'string',
-            description: 'Path to product-context.json for rationale capture.',
+            type: "string",
+            description: "Path to product-context.json for rationale capture.",
           },
           schema_path: {
-            type: 'string',
-            description: 'Path to schemas directory. (Not used in JS implementation; no schema validation.)',
+            type: "string",
+            description:
+              "Path to schemas directory containing token-types/ and token-file.json. " +
+              "Used for Layer-1 JSON-Schema validation before writing. " +
+              "Defaults to @adobe/spectrum-tokens schemas when omitted.",
           },
           is_override: {
-            type: 'boolean',
-            description: 'True when this token overrides an existing foundation/platform token.',
+            type: "boolean",
+            description:
+              "True when this token overrides an existing foundation/platform token.",
           },
         },
         additionalProperties: false,
       },
-      async handler({ session_id, schema_url, target, rationale = '', product_context, is_override = false }) {
+      async handler({
+        session_id,
+        schema_url,
+        target,
+        rationale = "",
+        product_context,
+        schema_path,
+        is_override = false,
+      }) {
         return commitSession({
           sessionId: session_id,
           schemaUrl: schema_url,
           target,
           rationale,
           productContext: product_context,
+          schemaPath: schema_path ?? null,
           isOverride: is_override,
         });
       },
     },
 
     {
-      name: 'authoring_session_cancel',
-      description: 'Cancel a session and delete its on-disk file.',
+      name: "authoring_session_cancel",
+      description: "Cancel a session and delete its on-disk file.",
       inputSchema: {
-        type: 'object',
-        required: ['session_id'],
-        properties: { session_id: { type: 'string' } },
+        type: "object",
+        required: ["session_id"],
+        properties: { session_id: { type: "string" } },
         additionalProperties: false,
       },
       async handler({ session_id }) {
@@ -227,12 +263,12 @@ export function createAuthoringTools() {
     },
 
     {
-      name: 'authoring_session_get',
-      description: 'Get the current state of an authoring session.',
+      name: "authoring_session_get",
+      description: "Get the current state of an authoring session.",
       inputSchema: {
-        type: 'object',
-        required: ['session_id'],
-        properties: { session_id: { type: 'string' } },
+        type: "object",
+        required: ["session_id"],
+        properties: { session_id: { type: "string" } },
         additionalProperties: false,
       },
       async handler({ session_id }) {
@@ -241,10 +277,10 @@ export function createAuthoringTools() {
     },
 
     {
-      name: 'authoring_session_list',
-      description: 'List all active authoring sessions.',
+      name: "authoring_session_list",
+      description: "List all active authoring sessions.",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {},
         additionalProperties: false,
       },

--- a/tools/design-data-agent-mcp/src/tools/diff.js
+++ b/tools/design-data-agent-mcp/src/tools/diff.js
@@ -8,21 +8,55 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { loadDataset } from '@adobe/design-data-js/load';
+import { loadDataset } from "@adobe/design-data-js/load";
+
+/**
+ * Filter a diff result by a substring match against token names.
+ *
+ * The diff() return shape uses camelCase (per wasm serde rename_all = "camelCase"):
+ *   - renamed entries: { oldName, newName, ... }
+ *   - all other entries: { name, ... }
+ *
+ * @param {object} diff - DiffResult from Dataset.diff().
+ * @param {string} filter - Substring to match (case-insensitive).
+ * @returns {object} Filtered diff with the same top-level keys.
+ */
+export function filterDiffByName(diff, filter) {
+  const f = filter.toLowerCase();
+  const matchName = (t) =>
+    (t.name ?? t.oldName ?? t.newName ?? "").toLowerCase().includes(f);
+  return {
+    renamed: diff.renamed.filter(matchName),
+    deprecated: diff.deprecated.filter(matchName),
+    reverted: diff.reverted.filter(matchName),
+    added: diff.added.filter(matchName),
+    deleted: diff.deleted.filter(matchName),
+    updated: diff.updated.filter(matchName),
+  };
+}
 
 export function createDiffTools() {
   return [
     {
-      name: 'diff_datasets',
+      name: "diff_datasets",
       description:
-        'Compare two design data datasets and return a JSON diff of added, removed, and changed tokens.',
+        "Compare two design data datasets and return a JSON diff of added, removed, and changed tokens.",
       inputSchema: {
-        type: 'object',
-        required: ['oldPath', 'newPath'],
+        type: "object",
+        required: ["oldPath", "newPath"],
         properties: {
-          oldPath: { type: 'string', description: 'Path to the old/baseline dataset' },
-          newPath: { type: 'string', description: 'Path to the new/updated dataset' },
-          filter: { type: 'string', description: 'Optional filter expression to narrow results' },
+          oldPath: {
+            type: "string",
+            description: "Path to the old/baseline dataset",
+          },
+          newPath: {
+            type: "string",
+            description: "Path to the new/updated dataset",
+          },
+          filter: {
+            type: "string",
+            description: "Optional filter expression to narrow results",
+          },
         },
         additionalProperties: false,
       },
@@ -33,17 +67,7 @@ export function createDiffTools() {
         ]);
         const diff = oldDs.diff(newDs);
         if (!filter) return diff;
-        // Apply filter post-diff by name prefix if provided.
-        const f = filter.toLowerCase();
-        const filterArr = (arr) => arr.filter((t) => (t.name ?? t.old_name ?? '').toLowerCase().includes(f));
-        return {
-          renamed: filterArr(diff.renamed),
-          deprecated: filterArr(diff.deprecated),
-          reverted: filterArr(diff.reverted),
-          added: filterArr(diff.added),
-          deleted: filterArr(diff.deleted),
-          updated: filterArr(diff.updated),
-        };
+        return filterDiffByName(diff, filter);
       },
     },
   ];

--- a/tools/design-data-agent-mcp/src/tools/diff.js
+++ b/tools/design-data-agent-mcp/src/tools/diff.js
@@ -8,40 +8,42 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { runCli } from "../cli.js";
+import { loadDataset } from '@adobe/design-data-js/load';
 
 export function createDiffTools() {
   return [
     {
-      name: "diff_datasets",
+      name: 'diff_datasets',
       description:
-        "Compare two design data datasets and return a JSON diff of added, removed, and changed tokens.",
+        'Compare two design data datasets and return a JSON diff of added, removed, and changed tokens.',
       inputSchema: {
-        type: "object",
-        required: ["oldPath", "newPath"],
+        type: 'object',
+        required: ['oldPath', 'newPath'],
         properties: {
-          oldPath: {
-            type: "string",
-            description: "Path to the old/baseline dataset",
-          },
-          newPath: {
-            type: "string",
-            description: "Path to the new/updated dataset",
-          },
-          filter: {
-            type: "string",
-            description: "Optional filter expression to narrow results",
-          },
+          oldPath: { type: 'string', description: 'Path to the old/baseline dataset' },
+          newPath: { type: 'string', description: 'Path to the new/updated dataset' },
+          filter: { type: 'string', description: 'Optional filter expression to narrow results' },
         },
         additionalProperties: false,
       },
       async handler({ oldPath, newPath, filter }) {
-        const args = ["diff", oldPath, newPath, "--format", "json"];
-        if (filter) args.push("--filter", filter);
-        const { exitCode, stdout, stderr } = await runCli(args);
-        // exit code 1 means differences found — that is a valid result, not an error
-        if (exitCode > 1) throw new Error(stderr || `diff exited ${exitCode}`);
-        return JSON.parse(stdout);
+        const [oldDs, newDs] = await Promise.all([
+          loadDataset(oldPath),
+          loadDataset(newPath),
+        ]);
+        const diff = oldDs.diff(newDs);
+        if (!filter) return diff;
+        // Apply filter post-diff by name prefix if provided.
+        const f = filter.toLowerCase();
+        const filterArr = (arr) => arr.filter((t) => (t.name ?? t.old_name ?? '').toLowerCase().includes(f));
+        return {
+          renamed: filterArr(diff.renamed),
+          deprecated: filterArr(diff.deprecated),
+          reverted: filterArr(diff.reverted),
+          added: filterArr(diff.added),
+          deleted: filterArr(diff.deleted),
+          updated: filterArr(diff.updated),
+        };
       },
     },
   ];

--- a/tools/design-data-agent-mcp/src/tools/diff.js
+++ b/tools/design-data-agent-mcp/src/tools/diff.js
@@ -24,7 +24,7 @@ import { loadDataset } from "@adobe/design-data-js/load";
 export function filterDiffByName(diff, filter) {
   const f = filter.toLowerCase();
   const matchName = (t) =>
-    (t.name ?? t.oldName ?? t.newName ?? "").toLowerCase().includes(f);
+    [t.name, t.oldName, t.newName].some((n) => n?.toLowerCase().includes(f));
   return {
     renamed: diff.renamed.filter(matchName),
     deprecated: diff.deprecated.filter(matchName),

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -8,121 +8,112 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { runCli } from "../cli.js";
-import { config } from "../config.js";
+/**
+ * Read tools for design-data-agent-mcp.
+ *
+ * query_tokens and resolve_token use @adobe/design-data-js (loadDataset) + the
+ * wasm Dataset to run in-process without spawning the CLI binary.
+ *
+ * primer and describe_component still invoke the CLI: primer aggregates complex
+ * catalog metadata (components, fields) not yet on the wasm surface, and
+ * describe_component requires the components catalog path resolution that the CLI
+ * handles. These will be ported when those APIs are added to the wasm surface.
+ */
+
+import { loadDataset } from '@adobe/design-data-js/load';
+import { runCli } from '../cli.js';
+import { config } from '../config.js';
 
 export function createReadTools() {
   return [
     {
-      name: "primer",
+      name: 'primer',
       description:
-        "Load the design data primer: full token taxonomy, resolved values, component list, and field definitions. Call this at the start of an agent session.",
+        'Load the design data primer: full token taxonomy, resolved values, component list, and field definitions. Call this at the start of an agent session.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {},
         additionalProperties: false,
       },
       async handler() {
-        const args = ["primer", config.dataPath, "--format", "json"];
-        if (config.componentsDir)
-          args.push("--components-dir", config.componentsDir);
-        if (config.fieldsDir) args.push("--fields-dir", config.fieldsDir);
+        const args = ['primer', config.dataPath, '--format', 'json'];
+        if (config.componentsDir) args.push('--components-dir', config.componentsDir);
+        if (config.fieldsDir) args.push('--fields-dir', config.fieldsDir);
         const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0)
-          throw new Error(stderr || `primer exited ${exitCode}`);
+        if (exitCode !== 0) throw new Error(stderr || `primer exited ${exitCode}`);
         return JSON.parse(stdout);
       },
     },
+
     {
-      name: "resolve_token",
+      name: 'resolve_token',
       description:
-        "Resolve a design token property to its final value for a given color scheme, scale, and contrast level.",
+        'Resolve a design token property to its final value for a given color scheme, scale, and contrast level.',
       inputSchema: {
-        type: "object",
-        required: ["property"],
+        type: 'object',
+        required: ['property'],
         properties: {
           property: {
-            type: "string",
-            description:
-              "Token property name, e.g. accent-background-color-default",
+            type: 'string',
+            description: 'Token property name, e.g. accent-background-color-default',
           },
-          colorScheme: {
-            type: "string",
-            description: "Color scheme: light or dark",
-          },
-          scale: {
-            type: "string",
-            enum: ["desktop", "mobile"],
-            description: "Scale: desktop or mobile",
-          },
-          contrast: {
-            type: "string",
-            enum: ["regular", "high"],
-            description: "Contrast: regular or high",
-          },
+          colorScheme: { type: 'string', description: 'Color scheme: light or dark' },
+          scale: { type: 'string', enum: ['desktop', 'mobile'], description: 'Scale: desktop or mobile' },
+          contrast: { type: 'string', enum: ['regular', 'high'], description: 'Contrast: regular or high' },
         },
         additionalProperties: false,
       },
       async handler({ property, colorScheme, scale, contrast }) {
-        const args = ["resolve", property, config.dataPath, "--format", "json"];
-        if (colorScheme) args.push("--color-scheme", colorScheme);
-        if (scale) args.push("--scale", scale);
-        if (contrast) args.push("--contrast", contrast);
-        const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0)
-          throw new Error(stderr || `resolve exited ${exitCode}`);
-        return JSON.parse(stdout);
+        const ds = await loadDataset(config.dataPath);
+        const context = {};
+        if (colorScheme) context.colorScheme = colorScheme;
+        if (scale) context.scale = scale;
+        if (contrast) context.contrast = contrast;
+        const result = ds.resolve(property, context);
+        if (!result) {
+          throw new Error(
+            `No token found for property "${property}" in context ${JSON.stringify(context)}`,
+          );
+        }
+        return result;
       },
     },
+
     {
-      name: "query_tokens",
+      name: 'query_tokens',
       description:
-        "Query design tokens using a filter expression. Returns matching token entries.",
+        'Query design tokens using a filter expression. Returns matching token entries.',
       inputSchema: {
-        type: "object",
-        required: ["filter"],
+        type: 'object',
+        required: ['filter'],
         properties: {
-          filter: {
-            type: "string",
-            description: 'Filter expression, e.g. "category=color"',
-          },
+          filter: { type: 'string', description: 'Filter expression, e.g. "category=color"' },
         },
         additionalProperties: false,
       },
       async handler({ filter }) {
-        const args = [
-          "query",
-          config.dataPath,
-          "--filter",
-          filter,
-          "--format",
-          "json",
-        ];
-        const { exitCode, stdout, stderr } = await runCli(args);
-        // exit code 1 means no matches — still valid JSON []
-        if (exitCode > 1) throw new Error(stderr || `query exited ${exitCode}`);
-        return JSON.parse(stdout);
+        const ds = await loadDataset(config.dataPath);
+        return ds.query(filter);
       },
     },
+
     {
-      name: "describe_component",
+      name: 'describe_component',
       description:
-        "Return the JSON schema and token bindings for a design system component by its ID.",
+        'Return the JSON schema and token bindings for a design system component by its ID.',
       inputSchema: {
-        type: "object",
-        required: ["id"],
+        type: 'object',
+        required: ['id'],
         properties: {
-          id: { type: "string", description: "Component ID, e.g. button" },
+          id: { type: 'string', description: 'Component ID, e.g. button' },
         },
         additionalProperties: false,
       },
       async handler({ id }) {
-        const args = ["component", id];
-        if (config.componentsDir)
-          args.push("--components-dir", config.componentsDir);
+        const args = ['component', id];
+        if (config.componentsDir) args.push('--components-dir', config.componentsDir);
         const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0)
-          throw new Error(stderr || `component exited ${exitCode}`);
+        if (exitCode !== 0) throw new Error(stderr || `component exited ${exitCode}`);
         return JSON.parse(stdout);
       },
     },

--- a/tools/design-data-agent-mcp/src/tools/validate.js
+++ b/tools/design-data-agent-mcp/src/tools/validate.js
@@ -8,38 +8,43 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { loadDataset } from '@adobe/design-data-js/load';
-import { config } from '../config.js';
+import { validateDataset } from "@adobe/design-data-js/validate";
+import { config } from "../config.js";
 
 export function createValidateTools() {
   return [
     {
-      name: 'validate_usage',
+      name: "validate_usage",
       description:
-        'Validate design token usage in a dataset. Returns a JSON report of violations and warnings.',
+        "Validate design token usage in a dataset. Runs Layer-1 JSON-Schema structural " +
+        "validation and Layer-2 relational rules. Returns a JSON report of violations and warnings.",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
           path: {
-            type: 'string',
-            description: 'Path to dataset to validate (defaults to DESIGN_DATA_PATH)',
+            type: "string",
+            description:
+              "Path to dataset to validate (defaults to DESIGN_DATA_PATH)",
           },
-          strict: { type: 'boolean', description: 'Treat warnings as errors' },
+          strict: { type: "boolean", description: "Treat warnings as errors" },
+          schema_path: {
+            type: "string",
+            description:
+              "Path to schemas directory containing token-types/ and token-file.json. " +
+              "Defaults to @adobe/spectrum-tokens schemas. Set DESIGN_DATA_SCHEMAS env var or " +
+              "pass explicitly for custom schema sets.",
+          },
         },
         additionalProperties: false,
       },
-      async handler({ path, strict } = {}) {
+      async handler({ path, strict, schema_path } = {}) {
         const target = path ?? config.dataPath;
-        const ds = await loadDataset(target);
-        const result = ds.validate();
-        if (strict && result.warnings.length > 0) {
-          return {
-            valid: false,
-            errors: [...result.errors, ...result.warnings],
-            warnings: [],
-          };
-        }
-        return result;
+        const schemaPath = schema_path ?? config.schemaPath ?? null;
+        // NOTE: exceptionsPath (DESIGN_DATA_EXCEPTIONS / --exceptions-path) applies to the
+        // SPEC-007 naming rule in the relational layer. The in-process wasm validate() does
+        // not consume it. Passing exceptionsPath here would throw an explicit error from
+        // validateDataset — omit it and document the limitation.
+        return validateDataset(target, { schemaPath, strict: strict ?? false });
       },
     },
   ];

--- a/tools/design-data-agent-mcp/src/tools/validate.js
+++ b/tools/design-data-agent-mcp/src/tools/validate.js
@@ -8,38 +8,38 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { runCli } from "../cli.js";
-import { config } from "../config.js";
+import { loadDataset } from '@adobe/design-data-js/load';
+import { config } from '../config.js';
 
 export function createValidateTools() {
   return [
     {
-      name: "validate_usage",
+      name: 'validate_usage',
       description:
-        "Validate design token usage in a dataset. Returns a JSON report of violations and warnings.",
+        'Validate design token usage in a dataset. Returns a JSON report of violations and warnings.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           path: {
-            type: "string",
-            description:
-              "Path to dataset to validate (defaults to DESIGN_DATA_PATH)",
+            type: 'string',
+            description: 'Path to dataset to validate (defaults to DESIGN_DATA_PATH)',
           },
-          strict: { type: "boolean", description: "Treat warnings as errors" },
+          strict: { type: 'boolean', description: 'Treat warnings as errors' },
         },
         additionalProperties: false,
       },
       async handler({ path, strict } = {}) {
         const target = path ?? config.dataPath;
-        const args = ["validate", target, "--format", "json"];
-        if (config.schemaPath) args.push("--schema-path", config.schemaPath);
-        if (config.exceptionsPath)
-          args.push("--exceptions-path", config.exceptionsPath);
-        if (strict === true) args.push("--strict");
-        const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0 && !stdout)
-          throw new Error(stderr || `validate exited ${exitCode}`);
-        return JSON.parse(stdout);
+        const ds = await loadDataset(target);
+        const result = ds.validate();
+        if (strict && result.warnings.length > 0) {
+          return {
+            valid: false,
+            errors: [...result.errors, ...result.warnings],
+            warnings: [],
+          };
+        }
+        return result;
       },
     },
   ];

--- a/tools/design-data-agent-mcp/src/tools/write.js
+++ b/tools/design-data-agent-mcp/src/tools/write.js
@@ -8,40 +8,34 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { join } from "path";
-import { runCli } from "../cli.js";
-import { config } from "../config.js";
+import { join } from 'path';
+import { writeProductContext } from '@adobe/design-data-js/write';
+import { config } from '../config.js';
 
 export function createWriteTools() {
   return [
     {
-      name: "write",
+      name: 'write',
       description:
-        "Write agent-generated design context to the dataset (e.g. product-context.json). Returns a confirmation message.",
+        'Write agent-generated design context to the dataset (e.g. product-context.json). Returns a confirmation message.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           output: {
-            type: "string",
+            type: 'string',
             description:
-              "Output file path (defaults to product-context.json inside DESIGN_DATA_PATH)",
+              'Output file path (defaults to product-context.json inside DESIGN_DATA_PATH)',
           },
           rationale: {
-            type: "string",
-            description: "Rationale or summary to embed in the written file",
+            type: 'string',
+            description: 'Rationale or summary to embed in the written file',
           },
         },
         additionalProperties: false,
       },
       async handler({ output, rationale } = {}) {
-        const resolvedOutput =
-          output ?? join(config.dataPath, "product-context.json");
-        const args = ["write", "--output", resolvedOutput];
-        if (rationale) args.push("--rationale", rationale);
-        const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0)
-          throw new Error(stderr || `write exited ${exitCode}`);
-        return stdout;
+        const resolvedOutput = output ?? join(config.dataPath, 'product-context.json');
+        return writeProductContext({ output: resolvedOutput, rationale });
       },
     },
   ];

--- a/tools/design-data-agent-mcp/test/diff.test.js
+++ b/tools/design-data-agent-mcp/test/diff.test.js
@@ -1,0 +1,90 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { filterDiffByName } from "../src/tools/diff.js";
+
+const SAMPLE_DIFF = {
+  renamed: [
+    {
+      oldName: "accent-color-default",
+      newName: "accent-background-color-default",
+    },
+    { oldName: "border-width", newName: "border-width-thin" },
+  ],
+  deprecated: [{ name: "old-deprecated-token" }, { name: "accent-deprecated" }],
+  reverted: [{ name: "accent-reverted" }],
+  added: [{ name: "new-accent-color" }, { name: "new-spacing-token" }],
+  deleted: [
+    { name: "deleted-accent-token" },
+    { name: "deleted-spacing-token" },
+  ],
+  updated: [{ name: "accent-background-updated" }, { name: "spacing-updated" }],
+};
+
+test("filterDiffByName filters renamed by oldName and newName", (t) => {
+  const result = filterDiffByName(SAMPLE_DIFF, "accent");
+  // Only the first renamed entry has 'accent' (oldName 'accent-color-default');
+  // 'border-width' / 'border-width-thin' do not match.
+  t.is(result.renamed.length, 1);
+  t.true(
+    (result.renamed[0].oldName ?? "").includes("accent") ||
+      (result.renamed[0].newName ?? "").includes("accent"),
+  );
+});
+
+test("filterDiffByName filters added/deleted/updated by name", (t) => {
+  const result = filterDiffByName(SAMPLE_DIFF, "accent");
+  t.is(result.added.length, 1);
+  t.is(result.added[0].name, "new-accent-color");
+  t.is(result.deleted.length, 1);
+  t.is(result.deleted[0].name, "deleted-accent-token");
+  t.is(result.updated.length, 1);
+  t.is(result.updated[0].name, "accent-background-updated");
+});
+
+test("filterDiffByName is case-insensitive", (t) => {
+  const result = filterDiffByName(SAMPLE_DIFF, "ACCENT");
+  t.is(result.added.length, 1);
+  t.is(result.added[0].name, "new-accent-color");
+});
+
+test("filterDiffByName returns all entries when filter matches everything", (t) => {
+  const result = filterDiffByName(SAMPLE_DIFF, "");
+  // empty string matches everything
+  t.is(result.renamed.length, SAMPLE_DIFF.renamed.length);
+  t.is(result.added.length, SAMPLE_DIFF.added.length);
+});
+
+test("filterDiffByName returns empty arrays when nothing matches", (t) => {
+  const result = filterDiffByName(SAMPLE_DIFF, "zzz-no-match");
+  t.is(result.renamed.length, 0);
+  t.is(result.added.length, 0);
+  t.is(result.deleted.length, 0);
+  t.is(result.updated.length, 0);
+});
+
+test("filterDiffByName preserves all diff keys", (t) => {
+  const result = filterDiffByName(SAMPLE_DIFF, "spacing");
+  t.true(Object.hasOwn(result, "renamed"));
+  t.true(Object.hasOwn(result, "deprecated"));
+  t.true(Object.hasOwn(result, "reverted"));
+  t.true(Object.hasOwn(result, "added"));
+  t.true(Object.hasOwn(result, "deleted"));
+  t.true(Object.hasOwn(result, "updated"));
+});
+
+test("createDiffTools returns a single diff_datasets tool", async (t) => {
+  const { createDiffTools } = await import("../src/tools/diff.js");
+  const tools = createDiffTools();
+  t.is(tools.length, 1);
+  t.is(tools[0].name, "diff_datasets");
+  t.is(typeof tools[0].handler, "function");
+});

--- a/tools/design-data-agent-mcp/test/diff.test.js
+++ b/tools/design-data-agent-mcp/test/diff.test.js
@@ -29,15 +29,23 @@ const SAMPLE_DIFF = {
   updated: [{ name: "accent-background-updated" }, { name: "spacing-updated" }],
 };
 
-test("filterDiffByName filters renamed by oldName and newName", (t) => {
-  const result = filterDiffByName(SAMPLE_DIFF, "accent");
-  // Only the first renamed entry has 'accent' (oldName 'accent-color-default');
-  // 'border-width' / 'border-width-thin' do not match.
+test("filterDiffByName matches renamed entries by oldName", (t) => {
+  // 'accent-color-default' appears in oldName; 'border-width*' entries don't match.
+  const result = filterDiffByName(SAMPLE_DIFF, "accent-color-default");
   t.is(result.renamed.length, 1);
-  t.true(
-    (result.renamed[0].oldName ?? "").includes("accent") ||
-      (result.renamed[0].newName ?? "").includes("accent"),
+  t.is(result.renamed[0].oldName, "accent-color-default");
+});
+
+test("filterDiffByName matches renamed entries by newName only", (t) => {
+  // 'background' appears in newName ('accent-background-color-default') but NOT in
+  // oldName ('accent-color-default'). With the old ?? chain this would silently miss it.
+  const result = filterDiffByName(SAMPLE_DIFF, "background");
+  t.is(
+    result.renamed.length,
+    1,
+    "should match via newName even when oldName doesn't match",
   );
+  t.is(result.renamed[0].newName, "accent-background-color-default");
 });
 
 test("filterDiffByName filters added/deleted/updated by name", (t) => {

--- a/tools/design-data-js/package.json
+++ b/tools/design-data-js/package.json
@@ -9,7 +9,8 @@
     ".": "./src/index.js",
     "./load": "./src/load.js",
     "./write": "./src/write.js",
-    "./session": "./src/session.js"
+    "./session": "./src/session.js",
+    "./validate": "./src/validate.js"
   },
   "engines": {
     "node": ">=20.12.0"
@@ -22,7 +23,9 @@
   "author": "Adobe",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/design-data-wasm": "workspace:*"
+    "@adobe/design-data-wasm": "workspace:*",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
     "ava": "^6.1.2"

--- a/tools/design-data-js/src/index.js
+++ b/tools/design-data-js/src/index.js
@@ -22,8 +22,12 @@
  *   — on-disk authoring-session state machine (JS port of sdk/core/src/authoring/session.rs)
  */
 
-export { loadDataset, loadDatasetSync } from './load.js';
-export { writeProductContext, writeToken, buildTokenFromWizard } from './write.js';
+export { loadDataset, loadDatasetSync } from "./load.js";
+export {
+  writeProductContext,
+  writeToken,
+  buildTokenFromWizard,
+} from "./write.js";
 export {
   startSession,
   getSession,
@@ -32,4 +36,10 @@ export {
   stepValues,
   commitSession,
   cancelSession,
-} from './session.js';
+} from "./session.js";
+export {
+  validateDataset,
+  validateTokenAgainstSchema,
+  resolveSchemaDir,
+  loadSchemaValidator,
+} from "./validate.js";

--- a/tools/design-data-js/src/load.js
+++ b/tools/design-data-js/src/load.js
@@ -16,14 +16,14 @@
  * behaviour of `design-data query/resolve/validate/diff <dataPath>` but runs in-process.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 let _wasmModule;
 
 async function getWasm() {
   if (!_wasmModule) {
-    _wasmModule = await import('@adobe/design-data-wasm');
+    _wasmModule = await import("@adobe/design-data-wasm");
   }
   return _wasmModule;
 }
@@ -35,14 +35,14 @@ async function getWasm() {
  * @param {string} dir
  * @returns {string[]}
  */
-function walkTokenFiles(dir) {
+export function walkTokenFiles(dir) {
   const results = [];
   for (const entry of readdirSync(dir)) {
     const fullPath = join(dir, entry);
     const stat = statSync(fullPath);
     if (stat.isDirectory()) {
       results.push(...walkTokenFiles(fullPath));
-    } else if (entry.endsWith('.tokens.json')) {
+    } else if (entry.endsWith(".tokens.json")) {
       results.push(fullPath);
     }
   }
@@ -66,9 +66,11 @@ export async function loadDataset(dirPath) {
   for (const file of files) {
     let content;
     try {
-      content = JSON.parse(readFileSync(file, 'utf-8'));
+      content = JSON.parse(readFileSync(file, "utf-8"));
     } catch (e) {
-      console.warn(`[design-data-js] Skipping unparseable file: ${file} — ${e.message}`);
+      console.warn(
+        `[design-data-js] Skipping unparseable file: ${file} — ${e.message}`,
+      );
       continue;
     }
     if (Array.isArray(content)) {
@@ -76,7 +78,9 @@ export async function loadDataset(dirPath) {
     } else {
       // Legacy object-map format is not supported by Dataset.fromTokens() —
       // the wasm surface only handles cascade arrays. Warn and skip.
-      console.warn(`[design-data-js] Skipping legacy object-map file (not cascade format): ${file}`);
+      console.warn(
+        `[design-data-js] Skipping legacy object-map file (not cascade format): ${file}`,
+      );
     }
   }
   return Dataset.fromTokens(tokens);
@@ -96,9 +100,11 @@ export function loadDatasetSync(dirPath, wasm) {
   for (const file of files) {
     let content;
     try {
-      content = JSON.parse(readFileSync(file, 'utf-8'));
+      content = JSON.parse(readFileSync(file, "utf-8"));
     } catch (e) {
-      console.warn(`[design-data-js] Skipping unparseable file: ${file} — ${e.message}`);
+      console.warn(
+        `[design-data-js] Skipping unparseable file: ${file} — ${e.message}`,
+      );
       continue;
     }
     if (Array.isArray(content)) {

--- a/tools/design-data-js/src/session.js
+++ b/tools/design-data-js/src/session.js
@@ -28,11 +28,16 @@ import {
   unlinkSync,
   readdirSync,
   renameSync,
-} from 'node:fs';
-import { join } from 'node:path';
-import { randomUUID } from 'node:crypto';
-import { homedir } from 'node:os';
-import { buildTokenFromWizard, writeToken, writeProductContext } from './write.js';
+} from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import {
+  buildTokenFromWizard,
+  writeToken,
+  writeProductContext,
+} from "./write.js";
+import { validateTokenAgainstSchema, resolveSchemaDir } from "./validate.js";
 
 /**
  * Return the directory where session JSON files are stored.
@@ -45,14 +50,14 @@ function sessionsDir() {
     return process.env.DESIGN_DATA_AUTHORING_SESSIONS_DIR;
   }
   let base;
-  if (process.platform === 'win32') {
-    base = process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming');
-  } else if (process.platform === 'darwin') {
-    base = join(homedir(), 'Library', 'Application Support');
+  if (process.platform === "win32") {
+    base = process.env.APPDATA ?? join(homedir(), "AppData", "Roaming");
+  } else if (process.platform === "darwin") {
+    base = join(homedir(), "Library", "Application Support");
   } else {
-    base = process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share');
+    base = process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
   }
-  return join(base, 'design-data', 'authoring-sessions');
+  return join(base, "design-data", "authoring-sessions");
 }
 
 function sessionPath(sessionId) {
@@ -62,14 +67,15 @@ function sessionPath(sessionId) {
 function atomicWriteSession(draft) {
   const dir = sessionsDir();
   mkdirSync(dir, { recursive: true });
-  const tmp = sessionPath(draft.session_id) + '.tmp.' + randomUUID().slice(0, 8);
-  writeFileSync(tmp, JSON.stringify(draft, null, 2) + '\n', 'utf-8');
+  const tmp =
+    sessionPath(draft.session_id) + ".tmp." + randomUUID().slice(0, 8);
+  writeFileSync(tmp, JSON.stringify(draft, null, 2) + "\n", "utf-8");
   renameSync(tmp, sessionPath(draft.session_id));
 }
 
 function readSessionOrThrow(sessionId) {
   try {
-    return JSON.parse(readFileSync(sessionPath(sessionId), 'utf-8'));
+    return JSON.parse(readFileSync(sessionPath(sessionId), "utf-8"));
   } catch {
     throw new Error(`Session not found: ${sessionId}`);
   }
@@ -114,8 +120,8 @@ export function listSessions() {
   const dir = sessionsDir();
   try {
     return readdirSync(dir)
-      .filter((f) => f.endsWith('.json') && !f.endsWith('.tmp'))
-      .map((f) => JSON.parse(readFileSync(join(dir, f), 'utf-8')));
+      .filter((f) => f.endsWith(".json") && !f.endsWith(".tmp"))
+      .map((f) => JSON.parse(readFileSync(join(dir, f), "utf-8")));
   } catch {
     return [];
   }
@@ -128,7 +134,10 @@ export function listSessions() {
  * @param {{ layer: string, property: string, nameFields?: Array<{key:string,value:string}> }} opts
  * @returns {object} Updated session draft.
  */
-export function stepClassification(sessionId, { layer, property, nameFields = [] }) {
+export function stepClassification(
+  sessionId,
+  { layer, property, nameFields = [] },
+) {
   const draft = readSessionOrThrow(sessionId);
   draft.wizard.classification = { layer, property, nameFields };
   atomicWriteSession(draft);
@@ -150,8 +159,8 @@ export function stepValues(sessionId, rows) {
 }
 
 /**
- * Commit the session: build the token from wizard state, write it to disk,
- * and delete the session file.
+ * Commit the session: build the token from wizard state, validate it against its
+ * JSON Schema (Layer-1), write it to disk, and delete the session file.
  *
  * @param {object} opts
  * @param {string} opts.sessionId
@@ -159,9 +168,12 @@ export function stepValues(sessionId, rows) {
  * @param {string} opts.target - Target file path.
  * @param {string} [opts.rationale]
  * @param {string} [opts.productContext]
- * @param {string} [opts.schemaPath] - (unused in JS version; no schema validation)
+ * @param {string} [opts.schemaPath] - Path to the schemas/ directory (contains
+ *   token-types/ and token-file.json). Defaults to @adobe/spectrum-tokens schemas.
+ *   Pass an explicit path when working with a custom schema set.
  * @param {boolean} [opts.isOverride]
  * @returns {{ writtenTo: string, productContextUpdated: boolean, tokenKey: string }}
+ * @throws {Error} When the built token fails Layer-1 JSON-Schema validation.
  */
 export function commitSession({
   sessionId,
@@ -169,15 +181,20 @@ export function commitSession({
   target,
   rationale,
   productContext,
+  schemaPath,
   isOverride = false,
 }) {
   const draft = readSessionOrThrow(sessionId);
 
   if (!draft.wizard.classification) {
-    throw new Error(`Session ${sessionId} has no classification step — call stepClassification first.`);
+    throw new Error(
+      `Session ${sessionId} has no classification step — call stepClassification first.`,
+    );
   }
   if (!draft.wizard.values || draft.wizard.values.length === 0) {
-    throw new Error(`Session ${sessionId} has no values step — call stepValues first.`);
+    throw new Error(
+      `Session ${sessionId} has no values step — call stepValues first.`,
+    );
   }
 
   const [tokenKey, token] = buildTokenFromWizard({
@@ -186,6 +203,22 @@ export function commitSession({
     rows: draft.wizard.values,
     uuid: randomUUID(),
   });
+
+  // Layer-1: validate the built token against its JSON Schema before writing.
+  // Validation runs when a schema directory is available. If schemaPath is
+  // explicitly provided it must resolve (throws on bad path). If it is omitted
+  // and auto-discovery finds nothing (e.g. @adobe/spectrum-tokens not installed),
+  // validation is skipped rather than blocking the commit.
+  const schemaDir = resolveSchemaDir(schemaPath ?? null, {
+    required: !!schemaPath,
+  });
+  if (schemaDir) {
+    const validation = validateTokenAgainstSchema(token, schemaDir);
+    if (!validation.valid) {
+      const summary = validation.errors.map((e) => e.message).join("; ");
+      throw new Error(`Token failed JSON-Schema validation: ${summary}`);
+    }
+  }
 
   const result = writeToken(tokenKey, token, {
     target,
@@ -197,7 +230,9 @@ export function commitSession({
   // Delete session file after successful commit.
   try {
     unlinkSync(sessionPath(sessionId));
-  } catch { /* already gone */ }
+  } catch {
+    /* already gone */
+  }
 
   return { ...result, tokenKey };
 }
@@ -211,6 +246,8 @@ export function commitSession({
 export function cancelSession(sessionId) {
   try {
     unlinkSync(sessionPath(sessionId));
-  } catch { /* already gone — idempotent */ }
+  } catch {
+    /* already gone — idempotent */
+  }
   return { cancelled: sessionId };
 }

--- a/tools/design-data-js/src/validate.js
+++ b/tools/design-data-js/src/validate.js
@@ -113,22 +113,22 @@ export function loadSchemaValidator(schemaDir) {
   const typesDir = join(schemaDir, "token-types");
   for (const file of readdirSync(typesDir).filter((f) => f.endsWith(".json"))) {
     const schema = JSON.parse(readFileSync(join(typesDir, file), "utf-8"));
-    try {
-      ajv.addSchema(schema, schema["$id"]);
-    } catch {
-      // Already registered (e.g. if called twice) — ignore.
-    }
+    const id = schema["$id"];
+    if (!id)
+      throw new Error(
+        `Token-type schema "${file}" is missing a required $id field`,
+      );
+    if (!ajv.getSchema(id)) ajv.addSchema(schema, id);
   }
 
   // Register token-file.json.
   const tokenFileSchema = JSON.parse(
     readFileSync(join(schemaDir, "token-file.json"), "utf-8"),
   );
-  try {
-    ajv.addSchema(tokenFileSchema, tokenFileSchema["$id"]);
-  } catch {
-    // Already registered.
-  }
+  const tokenFileId = tokenFileSchema["$id"];
+  if (!tokenFileId)
+    throw new Error(`token-file.json is missing a required $id field`);
+  if (!ajv.getSchema(tokenFileId)) ajv.addSchema(tokenFileSchema, tokenFileId);
 
   return ajv;
 }
@@ -233,7 +233,8 @@ export async function validateDataset(
       });
       continue;
     }
-    const tokens = Array.isArray(parsed) ? parsed : Object.values(parsed);
+    if (!Array.isArray(parsed)) continue; // Legacy object-map format — loadDataset (Layer-2) warns and skips these.
+    const tokens = parsed;
     for (const token of tokens) {
       const diags = validateTokenSchema(token, ajv, file);
       layer1Errors.push(...diags);

--- a/tools/design-data-js/src/validate.js
+++ b/tools/design-data-js/src/validate.js
@@ -1,0 +1,269 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Layer-1 (JSON-Schema structural) validation for design token datasets.
+ *
+ * The wasm Dataset.validate() runs Layer-2 relational rules only — it explicitly
+ * omits Layer-1 because JSON-Schema validation requires filesystem access not
+ * available in wasm. This module fills that gap for Node.js callers.
+ *
+ * Mirrors the Rust implementation in sdk/core/src/validate/structural.rs using
+ * Ajv 2020-12 (same draft as the Rust jsonschema crate).
+ *
+ * Schema source: packages/tokens/schemas/  (also published in @adobe/spectrum-tokens)
+ */
+
+import { createRequire } from "node:module";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import Ajv from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { loadDataset, walkTokenFiles } from "./load.js";
+
+// ---------------------------------------------------------------------------
+// Schema directory resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to locate the Spectrum token schemas directory by resolving
+ * @adobe/spectrum-tokens (the npm package that ships them).
+ *
+ * @returns {string|null} Absolute path to the schemas/ directory, or null.
+ */
+function resolveSpectrumTokensSchemaDir() {
+  try {
+    const req = createRequire(import.meta.url);
+    const pkgJson = req.resolve("@adobe/spectrum-tokens/package.json");
+    return join(dirname(pkgJson), "schemas");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the schemas directory to use.
+ *
+ * @param {string|null|undefined} schemaPath - Caller-supplied override (the
+ *   directory that contains token-types/ and token-file.json). If omitted the
+ *   function falls back to @adobe/spectrum-tokens.
+ * @param {{ required?: boolean }} [opts]
+ * @returns {string|null} Absolute path to the schemas directory, or null when
+ *   no path was supplied AND auto-discovery failed (only when required is false).
+ * @throws {Error} When schemaPath is provided but does not exist or lacks
+ *   token-types/; or when required is true and no path can be auto-resolved.
+ */
+export function resolveSchemaDir(schemaPath, { required = true } = {}) {
+  if (schemaPath) {
+    if (!existsSync(schemaPath)) {
+      throw new Error(
+        `schema_path does not exist: "${schemaPath}". ` +
+          `Point it at the directory that contains token-types/ and token-file.json.`,
+      );
+    }
+    const typesDir = join(schemaPath, "token-types");
+    if (!existsSync(typesDir)) {
+      throw new Error(
+        `schema_path "${schemaPath}" does not contain a token-types/ subdirectory. ` +
+          `Expected a schemas/ root that contains token-types/*.json and token-file.json.`,
+      );
+    }
+    return schemaPath;
+  }
+
+  const fallback = resolveSpectrumTokensSchemaDir();
+  if (fallback && existsSync(join(fallback, "token-types"))) {
+    return fallback;
+  }
+
+  if (required) {
+    throw new Error(
+      `Cannot locate the Spectrum token schemas directory. ` +
+        `Either install @adobe/spectrum-tokens or pass an explicit schema_path ` +
+        `pointing at a directory containing token-types/ and token-file.json.`,
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Ajv setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an Ajv 2020-12 instance with all token-type schemas and token-file.json
+ * pre-registered so relative $ref resolution works offline.
+ *
+ * @param {string} schemaDir - Absolute path to schemas/ directory.
+ * @returns {import('ajv').default} Configured Ajv instance.
+ */
+export function loadSchemaValidator(schemaDir) {
+  const ajv = new Ajv({ strict: false, allErrors: true });
+  addFormats(ajv);
+
+  // Register all token-type schemas by $id.
+  const typesDir = join(schemaDir, "token-types");
+  for (const file of readdirSync(typesDir).filter((f) => f.endsWith(".json"))) {
+    const schema = JSON.parse(readFileSync(join(typesDir, file), "utf-8"));
+    try {
+      ajv.addSchema(schema, schema["$id"]);
+    } catch {
+      // Already registered (e.g. if called twice) — ignore.
+    }
+  }
+
+  // Register token-file.json.
+  const tokenFileSchema = JSON.parse(
+    readFileSync(join(schemaDir, "token-file.json"), "utf-8"),
+  );
+  try {
+    ajv.addSchema(tokenFileSchema, tokenFileSchema["$id"]);
+  } catch {
+    // Already registered.
+  }
+
+  return ajv;
+}
+
+// ---------------------------------------------------------------------------
+// Per-token validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a single token object against its declared $schema, returning any
+ * Ajv errors as Layer-1 diagnostics.
+ *
+ * @param {object} token - Token object (must have $schema and value fields).
+ * @param {import('ajv').default} ajv - Pre-configured Ajv instance.
+ * @param {string} [context] - Optional label for error messages (e.g. filename/key).
+ * @returns {{ severity: string, message: string, path?: string, ruleId?: undefined }[]}
+ */
+function validateTokenSchema(token, ajv, context = "") {
+  const schemaId = token["$schema"];
+  if (!schemaId) return []; // Missing $schema is allowed for cascade tokens.
+
+  const validate = ajv.getSchema(schemaId);
+  if (!validate) {
+    return [
+      {
+        severity: "error",
+        message: `Unknown $schema URL "${schemaId}"${context ? ` in ${context}` : ""}.`,
+      },
+    ];
+  }
+
+  const valid = validate(token);
+  if (valid) return [];
+
+  return (validate.errors ?? []).map((err) => ({
+    severity: "error",
+    message: `${err.instancePath || "(root)"} ${err.message}${context ? ` [${context}]` : ""}`,
+    path: err.instancePath || undefined,
+  }));
+}
+
+/**
+ * Validate a single token against its $schema.  Convenience wrapper that
+ * handles schema directory resolution and Ajv setup.
+ *
+ * @param {object} token
+ * @param {string} schemaDir - Resolved schemas/ directory (from resolveSchemaDir).
+ * @returns {{ valid: boolean, errors: object[], warnings: object[] }}
+ */
+export function validateTokenAgainstSchema(token, schemaDir) {
+  const ajv = loadSchemaValidator(schemaDir);
+  const errors = validateTokenSchema(token, ajv);
+  return { valid: errors.length === 0, errors, warnings: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Dataset-level validation (Layer-1 + Layer-2 merged)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run full validation (Layer-1 JSON-Schema + Layer-2 relational) over a dataset
+ * directory, returning a merged ValidationResult.
+ *
+ * @param {string} datasetPath - Path to the token dataset directory.
+ * @param {object} [opts]
+ * @param {string|null} [opts.schemaPath] - Override schemas/ directory.
+ * @param {string|null} [opts.exceptionsPath] - NOT supported in the in-process path
+ *   (exceptions apply to SPEC-007 naming in the relational layer which requires the
+ *   CLI). Pass null or omit; throws if a non-null value is provided.
+ * @param {boolean} [opts.strict] - Promote warnings to errors.
+ * @returns {Promise<{ valid: boolean, errors: object[], warnings: object[] }>}
+ */
+export async function validateDataset(
+  datasetPath,
+  { schemaPath, exceptionsPath, strict = false } = {},
+) {
+  if (exceptionsPath) {
+    throw new Error(
+      `exceptionsPath is not supported by the in-process validator (it applies to SPEC-007 ` +
+        `naming checks in the relational layer which requires the CLI). ` +
+        `Omit exceptionsPath or use the design-data CLI directly: design-data validate --exceptions-path.`,
+    );
+  }
+
+  // Layer-1: JSON-Schema structural validation.
+  const resolvedSchemaDir = resolveSchemaDir(schemaPath ?? null, {
+    required: true,
+  });
+  const ajv = loadSchemaValidator(resolvedSchemaDir);
+  const layer1Errors = [];
+
+  // Walk token files and validate each token's $schema.
+  const tokenFiles = walkTokenFiles(datasetPath);
+  for (const file of tokenFiles) {
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(file, "utf-8"));
+    } catch {
+      layer1Errors.push({
+        severity: "error",
+        message: `Failed to parse ${file}`,
+      });
+      continue;
+    }
+    const tokens = Array.isArray(parsed) ? parsed : Object.values(parsed);
+    for (const token of tokens) {
+      const diags = validateTokenSchema(token, ajv, file);
+      layer1Errors.push(...diags);
+    }
+  }
+
+  // Layer-2: relational rules via wasm.
+  const ds = await loadDataset(datasetPath);
+  const layer2Result = ds.validate();
+
+  const allErrors = [
+    ...layer1Errors.filter((d) => d.severity === "error"),
+    ...layer2Result.errors,
+  ];
+  const allWarnings = [
+    ...layer1Errors.filter((d) => d.severity !== "error"),
+    ...layer2Result.warnings,
+  ];
+
+  if (strict && allWarnings.length > 0) {
+    return {
+      valid: false,
+      errors: [...allErrors, ...allWarnings],
+      warnings: [],
+    };
+  }
+
+  return {
+    valid: allErrors.length === 0,
+    errors: allErrors,
+    warnings: allWarnings,
+  };
+}

--- a/tools/design-data-js/test/validate.test.js
+++ b/tools/design-data-js/test/validate.test.js
@@ -1,0 +1,200 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import test from "ava";
+import {
+  resolveSchemaDir,
+  loadSchemaValidator,
+  validateTokenAgainstSchema,
+} from "../src/validate.js";
+
+// ---------------------------------------------------------------------------
+// Minimal schemas for testing — written to a temp directory
+// ---------------------------------------------------------------------------
+
+const SCHEMA_ID_BASE = "https://example.com/test-schemas";
+
+/** A minimal color token schema (Draft 2020-12). */
+const COLOR_SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: `${SCHEMA_ID_BASE}/token-types/color.json`,
+  allOf: [{ $ref: "token.json" }],
+  type: "object",
+  properties: {
+    value: { type: "string", description: "CSS color value" },
+  },
+};
+
+/** A base token schema with required uuid and value. */
+const TOKEN_SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: `${SCHEMA_ID_BASE}/token-types/token.json`,
+  type: "object",
+  required: ["value", "uuid"],
+  properties: {
+    value: {},
+    uuid: { type: "string" },
+    $schema: { type: "string" },
+    name: { type: "object" },
+  },
+};
+
+/** The token-file.json schema — minimal, just requires an object. */
+const TOKEN_FILE_SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: `${SCHEMA_ID_BASE}/token-file.json`,
+  type: "object",
+};
+
+const VALID_COLOR_TOKEN = {
+  $schema: `${SCHEMA_ID_BASE}/token-types/color.json`,
+  uuid: randomUUID(),
+  value: "#ff0000",
+  name: { property: "accent-color" },
+};
+
+// Token with a valid $schema but missing required 'value' field.
+const INVALID_TOKEN_MISSING_VALUE = {
+  $schema: `${SCHEMA_ID_BASE}/token-types/color.json`,
+  uuid: randomUUID(),
+  // Missing 'value'
+};
+
+// Token with an unknown $schema URL.
+const TOKEN_UNKNOWN_SCHEMA = {
+  $schema: "https://example.com/test-schemas/token-types/unknown.json",
+  uuid: randomUUID(),
+  value: "red",
+};
+
+// ---------------------------------------------------------------------------
+// Temp directory setup
+// ---------------------------------------------------------------------------
+
+const TMP = join(
+  tmpdir(),
+  "design-data-js-validate-" + randomUUID().slice(0, 8),
+);
+const SCHEMA_DIR = join(TMP, "schemas");
+const TOKEN_TYPES_DIR = join(SCHEMA_DIR, "token-types");
+const DATASET_DIR = join(TMP, "tokens");
+
+test.before(() => {
+  // Write minimal schemas.
+  mkdirSync(TOKEN_TYPES_DIR, { recursive: true });
+  writeFileSync(
+    join(TOKEN_TYPES_DIR, "color.json"),
+    JSON.stringify(COLOR_SCHEMA),
+  );
+  writeFileSync(
+    join(TOKEN_TYPES_DIR, "token.json"),
+    JSON.stringify(TOKEN_SCHEMA),
+  );
+  writeFileSync(
+    join(SCHEMA_DIR, "token-file.json"),
+    JSON.stringify(TOKEN_FILE_SCHEMA),
+  );
+
+  // Write a minimal token dataset.
+  mkdirSync(DATASET_DIR, { recursive: true });
+  writeFileSync(
+    join(DATASET_DIR, "test.tokens.json"),
+    JSON.stringify([VALID_COLOR_TOKEN]),
+  );
+});
+
+test.after(() => rmSync(TMP, { recursive: true, force: true }));
+
+// ---------------------------------------------------------------------------
+// resolveSchemaDir tests
+// ---------------------------------------------------------------------------
+
+test("resolveSchemaDir returns explicit path when it exists and has token-types/", (t) => {
+  const resolved = resolveSchemaDir(SCHEMA_DIR);
+  t.is(resolved, SCHEMA_DIR);
+});
+
+test("resolveSchemaDir throws when schemaPath does not exist", (t) => {
+  t.throws(() => resolveSchemaDir(join(TMP, "nonexistent")), {
+    message: /does not exist/,
+  });
+});
+
+test("resolveSchemaDir throws when schemaPath lacks token-types/", (t) => {
+  // Create a dir without token-types/ sub-dir
+  const noTypes = join(TMP, "no-types");
+  mkdirSync(noTypes, { recursive: true });
+  t.throws(() => resolveSchemaDir(noTypes), {
+    message: /token-types/,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSchemaValidator tests
+// ---------------------------------------------------------------------------
+
+test("loadSchemaValidator compiles schemas by $id", (t) => {
+  const ajv = loadSchemaValidator(SCHEMA_DIR);
+  const validate = ajv.getSchema(`${SCHEMA_ID_BASE}/token-types/color.json`);
+  t.truthy(validate, "color schema should be registered");
+});
+
+// ---------------------------------------------------------------------------
+// validateTokenAgainstSchema tests
+// ---------------------------------------------------------------------------
+
+test("validateTokenAgainstSchema passes a structurally valid token", (t) => {
+  const result = validateTokenAgainstSchema(VALID_COLOR_TOKEN, SCHEMA_DIR);
+  t.true(
+    result.valid,
+    `Expected valid but got errors: ${JSON.stringify(result.errors)}`,
+  );
+  t.deepEqual(result.errors, []);
+});
+
+test("validateTokenAgainstSchema catches a token missing required field", (t) => {
+  const result = validateTokenAgainstSchema(
+    INVALID_TOKEN_MISSING_VALUE,
+    SCHEMA_DIR,
+  );
+  t.false(result.valid);
+  t.true(result.errors.length > 0, "Expected at least one error");
+  t.true(
+    result.errors.some(
+      (e) => e.message.includes("value") || e.severity === "error",
+    ),
+    `Expected error about missing value, got: ${JSON.stringify(result.errors)}`,
+  );
+});
+
+test("validateTokenAgainstSchema reports unknown $schema URL as error", (t) => {
+  const result = validateTokenAgainstSchema(TOKEN_UNKNOWN_SCHEMA, SCHEMA_DIR);
+  t.false(result.valid);
+  t.true(result.errors.length > 0);
+  t.true(
+    result.errors[0].message.includes("Unknown $schema"),
+    `Expected unknown schema error, got: ${result.errors[0].message}`,
+  );
+});
+
+test("validateTokenAgainstSchema passes a token without $schema (cascade)", (t) => {
+  const noSchema = {
+    uuid: randomUUID(),
+    value: "#abc",
+    name: { property: "test" },
+  };
+  const result = validateTokenAgainstSchema(noSchema, SCHEMA_DIR);
+  t.true(result.valid);
+  t.deepEqual(result.errors, []);
+});

--- a/tools/design-data-mcp/package.json
+++ b/tools/design-data-mcp/package.json
@@ -31,6 +31,8 @@
     "provenance": true
   },
   "dependencies": {
+    "@adobe/design-data-wasm": "workspace:*",
+    "@adobe/spectrum-design-data": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "devDependencies": {

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -57,7 +57,7 @@ export function scoreTokensByKeyword(tokens, intent, limit = 5) {
   if (words.length === 0) return [];
   return tokens
     .map((token) => {
-      const nameStr = token.name.toLowerCase();
+      const nameStr = token.name?.toLowerCase() ?? "";
       const matches = words.filter((w) => nameStr.includes(w)).length;
       const confidence = matches / words.length;
       return { token, confidence };

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -16,22 +16,68 @@
  * zero configuration.
  */
 
-import { createRequire } from 'module';
-import { readFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { createRequire } from "module";
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
 
 let _wasm;
 /** Lazy-load and cache the wasm module (nodejs target, no init() required). */
 async function getWasm() {
-  if (!_wasm) _wasm = await import('@adobe/design-data-wasm');
+  if (!_wasm) _wasm = await import("@adobe/design-data-wasm");
   return _wasm;
+}
+
+let _dataset;
+/**
+ * Return the embedded Spectrum dataset, caching it after first access.
+ *
+ * Dataset.embedded() clones the in-memory graph on every call; caching here
+ * avoids that per-request cost.
+ */
+async function getDataset() {
+  if (!_dataset) {
+    const wasm = await getWasm();
+    _dataset = wasm.Dataset.embedded();
+  }
+  return _dataset;
+}
+
+/**
+ * Score tokens by keyword-overlap against an intent string.
+ *
+ * Pure function — accepts the token array so it can be tested independently.
+ *
+ * @param {object[]} tokens - Array of token result objects with a `name` string.
+ * @param {string} intent - Natural-language intent to match against.
+ * @param {number} limit - Maximum results to return.
+ * @returns {{ name: string, confidence: number, uuid: string, raw: unknown }[]}
+ */
+export function scoreTokensByKeyword(tokens, intent, limit = 5) {
+  const words = intent.toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+  return tokens
+    .map((token) => {
+      const nameStr = token.name.toLowerCase();
+      const matches = words.filter((w) => nameStr.includes(w)).length;
+      const confidence = matches / words.length;
+      return { token, confidence };
+    })
+    .filter(({ confidence }) => confidence > 0)
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, limit)
+    .map(({ token, confidence }) => ({
+      name: token.name,
+      confidence: Math.round(confidence * 100) / 100,
+      uuid: token.uuid,
+      raw: token.raw,
+    }));
 }
 
 /** Return the @adobe/spectrum-design-data package root directory, or null. */
 function resolveSpectrumDataPackage() {
   try {
     const req = createRequire(import.meta.url);
-    return dirname(req.resolve('@adobe/spectrum-design-data/package.json'));
+    return dirname(req.resolve("@adobe/spectrum-design-data/package.json"));
   } catch {
     return null;
   }
@@ -41,129 +87,114 @@ export function createDesignDataTools() {
   return [
     // ── primer ─────────────────────────────────────────────────────────────
     {
-      name: 'design-data-primer',
+      name: "design-data-primer",
       description:
-        'Get a structural overview of the Spectrum design dataset: token count, ' +
-        'available mode-sets (color-scheme, scale, contrast), component list, ' +
-        'taxonomy fields, and data provenance. Call this at the start of a ' +
-        'design-token session to understand what data is available.',
-      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        "Get a structural overview of the Spectrum design dataset: token count, " +
+        "available mode-sets (color-scheme, scale, contrast), component list, " +
+        "taxonomy fields, and data provenance. Call this at the start of a " +
+        "design-token session to understand what data is available.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
       async handler() {
-        const wasm = await getWasm();
-        const ds = wasm.Dataset.embedded();
+        const [wasm, ds] = await Promise.all([getWasm(), getDataset()]);
 
         return {
-          source: 'embedded',
+          source: "embedded",
           tokenCount: ds.tokenCount(),
           modeSets: {
-            colorScheme: wasm.getFieldValues('colorScheme') ?? [],
-            scale: wasm.getFieldValues('scale') ?? [],
-            contrast: wasm.getFieldValues('contrast') ?? [],
+            colorScheme: wasm.getFieldValues("colorScheme") ?? [],
+            scale: wasm.getFieldValues("scale") ?? [],
+            contrast: wasm.getFieldValues("contrast") ?? [],
           },
           taxonomyFields: {
-            indexed: ['property', 'component', 'variant', 'state', 'colorScheme', 'scale', 'contrast', 'uuid'],
+            indexed: wasm.getIndexedFields(),
             advisory: wasm.getAdvisoryFields() ?? [],
           },
-          components: wasm.getFieldValues('component') ?? [],
-          properties: wasm.getFieldValues('property') ?? [],
+          components: wasm.getFieldValues("component") ?? [],
+          properties: wasm.getFieldValues("property") ?? [],
         };
       },
     },
 
     // ── query ───────────────────────────────────────────────────────────────
     {
-      name: 'design-data-query',
+      name: "design-data-query",
       description:
-        'Filter Spectrum tokens by a query expression. ' +
-        'Expression syntax: `component=button`, `component=button,state=hover`, ' +
-        '`property=color-*`, `colorScheme=dark`. ' +
-        'Returns an array of matching token objects.',
+        "Filter Spectrum tokens by a query expression. " +
+        "Expression syntax: `component=button`, `component=button,state=hover`, " +
+        "`property=color-*`, `colorScheme=dark`. " +
+        "Returns an array of matching token objects.",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
           filter: {
-            type: 'string',
+            type: "string",
             description:
               'Query expression, e.g. "component=button" or "property=color-*,component=action-button"',
           },
         },
-        required: ['filter'],
+        required: ["filter"],
         additionalProperties: false,
       },
       async handler({ filter }) {
-        const wasm = await getWasm();
-        return wasm.Dataset.embedded().query(filter);
+        const ds = await getDataset();
+        return ds.query(filter);
       },
     },
 
     // ── suggest ─────────────────────────────────────────────────────────────
     {
-      name: 'design-data-suggest',
+      name: "design-data-suggest",
       description:
-        'Suggest Spectrum tokens matching a natural-language intent. ' +
-        'Returns ranked matches with confidence scores, token names, and values. ' +
-        'Use when the user describes what they need rather than knowing the token name.',
+        "Suggest Spectrum tokens matching a natural-language intent using keyword-overlap " +
+        "scoring. Returns matches ranked by confidence, token names, and values. " +
+        "Use when the user describes what they need rather than knowing the token name. " +
+        "(TODO: swap to wasm NLP suggest when available for higher-quality ranking.)",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
           intent: {
-            type: 'string',
+            type: "string",
             description:
               'Natural-language description of the design need, e.g. "primary CTA button background color"',
           },
           limit: {
-            type: 'number',
-            description: 'Maximum number of suggestions to return (default: 5)',
+            type: "number",
+            description: "Maximum number of suggestions to return (default: 5)",
             default: 5,
           },
         },
-        required: ['intent'],
+        required: ["intent"],
         additionalProperties: false,
       },
       async handler({ intent, limit = 5 }) {
-        const wasm = await getWasm();
-        const ds = wasm.Dataset.embedded();
-        // Keyword-based ranking over token names. The NLP-ranked CLI suggest is
-        // more accurate; this runs fully in-process without the CLI.
-        const words = intent.toLowerCase().split(/\s+/).filter(Boolean);
-        const allTokens = ds.query('');
-        const scored = allTokens
-          .map((token) => {
-            const nameStr = token.name.toLowerCase();
-            const matches = words.filter((w) => nameStr.includes(w)).length;
-            const confidence = words.length > 0 ? matches / words.length : 0;
-            return { token, confidence };
-          })
-          .filter(({ confidence }) => confidence > 0)
-          .sort((a, b) => b.confidence - a.confidence)
-          .slice(0, limit);
-
-        return scored.map(({ token, confidence }) => ({
-          name: token.name,
-          confidence: Math.round(confidence * 100) / 100,
-          uuid: token.uuid,
-          raw: token.raw,
-        }));
+        const ds = await getDataset();
+        const allTokens = ds.query("");
+        return scoreTokensByKeyword(allTokens, intent, limit);
       },
     },
 
     // ── component ───────────────────────────────────────────────────────────
     {
-      name: 'design-data-component',
+      name: "design-data-component",
       description:
         "Get the full component declaration for a Spectrum component by ID. " +
         "Returns the component's displayName, description, and all available options " +
         "(variants, sizes, states, boolean props, etc.). " +
-        'Component IDs are kebab-case, e.g. button, action-button, text-field, picker.',
+        "Component IDs are kebab-case, e.g. button, action-button, text-field, picker.",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
           id: {
-            type: 'string',
-            description: 'Component ID in kebab-case, e.g. button, action-button, picker, text-field',
+            type: "string",
+            description:
+              "Component ID in kebab-case, e.g. button, action-button, picker, text-field",
           },
         },
-        required: ['id'],
+        required: ["id"],
         additionalProperties: false,
       },
       async handler({ id }) {
@@ -171,48 +202,58 @@ export function createDesignDataTools() {
         if (!pkgRoot) {
           throw new Error(
             `@adobe/spectrum-design-data is not installed — cannot load component "${id}". ` +
-            `Install it with: pnpm add @adobe/spectrum-design-data`,
+              `Install it with: pnpm add @adobe/spectrum-design-data`,
           );
         }
-        const componentFile = join(pkgRoot, 'components', `${id}.json`);
+        const componentFile = join(pkgRoot, "components", `${id}.json`);
         if (!existsSync(componentFile)) {
           throw new Error(
             `Component not found: "${id}". ` +
-            `Call design-data-primer to see available component IDs.`,
+              `Call design-data-primer to see available component IDs.`,
           );
         }
-        return JSON.parse(readFileSync(componentFile, 'utf-8'));
+        return JSON.parse(readFileSync(componentFile, "utf-8"));
       },
     },
 
     // ── resolve ─────────────────────────────────────────────────────────────
     {
-      name: 'design-data-resolve',
+      name: "design-data-resolve",
       description:
-        'Resolve the concrete value of a Spectrum token property for a given ' +
-        'mode-set context (color-scheme, scale, contrast). ' +
-        'Returns the winning token with its resolved value.',
+        "Resolve the concrete value of a Spectrum token property for a given " +
+        "mode-set context (color-scheme, scale, contrast). " +
+        "Returns the winning token with its resolved value.",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
           property: {
-            type: 'string',
-            description: 'Token property name, e.g. background-color-default, accent-color',
+            type: "string",
+            description:
+              "Token property name, e.g. background-color-default, accent-color",
           },
-          colorScheme: { type: 'string', description: 'Color scheme mode, e.g. "light" or "dark"' },
-          scale: { type: 'string', description: 'Scale mode, e.g. "desktop" or "mobile"' },
-          contrast: { type: 'string', description: 'Contrast mode, e.g. "regular" or "high"' },
+          colorScheme: {
+            type: "string",
+            description: 'Color scheme mode, e.g. "light" or "dark"',
+          },
+          scale: {
+            type: "string",
+            description: 'Scale mode, e.g. "desktop" or "mobile"',
+          },
+          contrast: {
+            type: "string",
+            description: 'Contrast mode, e.g. "regular" or "high"',
+          },
         },
-        required: ['property'],
+        required: ["property"],
         additionalProperties: false,
       },
       async handler({ property, colorScheme, scale, contrast }) {
-        const wasm = await getWasm();
+        const ds = await getDataset();
         const context = {};
         if (colorScheme) context.colorScheme = colorScheme;
         if (scale) context.scale = scale;
         if (contrast) context.contrast = contrast;
-        const result = wasm.Dataset.embedded().resolve(property, context);
+        const result = ds.resolve(property, context);
         if (!result) {
           throw new Error(
             `No token found for property "${property}" in context ${JSON.stringify(context)}`,

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -9,199 +9,216 @@
 // governing permissions and limitations under the License.
 
 /**
- * MCP tool definitions that wrap the @adobe/design-data CLI.
+ * MCP tool definitions for @adobe/design-data-mcp.
  *
- * Each tool shells out to `npx @adobe/design-data <subcommand>` and returns
- * the parsed JSON output. The CLI handles data resolution automatically —
- * it uses the embedded Spectrum snapshot when no `.design-data.toml` is present,
- * or the configured source/version if one exists in the project.
+ * All tools run in-process via @adobe/design-data-wasm — no CLI binary or npx
+ * required. Dataset.embedded() provides the canonical Spectrum snapshot with
+ * zero configuration.
  */
 
-import { spawnSync } from "child_process";
+import { createRequire } from 'module';
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
 
-/** npx executable name — .cmd suffix required on Windows without shell: true. */
-const NPX = process.platform === "win32" ? "npx.cmd" : "npx";
+let _wasm;
+/** Lazy-load and cache the wasm module (nodejs target, no init() required). */
+async function getWasm() {
+  if (!_wasm) _wasm = await import('@adobe/design-data-wasm');
+  return _wasm;
+}
 
-/**
- * Run `npx -y @adobe/design-data` with the given args and return parsed JSON stdout.
- *
- * Uses spawnSync (blocking) intentionally: this MCP server serves a single
- * stdio client and processes requests sequentially, so blocking the event
- * loop is safe. The -y flag suppresses the interactive "install?" prompt on
- * first run so the server doesn't hang waiting for user input.
- *
- * Throws if the process can't start (result.error) or exits non-zero.
- */
-function runDesignData(args) {
-  const result = spawnSync(NPX, ["-y", "@adobe/design-data", ...args], {
-    encoding: "utf8",
-    // Allow up to 30s for first-run install + binary execution.
-    timeout: 30_000,
-  });
-
-  // result.error is set when the process can't start at all (binary not found,
-  // timeout exceeded, etc.) — check before result.status.
-  if (result.error) throw result.error;
-
-  if (result.status !== 0) {
-    const msg = (result.stderr || result.stdout || "").trim();
-    throw new Error(`design-data exited ${result.status}: ${msg}`);
-  }
-
+/** Return the @adobe/spectrum-design-data package root directory, or null. */
+function resolveSpectrumDataPackage() {
   try {
-    return JSON.parse(result.stdout);
+    const req = createRequire(import.meta.url);
+    return dirname(req.resolve('@adobe/spectrum-design-data/package.json'));
   } catch {
-    // Some commands (e.g. component) output valid JSON but without --format json.
-    // If JSON.parse fails, return the raw string so the caller can decide.
-    return result.stdout.trim();
+    return null;
   }
 }
 
 export function createDesignDataTools() {
   return [
-    // ── primer ────────────────────────────────────────────────────────────────
+    // ── primer ─────────────────────────────────────────────────────────────
     {
-      name: "design-data-primer",
+      name: 'design-data-primer',
       description:
-        "Get a structural overview of the Spectrum design dataset: token count, " +
-        "available mode-sets (color-scheme, scale, contrast), component list, " +
-        "taxonomy fields, and data provenance. Call this at the start of a " +
-        "design-token session to understand what data is available.",
-      inputSchema: {
-        type: "object",
-        properties: {},
-        additionalProperties: false,
-      },
-      handler() {
-        return runDesignData(["primer", "--format", "json"]);
+        'Get a structural overview of the Spectrum design dataset: token count, ' +
+        'available mode-sets (color-scheme, scale, contrast), component list, ' +
+        'taxonomy fields, and data provenance. Call this at the start of a ' +
+        'design-token session to understand what data is available.',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      async handler() {
+        const wasm = await getWasm();
+        const ds = wasm.Dataset.embedded();
+
+        return {
+          source: 'embedded',
+          tokenCount: ds.tokenCount(),
+          modeSets: {
+            colorScheme: wasm.getFieldValues('colorScheme') ?? [],
+            scale: wasm.getFieldValues('scale') ?? [],
+            contrast: wasm.getFieldValues('contrast') ?? [],
+          },
+          taxonomyFields: {
+            indexed: ['property', 'component', 'variant', 'state', 'colorScheme', 'scale', 'contrast', 'uuid'],
+            advisory: wasm.getAdvisoryFields() ?? [],
+          },
+          components: wasm.getFieldValues('component') ?? [],
+          properties: wasm.getFieldValues('property') ?? [],
+        };
       },
     },
 
-    // ── query ─────────────────────────────────────────────────────────────────
+    // ── query ───────────────────────────────────────────────────────────────
     {
-      name: "design-data-query",
+      name: 'design-data-query',
       description:
-        "Filter Spectrum tokens by a query expression. " +
-        "Expression syntax: `component=button`, `component=button,state=hover`, " +
-        "`property=color-*`, `colorScheme=dark`. " +
-        "Returns an array of matching token objects.",
+        'Filter Spectrum tokens by a query expression. ' +
+        'Expression syntax: `component=button`, `component=button,state=hover`, ' +
+        '`property=color-*`, `colorScheme=dark`. ' +
+        'Returns an array of matching token objects.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           filter: {
-            type: "string",
+            type: 'string',
             description:
               'Query expression, e.g. "component=button" or "property=color-*,component=action-button"',
           },
         },
-        required: ["filter"],
+        required: ['filter'],
         additionalProperties: false,
       },
-      handler({ filter }) {
-        return runDesignData(["query", "--filter", filter, "--format", "json"]);
+      async handler({ filter }) {
+        const wasm = await getWasm();
+        return wasm.Dataset.embedded().query(filter);
       },
     },
 
-    // ── suggest ───────────────────────────────────────────────────────────────
+    // ── suggest ─────────────────────────────────────────────────────────────
     {
-      name: "design-data-suggest",
+      name: 'design-data-suggest',
       description:
-        "Suggest Spectrum tokens matching a natural-language intent. " +
-        "Returns ranked matches with confidence scores, token names, and values. " +
-        "Use when the user describes what they need rather than knowing the token name.",
+        'Suggest Spectrum tokens matching a natural-language intent. ' +
+        'Returns ranked matches with confidence scores, token names, and values. ' +
+        'Use when the user describes what they need rather than knowing the token name.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           intent: {
-            type: "string",
+            type: 'string',
             description:
               'Natural-language description of the design need, e.g. "primary CTA button background color"',
           },
           limit: {
-            type: "number",
-            description: "Maximum number of suggestions to return (default: 5)",
+            type: 'number',
+            description: 'Maximum number of suggestions to return (default: 5)',
             default: 5,
           },
         },
-        required: ["intent"],
+        required: ['intent'],
         additionalProperties: false,
       },
-      handler({ intent, limit = 5 }) {
-        return runDesignData([
-          "suggest",
-          "--",
-          intent,
-          "--format",
-          "json",
-          "--limit",
-          String(limit),
-        ]);
+      async handler({ intent, limit = 5 }) {
+        const wasm = await getWasm();
+        const ds = wasm.Dataset.embedded();
+        // Keyword-based ranking over token names. The NLP-ranked CLI suggest is
+        // more accurate; this runs fully in-process without the CLI.
+        const words = intent.toLowerCase().split(/\s+/).filter(Boolean);
+        const allTokens = ds.query('');
+        const scored = allTokens
+          .map((token) => {
+            const nameStr = token.name.toLowerCase();
+            const matches = words.filter((w) => nameStr.includes(w)).length;
+            const confidence = words.length > 0 ? matches / words.length : 0;
+            return { token, confidence };
+          })
+          .filter(({ confidence }) => confidence > 0)
+          .sort((a, b) => b.confidence - a.confidence)
+          .slice(0, limit);
+
+        return scored.map(({ token, confidence }) => ({
+          name: token.name,
+          confidence: Math.round(confidence * 100) / 100,
+          uuid: token.uuid,
+          raw: token.raw,
+        }));
       },
     },
 
-    // ── component ─────────────────────────────────────────────────────────────
+    // ── component ───────────────────────────────────────────────────────────
     {
-      name: "design-data-component",
+      name: 'design-data-component',
       description:
         "Get the full component declaration for a Spectrum component by ID. " +
         "Returns the component's displayName, description, and all available options " +
         "(variants, sizes, states, boolean props, etc.). " +
-        "Component IDs are kebab-case, e.g. button, action-button, text-field, picker.",
+        'Component IDs are kebab-case, e.g. button, action-button, text-field, picker.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           id: {
-            type: "string",
-            description:
-              "Component ID in kebab-case, e.g. button, action-button, picker, text-field",
+            type: 'string',
+            description: 'Component ID in kebab-case, e.g. button, action-button, picker, text-field',
           },
         },
-        required: ["id"],
+        required: ['id'],
         additionalProperties: false,
       },
-      handler({ id }) {
-        // component always outputs JSON — no --format flag.
-        return runDesignData(["component", "--", id]);
+      async handler({ id }) {
+        const pkgRoot = resolveSpectrumDataPackage();
+        if (!pkgRoot) {
+          throw new Error(
+            `@adobe/spectrum-design-data is not installed — cannot load component "${id}". ` +
+            `Install it with: pnpm add @adobe/spectrum-design-data`,
+          );
+        }
+        const componentFile = join(pkgRoot, 'components', `${id}.json`);
+        if (!existsSync(componentFile)) {
+          throw new Error(
+            `Component not found: "${id}". ` +
+            `Call design-data-primer to see available component IDs.`,
+          );
+        }
+        return JSON.parse(readFileSync(componentFile, 'utf-8'));
       },
     },
 
-    // ── resolve ───────────────────────────────────────────────────────────────
+    // ── resolve ─────────────────────────────────────────────────────────────
     {
-      name: "design-data-resolve",
+      name: 'design-data-resolve',
       description:
-        "Resolve the concrete value of a Spectrum token property for a given " +
-        "mode-set context (color-scheme, scale, contrast). " +
-        "Returns the winning token with its resolved value.",
+        'Resolve the concrete value of a Spectrum token property for a given ' +
+        'mode-set context (color-scheme, scale, contrast). ' +
+        'Returns the winning token with its resolved value.',
       inputSchema: {
-        type: "object",
+        type: 'object',
         properties: {
           property: {
-            type: "string",
-            description:
-              "Token property name, e.g. background-color-default, accent-color",
+            type: 'string',
+            description: 'Token property name, e.g. background-color-default, accent-color',
           },
-          colorScheme: {
-            type: "string",
-            description: 'Color scheme mode, e.g. "light" or "dark"',
-          },
-          scale: {
-            type: "string",
-            description: 'Scale mode, e.g. "medium" or "large"',
-          },
-          contrast: {
-            type: "string",
-            description: 'Contrast mode, e.g. "standard" or "high"',
-          },
+          colorScheme: { type: 'string', description: 'Color scheme mode, e.g. "light" or "dark"' },
+          scale: { type: 'string', description: 'Scale mode, e.g. "desktop" or "mobile"' },
+          contrast: { type: 'string', description: 'Contrast mode, e.g. "regular" or "high"' },
         },
-        required: ["property"],
+        required: ['property'],
         additionalProperties: false,
       },
-      handler({ property, colorScheme, scale, contrast }) {
-        const args = ["resolve", "--", property, "--format", "json"];
-        if (colorScheme) args.push("--color-scheme", colorScheme);
-        if (scale) args.push("--scale", scale);
-        if (contrast) args.push("--contrast", contrast);
-        return runDesignData(args);
+      async handler({ property, colorScheme, scale, contrast }) {
+        const wasm = await getWasm();
+        const context = {};
+        if (colorScheme) context.colorScheme = colorScheme;
+        if (scale) context.scale = scale;
+        if (contrast) context.contrast = contrast;
+        const result = wasm.Dataset.embedded().resolve(property, context);
+        if (!result) {
+          throw new Error(
+            `No token found for property "${property}" in context ${JSON.stringify(context)}`,
+          );
+        }
+        return result;
       },
     },
   ];

--- a/tools/design-data-mcp/test/design-data.test.js
+++ b/tools/design-data-mcp/test/design-data.test.js
@@ -9,7 +9,14 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
-import { createDesignDataTools } from "../src/tools/design-data.js";
+import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  createDesignDataTools,
+  scoreTokensByKeyword,
+} from "../src/tools/design-data.js";
 
 const EXPECTED_TOOLS = [
   "design-data-primer",
@@ -19,7 +26,83 @@ const EXPECTED_TOOLS = [
   "design-data-resolve",
 ];
 
-test("createDesignDataTools exposes five CLI wrapper tools", (t) => {
+// ── scoreTokensByKeyword ─────────────────────────────────────────────────────
+
+const FIXTURE_TOKENS = [
+  { name: "accent-background-color-default", uuid: "aaa-001", raw: null },
+  { name: "accent-border-color-default", uuid: "aaa-002", raw: null },
+  { name: "neutral-background-color-default", uuid: "aaa-003", raw: null },
+  { name: "spacing-100", uuid: "aaa-004", raw: null },
+  { name: "font-size-100", uuid: "aaa-005", raw: null },
+];
+
+test("scoreTokensByKeyword returns matches ranked by confidence", (t) => {
+  const results = scoreTokensByKeyword(
+    FIXTURE_TOKENS,
+    "accent background color",
+    10,
+  );
+  t.true(results.length > 0);
+  // First result should be 'accent-background-color-default' (3/3 words match)
+  t.is(results[0].name, "accent-background-color-default");
+  t.is(results[0].confidence, 1);
+});
+
+test("scoreTokensByKeyword respects the limit", (t) => {
+  const results = scoreTokensByKeyword(FIXTURE_TOKENS, "color", 2);
+  t.is(results.length, 2);
+});
+
+test("scoreTokensByKeyword returns empty array when no tokens match", (t) => {
+  const results = scoreTokensByKeyword(FIXTURE_TOKENS, "zzz-no-match");
+  t.deepEqual(results, []);
+});
+
+test("scoreTokensByKeyword returns empty array for empty intent", (t) => {
+  const results = scoreTokensByKeyword(FIXTURE_TOKENS, "");
+  t.deepEqual(results, []);
+});
+
+test("scoreTokensByKeyword result includes name, confidence, uuid, raw", (t) => {
+  const results = scoreTokensByKeyword(FIXTURE_TOKENS, "accent");
+  t.true(results.length > 0);
+  for (const r of results) {
+    t.true(Object.hasOwn(r, "name"));
+    t.true(Object.hasOwn(r, "confidence"));
+    t.true(Object.hasOwn(r, "uuid"));
+    t.true(Object.hasOwn(r, "raw"));
+    t.is(typeof r.confidence, "number");
+  }
+});
+
+// ── component not-found error ────────────────────────────────────────────────
+
+const TMP = join(tmpdir(), "design-data-mcp-test-" + randomUUID().slice(0, 8));
+
+test.before(() => mkdirSync(TMP, { recursive: true }));
+test.after(() => rmSync(TMP, { recursive: true, force: true }));
+
+test("design-data-component throws for unknown component id", async (t) => {
+  const tools = Object.fromEntries(
+    createDesignDataTools().map((tool) => [tool.name, tool]),
+  );
+  const tool = tools["design-data-component"];
+  // This test relies on the package being unavailable in the test env for a
+  // fake component ID, or the component JSON not existing.
+  const err = await t.throwsAsync(() =>
+    tool.handler({ id: "zzz-nonexistent-component-xyz" }),
+  );
+  t.truthy(err);
+  t.true(
+    err.message.includes("zzz-nonexistent-component-xyz") ||
+      err.message.includes("not installed"),
+    `Expected error about missing component, got: ${err.message}`,
+  );
+});
+
+// ── structural tests ──────────────────────────────────────────────────────────
+
+test("createDesignDataTools exposes five wasm-backed tools", (t) => {
   const tools = createDesignDataTools();
   t.is(tools.length, 5);
   t.deepEqual(

--- a/tools/design-data-skill/skills/design-data/SKILL.md
+++ b/tools/design-data-skill/skills/design-data/SKILL.md
@@ -11,7 +11,7 @@ when_to_use: >
   "Spectrum component options", validate tokens, design-data primer, query tokens,
   suggest token, resolve token value, component schema, design system config,
   @adobe/design-data, design-data CLI.
-allowed-tools: mcp__design-data__primer, mcp__design-data__query_tokens, mcp__design-data__resolve_token, mcp__design-data__describe_component, mcp__design-data__validate_usage, mcp__design-data__diff_datasets
+allowed-tools: mcp__design-data__design-data-primer, mcp__design-data__design-data-query, mcp__design-data__design-data-suggest, mcp__design-data__design-data-component, mcp__design-data__design-data-resolve
 ---
 
 # Spectrum Design Data
@@ -21,105 +21,8 @@ via the `@adobe/design-data-mcp` MCP server (in-process wasm — no CLI binary r
 
 ## Bootstrap
 
-On first use, ensure the CLI is installed:
-
-```
-npx @adobe/design-data --version
-```
-
-`npx` installs the binary automatically on first run. For frequent use or
-air-gapped environments, install globally to avoid the per-invocation
-network check:
-
-```
-npm install -g @adobe/design-data
-```
-
-## Commands
-
-**Session overview** — call at the start of a design-token session to understand
-the available data:
-
-```
-npx @adobe/design-data primer --format json
-```
-
-Returns: token count, mode-sets, component list, fields, and data provenance
-(embedded snapshot or fetched version).
-
-***
-
-**Query tokens** — filter by name, property, component, state, or any combination:
-
-```
-npx @adobe/design-data query --filter "<expr>" --format json
-```
-
-Expression syntax examples:
-
-* `"component=button"` — all button tokens
-* `"component=button,state=hover"` — button hover tokens
-* `"property=color-*"` — all color property tokens
-* `"colorScheme=dark"` — dark-scheme tokens
-
-Returns an empty array when no tokens match (not an error). Exit code 1 only
-when the expression itself is malformed.
-
-***
-
-**Suggest tokens** — natural-language intent → ranked token matches:
-
-```
-npx @adobe/design-data suggest "<intent>" --format json
-npx @adobe/design-data suggest "<intent>" --format json --limit 10
-```
-
-Example: `"primary CTA button background color"`
-
-***
-
-**Component schema** — full component declaration:
-
-```
-npx @adobe/design-data component <id>
-```
-
-Example: `npx @adobe/design-data component button`
-
-Returns: displayName, description, options (variants, sizes, states, etc.).
-This command always outputs JSON; it does not accept a `--format` flag.
-
-***
-
-**Resolve token value** — resolve a token for a given mode-set context:
-
-```
-npx @adobe/design-data resolve <property> --format json
-npx @adobe/design-data resolve <property> --format json --color-scheme light --scale medium
-```
-
-Example: `npx @adobe/design-data resolve background-color-default --format json --color-scheme dark`
-
-## Workflow
-
-1. **Start with `primer`** to understand what data is available.
-2. **Use `query`** when you know the component/property/state.
-3. **Use `suggest`** when the user describes an intent in natural language.
-4. **Use `component`** to check all available options for a specific component.
-5. **Use `resolve`** to get the concrete value for a token in a given context.
-
-## When working in Cursor
-
-Install this skill as a **Remote Rule (GitHub)** — same pattern as the s2-docs skill:
-
-Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste:
-
-```
-https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
-```
-
-For always-available tool access (higher context cost), add `@adobe/design-data-mcp` to
-`.cursor/mcp.json` in your project root:
+Add `@adobe/design-data-mcp` to your project's `.cursor/mcp.json` (or equivalent
+MCP config) to activate the tools:
 
 ```json
 {
@@ -131,6 +34,82 @@ For always-available tool access (higher context cost), add `@adobe/design-data-
   }
 }
 ```
+
+The server uses an embedded Spectrum snapshot — no environment variables or
+dataset path configuration required for read operations.
+
+## Tools
+
+### `design-data-primer`
+
+Get a structural overview of the embedded Spectrum dataset: token count,
+available mode-sets (color-scheme, scale, contrast), component list, taxonomy
+fields, and data provenance. **Call this at the start of a design-token session.**
+
+No required inputs.
+
+### `design-data-query`
+
+Filter Spectrum tokens by a query expression. Returns an array of matching token objects.
+
+Required input: `filter` (string)
+
+Expression syntax examples:
+
+* `"component=button"` — all button tokens
+* `"component=button,state=hover"` — button hover tokens
+* `"property=color-*"` — all color property tokens
+* `"colorScheme=dark"` — dark-scheme tokens
+
+Returns an empty array when no tokens match.
+
+### `design-data-suggest`
+
+Suggest Spectrum tokens matching a natural-language intent using keyword-overlap
+scoring. Returns matches ranked by confidence.
+
+Required input: `intent` (string) — e.g. `"primary CTA button background color"`
+Optional input: `limit` (number, default 5)
+
+### `design-data-component`
+
+Get the full component declaration for a Spectrum component by ID. Returns the
+component's displayName, description, and all available options (variants, sizes,
+states, boolean props, etc.).
+
+Required input: `id` (string) — kebab-case component ID, e.g. `button`, `action-button`
+
+Call `design-data-primer` first to see available component IDs.
+
+### `design-data-resolve`
+
+Resolve the concrete value of a Spectrum token property for a given mode-set context.
+Returns the winning token with its resolved value.
+
+Required input: `property` (string) — token property name, e.g. `background-color-default`
+Optional inputs: `colorScheme` (`"light"` or `"dark"`), `scale` (`"desktop"` or `"mobile"`),
+`contrast` (`"regular"` or `"high"`)
+
+## Workflow
+
+1. **Start with `design-data-primer`** to understand what data is available.
+2. **Use `design-data-query`** when you know the component/property/state.
+3. **Use `design-data-suggest`** when the user describes an intent in natural language.
+4. **Use `design-data-component`** to check all available options for a specific component.
+5. **Use `design-data-resolve`** to get the concrete value for a token in a given context.
+
+## When working in Cursor
+
+Install this skill as a **Remote Rule (GitHub)** — same pattern as the s2-docs skill:
+
+Cursor Settings → Rules → **Add Rule** → **Remote Rule (GitHub)** → paste:
+
+```
+https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-skill/skills/design-data
+```
+
+For always-available tool access (higher context cost), add the MCP server to
+`.cursor/mcp.json` as shown in the Bootstrap section above.
 
 For custom datasets with validate/diff/write, use the `design-data-agent` skill or
 `@adobe/design-data-agent-mcp` instead — see

--- a/tools/design-data-skill/skills/design-data/SKILL.md
+++ b/tools/design-data-skill/skills/design-data/SKILL.md
@@ -11,13 +11,13 @@ when_to_use: >
   "Spectrum component options", validate tokens, design-data primer, query tokens,
   suggest token, resolve token value, component schema, design system config,
   @adobe/design-data, design-data CLI.
-allowed-tools: Bash(npx @adobe/design-data *)
+allowed-tools: mcp__design-data__primer, mcp__design-data__query_tokens, mcp__design-data__resolve_token, mcp__design-data__describe_component, mcp__design-data__validate_usage, mcp__design-data__diff_datasets
 ---
 
 # Spectrum Design Data
 
 Access Spectrum design tokens, component schemas, and design-system structure
-via the `@adobe/design-data` CLI.
+via the `@adobe/design-data-mcp` MCP server (in-process wasm — no CLI binary required).
 
 ## Bootstrap
 


### PR DESCRIPTION
## Description

Migrate `design-data-mcp` and `design-data-agent-mcp` from shelling out to the `@adobe/design-data` npm binary (via `spawnSync`) to running fully in-process using `@adobe/design-data-wasm` and the new `@adobe/design-data-js` Node glue package. Update both `SKILL.md` files to replace `Bash(npx @adobe/design-data *)` with MCP tool names.

### C1 — `design-data-mcp` (5 read tools → in-process)

All five tools (`primer`, `query`, `suggest`, `component`, `resolve`) now use `Dataset.embedded()` + wasm registry helpers. `suggest` uses keyword-overlap scoring over all embedded tokens (NLP `suggest` not yet on wasm surface). `component` reads JSON directly from `@adobe/spectrum-design-data/components/<id>.json` via `createRequire` — no CLI.

### C2 — `design-data-agent-mcp` read side

`query_tokens` and `resolve_token` now use `loadDataset(path).query/resolve` from `@adobe/design-data-js`. `validate_usage` uses `loadDataset(target).validate()`. `diff_datasets` uses `Promise.all([loadDataset(old), loadDataset(new)])` then `.diff()`. `primer` and `describe_component` retain the CLI (complex catalog aggregation / external path resolution).

### C3 — `design-data-agent-mcp` write + authoring

`write` uses `writeProductContext` from `@adobe/design-data-js/write`. Six of seven authoring tools use `@adobe/design-data-js/session` (the on-disk session store ported from `session.rs`). `authoring_session_step_intent` retains the CLI because the NLP `suggest` ranking is not yet on the wasm surface — documented with TODO in both files.

### C4 — SKILL.md rewrites

Both `tools/design-data-skill/skills/design-data/SKILL.md` and `tools/design-data-agent-mcp/skills/design-data/SKILL.md` `allowed-tools` updated from `Bash(npx @adobe/design-data *)` to explicit `mcp__design-data__*` tool names.

## Related Issue

Part of epic #731 — wasm rollout / CLI deprecation path.

## Motivation and Context

Spawning `npx @adobe/design-data` from MCP servers introduces cold-start latency on every tool call, requires the npm binary to be published and installed, and creates a process-boundary serialization cost for every request. In-process wasm eliminates all three. This is Phase C of the four-phase plan; Phase A (embedded blob, PR #1133) and Phase B (`@adobe/design-data-js`, PR #1134) are prerequisites in the stack.

## How Has This Been Tested?

- `design-data-mcp` and `design-data-agent-mcp` tool handlers reviewed for correct wasm/JS call patterns
- `@adobe/design-data-js` (Phase B) has 25 AVA tests covering `load`, `write`, and `session` modules
- `@adobe/design-data-wasm` (Phase A) has 4 new parity tests for `Dataset.embedded()` on top of 34 existing parity tests

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.