### PR TITLE
feat(agent-mcp): migrate primer + describe_component to in-process wasm

### DIFF
--- a/.changeset/agent-mcp-read-tools-in-process.md
+++ b/.changeset/agent-mcp-read-tools-in-process.md
@@ -1,0 +1,14 @@
+---
+"@adobe/design-data-agent-mcp": patch
+---
+
+Migrate `primer` and `describe_component` read tools off the native CLI to in-process wasm.
+
+- **tools/read.js**: replace `runCli` for `primer` with wasm `getWasm`/`getDataset`/`getFieldValues`
+  composing the primer response; matches sibling `design-data-mcp` pattern.
+- **tools/read.js**: replace `runCli` for `describe_component` with direct filesystem read;
+  add `validateComponentId` (mirrors `component.rs:validate_id`) to block path traversal.
+- **test/read.test.js**: tests for primer shape, id-validation edge cases, and not-found
+  error listing available components.
+- **package.json**, **README.md**: note that the `design-data` binary is now only needed
+  for `authoring_session_step_intent`.

--- a/.changeset/agent-mcp-read-tools-in-process.md
+++ b/.changeset/agent-mcp-read-tools-in-process.md
@@ -1,5 +1,5 @@
 ---
-"@adobe/design-data-agent-mcp": patch
+"@adobe/design-data-agent-mcp": minor
 ---
 
 Migrate `primer` and `describe_component` read tools off the native CLI to in-process wasm.

--- a/tools/design-data-agent-mcp/README.md
+++ b/tools/design-data-agent-mcp/README.md
@@ -1,6 +1,6 @@
 # `@adobe/design-data-agent-mcp`
 
-MCP server and Claude Code skill for the [Spectrum Design Data](../../packages/design-data/) agent surface. Shells out to the `design-data` CLI — all logic stays in the Rust SDK.
+MCP server and Claude Code skill for the [Spectrum Design Data](../../packages/design-data/) agent surface. Read tools (`primer`, `resolve_token`, `query_tokens`, `describe_component`) run fully in-process via `@adobe/design-data-wasm` — no CLI binary required for those. Only `authoring_session_step_intent` still invokes the native binary (for NLP suggest ranking, not yet on the wasm surface).
 
 ## Install
 
@@ -29,7 +29,7 @@ https://github.com/adobe/spectrum-design-data/tree/main/tools/design-data-agent-
 npx @adobe/design-data-agent-mcp
 ```
 
-Requires the `@adobe/design-data` CLI on `PATH` (or set `DESIGN_DATA_BIN`).
+The `@adobe/design-data` CLI binary is **only** needed for `authoring_session_step_intent`. All other tools run in-process. Set `DESIGN_DATA_BIN` if the binary is not on `PATH`.
 
 ## MCP server
 
@@ -49,7 +49,7 @@ node tools/design-data-agent-mcp/src/index.js
 
 | Variable                 | Default       | Description                                       |
 | ------------------------ | ------------- | ------------------------------------------------- |
-| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary                  |
+| `DESIGN_DATA_BIN`        | `design-data` | Path to the `design-data` binary (authoring only) |
 | `DESIGN_DATA_ROOT`       | —             | Absolute root that relative paths are anchored to |
 | `DESIGN_DATA_PATH`       | `.`           | Dataset root path                                 |
 | `DESIGN_DATA_COMPONENTS` | —             | Override components directory                     |
@@ -74,8 +74,9 @@ node tools/design-data-agent-mcp/src/index.js
 >    `packages/design-data`; when published it uses the installed dependency. This
 >    is independent of the working directory.
 > 3. **Fallback.** `dataPath` falls back to the (anchored) current directory; the
->    component/field overrides fall back to the `design-data` binary's own
->    discovery (including its embedded snapshot).
+>    component/field overrides fall back to `null` (not supplied), which means
+>    `describe_component` will throw an error if `@adobe/spectrum-design-data` is
+>    not resolvable.
 >
 > In a monorepo checkout you typically need no `DESIGN_DATA_*` env vars at all —
 > resolution via the workspace package handles it.

--- a/tools/design-data-agent-mcp/moon.yml
+++ b/tools/design-data-agent-mcp/moon.yml
@@ -21,6 +21,8 @@ tasks:
   test:
     command: [pnpm, ava]
     platform: node
+    deps:
+      - sdk-wasm:build
     inputs:
       - "src/**/*.js"
       - "test/**/*.js"

--- a/tools/design-data-agent-mcp/package.json
+++ b/tools/design-data-agent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/design-data-agent-mcp",
   "version": "1.5.0",
-  "description": "MCP server and Claude Code skill for the design-data agent surface — shells out to the design-data CLI",
+  "description": "MCP server and Claude Code skill for the design-data agent surface — read tools run in-process via wasm",
   "type": "module",
   "main": "./src/index.js",
   "bin": {

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -71,7 +71,16 @@ export function createReadTools() {
         additionalProperties: false,
       },
       async handler() {
-        const [wasm, ds] = await Promise.all([getWasm(), getDataset()]);
+        // Shape note: this response intentionally diverges from the CLI PrimerData
+        // struct (sdk/core/src/primer.rs). The CLI emits modeSets as an array of
+        // {name, values} objects and taxonomyFields as a flat array. This in-process
+        // shape uses keyed objects (matching the sibling design-data-mcp), which agents
+        // and the SKILL.md skill prompt consume by key name. Skill contract:
+        // tokenCount, modeSets.{colorScheme,scale,contrast}, components[],
+        // taxonomyFields.{indexed,advisory}. CLI-only fields (specVersion, manifest,
+        // provenance) are not present — no SKILL.md reference or consumer relies on them.
+        const wasm = await getWasm();
+        const ds = await getDataset();
         return {
           source: "embedded",
           tokenCount: ds.tokenCount(),

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -11,18 +11,53 @@
 /**
  * Read tools for design-data-agent-mcp.
  *
- * query_tokens and resolve_token use @adobe/design-data (loadDataset) + the
- * wasm Dataset to run in-process without spawning the CLI binary.
+ * All read tools run fully in-process via @adobe/design-data-wasm — no CLI binary
+ * required. primer and describe_component were migrated in issue m1r.
  *
- * primer and describe_component still invoke the CLI: primer aggregates complex
- * catalog metadata (components, fields) not yet on the wasm surface, and
- * describe_component requires the components catalog path resolution that the CLI
- * handles. These will be ported when those APIs are added to the wasm surface.
+ * Note: authoring_session_step_intent in authoring.js still uses the CLI because
+ * the NLP suggest ranking is not yet on the wasm surface.
  */
 
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { join } from "path";
 import { loadDataset } from "@adobe/design-data/load";
-import { runCli } from "../cli.js";
 import { config } from "../config.js";
+
+let _wasm;
+/** Lazy-load and cache the wasm module (nodejs target, no init() required). */
+async function getWasm() {
+  if (!_wasm) _wasm = await import("@adobe/design-data-wasm");
+  return _wasm;
+}
+
+let _dataset;
+/**
+ * Return the embedded Spectrum dataset, caching it after first access.
+ *
+ * Dataset.embedded() clones the in-memory graph on every call; caching here
+ * avoids that per-request cost.
+ */
+async function getDataset() {
+  if (!_dataset) {
+    const wasm = await getWasm();
+    _dataset = wasm.Dataset.embedded();
+  }
+  return _dataset;
+}
+
+/**
+ * Validate a component ID against the same rule as the Rust SDK.
+ * See sdk/core/src/component.rs:validate_id — prevents path traversal.
+ */
+const COMPONENT_ID_RE = /^[a-z][a-z0-9-]*$/;
+function validateComponentId(id) {
+  if (!COMPONENT_ID_RE.test(id)) {
+    throw new Error(
+      `Invalid component ID "${id}". IDs must be kebab-case: start with a lowercase ` +
+        `letter and contain only lowercase letters, digits, and hyphens.`,
+    );
+  }
+}
 
 export function createReadTools() {
   return [
@@ -36,14 +71,22 @@ export function createReadTools() {
         additionalProperties: false,
       },
       async handler() {
-        const args = ["primer", config.dataPath, "--format", "json"];
-        if (config.componentsDir)
-          args.push("--components-dir", config.componentsDir);
-        if (config.fieldsDir) args.push("--fields-dir", config.fieldsDir);
-        const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0)
-          throw new Error(stderr || `primer exited ${exitCode}`);
-        return JSON.parse(stdout);
+        const [wasm, ds] = await Promise.all([getWasm(), getDataset()]);
+        return {
+          source: "embedded",
+          tokenCount: ds.tokenCount(),
+          modeSets: {
+            colorScheme: wasm.getFieldValues("colorScheme") ?? [],
+            scale: wasm.getFieldValues("scale") ?? [],
+            contrast: wasm.getFieldValues("contrast") ?? [],
+          },
+          taxonomyFields: {
+            indexed: wasm.getIndexedFields(),
+            advisory: wasm.getAdvisoryFields() ?? [],
+          },
+          components: wasm.getFieldValues("component") ?? [],
+          properties: wasm.getFieldValues("property") ?? [],
+        };
       },
     },
 
@@ -127,13 +170,32 @@ export function createReadTools() {
         additionalProperties: false,
       },
       async handler({ id }) {
-        const args = ["component", id];
-        if (config.componentsDir)
-          args.push("--components-dir", config.componentsDir);
-        const { exitCode, stdout, stderr } = await runCli(args);
-        if (exitCode !== 0)
-          throw new Error(stderr || `component exited ${exitCode}`);
-        return JSON.parse(stdout);
+        validateComponentId(id);
+        const componentsDir = config.componentsDir;
+        if (!componentsDir) {
+          throw new Error(
+            `@adobe/spectrum-design-data is not installed — cannot load component "${id}". ` +
+              `Install it with: pnpm add @adobe/spectrum-design-data`,
+          );
+        }
+        const componentFile = join(componentsDir, `${id}.json`);
+        if (!existsSync(componentFile)) {
+          let available;
+          try {
+            available = readdirSync(componentsDir)
+              .filter((f) => f.endsWith(".json"))
+              .map((f) => f.replace(/\.json$/, ""))
+              .sort()
+              .join(", ");
+          } catch {
+            available = null;
+          }
+          const hint = available
+            ? `Available components: ${available}`
+            : `Call primer to see available component IDs.`;
+          throw new Error(`Component not found: "${id}". ${hint}`);
+        }
+        return JSON.parse(readFileSync(componentFile, "utf-8"));
       },
     },
   ];

--- a/tools/design-data-agent-mcp/test/read.test.js
+++ b/tools/design-data-agent-mcp/test/read.test.js
@@ -9,6 +9,7 @@
 // governing permissions and limitations under the License.
 
 import test from "ava";
+import { config } from "../src/config.js";
 import { createReadTools } from "../src/tools/read.js";
 
 // ── helpers ────────────────────────────────────────────────────────────────────
@@ -105,4 +106,42 @@ test("describe_component not-found error lists available component IDs", async (
     err.message.includes("button") || err.message.includes("primer"),
     `error should list available components or suggest primer, got: ${err.message}`,
   );
+});
+
+test("describe_component throws helpful error when componentsDir is null", async (t) => {
+  // Simulates a zero-config install where @adobe/spectrum-design-data is absent.
+  const saved = config.componentsDir;
+  t.teardown(() => {
+    config.componentsDir = saved;
+  });
+  config.componentsDir = null;
+
+  const describe = getHandler("describe_component");
+  const err = await t.throwsAsync(() => describe({ id: "button" }));
+  t.true(
+    err.message.includes("not installed"),
+    `expected 'not installed', got: ${err.message}`,
+  );
+});
+
+test("primer shape contract: SKILL.md fields are all present", async (t) => {
+  // Guards the contract described in SKILL.md: "returns the active dimensions,
+  // component list, taxonomy fields, and token count". If this shape changes,
+  // update the SKILL.md prompt accordingly.
+  const primer = getHandler("primer");
+  const result = await primer();
+  // active dimensions
+  t.true("colorScheme" in result.modeSets, "modeSets.colorScheme");
+  t.true("scale" in result.modeSets, "modeSets.scale");
+  t.true("contrast" in result.modeSets, "modeSets.contrast");
+  // component list
+  t.true(
+    result.components.includes("button"),
+    "components[] includes 'button'",
+  );
+  // taxonomy fields
+  t.true("indexed" in result.taxonomyFields, "taxonomyFields.indexed");
+  t.true("advisory" in result.taxonomyFields, "taxonomyFields.advisory");
+  // token count
+  t.is(typeof result.tokenCount, "number");
 });

--- a/tools/design-data-agent-mcp/test/read.test.js
+++ b/tools/design-data-agent-mcp/test/read.test.js
@@ -1,0 +1,108 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { createReadTools } from "../src/tools/read.js";
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function getHandler(name) {
+  const tools = createReadTools();
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool "${name}" not found`);
+  return tool.handler.bind(tool);
+}
+
+// ── primer ─────────────────────────────────────────────────────────────────────
+
+test("primer returns expected top-level keys", async (t) => {
+  const primer = getHandler("primer");
+  const result = await primer();
+  t.is(typeof result.tokenCount, "number");
+  t.true(result.tokenCount > 0, "tokenCount should be positive");
+  t.truthy(result.modeSets, "modeSets should be present");
+  t.true(
+    Array.isArray(result.modeSets.colorScheme),
+    "modeSets.colorScheme is an array",
+  );
+  t.true(Array.isArray(result.modeSets.scale), "modeSets.scale is an array");
+  t.true(
+    Array.isArray(result.modeSets.contrast),
+    "modeSets.contrast is an array",
+  );
+  t.truthy(result.taxonomyFields, "taxonomyFields should be present");
+  t.true(Array.isArray(result.components), "components is an array");
+  t.true(result.components.length > 0, "components should be non-empty");
+  t.true(Array.isArray(result.properties), "properties is an array");
+  t.is(result.source, "embedded");
+});
+
+test("primer does not require a CLI binary (no runCli import)", async (t) => {
+  // Structural check: the compiled source of read.js must not import cli.js
+  const src = await import("fs").then((fs) =>
+    fs.promises.readFile(
+      new URL("../src/tools/read.js", import.meta.url),
+      "utf-8",
+    ),
+  );
+  t.false(src.includes("runCli"), "read.js must not reference runCli");
+  t.false(src.includes('../cli.js"'), "read.js must not import cli.js");
+});
+
+// ── describe_component ─────────────────────────────────────────────────────────
+
+test("describe_component returns component data for a known ID", async (t) => {
+  const describe = getHandler("describe_component");
+  const result = await describe({ id: "button" });
+  t.is(typeof result, "object", "result should be an object");
+  t.truthy(result, "result should be non-null");
+  // All component files have at least a name/id field
+  t.true(
+    typeof result.id === "string" || typeof result.name === "string",
+    "result should have an id or name field",
+  );
+});
+
+test("describe_component rejects path-traversal ID (../foo)", async (t) => {
+  const describe = getHandler("describe_component");
+  const err = await t.throwsAsync(() => describe({ id: "../foo" }));
+  t.true(err.message.includes("Invalid component ID"), `got: ${err.message}`);
+});
+
+test("describe_component rejects ID with uppercase letters", async (t) => {
+  const describe = getHandler("describe_component");
+  const err = await t.throwsAsync(() => describe({ id: "Button" }));
+  t.true(err.message.includes("Invalid component ID"), `got: ${err.message}`);
+});
+
+test("describe_component rejects empty ID", async (t) => {
+  const describe = getHandler("describe_component");
+  const err = await t.throwsAsync(() => describe({ id: "" }));
+  t.true(err.message.includes("Invalid component ID"), `got: ${err.message}`);
+});
+
+test("describe_component rejects ID with path separator", async (t) => {
+  const describe = getHandler("describe_component");
+  const err = await t.throwsAsync(() => describe({ id: "a/b" }));
+  t.true(err.message.includes("Invalid component ID"), `got: ${err.message}`);
+});
+
+test("describe_component not-found error lists available component IDs", async (t) => {
+  const describe = getHandler("describe_component");
+  const err = await t.throwsAsync(() =>
+    describe({ id: "zzz-nonexistent-xyz" }),
+  );
+  t.true(err.message.includes("not found"), `got: ${err.message}`);
+  // Should list real available components or fall back to a hint
+  t.true(
+    err.message.includes("button") || err.message.includes("primer"),
+    `error should list available components or suggest primer, got: ${err.message}`,
+  );
+});


### PR DESCRIPTION
## Description

Migrates the two remaining CLI-backed read tools in `@adobe/design-data-agent-mcp` to run fully in-process via `@adobe/design-data-wasm`. Mirrors the pattern already used in the sibling `design-data-mcp`.

- **`primer`**: replaces `runCli(["primer", ...])` with an in-process composition using `Dataset.embedded()` + `getFieldValues`/`getIndexedFields`/`getAdvisoryFields`.
- **`describe_component`**: replaces `runCli(["component", id, ...])` with a direct filesystem read of `<componentsDir>/<id>.json`; adds `validateComponentId()` guard matching `sdk/core/src/component.rs:validate_id` to prevent path traversal.
- `cli.js` is kept — `authoring_session_step_intent` still needs the native binary for NLP suggest ranking (not yet on the wasm surface).

## Related Issue

Closes beads issue `spectrum-design-data-m1r`.

## Motivation and Context

The `design-data` native binary on PATH was the last configuration requirement for the read path of this MCP server. With this change, `npx @adobe/design-data-agent-mcp` works zero-config for all read and authoring tools except `authoring_session_step_intent`.

## How Has This Been Tested?

- `moon run design-data-agent-mcp:test` — 33/33 tests pass, including new tests in `test/read.test.js` covering:
  - `primer` shape and key presence
  - `primer` source-level guard (no `runCli` import)
  - `describe_component` id validation: path-traversal (`../foo`), uppercase, empty, path-separator
  - `describe_component` not-found error listing available component IDs

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.