### PR TITLE
fix(tui): show readable token names in wizard suggestion list

### DIFF
--- a/.changeset/wizard-suggestion-display-names.md
+++ b/.changeset/wizard-suggestion-display-names.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-tui": patch
+---
+
+Fix wizard S1 suggestion list to show readable token names, not file-path IDs.
+
+- **sdk/tui/src/view.rs** (`render_intent_content`): use `display_name()` as
+  the primary label; show source file basename as a dimmed secondary column.
+- **sdk/core/src/suggest.rs** (`SuggestionResult::display_name`): new method
+  deriving the legacy name from the token's `name` object via
+  `extract_legacy_key`; falls back to the raw graph key when no name object
+  is present.

--- a/sdk/core/src/suggest.rs
+++ b/sdk/core/src/suggest.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use serde_json::Value;
 
 use crate::graph::{Layer, TokenGraph, TokenRecord};
+use crate::naming::extract_legacy_key;
 
 /// A ranked suggestion result.
 #[derive(Debug, Clone)]
@@ -38,6 +39,22 @@ pub struct SuggestionResult {
     pub name_object: Option<Value>,
     /// The token's raw value, if any.
     pub value: Option<Value>,
+}
+
+impl SuggestionResult {
+    /// Human-readable label for display in the wizard suggestion list.
+    ///
+    /// Derives the legacy name from the token's `name` object when present —
+    /// the same derivation used by the graph loader to populate
+    /// `legacy_name_index`. Falls back to the raw graph key (`token_name`)
+    /// when no name object is available (e.g. object-format tokens whose graph
+    /// key is already a readable name like `accent-background-color-default`).
+    pub fn display_name(&self) -> String {
+        self.name_object
+            .as_ref()
+            .and_then(extract_legacy_key)
+            .unwrap_or_else(|| self.token_name.clone())
+    }
 }
 
 /// Suggest existing tokens that match the given `intent` string.
@@ -291,6 +308,66 @@ mod tests {
             results[0].value.as_ref().and_then(|v| v.as_str()),
             Some("rgb(0, 0, 0)")
         );
+    }
+
+    // ── display_name() ────────────────────────────────────────────────────────
+
+    fn make_suggestion(token_name: &str, name_object: Option<serde_json::Value>) -> SuggestionResult {
+        SuggestionResult {
+            token_uuid: None,
+            token_name: token_name.to_string(),
+            file: PathBuf::from("tokens/color-aliases.tokens.json"),
+            layer: crate::graph::Layer::Foundation,
+            confidence: 0.18,
+            name_object,
+            value: None,
+        }
+    }
+
+    #[test]
+    fn display_name_derives_readable_name_from_color_domain_name_object() {
+        // Cascade token: graph key is file:index, but name_object is a color-domain object.
+        let s = make_suggestion(
+            "tokens/color-aliases.tokens.json:0",
+            Some(json!({
+                "variant": "accent",
+                "colorFamily": "background-color",
+                "scaleIndex": 100
+            })),
+        );
+        assert_eq!(s.display_name(), "accent-background-color-100");
+    }
+
+    #[test]
+    fn display_name_derives_readable_name_from_component_name_object() {
+        // Cascade token with property/component/state name object.
+        let s = make_suggestion(
+            "tokens/layout.tokens.json:7",
+            Some(json!({
+                "property": "background-color",
+                "component": "button",
+                "state": "hover"
+            })),
+        );
+        assert_eq!(s.display_name(), "button-background-color-hover");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_token_name_when_no_name_object() {
+        // Object-format token: graph key is already readable; name_object is None.
+        let s = make_suggestion("accent-background-color-default", None);
+        assert_eq!(s.display_name(), "accent-background-color-default");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_token_name_when_name_object_is_not_object() {
+        // Defensive: name_object present but not a valid name structure.
+        let s = make_suggestion(
+            "tokens/misc.tokens.json:2",
+            Some(json!("some-legacy-string-key")),
+        );
+        // extract_legacy_key handles string escape hatch: returns the string itself.
+        assert_eq!(s.display_name(), "some-legacy-string-key");
     }
 
     #[test]

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -504,9 +504,19 @@ fn render_intent_content(
             .map(|(i, s)| {
                 let marker = if i == selected_suggestion { "▶" } else { " " };
                 let conf = format!("{:.0}%", s.confidence * 100.0);
+                let source = s
+                    .file
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
                 Row::new(vec![
                     Cell::from(marker),
-                    Cell::from(s.token_name.as_str()),
+                    Cell::from(s.display_name()),
+                    Cell::from(Span::styled(
+                        source,
+                        Style::default().fg(theme.muted),
+                    )),
                     Cell::from(conf),
                 ])
             })
@@ -514,6 +524,7 @@ fn render_intent_content(
         let widths = [
             Constraint::Length(2),
             Constraint::Min(0),
+            Constraint::Length(28),
             Constraint::Length(5),
         ];
         let table =

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -509,6 +509,7 @@ fn render_intent_content(
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("")
+                    .trim_end_matches(".tokens.json")
                     .to_string();
                 Row::new(vec![
                     Cell::from(marker),
@@ -524,7 +525,7 @@ fn render_intent_content(
         let widths = [
             Constraint::Length(2),
             Constraint::Min(0),
-            Constraint::Length(28),
+            Constraint::Max(24),
             Constraint::Length(5),
         ];
         let table =

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -498,24 +498,35 @@ fn render_intent_content(
             );
         }
     } else {
-        let rows: Vec<Row> = suggestions
+        let sources: Vec<String> = suggestions
             .iter()
-            .enumerate()
-            .map(|(i, s)| {
-                let marker = if i == selected_suggestion { "▶" } else { " " };
-                let conf = format!("{:.0}%", s.confidence * 100.0);
-                let source = s
-                    .file
+            .map(|s| {
+                s.file
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("")
                     .trim_end_matches(".tokens.json")
-                    .to_string();
+                    .to_string()
+            })
+            .collect();
+        let source_col_width = sources
+            .iter()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0)
+            .min(24) as u16;
+        let rows: Vec<Row> = suggestions
+            .iter()
+            .enumerate()
+            .zip(sources.iter())
+            .map(|((i, s), source)| {
+                let marker = if i == selected_suggestion { "▶" } else { " " };
+                let conf = format!("{:.0}%", s.confidence * 100.0);
                 Row::new(vec![
                     Cell::from(marker),
                     Cell::from(s.display_name()),
                     Cell::from(Span::styled(
-                        source,
+                        source.clone(),
                         Style::default().fg(theme.muted),
                     )),
                     Cell::from(conf),
@@ -525,7 +536,7 @@ fn render_intent_content(
         let widths = [
             Constraint::Length(2),
             Constraint::Min(0),
-            Constraint::Max(24),
+            Constraint::Length(source_col_width),
             Constraint::Length(5),
         ];
         let table =

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/tests/snapshots.rs
+assertion_line: 117
 expression: rendered
 ---
 ▶ test · 0 tokens
@@ -9,7 +10,7 @@ expression: rendered
   >    │  These tokens already exist for similar intents.               │
     que│  Reusing one keeps the cascade healthy.  Tab to alias · Enter t│
     res│                                                                │
-    des│▶  accent-background-color-de test.json                    50%  │
+    des│▶  accent-background-color-defaul test.json                50%  │
     val│                                                                │
     new│                                                                │
     nam│                                                                │

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/tests/snapshots.rs
-assertion_line: 117
 expression: rendered
 ---
 ▶ test · 0 tokens
@@ -10,7 +9,7 @@ expression: rendered
   >    │  These tokens already exist for similar intents.               │
     que│  Reusing one keeps the cascade healthy.  Tab to alias · Enter t│
     res│                                                                │
-    des│▶  accent-background-color-defaul test.json                50%  │
+    des│▶  accent-background-color-default               test.json 50%  │
     val│                                                                │
     new│                                                                │
     nam│                                                                │

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/tests/snapshots.rs
-assertion_line: 117
 expression: rendered
 ---
 ▶ test · 0 tokens
@@ -10,7 +9,7 @@ expression: rendered
   >    │  These tokens already exist for similar intents.               │
     que│  Reusing one keeps the cascade healthy.  Tab to alias · Enter t│
     res│                                                                │
-    des│▶  accent-background-color-default                         50%  │
+    des│▶  accent-background-color-de test.json                    50%  │
     val│                                                                │
     new│                                                                │
     nam│                                                                │

--- a/sdk/tui/tests/wizard.rs
+++ b/sdk/tui/tests/wizard.rs
@@ -9,10 +9,10 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::{key, make_graph, update_ctx};
+use common::{key, make_graph, render_to_buffer, update_ctx};
 
 use crossterm::event::KeyCode;
-use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph};
+use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
 use design_data_tui::app::Modal;
 use design_data_tui::wizard::{ValueKind, WizardPath, WizardScreen};
 use design_data_tui::{update, Message, Model, Task, UpdateCtx};
@@ -494,4 +494,63 @@ fn assembled_name_joins_property_and_fields() {
             value: Input::from("hover".to_string()),
         });
     assert_eq!(ws.assembled_name(), "background-color-hover");
+}
+
+// ── Suggestion display-name render tests ─────────────────────────────────────
+
+/// Build a graph that contains a cascade-format token: graph key is
+/// `"tokens/color-aliases.tokens.json:0"` (a file:index string), but the
+/// token's raw JSON carries a readable `name` object so `display_name()`
+/// can derive `accent-background-color`.
+fn make_cascade_graph() -> TokenGraph {
+    let record = TokenRecord {
+        name: "tokens/color-aliases.tokens.json:0".to_string(),
+        file: PathBuf::from("tokens/color-aliases.tokens.json"),
+        index: 0,
+        schema_url: None,
+        uuid: None,
+        alias_target: None,
+        raw: serde_json::json!({
+            "value": "red",
+            "name": {
+                "variant": "accent",
+                "colorFamily": "background-color"
+            }
+        }),
+        layer: Layer::Foundation,
+    };
+    TokenGraph::from_records(vec![record])
+}
+
+#[test]
+fn wizard_s1_renders_readable_name_not_file_index_key() {
+    // Regression guard for spectrum-design-data-xxh:
+    // Cascade-format tokens must appear with their derived legacy name in the
+    // wizard suggestion list, not as the raw `file:index` graph key.
+    let graph = make_cascade_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    // Open wizard with an intent that matches the cascade token ("accent background").
+    open_wizard(&mut model, &ctx, "accent background");
+
+    // Render at a comfortable size so the suggestion list is visible.
+    let buf = render_to_buffer(&mut model, 120, 36);
+    let rendered: String = buf
+        .content()
+        .iter()
+        .map(|c| c.symbol().to_string())
+        .collect();
+
+    // The readable derived name should appear in the buffer.
+    assert!(
+        rendered.contains("accent-background-color"),
+        "expected readable suggestion label 'accent-background-color' in wizard render; \
+         got (excerpt): {:?}",
+        &rendered[..rendered.len().min(400)]
+    );
+    // The raw file:index key must NOT appear as a label.
+    assert!(
+        !rendered.contains("color-aliases.tokens.json:0"),
+        "file:index key must not appear as a suggestion label; regression in display_name()"
+    );
 }


### PR DESCRIPTION
## Description

Wizard Screen 1 (Intent) was showing internal file-path IDs as the primary label in the reuse-first suggestion list:

```
▶  packages/design-data/tokens/color-aliases.tokens.json:0      18%
   packages/design-data/tokens/color-aliases.tokens.json:1      18%
```

It now shows the human-readable token name with the source file as dimmed secondary metadata:

```
▶  accent-background-color-default      color-aliases.tokens.json   18%
   accent-background-color-down         color-aliases.tokens.json   18%
```

## Related Issue

Fixes spectrum-design-data-xxh — discovered during the PR #1157 UX review pass.

## Motivation and Context

The reuse-first suggestion list is the wizard's headline feature. When labels are internal `file:index` keys, users can't evaluate whether a match is relevant and will press Enter to create a new token rather than reuse an existing one — defeating the purpose of the screen.

The readable name was never lost: `SuggestionResult` already carried a `name_object` field with the token's structured name. The fix adds a `display_name()` method in core that derives the legacy name from that object via the existing `extract_legacy_key` function (the same derivation already used by `graph.rs` to build `legacy_name_index`).

## How Has This Been Tested?

- New unit tests in `core/src/suggest.rs`: `display_name` with a color-domain name object, a `property/component/state` name object, `name_object: None` fallback, and string escape-hatch.
- New render regression test in `tui/tests/wizard.rs`: builds a graph with a cascade-format token (`file:index` graph key + readable `name` object), opens the wizard, renders to a `TestBackend` buffer, and asserts the buffer contains the readable name and does NOT contain the `.json:N` key.
- Full `cargo test -p design-data-tui && cargo test -p design-data-core` suite passes.
- Visual: `tui_headless` with `new accent background` intent confirms readable labels in the rendered output.

## Screenshots (if appropriate):

**Before:** suggestions showed `packages/design-data/tokens/color-aliases.tokens.json:0`

**After:** suggestions show `accent-background-color-default   color-aliases.tokens.json   18%`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
