### PR TITLE
feat(tui): footer hints, g/G jump, and empty-state copy for result views

### DIFF
--- a/.changeset/tui-result-view-polish.md
+++ b/.changeset/tui-result-view-polish.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-tui": patch
+---
+
+Add footer hints, g/G jump, and empty-state copy to result views.
+
+- **results.rs**: add 1-row muted footer hint line to query, resolve, validate,
+  and describe views showing available keys (j/k, g/G, y, Esc).
+- **update.rs** + **app.rs**: add `g`/`G` to jump first/last row in list views;
+  scroll top/bottom in describe.
+- **results.rs**: show centered empty-state message when query/resolve returns
+  zero results or validate finds no issues.

--- a/sdk/tui/src/app.rs
+++ b/sdk/tui/src/app.rs
@@ -80,6 +80,14 @@ pub fn move_table_selection(state: &mut TableState, len: usize, delta: i64) {
     state.select(Some(next));
 }
 
+/// Jump a `TableState` selection to the first (`last = false`) or last (`last = true`) row.
+pub fn select_edge(state: &mut TableState, len: usize, last: bool) {
+    if len == 0 {
+        return;
+    }
+    state.select(Some(if last { len - 1 } else { 0 }));
+}
+
 /// Test whether `(row, col)` is inside `rect`.
 pub(crate) fn rect_contains(rect: Rect, row: u16, col: u16) -> bool {
     col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -28,7 +28,8 @@ use design_data_core::write::write_token;
 use tui_input::backend::crossterm::EventHandler;
 
 use crate::app::{
-    move_table_selection, rect_contains, ActiveView, HitAction, Modal, StatusMessage, ValidateView,
+    move_table_selection, select_edge, rect_contains, ActiveView, HitAction, Modal, StatusMessage,
+    ValidateView,
 };
 use crate::clipboard::write_clipboard;
 use crate::command::Command;
@@ -441,6 +442,46 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
                 false
             }
         }
+        // g/G: jump to first/last row (vim convention, tui-conventions.md §1).
+        KeyCode::Char('g') => match &mut model.active_view {
+            ActiveView::Query(qv) => {
+                select_edge(&mut qv.table_state, qv.rows.len(), false);
+                true
+            }
+            ActiveView::Resolve(rv) => {
+                select_edge(&mut rv.table_state, rv.rows.len(), false);
+                true
+            }
+            ActiveView::Validate(vv) => {
+                select_edge(&mut vv.table_state, vv.rows.len(), false);
+                true
+            }
+            ActiveView::Describe(dv) => {
+                dv.scroll = 0;
+                true
+            }
+            ActiveView::Empty => false,
+        },
+        KeyCode::Char('G') => match &mut model.active_view {
+            ActiveView::Query(qv) => {
+                select_edge(&mut qv.table_state, qv.rows.len(), true);
+                true
+            }
+            ActiveView::Resolve(rv) => {
+                select_edge(&mut rv.table_state, rv.rows.len(), true);
+                true
+            }
+            ActiveView::Validate(vv) => {
+                select_edge(&mut vv.table_state, vv.rows.len(), true);
+                true
+            }
+            ActiveView::Describe(dv) => {
+                let max_scroll = dv.pretty_json.lines().count().saturating_sub(1) as u16;
+                dv.scroll = max_scroll;
+                true
+            }
+            ActiveView::Empty => false,
+        },
         KeyCode::Char('y') => {
             let yank = match &model.active_view {
                 ActiveView::Query(qv) => qv.selected_row().map(|r| r.name.clone()),

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -101,7 +101,7 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
         }
         ActiveView::Query(ref mut qv) => render_query(frame, qv, chunks[1], theme),
         ActiveView::Resolve(ref mut rv) => render_resolve(frame, rv, chunks[1], theme),
-        ActiveView::Describe(ref dv) => render_describe(frame, dv, chunks[1]),
+        ActiveView::Describe(ref dv) => render_describe(frame, dv, chunks[1], theme),
         ActiveView::Validate(ref mut vv) => render_validate(frame, vv, chunks[1], theme),
     }
 

--- a/sdk/tui/src/view/results.rs
+++ b/sdk/tui/src/view/results.rs
@@ -14,8 +14,9 @@
 //! (GH #1018).
 
 use ratatui::{
-    layout::{Constraint, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Modifier, Style},
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
     Frame,
 };
@@ -26,13 +27,63 @@ use crate::model::views::{
 };
 use crate::theme::Theme;
 
+/// Split `area` into [body, hint] — body gets all but the bottom 1-row hint line.
+fn split_body_hint(area: Rect) -> [Rect; 2] {
+    Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(area)
+}
+
+/// Render a muted 1-row hint line into `area`.
+fn render_hint(f: &mut Frame<'_>, text: &str, area: Rect, theme: &Theme) {
+    let hint = Line::from(Span::styled(text, Style::default().fg(theme.muted)));
+    f.render_widget(Paragraph::new(hint), area);
+}
+
+/// Render a centered empty-state message inside a bordered block with `title`.
+fn render_empty_state(f: &mut Frame<'_>, title: &str, msg: &str, area: Rect, theme: &Theme) {
+    let block = Block::default().borders(Borders::ALL).title(title.to_string());
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    // Vertically center the message in the inner area.
+    let [_, msg_area, _] = Layout::vertical([
+        Constraint::Percentage(35),
+        Constraint::Min(1),
+        Constraint::Percentage(35),
+    ])
+    .areas(inner);
+    f.render_widget(
+        Paragraph::new(msg)
+            .style(Style::default().fg(theme.muted))
+            .alignment(Alignment::Center),
+        msg_area,
+    );
+}
+
 pub(crate) fn render_query(
     f: &mut Frame<'_>,
     qv: &mut QueryView,
     area: Rect,
     theme: &Theme,
 ) {
-    let name_max = column_budget(area.width, 5, QUERY_NAME_PCT);
+    let [body, hint_area] = split_body_hint(area);
+    let title = if qv.is_fuzzy {
+        format!(" Fuzzy: /{} ", qv.expr_text)
+    } else {
+        format!(" Query: {} ", qv.expr_text)
+    };
+
+    if qv.rows.is_empty() {
+        render_empty_state(
+            f,
+            &title,
+            "No tokens matched. Try: query property=background-color or query background-color/*",
+            body,
+            theme,
+        );
+        render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+        return;
+    }
+
+    let name_max = column_budget(body.width, 5, QUERY_NAME_PCT);
     let header = Row::new(vec![
         Cell::from("Name").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("Value").style(Style::default().add_modifier(Modifier::BOLD)),
@@ -57,16 +108,12 @@ pub(crate) fn render_query(
         Constraint::Percentage(20),
         Constraint::Percentage(10),
     ];
-    let title = if qv.is_fuzzy {
-        format!(" Fuzzy: /{} ", qv.expr_text)
-    } else {
-        format!(" Query: {} ", qv.expr_text)
-    };
     let table = Table::new(rows, widths)
         .header(header)
         .block(Block::default().borders(Borders::ALL).title(title))
         .row_highlight_style(Style::default().bg(theme.selection_bg));
-    f.render_stateful_widget(table, area, &mut qv.table_state);
+    f.render_stateful_widget(table, body, &mut qv.table_state);
+    render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
 }
 
 pub(crate) fn render_resolve(
@@ -75,7 +122,21 @@ pub(crate) fn render_resolve(
     area: Rect,
     theme: &Theme,
 ) {
-    let name_max = column_budget(area.width, 9, RESOLVE_NAME_PCT);
+    let [body, hint_area] = split_body_hint(area);
+
+    if rv.rows.is_empty() {
+        render_empty_state(
+            f,
+            &format!(" Resolve: {} ", rv.property),
+            "No match for that property/mode combination. Try without mode filters.",
+            body,
+            theme,
+        );
+        render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+        return;
+    }
+
+    let name_max = column_budget(body.width, 9, RESOLVE_NAME_PCT);
     let header = Row::new(vec![
         Cell::from("★").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("Name").style(Style::default().add_modifier(Modifier::BOLD)),
@@ -114,10 +175,12 @@ pub(crate) fn render_resolve(
                 .title(format!(" Resolve: {} ", rv.property)),
         )
         .row_highlight_style(Style::default().bg(theme.selection_bg));
-    f.render_stateful_widget(table, area, &mut rv.table_state);
+    f.render_stateful_widget(table, body, &mut rv.table_state);
+    render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
 }
 
-pub(crate) fn render_describe(f: &mut Frame<'_>, dv: &DescribeView, area: Rect) {
+pub(crate) fn render_describe(f: &mut Frame<'_>, dv: &DescribeView, area: Rect, theme: &Theme) {
+    let [body, hint_area] = split_body_hint(area);
     let para = Paragraph::new(dv.pretty_json.as_str())
         .block(
             Block::default()
@@ -125,7 +188,8 @@ pub(crate) fn render_describe(f: &mut Frame<'_>, dv: &DescribeView, area: Rect) 
                 .title(format!(" Describe: {} ", dv.component)),
         )
         .scroll((dv.scroll, 0));
-    f.render_widget(para, area);
+    f.render_widget(para, body);
+    render_hint(f, "j/k scroll · PgUp/PgDn ×10 · Esc back", hint_area, theme);
 }
 
 pub(crate) fn render_validate(
@@ -134,7 +198,15 @@ pub(crate) fn render_validate(
     area: Rect,
     theme: &Theme,
 ) {
-    let token_max = column_budget(area.width, 12, VALIDATE_TOKEN_PCT);
+    let [body, hint_area] = split_body_hint(area);
+
+    if vv.rows.is_empty() {
+        render_empty_state(f, " Validate ", "All tokens valid ✓", body, theme);
+        render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+        return;
+    }
+
+    let token_max = column_budget(body.width, 12, VALIDATE_TOKEN_PCT);
     let header = Row::new(vec![
         Cell::from("Sev").style(Style::default().add_modifier(Modifier::BOLD)),
         Cell::from("Rule").style(Style::default().add_modifier(Modifier::BOLD)),
@@ -163,5 +235,6 @@ pub(crate) fn render_validate(
         .header(header)
         .block(Block::default().borders(Borders::ALL).title(" Validate "))
         .row_highlight_style(Style::default().bg(theme.selection_bg));
-    f.render_stateful_widget(table, area, &mut vv.table_state);
+    f.render_stateful_widget(table, body, &mut vv.table_state);
+    render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
 }

--- a/sdk/tui/src/view/results.rs
+++ b/sdk/tui/src/view/results.rs
@@ -27,6 +27,11 @@ use crate::model::views::{
 };
 use crate::theme::Theme;
 
+/// Footer hint shown on list result views (query, resolve, validate).
+const LIST_HINT: &str = "j/k navigate · g/G top/bottom · y yank · Esc back";
+/// Footer hint shown on the scrollable describe view.
+const DESCRIBE_HINT: &str = "j/k scroll · g/G top/bottom · PgUp/PgDn ×10 · Esc back";
+
 /// Split `area` into [body, hint] — body gets all but the bottom 1-row hint line.
 fn split_body_hint(area: Rect) -> [Rect; 2] {
     Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(area)
@@ -79,7 +84,7 @@ pub(crate) fn render_query(
             body,
             theme,
         );
-        render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+        render_hint(f, LIST_HINT, hint_area, theme);
         return;
     }
 
@@ -113,7 +118,7 @@ pub(crate) fn render_query(
         .block(Block::default().borders(Borders::ALL).title(title))
         .row_highlight_style(Style::default().bg(theme.selection_bg));
     f.render_stateful_widget(table, body, &mut qv.table_state);
-    render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+    render_hint(f, LIST_HINT, hint_area, theme);
 }
 
 pub(crate) fn render_resolve(
@@ -132,7 +137,7 @@ pub(crate) fn render_resolve(
             body,
             theme,
         );
-        render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+        render_hint(f, LIST_HINT, hint_area, theme);
         return;
     }
 
@@ -176,7 +181,7 @@ pub(crate) fn render_resolve(
         )
         .row_highlight_style(Style::default().bg(theme.selection_bg));
     f.render_stateful_widget(table, body, &mut rv.table_state);
-    render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+    render_hint(f, LIST_HINT, hint_area, theme);
 }
 
 pub(crate) fn render_describe(f: &mut Frame<'_>, dv: &DescribeView, area: Rect, theme: &Theme) {
@@ -189,7 +194,7 @@ pub(crate) fn render_describe(f: &mut Frame<'_>, dv: &DescribeView, area: Rect, 
         )
         .scroll((dv.scroll, 0));
     f.render_widget(para, body);
-    render_hint(f, "j/k scroll · PgUp/PgDn ×10 · Esc back", hint_area, theme);
+    render_hint(f, DESCRIBE_HINT, hint_area, theme);
 }
 
 pub(crate) fn render_validate(
@@ -202,7 +207,7 @@ pub(crate) fn render_validate(
 
     if vv.rows.is_empty() {
         render_empty_state(f, " Validate ", "All tokens valid ✓", body, theme);
-        render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+        render_hint(f, LIST_HINT, hint_area, theme);
         return;
     }
 
@@ -236,5 +241,5 @@ pub(crate) fn render_validate(
         .block(Block::default().borders(Borders::ALL).title(" Validate "))
         .row_highlight_style(Style::default().bg(theme.selection_bg));
     f.render_stateful_widget(table, body, &mut vv.table_state);
-    render_hint(f, "j/k navigate · g/G top/bottom · y yank · Esc back", hint_area, theme);
+    render_hint(f, LIST_HINT, hint_area, theme);
 }

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -9,11 +9,11 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::{key, settle, update_ctx_builder};
+use common::{key, settle, update_ctx, update_ctx_builder};
 
 use crossterm::event::KeyCode;
 use design_data_core::graph::{ComponentRecord, TokenGraph};
-use design_data_tui::app::ActiveView;
+use design_data_tui::app::{ActiveView, DescribeView};
 use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
 use std::path::PathBuf;
@@ -173,4 +173,50 @@ fn esc_from_describe_view_returns_to_empty() {
     assert!(matches!(model.active_view, ActiveView::Describe(_)));
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
     assert!(matches!(model.active_view, ActiveView::Empty));
+}
+
+// ── g/G scroll ────────────────────────────────────────────────────────────────
+
+/// Build a DescribeView with enough lines to make G scrolling observable.
+fn multi_line_describe() -> DescribeView {
+    let json = (0..30).map(|i| format!("  \"line{i}\": {i}")).collect::<Vec<_>>().join(",\n");
+    DescribeView {
+        component: "test".to_string(),
+        pretty_json: format!("{{\n{json}\n}}"),
+        scroll: 0,
+    }
+}
+
+#[test]
+fn g_key_scrolls_describe_to_top() {
+    use design_data_core::graph::TokenGraph;
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(multi_line_describe());
+    model.close_palette(); // palette must be closed for view-key routing
+    // Advance scroll, then jump back to top.
+    update(&mut model, Message::Key(key(KeyCode::PageDown)), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('g'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.scroll, 0, "g should scroll describe to top");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+#[test]
+fn shift_g_key_scrolls_describe_to_bottom() {
+    use design_data_core::graph::TokenGraph;
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(multi_line_describe());
+    model.close_palette(); // palette must be closed for view-key routing
+    update(&mut model, Message::Key(key(KeyCode::Char('G'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert!(dv.scroll > 0, "G should scroll describe toward bottom (got scroll={})", dv.scroll);
+    } else {
+        panic!("expected Describe view");
+    }
 }

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -208,3 +208,47 @@ fn re_query_replaces_results_and_resets_selection() {
         panic!("expected Query view");
     }
 }
+
+#[test]
+fn g_key_jumps_to_first_row() {
+    let graph = make_graph_with_tokens(&["a", "b", "c"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
+    // Move to row 2, then jump back to first.
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('g'))), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
+        assert_eq!(qv.table_state.selected(), Some(0), "g should jump to first row");
+    } else {
+        panic!("expected Query view");
+    }
+}
+
+#[test]
+fn shift_g_key_jumps_to_last_row() {
+    let graph = make_graph_with_tokens(&["a", "b", "c"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=*".into()),
+        &ctx,
+    );
+    update(&mut model, Message::Key(key(KeyCode::Char('G'))), &ctx);
+    if let ActiveView::Query(ref qv) = model.active_view {
+        let last = qv.rows.len() - 1;
+        assert_eq!(
+            qv.table_state.selected(),
+            Some(last),
+            "G should jump to last row (index {last})"
+        );
+    } else {
+        panic!("expected Query view");
+    }
+}

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -17,8 +17,13 @@ mod common;
 use common::{key, make_graph_with_tokens, render_to_buffer, update_ctx, TEST_PRIMER};
 
 use crossterm::event::KeyCode;
+use design_data_core::graph::{Layer, ModeSetRecord, TokenGraph, TokenRecord};
+use design_data_tui::app::{ActiveView, DescribeView, ValidateView};
+use ratatui::widgets::TableState;
 use design_data_tui::{update, Message, Model};
 use ratatui::buffer::Buffer;
+use serde_json::json;
+use std::path::PathBuf;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -225,6 +230,87 @@ fn query_view_empty_state_still_shows_footer_hint() {
     submit_query(&mut model, &ctx, "query property=zzznomatch");
     let buf = render_to_buffer(&mut model, W, H);
     find_row_containing(&buf, "j/k navigate", W, H);
+}
+
+// ── Resolve empty state ───────────────────────────────────────────────────────
+
+/// Build a minimal resolve-capable graph (same shape as tests/resolve.rs).
+fn make_resolve_graph() -> TokenGraph {
+    let ms = ModeSetRecord {
+        file: PathBuf::from("mode-sets/color-scheme.json"),
+        name: "colorScheme".into(),
+        modes: vec!["light".into(), "dark".into()],
+        default_mode: "light".into(),
+    };
+    let records = vec![TokenRecord {
+        name: "bg-base".into(),
+        file: PathBuf::from("tokens.json"),
+        index: 0,
+        schema_url: None,
+        uuid: None,
+        alias_target: None,
+        raw: json!({"name": {"property": "background-color"}, "value": "#fff"}),
+        layer: Layer::Foundation,
+    }];
+    TokenGraph::from_records(records).with_mode_sets(vec![ms])
+}
+
+#[test]
+fn resolve_empty_state_shows_no_match_copy() {
+    let graph = make_resolve_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("resolve property=nonexistent-property".into()), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "No match for that property", W, H);
+}
+
+#[test]
+fn resolve_empty_state_shows_footer_hint() {
+    let graph = make_resolve_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("resolve property=nonexistent-property".into()), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "j/k navigate", W, H);
+}
+
+// ── Validate empty state ──────────────────────────────────────────────────────
+
+#[test]
+fn validate_empty_state_shows_all_valid_copy() {
+    // Drive the validate view into the zero-errors state by injecting it directly,
+    // mirroring the m5 pattern for views that require complex IO setup.
+    let mut model = Model::new();
+    model.active_view = ActiveView::Validate(ValidateView { rows: vec![], table_state: TableState::default() });
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "All tokens valid", W, H);
+}
+
+#[test]
+fn validate_empty_state_shows_footer_hint() {
+    let mut model = Model::new();
+    model.active_view = ActiveView::Validate(ValidateView { rows: vec![], table_state: TableState::default() });
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "j/k navigate", W, H);
+}
+
+// ── Describe footer hint ──────────────────────────────────────────────────────
+
+#[test]
+fn describe_view_footer_hint_includes_g_g() {
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(DescribeView {
+        component: "button".to_string(),
+        pretty_json: "{\n  \"name\": \"button\"\n}".to_string(),
+        scroll: 0,
+    });
+    let buf = render_to_buffer(&mut model, W, H);
+    let hint_row = find_row_containing(&buf, "j/k scroll", W, H);
+    assert!(
+        hint_row.contains("g/G"),
+        "describe footer hint should advertise g/G: {hint_row}"
+    );
 }
 
 // ── Determinism ───────────────────────────────────────────────────────────────

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -179,6 +179,54 @@ fn typing_in_palette_updates_home_prompt() {
     assert!(last_row.trim().is_empty(), "bottom strip should be empty");
 }
 
+// ── Footer hints ─────────────────────────────────────────────────────────────
+
+#[test]
+fn query_view_renders_footer_hint_line() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit_query(&mut model, &ctx, "query property=accent-color");
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "j/k navigate", W, H);
+}
+
+#[test]
+fn query_view_hint_includes_g_g_shortcut() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit_query(&mut model, &ctx, "query property=accent-color");
+    let buf = render_to_buffer(&mut model, W, H);
+    let hint_row = find_row_containing(&buf, "j/k navigate", W, H);
+    assert!(
+        hint_row.contains("g/G"),
+        "footer hint should advertise g/G: {hint_row}"
+    );
+}
+
+// ── Empty-state copy ──────────────────────────────────────────────────────────
+
+#[test]
+fn query_view_empty_state_shows_hint() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit_query(&mut model, &ctx, "query property=zzznomatch");
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "No tokens matched", W, H);
+}
+
+#[test]
+fn query_view_empty_state_still_shows_footer_hint() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit_query(&mut model, &ctx, "query property=zzznomatch");
+    let buf = render_to_buffer(&mut model, W, H);
+    find_row_containing(&buf, "j/k navigate", W, H);
+}
+
 // ── Determinism ───────────────────────────────────────────────────────────────
 
 #[test]

--- a/sdk/tui/tests/resolve.rs
+++ b/sdk/tui/tests/resolve.rs
@@ -212,3 +212,42 @@ fn esc_from_resolve_view_returns_to_empty() {
     update(&mut model, Message::Key(key(KeyCode::Esc)), &ctx);
     assert!(matches!(model.active_view, ActiveView::Empty));
 }
+
+// ── g/G jump ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn g_key_jumps_to_first_row_in_resolve() {
+    let graph = make_resolve_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    // background-color has 3 candidates (base + light + dark mode).
+    submit(&mut model, &ctx, "resolve property=background-color");
+    // Move down, then jump back to first.
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('j'))), &ctx);
+    update(&mut model, Message::Key(key(KeyCode::Char('g'))), &ctx);
+    if let ActiveView::Resolve(ref rv) = model.active_view {
+        assert_eq!(rv.table_state.selected(), Some(0), "g should jump to first row");
+    } else {
+        panic!("expected Resolve view");
+    }
+}
+
+#[test]
+fn shift_g_key_jumps_to_last_row_in_resolve() {
+    let graph = make_resolve_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    submit(&mut model, &ctx, "resolve property=background-color");
+    update(&mut model, Message::Key(key(KeyCode::Char('G'))), &ctx);
+    if let ActiveView::Resolve(ref rv) = model.active_view {
+        let last = rv.rows.len() - 1;
+        assert_eq!(
+            rv.table_state.selected(),
+            Some(last),
+            "G should jump to last row (index {last})"
+        );
+    } else {
+        panic!("expected Resolve view");
+    }
+}

--- a/sdk/tui/tests/snapshots/snapshots__query_view_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__query_view_80x24.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/tests/snapshots.rs
+assertion_line: 76
 expression: rendered
 ---
 ▶ test · 0 tokens
@@ -22,6 +23,6 @@ expression: rendered
 │                                                                              │
 │                                                                              │
 │                                                                              │
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
+j/k navigate · g/G top/bottom · y yank · Esc back
 3 token(s) matched


### PR DESCRIPTION
## Description

Three small TUI result-view polish improvements, batched into one PR (beads: qsj, 8t9, og8):

1. **Footer hint line** (qsj) — every result view (query, resolve, validate, describe) now shows a 1-row muted hint line at the bottom of the view listing available keys. Mirrors the pattern already in wizard/find/home screens.
2. **g/G jump** (8t9) — pressing `g` jumps to the first row and `G` to the last row in all list views (query, resolve, validate), and scrolls to the top/bottom in describe. Follows vim/lazygit/k9s conventions.
3. **Empty-state copy** (og8) — when query/resolve returns zero results, or validate finds no issues, the empty table body is replaced with a centered muted hint explaining the situation and suggesting next steps.

## Related Issue

Beads issues: `spectrum-design-data-qsj`, `spectrum-design-data-8t9`, `spectrum-design-data-og8`

## Motivation and Context

Result views had no footer hint (unlike wizards/home), no way to quickly jump to the first/last row, and showed a blank table body on zero results — all friction points called out in the TUI conventions doc.

## How Has This Been Tested?

- New in-process buffer tests in `tests/render.rs`: footer hint renders in query view, hint advertises g/G, empty-state copy appears on no-match query, hint still renders in empty state.
- New key-driver tests in `tests/query.rs`: `g` key selects index 0, `G` key selects last index.
- Updated snapshot `tests/snapshots/snapshots__query_view_80x24.snap` (footer hint now appears below table border — one blank row inside the table replaced by the hint outside).
- Budget tests (`tests/budget.rs`): all three caps pass — LOC ≤ 800 per file, no async in render path, `Message` size ≤ 128 bytes.
- Full `cargo test` suite: all passing.

## Screenshots (if appropriate):

Footer hint line appears below each result view table. Empty state shows centered muted copy inside the bordered block.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.