### PR TITLE
feat(tui): add horizontal scroll to describe view

### DIFF
--- a/sdk/tui/src/model/views.rs
+++ b/sdk/tui/src/model/views.rs
@@ -227,6 +227,7 @@ pub struct DescribeView {
     pub component: String,
     pub pretty_json: String,
     pub scroll: u16,
+    pub h_scroll: u16,
 }
 
 /// One row in the validate diagnostics table.

--- a/sdk/tui/src/model/views.rs
+++ b/sdk/tui/src/model/views.rs
@@ -230,6 +230,21 @@ pub struct DescribeView {
     pub h_scroll: u16,
 }
 
+impl DescribeView {
+    /// Widest line in `pretty_json`, measured in terminal display columns
+    /// (via `unicode-width`, consistent with [`truncate_cell`]). Used to bound
+    /// horizontal scroll so it matches how ratatui counts column offsets.
+    pub(crate) fn max_line_width(&self) -> u16 {
+        use unicode_width::UnicodeWidthStr;
+        self.pretty_json
+            .lines()
+            .map(|l| l.width())
+            .max()
+            .unwrap_or(0)
+            .min(u16::MAX as usize) as u16
+    }
+}
+
 /// One row in the validate diagnostics table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiagnosticRow {

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -442,6 +442,29 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
                 false
             }
         }
+        // h/Left · l/Right: horizontal scroll in describe view (4 columns per step).
+        KeyCode::Left | KeyCode::Char('h') => {
+            if let ActiveView::Describe(ref mut dv) = model.active_view {
+                dv.h_scroll = dv.h_scroll.saturating_sub(4);
+                true
+            } else {
+                false
+            }
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            if let ActiveView::Describe(ref mut dv) = model.active_view {
+                let max_h = dv
+                    .pretty_json
+                    .lines()
+                    .map(|l| l.chars().count())
+                    .max()
+                    .unwrap_or(0) as u16;
+                dv.h_scroll = (dv.h_scroll + 4).min(max_h.saturating_sub(1));
+                true
+            } else {
+                false
+            }
+        }
         // Enter: expand/collapse the selected group in the validate view.
         KeyCode::Enter => match &mut model.active_view {
             ActiveView::Validate(vv) => {
@@ -467,6 +490,7 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
             }
             ActiveView::Describe(dv) => {
                 dv.scroll = 0;
+                dv.h_scroll = 0;
                 true
             }
             ActiveView::Empty => false,

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -43,6 +43,9 @@ use crate::wizard::WizardEvent;
 use command::handle_palette_submit;
 use ctx::UpdateCtx;
 
+/// Columns moved per h/l horizontal-scroll step in the describe view.
+const H_SCROLL_STEP: u16 = 4;
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 /// The single state-transition function for the TUI runtime.
@@ -442,10 +445,10 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
                 false
             }
         }
-        // h/Left · l/Right: horizontal scroll in describe view (4 columns per step).
+        // h/Left · l/Right: horizontal scroll in describe view (H_SCROLL_STEP columns per step).
         KeyCode::Left | KeyCode::Char('h') => {
             if let ActiveView::Describe(ref mut dv) = model.active_view {
-                dv.h_scroll = dv.h_scroll.saturating_sub(4);
+                dv.h_scroll = dv.h_scroll.saturating_sub(H_SCROLL_STEP);
                 true
             } else {
                 false
@@ -453,13 +456,8 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
         }
         KeyCode::Right | KeyCode::Char('l') => {
             if let ActiveView::Describe(ref mut dv) = model.active_view {
-                let max_h = dv
-                    .pretty_json
-                    .lines()
-                    .map(|l| l.chars().count())
-                    .max()
-                    .unwrap_or(0) as u16;
-                dv.h_scroll = (dv.h_scroll + 4).min(max_h.saturating_sub(1));
+                let max_h = dv.max_line_width();
+                dv.h_scroll = (dv.h_scroll + H_SCROLL_STEP).min(max_h.saturating_sub(1));
                 true
             } else {
                 false
@@ -512,6 +510,7 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
             ActiveView::Describe(dv) => {
                 let max_scroll = dv.pretty_json.lines().count().saturating_sub(1) as u16;
                 dv.scroll = max_scroll;
+                dv.h_scroll = 0;
                 true
             }
             ActiveView::Empty => false,

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -457,7 +457,10 @@ fn handle_view_key(model: &mut Model, code: KeyCode) -> bool {
         KeyCode::Right | KeyCode::Char('l') => {
             if let ActiveView::Describe(ref mut dv) = model.active_view {
                 let max_h = dv.max_line_width();
-                dv.h_scroll = (dv.h_scroll + H_SCROLL_STEP).min(max_h.saturating_sub(1));
+                dv.h_scroll = dv
+                    .h_scroll
+                    .saturating_add(H_SCROLL_STEP)
+                    .min(max_h.saturating_sub(1));
                 true
             } else {
                 false

--- a/sdk/tui/src/update/command.rs
+++ b/sdk/tui/src/update/command.rs
@@ -250,6 +250,7 @@ fn dispatch_command(
                                         component: id,
                                         pretty_json: pretty,
                                         scroll: 0,
+                                        h_scroll: 0,
                                     }),
                                     Err(e) => Err(format!("describe: render error: {e}")),
                                 },

--- a/sdk/tui/src/view/results.rs
+++ b/sdk/tui/src/view/results.rs
@@ -32,7 +32,7 @@ const LIST_HINT: &str = "j/k navigate · g/G top/bottom · y yank · Esc back";
 /// Footer hint shown on the validate view (includes Enter to expand/collapse groups).
 const VALIDATE_HINT: &str = "j/k navigate · Enter expand · g/G top/bottom · y yank · Esc back";
 /// Footer hint shown on the scrollable describe view.
-const DESCRIBE_HINT: &str = "j/k scroll · g/G top/bottom · PgUp/PgDn ×10 · Esc back";
+const DESCRIBE_HINT: &str = "j/k scroll · h/l ←→ · g/G top/bottom · PgUp/PgDn ×10 · Esc back";
 
 /// Split `area` into [body, hint] — body gets all but the bottom 1-row hint line.
 fn split_body_hint(area: Rect) -> [Rect; 2] {
@@ -186,7 +186,7 @@ pub(crate) fn render_describe(f: &mut Frame<'_>, dv: &DescribeView, area: Rect, 
                 .borders(Borders::ALL)
                 .title(format!(" Describe: {} ", dv.component)),
         )
-        .scroll((dv.scroll, 0));
+        .scroll((dv.scroll, dv.h_scroll));
     f.render_widget(para, body);
     render_hint(f, DESCRIBE_HINT, hint_area, theme);
 }

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -16,7 +16,7 @@ use design_data_core::graph::{ComponentRecord, TokenGraph};
 use design_data_tui::app::{ActiveView, DescribeView};
 use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn fixtures_components_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/components")
@@ -31,10 +31,8 @@ fn make_graph_with_components() -> TokenGraph {
     TokenGraph::default().with_components(comps)
 }
 
-fn describe_ctx<'a>(graph: &'a TokenGraph, dir: &'a PathBuf) -> UpdateCtx<'a> {
-    update_ctx_builder(graph)
-        .components_dir(dir.as_path())
-        .build()
+fn describe_ctx<'a>(graph: &'a TokenGraph, dir: &'a Path) -> UpdateCtx<'a> {
+    update_ctx_builder(graph).components_dir(dir).build()
 }
 
 fn submit_describe(model: &mut Model, ctx: &UpdateCtx<'_>, id: &str) {
@@ -288,6 +286,144 @@ fn g_key_resets_both_scroll_and_h_scroll() {
     if let ActiveView::Describe(ref dv) = model.active_view {
         assert_eq!(dv.scroll, 0, "g should reset vertical scroll to 0");
         assert_eq!(dv.h_scroll, 0, "g should reset horizontal scroll to 0");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+// ── Arrow-key aliases ─────────────────────────────────────────────────────────
+
+#[test]
+fn right_arrow_advances_h_scroll_like_l() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(wide_describe());
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Right)), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.h_scroll, 4, "Right arrow should advance h_scroll by 4");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+#[test]
+fn left_arrow_decrements_h_scroll_like_h() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    let mut dv = wide_describe();
+    dv.h_scroll = 8;
+    model.active_view = ActiveView::Describe(dv);
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Left)), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.h_scroll, 4, "Left arrow should decrement h_scroll by 4");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+// ── Saturation boundaries ─────────────────────────────────────────────────────
+
+#[test]
+fn h_key_at_zero_stays_zero() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(wide_describe()); // h_scroll starts at 0
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('h'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.h_scroll, 0, "h at 0 should stay at 0 (saturating_sub)");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+#[test]
+fn l_key_clamps_at_max_line_width() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    let mut dv = wide_describe();
+    // Seed h_scroll well past the actual max so a single 'l' must clamp.
+    dv.h_scroll = u16::MAX - 4;
+    model.active_view = ActiveView::Describe(dv);
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        // wide_describe() produces one line: `{ "content": "<200 x's>" }` = 217 display
+        // columns, so max_line_width() == 217 and the cap is 216.
+        assert!(
+            dv.h_scroll <= 216,
+            "l should clamp h_scroll at max_line_width - 1 (got {})",
+            dv.h_scroll
+        );
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+// ── Shift-G resets h_scroll ───────────────────────────────────────────────────
+
+#[test]
+fn shift_g_resets_h_scroll_to_zero() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    let mut dv = wide_describe();
+    dv.scroll = 0;
+    dv.h_scroll = 16;
+    model.active_view = ActiveView::Describe(dv);
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('G'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.h_scroll, 0, "G should reset h_scroll to 0");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+// ── Unicode display-column width ──────────────────────────────────────────────
+
+/// Build a DescribeView whose longest line consists of wide (CJK) glyphs.
+/// "宽" is 1 char but 2 terminal display columns.  Ten of them == 20 display cols.
+/// Wrapped in minimal JSON that keeps the line as the widest one: `{"v":"宽宽…"}`.
+/// The full line is ~28 display columns wide (14 ASCII + 20 CJK = 34 cols).
+fn cjk_describe() -> DescribeView {
+    let wide_chars = "宽".repeat(10); // 10 chars, 20 display columns
+    DescribeView {
+        component: "cjk".to_string(),
+        pretty_json: format!("{{ \"v\": \"{wide_chars}\" }}"),
+        scroll: 0,
+        h_scroll: 0,
+    }
+}
+
+#[test]
+fn l_scroll_cap_respects_display_columns_not_char_count() {
+    // If the cap used chars().count() it would stop at 13 (the ASCII wrapper chars).
+    // With unicode-width it stops at ~33 (14 ASCII + 20 CJK display cols - 1).
+    // Seed h_scroll at a value that chars().count() would clamp to but
+    // display-column width would not, then press 'l' and confirm we advance.
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    let mut dv = cjk_describe();
+    // chars().count() of the whole line is ~14; set h_scroll just above that.
+    // A display-column-aware cap (~33) should still allow advancement.
+    dv.h_scroll = 14;
+    model.active_view = ActiveView::Describe(dv);
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert!(
+            dv.h_scroll > 14,
+            "l should advance past the char-count ceiling ({}); display-col cap is higher",
+            dv.h_scroll
+        );
     } else {
         panic!("expected Describe view");
     }

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -180,6 +180,17 @@ fn esc_from_describe_view_returns_to_empty() {
 // ── g/G scroll ────────────────────────────────────────────────────────────────
 
 /// Build a DescribeView with enough lines to make G scrolling observable.
+fn wide_describe() -> DescribeView {
+    // A single long line (200 chars) to exercise horizontal scroll.
+    let long_value = "x".repeat(200);
+    DescribeView {
+        component: "wide".to_string(),
+        pretty_json: format!("{{ \"content\": \"{long_value}\" }}"),
+        scroll: 0,
+        h_scroll: 0,
+    }
+}
+
 fn multi_line_describe() -> DescribeView {
     let json = (0..30)
         .map(|i| format!("  \"line{i}\": {i}"))
@@ -189,6 +200,7 @@ fn multi_line_describe() -> DescribeView {
         component: "test".to_string(),
         pretty_json: format!("{{\n{json}\n}}"),
         scroll: 0,
+        h_scroll: 0,
     }
 }
 
@@ -225,6 +237,57 @@ fn shift_g_key_scrolls_describe_to_bottom() {
             "G should scroll describe toward bottom (got scroll={})",
             dv.scroll
         );
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+#[test]
+fn l_key_advances_h_scroll_by_4() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(wide_describe());
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.h_scroll, 4, "l should advance h_scroll by 4");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+#[test]
+fn h_key_decrements_h_scroll() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    let mut dv = wide_describe();
+    dv.h_scroll = 8;
+    model.active_view = ActiveView::Describe(dv);
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('h'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.h_scroll, 4, "h should decrement h_scroll by 4");
+    } else {
+        panic!("expected Describe view");
+    }
+}
+
+#[test]
+fn g_key_resets_both_scroll_and_h_scroll() {
+    let graph = TokenGraph::default();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    let mut dv = wide_describe();
+    dv.scroll = 5;
+    dv.h_scroll = 12;
+    model.active_view = ActiveView::Describe(dv);
+    model.close_palette();
+    update(&mut model, Message::Key(key(KeyCode::Char('g'))), &ctx);
+    if let ActiveView::Describe(ref dv) = model.active_view {
+        assert_eq!(dv.scroll, 0, "g should reset vertical scroll to 0");
+        assert_eq!(dv.h_scroll, 0, "g should reset horizontal scroll to 0");
     } else {
         panic!("expected Describe view");
     }

--- a/sdk/tui/tests/describe.rs
+++ b/sdk/tui/tests/describe.rs
@@ -348,16 +348,18 @@ fn l_key_clamps_at_max_line_width() {
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
     let mut dv = wide_describe();
-    // Seed h_scroll well past the actual max so a single 'l' must clamp.
-    dv.h_scroll = u16::MAX - 4;
+    // Seed h_scroll at u16::MAX - 1, one step below the overflow boundary.
+    // With plain `+` this would overflow on the +4 add before `.min()` runs.
+    // With saturating_add it must clamp at max_line_width - 1 instead.
+    // wide_describe() produces one line: `{ "content": "<200 x's>" }` = 217 display
+    // columns, so max_line_width() == 217 and the cap is 216.
+    dv.h_scroll = u16::MAX - 1;
     model.active_view = ActiveView::Describe(dv);
     model.close_palette();
     update(&mut model, Message::Key(key(KeyCode::Char('l'))), &ctx);
     if let ActiveView::Describe(ref dv) = model.active_view {
-        // wide_describe() produces one line: `{ "content": "<200 x's>" }` = 217 display
-        // columns, so max_line_width() == 217 and the cap is 216.
-        assert!(
-            dv.h_scroll <= 216,
+        assert_eq!(
+            dv.h_scroll, 216,
             "l should clamp h_scroll at max_line_width - 1 (got {})",
             dv.h_scroll
         );

--- a/sdk/tui/tests/m5.rs
+++ b/sdk/tui/tests/m5.rs
@@ -212,6 +212,7 @@ fn wheel_scroll_down_increments_describe_scroll() {
         component: "button".to_string(),
         pretty_json: "{}".to_string(),
         scroll: 0,
+        h_scroll: 0,
     });
     update(
         &mut model,

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -312,6 +312,7 @@ fn describe_view_footer_hint_includes_g_g() {
         component: "button".to_string(),
         pretty_json: "{\n  \"name\": \"button\"\n}".to_string(),
         scroll: 0,
+        h_scroll: 0,
     });
     let buf = render_to_buffer(&mut model, W, H);
     let hint_row = find_row_containing(&buf, "j/k scroll", W, H);


### PR DESCRIPTION
## Description

Adds horizontal scroll to the TUI describe view. Long JSON lines (component `content` prose, long property values) were hard-truncated at the terminal right edge with no way to view the rest. This wires up ratatui's native `Paragraph::scroll` horizontal offset — which was already supported but hardcoded to `0`.

## Related Issue

Closes #8y7 (beads: spectrum-design-data-8y7)

## Motivation and Context

Long JSON lines in the describe view were unreadable — cut off mid-value with no scroll indicator and no way to pan. This follows the ranger/vim/pager convention of h/l for horizontal navigation.

## How Has This Been Tested?

- `cargo test` — all 24 test suites pass (zero failures)
- 3 new key-handler tests added in `tests/describe.rs`: `l_key_advances_h_scroll_by_4`, `h_key_decrements_h_scroll`, `g_key_resets_both_scroll_and_h_scroll`
- LOC budget test (`tests/budget.rs`, 800-line cap) still passes; `src/update.rs` is at 691 lines

## Screenshots (if appropriate):

N/A — TUI feature; verified via deterministic buffer tests.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.