### PR TITLE
feat(tui): modal consolidation + auto-dismissing toast overlay

### DIFF
--- a/.changeset/tui-modal-toast.md
+++ b/.changeset/tui-modal-toast.md
@@ -1,0 +1,21 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Add auto-dismissing toast overlay and consolidate modal popup boilerplate.
+
+- **sdk/tui/Cargo.toml**: add `tui-popup = "0.7"`.
+- **sdk/tui/src/model/views.rs** (`Toast`): new type reusing `StatusKind` for
+  severity; auto-dismissed by a subscription timer, not the persistent status line.
+- **sdk/tui/src/model.rs** (`toast`, `set_toast`, `clear_toast`, `toast()`): toast
+  field and accessors alongside the existing `status_message`.
+- **sdk/tui/src/message.rs** (`ToastExpired`): unit variant emitted when the toast
+  timer fires; clears the model toast in `update`.
+- **sdk/tui/src/subscription.rs** (`TOAST_DURATION`, `subscriptions`): 3 s duration
+  const; `Named("toast")` interval gated on `model.toast().is_some()` — starts and
+  stops automatically via `Subscriptions::diff`.
+- **sdk/tui/src/update.rs**: handle `ToastExpired`; `ClipboardDone(None)` now
+  shows a "✓ copied" toast instead of silently succeeding.
+- **sdk/tui/src/view.rs** (`modal_frame`): shared helper replaces duplicated
+  `centered_rect + Clear` across all four modals; toast rendered via `tui-popup`
+  `Popup` in the right half of the active view; Help border uses `border::ROUNDED`.

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -515,12 +515,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -538,11 +562,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -560,6 +595,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -581,6 +627,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_setters"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e6f6fa1f03c14ae082120b84b3c7fbd7b8588d924cf2d7c3daf9afd49df8b9"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -644,6 +702,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tui-input",
+ "tui-popup",
  "unicode-width 0.2.2",
  "uuid",
 ]
@@ -1412,7 +1471,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3438,6 +3497,19 @@ dependencies = [
  "ratatui",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "tui-popup"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cef964ca43a21027744e3072a6f24106bfae6d7945a80ec7d41259f69298081"
+dependencies = [
+ "derive-getters",
+ "derive_setters",
+ "document-features",
+ "ratatui-core",
+ "ratatui-widgets",
 ]
 
 [[package]]

--- a/sdk/tui/Cargo.toml
+++ b/sdk/tui/Cargo.toml
@@ -14,6 +14,7 @@ design-data-core = { path = "../core" }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.29", features = ["serde"] }
 tui-input = "0.15"
+tui-popup = "0.7"
 clap = { version = "4.5", features = ["derive"] }
 miette = { version = "7.4", features = ["fancy"] }
 thiserror = "2.0"

--- a/sdk/tui/src/message.rs
+++ b/sdk/tui/src/message.rs
@@ -67,6 +67,13 @@ pub enum Message {
     /// The find wizard was dismissed.
     FindCancel,
 
+    // ── Toast ─────────────────────────────────────────────────────────────────
+    /// The toast auto-dismiss timer fired; clear the active toast from the model.
+    ///
+    /// Emitted by the [`SubscriptionId::Named("toast")`] interval. Once the toast
+    /// is cleared the subscription disappears on the next frame.
+    ToastExpired,
+
     // ── Side-effect completions ───────────────────────────────────────────────
     /// A write-token operation completed. `Ok` carries the assembled token name
     /// and the written path (so the confirmation can name the token);

--- a/sdk/tui/src/model.rs
+++ b/sdk/tui/src/model.rs
@@ -18,7 +18,7 @@ pub(crate) mod mode;
 pub(crate) mod views;
 
 use self::mode::{BrowsingState, ModalState, Mode, MouseMode, PaletteState};
-use crate::app::{ActiveView, HitRegion, Modal, StatusMessage};
+use crate::app::{ActiveView, HitRegion, Modal, StatusKind, StatusMessage, Toast};
 
 /// Top-level application state for the TEA runtime.
 pub struct Model {
@@ -30,6 +30,8 @@ pub struct Model {
     pub active_view: ActiveView,
     /// One-line status message; `None` when hidden.
     pub status_message: Option<StatusMessage>,
+    /// Transient overlay toast; auto-dismissed by the toast subscription timer.
+    pub toast: Option<Toast>,
     /// Text queued for clipboard write via `Task::Cmd`.
     pub pending_yank: Option<String>,
     /// Previously submitted palette commands, newest first.
@@ -67,6 +69,7 @@ impl Model {
             quit: false,
             active_view: ActiveView::Empty,
             status_message: None,
+            toast: None,
             pending_yank: None,
             palette_history: Vec::new(),
             hit_regions: Vec::new(),
@@ -163,6 +166,31 @@ impl Model {
         } else {
             None
         }
+    }
+
+    // ── Toast helpers ─────────────────────────────────────────────────────────
+
+    /// Display a transient overlay message. Replaces any currently-showing toast.
+    ///
+    /// The toast is auto-dismissed by the [`SubscriptionId::Named("toast")`]
+    /// interval in [`subscriptions`]; callers need not clear it manually.
+    ///
+    /// [`subscriptions`]: crate::subscription::subscriptions
+    pub fn set_toast(&mut self, text: impl Into<String>, kind: StatusKind) {
+        self.toast = Some(Toast {
+            text: text.into(),
+            kind,
+        });
+    }
+
+    /// Clear the active toast. Called by the `ToastExpired` message handler.
+    pub fn clear_toast(&mut self) {
+        self.toast = None;
+    }
+
+    /// Immutable reference to the active toast, if any.
+    pub fn toast(&self) -> Option<&Toast> {
+        self.toast.as_ref()
     }
 
     // ── Palette accessors ─────────────────────────────────────────────────────

--- a/sdk/tui/src/model/views.rs
+++ b/sdk/tui/src/model/views.rs
@@ -88,21 +88,6 @@ pub struct Toast {
     pub kind: StatusKind,
 }
 
-impl Toast {
-    pub fn info(text: impl Into<String>) -> Self {
-        Self {
-            text: text.into(),
-            kind: StatusKind::Info,
-        }
-    }
-    pub fn error(text: impl Into<String>) -> Self {
-        Self {
-            text: text.into(),
-            kind: StatusKind::Error,
-        }
-    }
-}
-
 // ── View state types ──────────────────────────────────────────────────────────
 
 /// One row in the query results table.

--- a/sdk/tui/src/model/views.rs
+++ b/sdk/tui/src/model/views.rs
@@ -75,6 +75,34 @@ impl StatusMessage {
     }
 }
 
+/// A transient overlay message that auto-dismisses after [`TOAST_DURATION`].
+///
+/// Unlike [`StatusMessage`] (which persists until overwritten), a toast is
+/// cleared automatically by a [`SubscriptionId::Named("toast")`] interval that
+/// fires once and then disappears when the model has no toast.
+///
+/// [`TOAST_DURATION`]: crate::subscription::TOAST_DURATION
+#[derive(Debug, Clone)]
+pub struct Toast {
+    pub text: String,
+    pub kind: StatusKind,
+}
+
+impl Toast {
+    pub fn info(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: StatusKind::Info,
+        }
+    }
+    pub fn error(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: StatusKind::Error,
+        }
+    }
+}
+
 // ── View state types ──────────────────────────────────────────────────────────
 
 /// One row in the query results table.

--- a/sdk/tui/src/subscription.rs
+++ b/sdk/tui/src/subscription.rs
@@ -32,6 +32,9 @@ use crate::model::Model;
 /// The runtime tick cadence (~60 fps), used by the default [`subscriptions`].
 pub const TICK_INTERVAL: Duration = Duration::from_millis(16);
 
+/// How long a toast overlay stays visible before auto-dismissal.
+pub const TOAST_DURATION: Duration = Duration::from_millis(3_000);
+
 /// Stable identity for a subscription. Two subscriptions with the same id are
 /// the "same" stream across frames; the runtime starts a stream when its id
 /// first appears and stops it when the id disappears.
@@ -169,13 +172,25 @@ impl<M> Subscriptions<M> {
 
 /// The subscriptions the runtime should keep active for `model`.
 ///
-/// Currently a single periodic [`SubscriptionId::Tick`]; future external event
-/// sources (file watches, async streams) slot in here and are started/stopped
-/// automatically by [`Subscriptions::diff`].
-pub fn subscriptions(_model: &Model) -> Vec<Subscription<Message>> {
-    vec![Subscription::interval(
+/// Returns at minimum a periodic [`SubscriptionId::Tick`]. When a toast is
+/// active, a [`SubscriptionId::Named("toast")`] interval is added; it emits
+/// [`Message::ToastExpired`] once after [`TOAST_DURATION`] and then disappears
+/// automatically on the next [`Subscriptions::diff`] (because [`model.toast`]
+/// is cleared by the `ToastExpired` handler before the next frame).
+///
+/// [`model.toast`]: crate::model::Model::toast
+pub fn subscriptions(model: &Model) -> Vec<Subscription<Message>> {
+    let mut subs = vec![Subscription::interval(
         SubscriptionId::Tick,
         TICK_INTERVAL,
         || Message::Tick,
-    )]
+    )];
+    if model.toast().is_some() {
+        subs.push(Subscription::interval(
+            SubscriptionId::Named("toast"),
+            TOAST_DURATION,
+            || Message::ToastExpired,
+        ));
+    }
+    subs
 }

--- a/sdk/tui/src/subscription.rs
+++ b/sdk/tui/src/subscription.rs
@@ -173,10 +173,12 @@ impl<M> Subscriptions<M> {
 /// The subscriptions the runtime should keep active for `model`.
 ///
 /// Returns at minimum a periodic [`SubscriptionId::Tick`]. When a toast is
-/// active, a [`SubscriptionId::Named("toast")`] interval is added; it emits
-/// [`Message::ToastExpired`] once after [`TOAST_DURATION`] and then disappears
-/// automatically on the next [`Subscriptions::diff`] (because [`model.toast`]
-/// is cleared by the `ToastExpired` handler before the next frame).
+/// active, a [`SubscriptionId::Named("toast")`] interval is added; it fires
+/// at [`TOAST_DURATION`] cadence. In practice it behaves as a one-shot: the
+/// first fire dispatches [`Message::ToastExpired`], which clears the toast,
+/// so the next [`Subscriptions::diff`] removes the subscription before it
+/// can fire a second time. The one-shot property is emergent — it relies on
+/// `diff` being called after every message, which the runtime guarantees.
 ///
 /// [`model.toast`]: crate::model::Model::toast
 pub fn subscriptions(model: &Model) -> Vec<Subscription<Message>> {

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -29,7 +29,7 @@ use design_data_core::write::write_token;
 use tui_input::backend::crossterm::EventHandler;
 
 use crate::app::{
-    move_table_selection, select_edge, ActiveView, Modal, StatusMessage, ValidateView,
+    move_table_selection, select_edge, ActiveView, Modal, StatusKind, StatusMessage, ValidateView,
 };
 use crate::clipboard::write_clipboard;
 use crate::command::Command;
@@ -92,6 +92,11 @@ pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Mess
                 }
             }
         }
+        // Auto-dismiss the toast overlay when its timer fires.
+        Message::ToastExpired => {
+            model.clear_toast();
+            Task::none()
+        }
         // Synthetic modal messages exist in Message for replay/injection use.
         // The Key path handles them via modal delegation above; no-op here.
         Message::WizardAdvance
@@ -102,8 +107,12 @@ pub fn update(model: &mut Model, msg: Message, ctx: &UpdateCtx<'_>) -> Task<Mess
         | Message::NamingCancel
         | Message::FindOpenResults
         | Message::FindCancel
-        | Message::Tick
-        | Message::ClipboardDone(None) => Task::none(),
+        | Message::Tick => Task::none(),
+        Message::ClipboardDone(None) => {
+            // Clipboard write succeeded — show a transient "copied" toast.
+            model.set_toast("✓ copied", StatusKind::Info);
+            Task::none()
+        }
         Message::ClipboardDone(Some(err)) => {
             model.status_message = Some(StatusMessage::error(format!(
                 "clipboard unavailable: {err}"
@@ -571,7 +580,8 @@ fn route_modal_key(
                 model.status_message = Some(StatusMessage::info("naming wizard cancelled"));
             }
             NamingEvent::Copy(name) => {
-                model.status_message = Some(StatusMessage::info(format!("copied: {name}")));
+                // Toast shown on ClipboardDone(None); clear any stale status message.
+                model.status_message = None;
                 let text = name.clone();
                 return Task::cmd(move || {
                     let err = write_clipboard(&text).err().map(|e| e.to_string());

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -11,10 +11,12 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
+    symbols::border,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
+use tui_popup::Popup;
 
 mod find;
 mod home;
@@ -51,6 +53,17 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vert[1])[1]
+}
+
+/// Prepare a centered modal overlay: compute the popup rect, punch a `Clear`
+/// hole in the background, and return the rect for the caller to render into.
+///
+/// All modals that use percentage-based sizing route through here so the
+/// `centered_rect` + `Clear` boilerplate lives in exactly one place.
+fn modal_frame(f: &mut Frame, area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    let popup_area = centered_rect(percent_x, percent_y, area);
+    f.render_widget(Clear, popup_area);
+    popup_area
 }
 
 /// Render a complete frame: primer header, active view, status bar, palette prompt, and any
@@ -120,22 +133,40 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
     // chunk[3] is kept as a 1-row reserve to stay in sync with compute_hit_regions.
     // The palette prompt lives inside render_home (always-on home palette).
 
-    // Overlay modal (rendered last so it appears on top).
+    // Toast overlay — floats over the active view, below any open modal.
+    // Rendered before the modal block so an open modal visually wins.
+    if let Some(ref toast) = model.toast {
+        let color = match toast.kind {
+            StatusKind::Info => theme.ok,
+            StatusKind::Error => theme.error,
+        };
+        // Position the toast in the right half of the active view area so it
+        // doesn't obscure table headers or the left-aligned content.
+        let right_half = Rect::new(
+            chunks[1].x + chunks[1].width / 2,
+            chunks[1].y,
+            chunks[1].width - chunks[1].width / 2,
+            chunks[1].height,
+        );
+        let popup = Popup::new(format!(" {} ", toast.text))
+            .border_set(border::ROUNDED)
+            .border_style(Style::default().fg(color));
+        frame.render_widget(popup, right_half);
+    }
+
+    // Overlay modal (rendered last so it appears on top of everything).
     if let Some(modal) = model.modal_mut() {
         match modal {
             Modal::Find(ref mut fs) => {
-                let popup_area = centered_rect(82, 85, area);
-                frame.render_widget(Clear, popup_area);
+                let popup_area = modal_frame(frame, area, 82, 85);
                 render_find(frame, fs, popup_area, theme);
             }
             Modal::Wizard(ref mut ws) => {
-                let popup_area = centered_rect(82, 85, area);
-                frame.render_widget(Clear, popup_area);
+                let popup_area = modal_frame(frame, area, 82, 85);
                 render_wizard(frame, ws, popup_area, theme);
             }
             Modal::Naming(ref mut ns) => {
-                let popup_area = centered_rect(82, 85, area);
-                frame.render_widget(Clear, popup_area);
+                let popup_area = modal_frame(frame, area, 82, 85);
                 render_naming(frame, ns, popup_area, theme);
             }
             Modal::Help(ref hm) => {
@@ -145,13 +176,16 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
     }
 }
 
+/// Render the Help overlay. Uses a scroll-supporting `Paragraph` because the
+/// help text (~80 lines) exceeds a typical terminal height and needs scrolling.
+/// The modal background is cleared via [`modal_frame`].
 fn render_help_modal(f: &mut Frame<'_>, scroll: u16, area: Rect) {
-    let popup_area = centered_rect(80, 90, area);
-    f.render_widget(Clear, popup_area);
+    let popup_area = modal_frame(f, area, 80, 90);
     let para = Paragraph::new(HELP_TEXT)
         .block(
             Block::default()
                 .borders(Borders::ALL)
+                .border_set(border::ROUNDED)
                 .title(" Help  ?/Esc to close "),
         )
         .scroll((scroll, 0));

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -213,12 +213,12 @@ fn copy_event_sets_pending_yank_and_status() {
         model.pending_yank.is_none(),
         "pending_yank should not be set — clipboard is via Task::Cmd"
     );
-    let msg = model
-        .status_message
-        .as_ref()
-        .map(|m| m.text.as_str())
-        .unwrap_or("");
-    assert!(msg.contains("copied"), "expected 'copied' in status: {msg}");
+    // The "copied" confirmation is now a toast (set when ClipboardDone(None) arrives),
+    // not a persistent status_message.  The status message should be clear here.
+    assert!(
+        model.status_message.is_none(),
+        "status_message should be clear after copy (confirmation is a toast)"
+    );
     assert!(
         model.is_modal_open(),
         "Copy should not close the Naming modal"

--- a/sdk/tui/tests/subscription.rs
+++ b/sdk/tui/tests/subscription.rs
@@ -15,7 +15,8 @@
 
 use std::time::Instant;
 
-use design_data_tui::subscription::TICK_INTERVAL;
+use design_data_tui::app::StatusKind;
+use design_data_tui::subscription::{TICK_INTERVAL, TOAST_DURATION};
 use design_data_tui::{subscriptions, Message, Model, SubscriptionId, Subscriptions};
 
 #[test]
@@ -162,4 +163,87 @@ fn subscription_poll_does_not_emit_before_interval_elapses() {
             "tick must not fire before interval at step {i}"
         );
     }
+}
+
+// ── Toast subscription tests ──────────────────────────────────────────────────
+
+#[test]
+fn toast_subscription_absent_without_toast() {
+    // With no toast, `subscriptions` should return only the Tick stream.
+    let model = Model::new();
+    let ids: Vec<SubscriptionId> = subscriptions(&model)
+        .into_iter()
+        .map(|s| s.id().clone())
+        .collect();
+    assert!(!ids.contains(&SubscriptionId::Named("toast")));
+    assert!(ids.contains(&SubscriptionId::Tick));
+}
+
+#[test]
+fn toast_subscription_present_with_toast() {
+    let mut model = Model::new();
+    model.set_toast("✓ copied", StatusKind::Info);
+    let ids: Vec<SubscriptionId> = subscriptions(&model)
+        .into_iter()
+        .map(|s| s.id().clone())
+        .collect();
+    assert!(
+        ids.contains(&SubscriptionId::Named("toast")),
+        "Named('toast') should appear when model has an active toast"
+    );
+}
+
+#[test]
+fn toast_subscription_fires_toast_expired_after_duration() {
+    let mut model = Model::new();
+    model.set_toast("hello", StatusKind::Info);
+
+    let mut subs: Subscriptions<Message> = Subscriptions::new();
+    let start = Instant::now();
+    subs.diff(subscriptions(&model), start);
+
+    // Before TOAST_DURATION elapses: no fire.
+    assert!(
+        subs.poll(start).is_empty(),
+        "toast must not fire immediately"
+    );
+
+    // Exactly at TOAST_DURATION: at least one ToastExpired fires.
+    // (Tick also fires because TOAST_DURATION >> TICK_INTERVAL; filter for the
+    // specific variant we care about.)
+    let at_expiry = start + TOAST_DURATION;
+    let fired = subs.poll(at_expiry);
+    let expired_count = fired
+        .iter()
+        .filter(|m| matches!(m, Message::ToastExpired))
+        .count();
+    assert_eq!(
+        expired_count, 1,
+        "exactly one ToastExpired should fire at expiry (got {:?})",
+        fired
+    );
+}
+
+#[test]
+fn toast_subscription_disappears_after_model_clears_toast() {
+    let mut model = Model::new();
+    model.set_toast("gone soon", StatusKind::Info);
+
+    let mut subs: Subscriptions<Message> = Subscriptions::new();
+    let now = Instant::now();
+    subs.diff(subscriptions(&model), now);
+    assert!(
+        subs.active_ids().contains(&SubscriptionId::Named("toast")),
+        "Named('toast') should be active while toast is set"
+    );
+
+    // Simulate ToastExpired handler clearing the toast.
+    model.clear_toast();
+
+    // Next diff with toast-free model removes the Named("toast") stream.
+    subs.diff(subscriptions(&model), now);
+    assert!(
+        !subs.active_ids().contains(&SubscriptionId::Named("toast")),
+        "Named('toast') should be gone after toast is cleared"
+    );
 }

--- a/sdk/tui/tests/toast.rs
+++ b/sdk/tui/tests/toast.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Toast overlay render tests and update-handler tests.
+//!
+//! Covers: toast appears in the rendered buffer, disappears after ToastExpired,
+//! and the existing bottom-strip/help invariants are unaffected.
+
+mod common;
+use common::{make_graph_with_tokens, render_to_buffer, update_ctx};
+
+use crossterm::event::KeyCode;
+use design_data_tui::app::StatusKind;
+use design_data_tui::{update, Message, Model};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const W: u16 = 80;
+const H: u16 = 24;
+
+fn row_str(buf: &ratatui::buffer::Buffer, y: u16, w: u16) -> String {
+    (0..w)
+        .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+        .collect()
+}
+
+fn any_row_contains(buf: &ratatui::buffer::Buffer, needle: &str, w: u16, h: u16) -> bool {
+    (0..h).any(|y| row_str(buf, y, w).contains(needle))
+}
+
+fn key(code: KeyCode) -> crossterm::event::KeyEvent {
+    crossterm::event::KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)
+}
+
+// ── Toast render ──────────────────────────────────────────────────────────────
+
+#[test]
+fn toast_text_appears_in_buffer_when_set() {
+    let mut model = Model::new();
+    model.set_toast("✓ copied", StatusKind::Info);
+    let buf = render_to_buffer(&mut model, W, H);
+    assert!(
+        any_row_contains(&buf, "copied", W, H),
+        "toast text should appear somewhere in the rendered buffer"
+    );
+}
+
+#[test]
+fn no_toast_renders_no_copied_text_by_default() {
+    let mut model = Model::new();
+    // No toast set; "copied" must not appear on a fresh home screen.
+    let buf = render_to_buffer(&mut model, W, H);
+    assert!(
+        !any_row_contains(&buf, "copied", W, H),
+        "no toast should be visible on a fresh model"
+    );
+}
+
+#[test]
+fn toast_text_absent_after_clear() {
+    let mut model = Model::new();
+    model.set_toast("✓ copied", StatusKind::Info);
+    model.clear_toast();
+    let buf = render_to_buffer(&mut model, W, H);
+    assert!(
+        !any_row_contains(&buf, "copied", W, H),
+        "cleared toast must not appear in buffer"
+    );
+}
+
+// ── Update: ToastExpired ──────────────────────────────────────────────────────
+
+#[test]
+fn toast_expired_clears_toast() {
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.set_toast("going away", StatusKind::Info);
+    assert!(model.toast().is_some());
+
+    update(&mut model, Message::ToastExpired, &ctx);
+
+    assert!(
+        model.toast().is_none(),
+        "ToastExpired must clear model.toast"
+    );
+}
+
+#[test]
+fn clipboard_done_none_sets_toast() {
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+
+    // ClipboardDone(None) is the clipboard-write success path.
+    update(&mut model, Message::ClipboardDone(None), &ctx);
+
+    let toast = model
+        .toast()
+        .expect("ClipboardDone(None) should set a toast");
+    assert!(
+        toast.text.contains("copied"),
+        "toast text should mention 'copied', got: {}",
+        toast.text
+    );
+    assert_eq!(toast.kind, StatusKind::Info);
+}
+
+// ── Existing invariant: Help modal still shows title ──────────────────────────
+
+#[test]
+fn help_modal_still_renders_title_after_tui_popup_swap() {
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    assert!(
+        any_row_contains(&buf, "Help", W, H),
+        "Help modal title should still render"
+    );
+}


### PR DESCRIPTION
## Description

Phase 1 of the TUI UX improvement initiative (`spectrum-design-data-may`). Adds an auto-dismissing toast overlay for transient messages (e.g. "✓ copied") and consolidates the duplicated modal popup boilerplate into a single shared helper.

## Related Issue

Closes `spectrum-design-data-5xm` — Phase 1: modal + toast consolidation via tui-popup. Unblocks Phase 2 (`spectrum-design-data-7ga`, autocomplete dropdown).

## Motivation and Context

Two problems in `sdk/tui` before this PR:

1. **Duplicated popup math.** The 82%×85% centered-popup placement (`centered_rect` + `frame.render_widget(Clear, …)`) was copy-pasted across all four modal arms in `view.rs`. A single typo in one copy silently diverges from the others.

2. **No transient messaging.** The only status affordance was `status_message` — a persistent one-liner that stays until the next command overwrites it. Clipboard yanks had no visible confirmation; `ClipboardDone(None)` was a silent no-op.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — all 25 test suites pass (0 failures).
- `cargo clippy -p design-data-tui` — no warnings.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset clean.
- Budget test (`tests/budget.rs`) confirms all src files under 800 LOC and no async in render path.
- New tests added: `tests/toast.rs` (7 render + update tests), 4 new timer tests in `tests/subscription.rs`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

**What changed:**

| File | Change |
|---|---|
| `sdk/tui/Cargo.toml` | Add `tui-popup = "0.7"` |
| `src/model/views.rs` | New `Toast { text, kind }` struct (reuses `StatusKind`) |
| `src/model.rs` | `toast: Option<Toast>` field + `set_toast` / `clear_toast` / `toast()` |
| `src/message.rs` | New `Message::ToastExpired` unit variant (within 128-byte budget) |
| `src/subscription.rs` | `TOAST_DURATION = 3 s` const; `Named("toast")` interval gated on `model.toast().is_some()` |
| `src/update.rs` | Handle `ToastExpired`; `ClipboardDone(None)` → "✓ copied" toast instead of no-op |
| `src/view.rs` | `modal_frame()` shared helper; toast via `tui-popup::Popup` in right half of active view; Help border → `ROUNDED` |
| `tests/toast.rs` | New: 7 render + update tests |
| `tests/subscription.rs` | +4 toast timer tests |
| `tests/naming.rs` | Updated: "copied" confirmation now arrives as toast, not status_message |