### PR TITLE
feat(tui): fuzzy autocomplete with matched-char highlights for command palette

### DIFF
--- a/.changeset/tui-fuzzy-palette.md
+++ b/.changeset/tui-fuzzy-palette.md
@@ -1,0 +1,15 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Upgrade command palette to fuzzy subsequence matching with matched-char highlights.
+
+- **sdk/core/src/query.rs** (`subsequence_match`): new sibling of `subsequence_score`
+  returning matched character indices alongside the score; `subsequence_score` now
+  delegates to it.
+- **sdk/tui/src/command.rs** (`CommandMatch`, `Command::matches`): fuzzy-ranked candidate
+  list sorted best-score-first; `Command::filter` rewritten as a thin wrapper so all
+  callers (Tab/Enter completion, `update.rs`) continue to work unchanged.
+- **sdk/tui/src/view/home.rs** (`render_home`): switches to `Command::matches` and renders
+  each candidate name as per-character spans, underling matched positions for unselected
+  rows and applying bold accent for the selected/top-hint row.

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -369,16 +369,21 @@ pub fn filter_with_index<'a>(
 /// after one of these (or at the start of the string) earns a boundary bonus.
 const BOUNDARY_CHARS: &[char] = &['-', '_', '.', '[', ']', ' ', ',', '='];
 
-/// Score `needle` as a subsequence of `haystack` (both matched case-insensitively).
+/// Score `needle` as a subsequence of `haystack` (both matched case-insensitively),
+/// and return the matched char indices into `haystack`'s character sequence.
 ///
 /// Returns `None` when `needle` is not a subsequence of `haystack`.  An empty
-/// needle matches everything with a score of `0`.  Higher scores indicate
-/// tighter matches: each matched character scores `1`, with a `+3` bonus for
-/// runs of consecutive matches and a `+5` bonus for matches landing on a word
-/// boundary (so `btnbg` ranks `button-background` above incidental hits).
-pub fn subsequence_score(haystack: &str, needle: &str) -> Option<i32> {
+/// needle matches everything with score `0` and an empty index list.  Higher
+/// scores indicate tighter matches: each matched character scores `1`, with a
+/// `+3` bonus for runs of consecutive matches and a `+5` bonus for matches
+/// landing on a word boundary (so `btnbg` ranks `button-background` above
+/// incidental hits).
+///
+/// The returned indices are positions in the **lowercased** char sequence of
+/// `haystack`, which is 1:1 with the original positions for ASCII input.
+pub fn subsequence_match(haystack: &str, needle: &str) -> Option<(i32, Vec<usize>)> {
     if needle.is_empty() {
-        return Some(0);
+        return Some((0, vec![]));
     }
     let hay: Vec<char> = haystack.chars().flat_map(char::to_lowercase).collect();
     let pat: Vec<char> = needle.chars().flat_map(char::to_lowercase).collect();
@@ -386,6 +391,7 @@ pub fn subsequence_score(haystack: &str, needle: &str) -> Option<i32> {
     let mut score: i32 = 0;
     let mut hi: usize = 0;
     let mut last_match: Option<usize> = None;
+    let mut indices: Vec<usize> = Vec::with_capacity(pat.len());
 
     for &pc in &pat {
         let mut found = false;
@@ -403,6 +409,7 @@ pub fn subsequence_score(haystack: &str, needle: &str) -> Option<i32> {
                     score += 3;
                 }
                 last_match = Some(idx);
+                indices.push(idx);
                 found = true;
                 break;
             }
@@ -412,7 +419,21 @@ pub fn subsequence_score(haystack: &str, needle: &str) -> Option<i32> {
         }
     }
 
-    Some(score)
+    Some((score, indices))
+}
+
+/// Score `needle` as a subsequence of `haystack` (both matched case-insensitively).
+///
+/// Returns `None` when `needle` is not a subsequence of `haystack`.  An empty
+/// needle matches everything with a score of `0`.  Higher scores indicate
+/// tighter matches: each matched character scores `1`, with a `+3` bonus for
+/// runs of consecutive matches and a `+5` bonus for matches landing on a word
+/// boundary (so `btnbg` ranks `button-background` above incidental hits).
+///
+/// Use [`subsequence_match`] instead when matched-character positions are needed
+/// (e.g. for highlight rendering).
+pub fn subsequence_score(haystack: &str, needle: &str) -> Option<i32> {
+    subsequence_match(haystack, needle).map(|(score, _)| score)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -797,5 +818,59 @@ mod tests {
         let idx = build_index(&g, "component");
         assert_eq!(idx.get("button").map(|v| v.len()), Some(2));
         assert_eq!(idx.get("checkbox").map(|v| v.len()), Some(1));
+    }
+
+    // ── subsequence_match / subsequence_score ───────────────────────────
+
+    #[test]
+    fn subsequence_match_empty_needle() {
+        let result = super::subsequence_match("anything", "");
+        assert_eq!(result, Some((0, vec![])));
+    }
+
+    #[test]
+    fn subsequence_match_no_match_returns_none() {
+        assert!(super::subsequence_match("query", "xyz").is_none());
+        // Out-of-order subsequence must also fail.
+        assert!(super::subsequence_match("abc", "cba").is_none());
+    }
+
+    #[test]
+    fn subsequence_match_returns_correct_indices() {
+        // "query" chars: q=0, u=1, e=2, r=3, y=4.
+        // "qry" matches: q→0, r→3, y→4.
+        let (score, indices) = super::subsequence_match("query", "qry").unwrap();
+        assert_eq!(indices, vec![0, 3, 4]);
+        assert!(score > 0);
+    }
+
+    #[test]
+    fn subsequence_match_all_chars_consecutive_bonus() {
+        let (tight, _) = super::subsequence_match("validate", "val").unwrap();
+        let (loose, _) = super::subsequence_match("variable", "val").unwrap();
+        // "val" is a prefix of "validate" → consecutive bonus; "variable" spreads.
+        assert!(tight > loose, "tight={tight} loose={loose}");
+    }
+
+    #[test]
+    fn subsequence_match_score_agrees_with_subsequence_score() {
+        let pairs = &[("query", "qry"), ("validate", "vld"), ("resolve", "rsv")];
+        for (hay, needle) in pairs {
+            let via_match = super::subsequence_match(hay, needle).map(|(s, _)| s);
+            let direct = super::subsequence_score(hay, needle);
+            assert_eq!(
+                via_match, direct,
+                "score mismatch for haystack={hay} needle={needle}"
+            );
+        }
+    }
+
+    #[test]
+    fn subsequence_match_boundary_bonus_applies() {
+        // 'd' at the start of "describe" earns the boundary bonus.
+        let (boundary, _) = super::subsequence_match("describe", "d").unwrap();
+        // 'd' in "validate" is mid-word (no boundary before 'd' in "validate").
+        let (mid, _) = super::subsequence_match("validate", "d").unwrap();
+        assert!(boundary > mid, "boundary={boundary} mid={mid}");
     }
 }

--- a/sdk/tui/src/command.rs
+++ b/sdk/tui/src/command.rs
@@ -16,6 +16,11 @@
 //! home-screen `COMMANDS` table in `logo.rs` is kept in lock-step by a
 //! bidirectional sync test (see the `tests` module below). Adding a variant here
 //! is the one place a new command is declared; everything else derives from it.
+//!
+//! Fuzzy matching is provided by [`Command::matches`], which scores and sorts
+//! candidates using [`design_data_core::query::subsequence_match`]. The older
+//! prefix-based [`Command::filter`] is a thin wrapper around it for callers that
+//! don't need highlight indices.
 
 /// Declare the `Command` enum together with its `ALL` list, `canonical()` name,
 /// `aliases()`, and `description()` from a single table.
@@ -79,6 +84,18 @@ define_commands! {
     Quit    => "quit",                    "Quit the TUI",
 }
 
+/// A command candidate returned by [`Command::matches`], carrying the command
+/// variant and the matched character positions in its canonical name for
+/// highlight rendering.
+pub struct CommandMatch {
+    /// The matched command variant.
+    pub command: Command,
+    /// Indices into the canonical name's character sequence that were matched by
+    /// the query needle. Empty when the command matched only via an alias (the
+    /// canonical name still renders, but no chars are highlighted).
+    pub indices: Vec<usize>,
+}
+
 impl Command {
     /// Parse a command token (the part before the first space) into a variant.
     ///
@@ -92,21 +109,75 @@ impl Command {
         })
     }
 
-    /// Return all commands whose canonical name or any alias starts with the
-    /// first whitespace-delimited token of `input` (lowercased). An empty input
-    /// returns all commands. Used by the live command list and Tab autocomplete.
-    pub fn filter(input: &str) -> Vec<Command> {
-        let tok = input.split_whitespace().next().unwrap_or("").to_lowercase();
+    /// Fuzzy-rank commands against the first whitespace-delimited token of
+    /// `input`, returning them sorted best-score-first (stable on ties, so
+    /// `Command::ALL` declaration order is preserved within tied groups).
+    ///
+    /// Each result carries highlight [`indices`][CommandMatch::indices] — the
+    /// positions within the canonical name that matched the needle — for use by
+    /// the renderer. When a command matched only via an alias the canonical name
+    /// is still shown but `indices` is empty.
+    ///
+    /// An empty token (no input or only whitespace) returns all commands in
+    /// `Command::ALL` order with empty indices.
+    pub fn matches(input: &str) -> Vec<CommandMatch> {
+        use design_data_core::query::subsequence_match;
+        use std::cmp::Reverse;
+
+        let tok = input.split_whitespace().next().unwrap_or("");
         if tok.is_empty() {
-            return Command::ALL.to_vec();
+            return Command::ALL
+                .iter()
+                .copied()
+                .map(|c| CommandMatch {
+                    command: c,
+                    indices: vec![],
+                })
+                .collect();
         }
-        Command::ALL
+
+        let mut scored: Vec<(i32, CommandMatch)> = Command::ALL
             .iter()
             .copied()
-            .filter(|c| {
-                c.canonical().starts_with(tok.as_str())
-                    || c.aliases().iter().any(|&a| a.starts_with(tok.as_str()))
+            .filter_map(|cmd| {
+                // Score against canonical name first; fall back to best alias score.
+                let canonical_result = subsequence_match(cmd.canonical(), tok);
+                let (score, indices) = if let Some((s, idx)) = canonical_result {
+                    (s, idx)
+                } else {
+                    // Try aliases; keep highest score but indices stay empty
+                    // (we highlight the canonical name, not the alias).
+                    let alias_score = cmd
+                        .aliases()
+                        .iter()
+                        .filter_map(|&a| subsequence_match(a, tok).map(|(s, _)| s))
+                        .max()?;
+                    (alias_score, vec![])
+                };
+                Some((
+                    score,
+                    CommandMatch {
+                        command: cmd,
+                        indices,
+                    },
+                ))
             })
+            .collect();
+
+        // Stable sort descending by score; ties preserve Command::ALL order.
+        scored.sort_by_key(|(s, _)| Reverse(*s));
+        scored.into_iter().map(|(_, m)| m).collect()
+    }
+
+    /// Return all commands whose canonical name or any alias is a fuzzy match
+    /// for the first whitespace-delimited token of `input`, sorted best-first.
+    ///
+    /// An empty input returns all commands. This is a convenience wrapper around
+    /// [`Command::matches`] for callers that don't need highlight indices.
+    pub fn filter(input: &str) -> Vec<Command> {
+        Command::matches(input)
+            .into_iter()
+            .map(|m| m.command)
             .collect()
     }
 }

--- a/sdk/tui/src/command.rs
+++ b/sdk/tui/src/command.rs
@@ -87,6 +87,7 @@ define_commands! {
 /// A command candidate returned by [`Command::matches`], carrying the command
 /// variant and the matched character positions in its canonical name for
 /// highlight rendering.
+#[derive(Debug, Clone)]
 pub struct CommandMatch {
     /// The matched command variant.
     pub command: Command,
@@ -124,6 +125,8 @@ impl Command {
         use design_data_core::query::subsequence_match;
         use std::cmp::Reverse;
 
+        // No .to_lowercase() needed here: subsequence_match handles
+        // case-insensitivity internally via flat_map(char::to_lowercase).
         let tok = input.split_whitespace().next().unwrap_or("");
         if tok.is_empty() {
             return Command::ALL

--- a/sdk/tui/src/view/home.rs
+++ b/sdk/tui/src/view/home.rs
@@ -120,11 +120,11 @@ pub(crate) fn render_home(
                     .add_modifier(Modifier::BOLD),
                 // Row selected + non-matched: normal accent on selection bg.
                 (true, _, false) => Style::default().fg(theme.accent).bg(theme.selection_bg),
-                // Top-hint (Enter will run) + matched char: bright bold.
+                // Top-hint row (Enter will run): bold for all chars; matched
+                // chars also get underline so fuzzy hits are still visible.
                 (false, true, true) => Style::default()
                     .fg(theme.accent)
-                    .add_modifier(Modifier::BOLD),
-                // Top-hint + non-matched: bold accent without extra emphasis.
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
                 (false, true, false) => Style::default()
                     .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),

--- a/sdk/tui/src/view/home.rs
+++ b/sdk/tui/src/view/home.rs
@@ -20,7 +20,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::command::Command;
+use crate::command::{Command, CommandMatch};
 use crate::logo::LOGO;
 use crate::theme::Theme;
 
@@ -37,11 +37,11 @@ pub(crate) fn render_home(
     const MARGIN: &str = "  ";
     const PROMPT_PREFIX: &str = "> ";
 
-    let filtered = Command::filter(palette_input);
-    // cmd_col: widest canonical name in the filtered set, for alignment.
-    let cmd_col = filtered
+    let candidates: Vec<CommandMatch> = Command::matches(palette_input);
+    // cmd_col: widest canonical name in the candidate set, for alignment.
+    let cmd_col = candidates
         .iter()
-        .map(|c| c.canonical().len())
+        .map(|m| m.command.canonical().len())
         .max()
         .unwrap_or(0);
 
@@ -88,43 +88,60 @@ pub(crate) fn render_home(
         Span::raw(palette_input),
     ]));
 
-    for (i, cmd) in filtered.iter().enumerate() {
-        let name = cmd.canonical();
+    for (i, m) in candidates.iter().enumerate() {
+        let name = m.command.canonical();
         // Selection style: when list is focused (list_selected is Some), the
         // highlighted row gets selection_bg. When input is focused, the top
         // match is bolded as a subtle "this is what Enter will run" hint.
-        let (row_style, name_style) = if list_selected == Some(i) {
-            (
-                Style::default().bg(theme.selection_bg),
-                Style::default()
-                    .fg(theme.accent)
-                    .bg(theme.selection_bg)
-                    .add_modifier(Modifier::BOLD),
-            )
-        } else if list_selected.is_none() && i == 0 {
-            (
-                Style::default(),
-                Style::default()
-                    .fg(theme.accent)
-                    .add_modifier(Modifier::BOLD),
-            )
+        let selected = list_selected == Some(i);
+        let top_hint = list_selected.is_none() && i == 0;
+        let row_style = if selected {
+            Style::default().bg(theme.selection_bg)
         } else {
-            (Style::default(), Style::default().fg(theme.accent))
+            Style::default()
         };
-        let padding = " ".repeat(cmd_col.saturating_sub(name.len()) + 2);
-        let desc_style = if list_selected == Some(i) {
+        let desc_style = if selected {
             Style::default().fg(theme.muted).bg(theme.selection_bg)
         } else {
             Style::default().fg(theme.muted)
         };
-        lines.push(
-            Line::from(vec![
-                Span::styled(format!("{MARGIN}  {name}"), name_style),
-                Span::styled(padding, row_style),
-                Span::styled(cmd.description(), desc_style),
-            ])
-            .style(row_style),
-        );
+
+        // Build per-character name spans so matched positions can be highlighted.
+        // Non-matched chars use the base name style; matched chars get a distinct
+        // accent + bold treatment on top of the row state (selection/hint).
+        let mut name_spans: Vec<Span> = vec![Span::raw(format!("{MARGIN}  "))];
+        for (ci, ch) in name.chars().enumerate() {
+            let is_match = m.indices.contains(&ci);
+            let char_style = match (selected, top_hint, is_match) {
+                // Row selected + matched char: accent + bold on selection bg.
+                (true, _, true) => Style::default()
+                    .fg(theme.accent)
+                    .bg(theme.selection_bg)
+                    .add_modifier(Modifier::BOLD),
+                // Row selected + non-matched: normal accent on selection bg.
+                (true, _, false) => Style::default().fg(theme.accent).bg(theme.selection_bg),
+                // Top-hint (Enter will run) + matched char: bright bold.
+                (false, true, true) => Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+                // Top-hint + non-matched: bold accent without extra emphasis.
+                (false, true, false) => Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+                // Unselected + matched char: accent + underline to show the hit.
+                (false, false, true) => Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::UNDERLINED),
+                // Unselected + non-matched: plain accent.
+                (false, false, false) => Style::default().fg(theme.accent),
+            };
+            name_spans.push(Span::styled(ch.to_string(), char_style));
+        }
+
+        let padding = " ".repeat(cmd_col.saturating_sub(name.len()) + 2);
+        name_spans.push(Span::styled(padding, row_style));
+        name_spans.push(Span::styled(m.command.description(), desc_style));
+        lines.push(Line::from(name_spans).style(row_style));
     }
 
     // Prompt row offset: logo+spacer (if shown) + name + hint + separator = N.

--- a/sdk/tui/tests/autocomplete.rs
+++ b/sdk/tui/tests/autocomplete.rs
@@ -9,10 +9,10 @@
 // governing permissions and limitations under the License.
 
 mod common;
-use common::{empty_graph, key, update_ctx};
+use common::{empty_graph, key, render_to_buffer, update_ctx};
 
 use crossterm::event::KeyCode;
-use design_data_tui::{update, Message, Model};
+use design_data_tui::{command::Command, update, Message, Model};
 
 fn type_str(model: &mut Model, ctx: &design_data_tui::UpdateCtx<'_>, s: &str) {
     for c in s.chars() {
@@ -100,4 +100,110 @@ fn typing_accumulates_characters_in_input() {
     let mut model = Model::new();
     type_str(&mut model, &ctx, "fin");
     assert_eq!(model.palette_input_value(), "fin");
+}
+
+// ── Fuzzy matching tests ──────────────────────────────────────────────────────
+
+#[test]
+fn fuzzy_subsequence_completes_validate() {
+    // "vld" is not a prefix but it is a subsequence of "validate".
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    type_str(&mut model, &ctx, "vld");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input_value(), "validate ");
+}
+
+#[test]
+fn fuzzy_subsequence_completes_resolve() {
+    // "rslv" is a subsequence of "resolve".
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    type_str(&mut model, &ctx, "rslv");
+    update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx);
+    assert_eq!(model.palette_input_value(), "resolve ");
+}
+
+#[test]
+fn fuzzy_ranks_describe_above_validate_for_d() {
+    // "d" is a boundary match for "describe" (first char) and a mid-word match
+    // for "validate". The boundary bonus should put describe first.
+    let matches = Command::matches("d");
+    assert!(!matches.is_empty(), "expected at least one match for 'd'");
+    assert_eq!(
+        matches[0].command,
+        Command::Describe,
+        "describe should rank first for 'd' (boundary bonus); got {:?}",
+        matches[0].command
+    );
+    let has_validate = matches.iter().any(|m| m.command == Command::Validate);
+    assert!(has_validate, "validate should also match 'd'");
+}
+
+#[test]
+fn fuzzy_matches_returns_highlight_indices_for_query() {
+    // "query" chars: q=0, u=1, e=2, r=3, y=4.
+    // "qry" matches: q→0, r→3, y→4.
+    let matches = Command::matches("qry");
+    let qm = matches.iter().find(|m| m.command == Command::Query);
+    assert!(qm.is_some(), "query should match 'qry'");
+    let indices = &qm.unwrap().indices;
+    assert!(
+        !indices.is_empty(),
+        "matched indices must be non-empty for 'qry'"
+    );
+    assert_eq!(indices, &vec![0usize, 3, 4]);
+}
+
+#[test]
+fn fuzzy_empty_input_returns_all_commands_with_empty_indices() {
+    let matches = Command::matches("");
+    assert_eq!(matches.len(), Command::ALL.len());
+    for m in &matches {
+        assert!(
+            m.indices.is_empty(),
+            "empty query should produce no highlight indices"
+        );
+    }
+}
+
+#[test]
+fn fuzzy_no_match_returns_empty() {
+    let matches = Command::matches("zzz");
+    assert!(matches.is_empty(), "zzz should not match any command");
+}
+
+#[test]
+fn fuzzy_render_shows_expected_command_first() {
+    // Type "vld" (fuzzy match for "validate"), then render at 120×36 and
+    // confirm the validate row appears in the buffer ahead of other rows.
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    type_str(&mut model, &ctx, "vld");
+    let buf = render_to_buffer(&mut model, 120, 36);
+    // scan rows to find "validate" and "query" — validate must appear first.
+    let mut validate_row: Option<u16> = None;
+    let mut query_row: Option<u16> = None;
+    for y in 0..36 {
+        let row: String = (0..120u16)
+            .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+        if row.contains("validate") && validate_row.is_none() {
+            validate_row = Some(y);
+        }
+        if row.contains("query") && query_row.is_none() {
+            query_row = Some(y);
+        }
+    }
+    assert!(
+        validate_row.is_some(),
+        "validate must appear in the buffer for input 'vld'"
+    );
+    assert!(
+        validate_row < query_row || query_row.is_none(),
+        "validate (row {validate_row:?}) should appear before or instead of query (row {query_row:?})"
+    );
 }

--- a/sdk/tui/tests/autocomplete.rs
+++ b/sdk/tui/tests/autocomplete.rs
@@ -177,33 +177,37 @@ fn fuzzy_no_match_returns_empty() {
 
 #[test]
 fn fuzzy_render_shows_expected_command_first() {
-    // Type "vld" (fuzzy match for "validate"), then render at 120×36 and
-    // confirm the validate row appears in the buffer ahead of other rows.
+    // Type "d": "describe" gets a boundary bonus (d=index 0) → score 6;
+    // "validate" matches mid-word (d=index 4, no boundary) → score 1.
+    // Both must appear in the buffer and describe must come first.
     let graph = empty_graph();
     let ctx = update_ctx(&graph);
     let mut model = Model::new();
-    type_str(&mut model, &ctx, "vld");
+    type_str(&mut model, &ctx, "d");
     let buf = render_to_buffer(&mut model, 120, 36);
-    // scan rows to find "validate" and "query" — validate must appear first.
+    let mut describe_row: Option<u16> = None;
     let mut validate_row: Option<u16> = None;
-    let mut query_row: Option<u16> = None;
     for y in 0..36 {
         let row: String = (0..120u16)
             .map(|x| buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "))
             .collect();
+        if row.contains("describe") && describe_row.is_none() {
+            describe_row = Some(y);
+        }
         if row.contains("validate") && validate_row.is_none() {
             validate_row = Some(y);
         }
-        if row.contains("query") && query_row.is_none() {
-            query_row = Some(y);
-        }
     }
     assert!(
-        validate_row.is_some(),
-        "validate must appear in the buffer for input 'vld'"
+        describe_row.is_some(),
+        "describe must appear in the buffer for input 'd'"
     );
     assert!(
-        validate_row < query_row || query_row.is_none(),
-        "validate (row {validate_row:?}) should appear before or instead of query (row {query_row:?})"
+        validate_row.is_some(),
+        "validate must also appear in the buffer for input 'd'"
+    );
+    assert!(
+        describe_row < validate_row,
+        "describe (row {describe_row:?}) should rank above validate (row {validate_row:?}) for input 'd'"
     );
 }


### PR DESCRIPTION
## Description

Upgrades the TUI command palette from prefix-only matching to fuzzy subsequence
matching, sorted best-score-first, with matched characters visually highlighted
in each candidate row.

**Phase 2** of the TUI UX improvement initiative (bd: spectrum-design-data-may /
[#spectrum-design-data-7ga]).

Key changes:
- `sdk/core/src/query.rs`: new `subsequence_match` function returns `(score, indices)`;
  `subsequence_score` is rewritten as a thin delegating wrapper — no scoring rule
  duplication.
- `sdk/tui/src/command.rs`: new `CommandMatch` struct + `Command::matches()` returns
  fuzzy-ranked candidates with matched-char indices; `Command::filter()` kept as a
  convenience wrapper so all existing callers (`update.rs` Tab/Enter logic) are untouched.
- `sdk/tui/src/view/home.rs`: `render_home` switches from `Command::filter` to
  `Command::matches` and renders each candidate's name as per-character `Span`s —
  underlined on unselected rows, bold on selected/top-hint.

## Related Issue

Part of TUI UX initiative — beads Phase 2 (spectrum-design-data-7ga).

## Motivation and Context

`Command::filter` did prefix matching only, so typing `vld` showed nothing even though
`validate` is an obvious intent. The existing `subsequence_score` in `design-data-core`
already had the right scoring rules (boundary/consecutive bonuses); this change extends it
to return matched positions and wires the result through to the renderer.

No new crate dependency (`tui-widget-list` was considered but there are only 8 commands,
the list already renders inline, and the crate has ratatui-0.30 compat risk).

## How Has This Been Tested?

- `cargo test -p design-data-core -p design-data-tui` — all 700+ tests green including:
  - New `subsequence_match` unit tests in `core/src/query.rs`
  - New fuzzy autocomplete tests in `tui/tests/autocomplete.rs`:
    - `fuzzy_subsequence_completes_validate` / `_resolve` — Tab-completes non-prefix inputs
    - `fuzzy_ranks_describe_above_validate_for_d` — boundary bonus ordering
    - `fuzzy_matches_returns_highlight_indices_for_query` — correct index positions
    - `fuzzy_render_shows_expected_command_first` — buffer render ordering
  - All pre-existing prefix/Tab/navigation tests still pass
- `cargo test --test budget -p design-data-tui` — LOC caps pass
- `cargo clippy -p design-data-core -p design-data-tui` — clean
- Changeset validated with `node tools/changeset-linter/src/cli.js check --fail-on-warnings`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.