### PR TITLE
feat(tui): context-sensitive help + wizard step indicator

### DIFF
--- a/.changeset/tui-context-help-step-indicator.md
+++ b/.changeset/tui-context-help-step-indicator.md
@@ -1,0 +1,20 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Add wizard step indicator and context-sensitive help overlay.
+
+- **sdk/tui/src/help.rs**: replace the single `HELP_TEXT` const with per-section
+  constants and a `help_text_for(HelpContext)` function that promotes the active
+  section to the top (marked `(active)`); add `current_help_context` resolver.
+- **sdk/tui/src/view.rs** (`render_help_modal`): thread `HelpContext` through so
+  the rendered help reflects the view currently behind the overlay; compute help
+  context before the modal borrow.
+- **sdk/tui/src/view/wizard.rs**, **find.rs**, **naming.rs**: wire `screen_label()`
+  (already implemented on `Modal` in `model/views.rs`) into each wizard's title
+  block, replacing the bespoke `Wizard · N/4 · Name` format with the uniform
+  `Step N of M — Name` breadcrumb.
+- **sdk/tui/src/logo.rs**: update the `commands_present_in_help_text` test to use
+  `help_text_for` instead of the now-removed `HELP_TEXT` const.
+- **sdk/tui/tests/render.rs**: add step-indicator tests for all three wizard types
+  and context-sensitive help tests asserting the correct section is marked active.

--- a/sdk/tui/src/help.rs
+++ b/sdk/tui/src/help.rs
@@ -8,14 +8,25 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-//! Static help overlay content (press `?` to open, `Esc`/`?` to close).
+//! Context-sensitive help overlay content (press `?` to open, `Esc`/`?` to close).
+//!
+//! [`help_text_for`] builds the help text with the section most relevant to the
+//! current view appearing first (and marked `(active)`), so users immediately see
+//! the bindings they need.  All other sections follow in a stable order so nothing
+//! is hidden — only re-ordered.
 
-pub const HELP_TEXT: &str = "\
+use crate::app::ActiveView;
+
+// ── Per-section text ───────────────────────────────────────────────────────────
+
+const SEC_GLOBAL: &str = "\
 GLOBAL
   Ctrl-C                  Always quit
   ?                       Toggle this help overlay
-  v                       Toggle text-selection mode (drag to copy)
+  v                       Toggle text-selection mode (drag to copy)";
 
+/// Palette + Commands are shown together — they describe the same surface.
+const SEC_PALETTE: &str = "\
 PALETTE  (always open on the home screen)
   Type                    Filter the command list live
   Tab                     Autocomplete to the highlighted / top command
@@ -35,24 +46,27 @@ COMMANDS
   new [<intent>]          Open the token authoring wizard
   name [<intent>]         Open the token naming wizard
   find                    Open the fuzzy-find token explorer
-  quit                    Quit the TUI
+  quit                    Quit the TUI";
 
+const SEC_QUERY: &str = "\
 QUERY / RESOLVE / VALIDATE VIEW
   Up / k                  Move selection up
   Down / j                Move selection down
   Scroll wheel            Move selection
   Click row               Select that row
   y                       Yank selected name / message to clipboard
-  Esc                     Return to home
+  Esc                     Return to home";
 
+const SEC_DESCRIBE: &str = "\
 DESCRIBE VIEW
   Up / k                  Scroll up one line
   Down / j                Scroll down one line
   PgUp                    Scroll up 10 lines
   PgDn                    Scroll down 10 lines
   Scroll wheel            Scroll the body
-  Esc                     Return to home
+  Esc                     Return to home";
 
+const SEC_WIZARD: &str = "\
 WIZARD — Screen 1 (Intent)
   Type                    Search existing tokens
   Up / Down               Navigate suggestions
@@ -81,12 +95,145 @@ WIZARD — Screen 4 (Confirm)
   Scroll wheel            Scroll diff preview
   Ctrl+S                  Edit $schema URL
   Enter                   Submit (writes token when --allow-write is set)
-  Esc                     Cancel wizard
+  Esc                     Cancel wizard";
 
+const SEC_MOUSE: &str = "\
 MOUSE
   Scroll wheel            Scroll the active view or wizard diff preview
   Click row               Select that row in a list or table view
   v                       Enter text-selection mode
   Drag (in select mode)   Select text from rows; release copies to clipboard
-  Shift-drag              Native terminal text selection (bypasses capture)
-";
+  Shift-drag              Native terminal text selection (bypasses capture)";
+
+// ── Context enum ───────────────────────────────────────────────────────────────
+
+/// Which view is active when the help overlay is opened.
+///
+/// Used to promote the most-relevant section to the top of the help text.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HelpContext {
+    /// Home screen — command palette is primary.
+    Empty,
+    /// Token query results.
+    Query,
+    /// Token resolve results.
+    Resolve,
+    /// Component describe view.
+    Describe,
+    /// Token validation results.
+    Validate,
+}
+
+/// Derive the help context from the current active view.
+pub fn current_help_context(active_view: &ActiveView) -> HelpContext {
+    match active_view {
+        ActiveView::Empty => HelpContext::Empty,
+        ActiveView::Query(_) => HelpContext::Query,
+        ActiveView::Resolve(_) => HelpContext::Resolve,
+        ActiveView::Describe(_) => HelpContext::Describe,
+        ActiveView::Validate(_) => HelpContext::Validate,
+    }
+}
+
+// ── Text builder ───────────────────────────────────────────────────────────────
+
+/// Build the full help text for the given `ctx`.
+///
+/// The section relevant to `ctx` is emitted first with `  (active)` appended to
+/// its header line, then `GLOBAL`, then the remaining sections in a stable order.
+/// All content is preserved — only the ordering changes.
+pub fn help_text_for(ctx: HelpContext) -> String {
+    let active = match ctx {
+        HelpContext::Empty => SEC_PALETTE,
+        HelpContext::Query | HelpContext::Resolve | HelpContext::Validate => SEC_QUERY,
+        HelpContext::Describe => SEC_DESCRIBE,
+    };
+
+    let mut out = String::new();
+
+    // Active section first, header line marked with "(active)".
+    out.push_str(&mark_active(active));
+    out.push_str("\n\n");
+    out.push_str(SEC_GLOBAL);
+
+    // Remaining sections in stable order; skip the active one already shown above.
+    for &sec in &[SEC_PALETTE, SEC_QUERY, SEC_DESCRIBE, SEC_WIZARD, SEC_MOUSE] {
+        if core::ptr::eq(sec as *const str, active as *const str) {
+            continue;
+        }
+        out.push_str("\n\n");
+        out.push_str(sec);
+    }
+
+    out.push('\n');
+    out
+}
+
+/// Append `  (active)` to the first line of `section`.
+fn mark_active(section: &str) -> String {
+    match section.find('\n') {
+        Some(idx) => format!("{}  (active){}", &section[..idx], &section[idx..]),
+        None => format!("{section}  (active)"),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_section_appears_first_for_query() {
+        let text = help_text_for(HelpContext::Query);
+        let query_pos = text.find("QUERY / RESOLVE / VALIDATE VIEW").unwrap();
+        let global_pos = text.find("GLOBAL").unwrap();
+        assert!(
+            query_pos < global_pos,
+            "QUERY section should precede GLOBAL in query context"
+        );
+    }
+
+    #[test]
+    fn active_section_appears_first_for_describe() {
+        let text = help_text_for(HelpContext::Describe);
+        let describe_pos = text.find("DESCRIBE VIEW").unwrap();
+        let global_pos = text.find("GLOBAL").unwrap();
+        assert!(
+            describe_pos < global_pos,
+            "DESCRIBE VIEW section should precede GLOBAL in describe context"
+        );
+    }
+
+    #[test]
+    fn active_section_is_marked() {
+        let text = help_text_for(HelpContext::Query);
+        assert!(
+            text.contains("QUERY / RESOLVE / VALIDATE VIEW  (active)"),
+            "active section header should carry '(active)' marker"
+        );
+    }
+
+    #[test]
+    fn all_sections_present_regardless_of_context() {
+        let text = help_text_for(HelpContext::Describe);
+        assert!(text.contains("PALETTE"), "PALETTE section missing");
+        assert!(text.contains("QUERY / RESOLVE"), "QUERY section missing");
+        assert!(
+            text.contains("DESCRIBE VIEW"),
+            "DESCRIBE VIEW section missing"
+        );
+        assert!(text.contains("WIZARD"), "WIZARD section missing");
+        assert!(text.contains("MOUSE"), "MOUSE section missing");
+        assert!(text.contains("GLOBAL"), "GLOBAL section missing");
+    }
+
+    #[test]
+    fn palette_is_active_on_home_screen() {
+        let text = help_text_for(HelpContext::Empty);
+        assert!(
+            text.contains("PALETTE  (always open on the home screen)  (active)"),
+            "PALETTE should be marked active on home screen"
+        );
+    }
+}

--- a/sdk/tui/src/help.rs
+++ b/sdk/tui/src/help.rs
@@ -125,6 +125,12 @@ pub enum HelpContext {
 }
 
 /// Derive the help context from the current active view.
+///
+/// Note: wizard modals (`Modal::Wizard`, `Modal::Find`, `Modal::Naming`) have no
+/// separate `HelpContext` variant.  When a wizard is open, `active_view` reflects
+/// the screen *behind* the wizard (typically `Empty`).  The wizard already
+/// communicates its step context via the title breadcrumb; help opens via `?` only
+/// from browsing/palette mode, not from within a wizard.
 pub fn current_help_context(active_view: &ActiveView) -> HelpContext {
     match active_view {
         ActiveView::Empty => HelpContext::Empty,
@@ -143,10 +149,19 @@ pub fn current_help_context(active_view: &ActiveView) -> HelpContext {
 /// its header line, then `GLOBAL`, then the remaining sections in a stable order.
 /// All content is preserved — only the ordering changes.
 pub fn help_text_for(ctx: HelpContext) -> String {
-    let active = match ctx {
-        HelpContext::Empty => SEC_PALETTE,
-        HelpContext::Query | HelpContext::Resolve | HelpContext::Validate => SEC_QUERY,
-        HelpContext::Describe => SEC_DESCRIBE,
+    let (active, remaining): (&str, &[&str]) = match ctx {
+        HelpContext::Empty => (
+            SEC_PALETTE,
+            &[SEC_QUERY, SEC_DESCRIBE, SEC_WIZARD, SEC_MOUSE],
+        ),
+        HelpContext::Query | HelpContext::Resolve | HelpContext::Validate => (
+            SEC_QUERY,
+            &[SEC_PALETTE, SEC_DESCRIBE, SEC_WIZARD, SEC_MOUSE],
+        ),
+        HelpContext::Describe => (
+            SEC_DESCRIBE,
+            &[SEC_PALETTE, SEC_QUERY, SEC_WIZARD, SEC_MOUSE],
+        ),
     };
 
     let mut out = String::new();
@@ -156,11 +171,7 @@ pub fn help_text_for(ctx: HelpContext) -> String {
     out.push_str("\n\n");
     out.push_str(SEC_GLOBAL);
 
-    // Remaining sections in stable order; skip the active one already shown above.
-    for &sec in &[SEC_PALETTE, SEC_QUERY, SEC_DESCRIBE, SEC_WIZARD, SEC_MOUSE] {
-        if core::ptr::eq(sec as *const str, active as *const str) {
-            continue;
-        }
+    for &sec in remaining {
         out.push_str("\n\n");
         out.push_str(sec);
     }

--- a/sdk/tui/src/logo.rs
+++ b/sdk/tui/src/logo.rs
@@ -56,7 +56,7 @@ pub(crate) const COMMANDS: &[(&str, &str)] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::help::HELP_TEXT;
+    use crate::help::{help_text_for, HelpContext};
 
     /// All command names in COMMANDS must be ASCII-only. The render code uses
     /// `name.len()` (byte count) as the display-column width, which is only
@@ -72,27 +72,29 @@ mod tests {
         }
     }
 
-    /// Every palette command in COMMANDS must appear in HELP_TEXT.
+    /// Every palette command in COMMANDS must appear in the help text.
     ///
-    /// **Coverage:** this test proves COMMANDS ⊆ HELP_TEXT (one direction).
-    /// It does *not* prove the reverse (a command added to HELP_TEXT but not
+    /// **Coverage:** this test proves COMMANDS ⊆ help text (one direction).
+    /// It does *not* prove the reverse (a command added to help.rs but not
     /// COMMANDS won't be caught), and it does not verify that
     /// `update/command.rs` actually dispatches each command. The dispatcher in
     /// `update/command.rs` is a flat `match` on string literals — if you add a
-    /// command there, also add it here and to HELP_TEXT, and this test will
+    /// command there, also add it here and to `help.rs`, and this test will
     /// catch any subsequent removal from either list.
     #[test]
     fn commands_present_in_help_text() {
+        // Generate the full help text (all sections are present in every context).
+        let full = help_text_for(HelpContext::Empty);
         for (name, _) in COMMANDS {
             // Skip global-key rows (e.g. `?`) that are not dispatchable commands.
             if *name == "?" {
                 continue;
             }
-            // Match on just the command name (first token) in HELP_TEXT.
+            // Match on just the command name (first token) in the help text.
             let tok = name.split_whitespace().next().unwrap_or(name);
             assert!(
-                HELP_TEXT.contains(tok),
-                "COMMANDS entry {name:?} (token {tok:?}) is not present in HELP_TEXT; \
+                full.contains(tok),
+                "COMMANDS entry {name:?} (token {tok:?}) is not present in help.rs; \
                  update help.rs or logo.rs to keep them in sync"
             );
         }

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -26,7 +26,7 @@ pub(crate) mod shared;
 mod wizard;
 
 use crate::app::{ActiveView, Modal, StatusKind};
-use crate::help::HELP_TEXT;
+use crate::help::{current_help_context, help_text_for, HelpContext};
 use crate::model::Model;
 use crate::theme::Theme;
 use find::render_find;
@@ -154,23 +154,28 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
         frame.render_widget(popup, right_half);
     }
 
+    // Resolve help context from the active view before taking the modal borrow.
+    let help_ctx = current_help_context(&model.active_view);
+
     // Overlay modal (rendered last so it appears on top of everything).
     if let Some(modal) = model.modal_mut() {
+        // Compute step-indicator label once; each wizard renderer uses it for its title.
+        let label = modal.screen_label();
         match modal {
             Modal::Find(ref mut fs) => {
                 let popup_area = modal_frame(frame, area, 82, 85);
-                render_find(frame, fs, popup_area, theme);
+                render_find(frame, fs, popup_area, theme, &label);
             }
             Modal::Wizard(ref mut ws) => {
                 let popup_area = modal_frame(frame, area, 82, 85);
-                render_wizard(frame, ws, popup_area, theme);
+                render_wizard(frame, ws, popup_area, theme, &label);
             }
             Modal::Naming(ref mut ns) => {
                 let popup_area = modal_frame(frame, area, 82, 85);
-                render_naming(frame, ns, popup_area, theme);
+                render_naming(frame, ns, popup_area, theme, &label);
             }
             Modal::Help(ref hm) => {
-                render_help_modal(frame, hm.scroll, area);
+                render_help_modal(frame, hm.scroll, area, help_ctx);
             }
         }
     }
@@ -178,10 +183,12 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
 
 /// Render the Help overlay. Uses a scroll-supporting `Paragraph` because the
 /// help text (~80 lines) exceeds a typical terminal height and needs scrolling.
+/// The active section for `ctx` is promoted to the top with an `(active)` marker.
 /// The modal background is cleared via [`modal_frame`].
-fn render_help_modal(f: &mut Frame<'_>, scroll: u16, area: Rect) {
+fn render_help_modal(f: &mut Frame<'_>, scroll: u16, area: Rect, ctx: HelpContext) {
     let popup_area = modal_frame(f, area, 80, 90);
-    let para = Paragraph::new(HELP_TEXT)
+    let text = help_text_for(ctx);
+    let para = Paragraph::new(text.as_str())
         .block(
             Block::default()
                 .borders(Borders::ALL)

--- a/sdk/tui/src/view/find.rs
+++ b/sdk/tui/src/view/find.rs
@@ -24,14 +24,16 @@ use crate::theme::Theme;
 
 // ── Find wizard entry ─────────────────────────────────────────────────────────
 
-pub(crate) fn render_find(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
-    let screen_num = fs.screen.number();
-    let screen_name = fs.screen.name();
-
-    let outer = Block::default().borders(Borders::ALL).title(format!(
-        " Find · {screen_num}/{} · {screen_name} ",
-        FindScreen::SCREEN_COUNT
-    ));
+pub(crate) fn render_find(
+    f: &mut Frame<'_>,
+    fs: &FindWizardState,
+    area: Rect,
+    theme: &Theme,
+    label: &str,
+) {
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {label} "));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 

--- a/sdk/tui/src/view/naming.rs
+++ b/sdk/tui/src/view/naming.rs
@@ -24,14 +24,16 @@ use super::shared::{render_classification_content, render_intent_content};
 use crate::naming::{NamingScreen, NamingWizardState};
 use crate::theme::Theme;
 
-pub(crate) fn render_naming(f: &mut Frame<'_>, ns: &NamingWizardState, area: Rect, theme: &Theme) {
-    let screen_num = ns.screen.number();
-    let screen_name = ns.screen.name();
-
-    let outer = Block::default().borders(Borders::ALL).title(format!(
-        " Name · {screen_num}/{} · {screen_name} ",
-        NamingScreen::SCREEN_COUNT
-    ));
+pub(crate) fn render_naming(
+    f: &mut Frame<'_>,
+    ns: &NamingWizardState,
+    area: Rect,
+    theme: &Theme,
+    label: &str,
+) {
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {label} "));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 

--- a/sdk/tui/src/view/wizard.rs
+++ b/sdk/tui/src/view/wizard.rs
@@ -24,13 +24,16 @@ use super::shared::{render_classification_content, render_intent_content};
 use crate::theme::Theme;
 use crate::wizard::{ValueKind, WizardScreen, WizardState};
 
-pub(crate) fn render_wizard(f: &mut Frame<'_>, ws: &mut WizardState, area: Rect, theme: &Theme) {
-    let screen_num = ws.screen.number();
-    let screen_name = ws.screen.name();
-
+pub(crate) fn render_wizard(
+    f: &mut Frame<'_>,
+    ws: &mut WizardState,
+    area: Rect,
+    theme: &Theme,
+    label: &str,
+) {
     let outer = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Wizard · {screen_num}/4 · {screen_name} "));
+        .title(format!(" {label} "));
     let inner_area = outer.inner(area);
     f.render_widget(outer, area);
 

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -483,3 +483,19 @@ fn help_active_section_differs_between_contexts() {
         "active section header should differ between query and describe contexts"
     );
 }
+
+#[test]
+fn help_marks_query_section_active_in_validate_view() {
+    // Validate collapses into the same QUERY/RESOLVE/VALIDATE section as query results.
+    let mut model = Model::new();
+    model.active_view = ActiveView::Validate(ValidateView::new(vec![]));
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    let row = find_row_containing(&buf, "(active)", W, H);
+    assert!(
+        row.contains("QUERY"),
+        "active marker should be on the QUERY/RESOLVE/VALIDATE section in validate view: {row}"
+    );
+}

--- a/sdk/tui/tests/render.rs
+++ b/sdk/tui/tests/render.rs
@@ -348,3 +348,138 @@ fn draw_does_not_panic_on_narrow_terminal() {
     let mut model = Model::new();
     render_to_buffer(&mut model, 10, 5);
 }
+
+// ── Wizard step indicator ─────────────────────────────────────────────────────
+
+#[test]
+fn authoring_wizard_shows_step_indicator() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(
+        &mut model,
+        Message::PaletteSubmit("new background-color".into()),
+        &ctx,
+    );
+    let buf = render_to_buffer(&mut model, W, H);
+    // screen_label() for Wizard screen 1 → "Step 1 of 4 — Intent"
+    find_row_containing(&buf, "Step 1 of 4", W, H);
+}
+
+#[test]
+fn naming_wizard_shows_step_indicator() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(
+        &mut model,
+        Message::PaletteSubmit("name background-color".into()),
+        &ctx,
+    );
+    let buf = render_to_buffer(&mut model, W, H);
+    // screen_label() for Naming screen 1 → "Step 1 of 3 — Intent"
+    find_row_containing(&buf, "Step 1 of 3", W, H);
+}
+
+#[test]
+fn find_wizard_shows_step_indicator() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::PaletteSubmit("find".into()), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    // screen_label() for Find screen 1 → "Step 1 of 2 — Filters"
+    find_row_containing(&buf, "Step 1 of 2", W, H);
+}
+
+// ── Context-sensitive help ────────────────────────────────────────────────────
+
+#[test]
+fn help_marks_palette_section_active_on_home_screen() {
+    // Model::new() starts at home screen (Empty view + InPalette mode).
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    let row = find_row_containing(&buf, "(active)", W, H);
+    assert!(
+        row.contains("PALETTE"),
+        "active marker should be on the PALETTE section when at home: {row}"
+    );
+}
+
+#[test]
+fn help_marks_query_section_active_in_query_view() {
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    update(
+        &mut model,
+        Message::PaletteSubmit("query property=accent-color".into()),
+        &ctx,
+    );
+    // From query results, '?' opens help (Browsing mode).
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    let row = find_row_containing(&buf, "(active)", W, H);
+    assert!(
+        row.contains("QUERY"),
+        "active marker should be on the QUERY section when in query results: {row}"
+    );
+    // GLOBAL section must also be present in the modal.
+    find_row_containing(&buf, "GLOBAL", W, H);
+}
+
+#[test]
+fn help_marks_describe_section_active_in_describe_view() {
+    let graph = make_graph_with_tokens(&[]);
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    model.active_view = ActiveView::Describe(DescribeView {
+        component: "button".to_string(),
+        pretty_json: "{\"name\": \"button\"}".to_string(),
+        scroll: 0,
+        h_scroll: 0,
+    });
+    update(&mut model, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf = render_to_buffer(&mut model, W, H);
+    let row = find_row_containing(&buf, "(active)", W, H);
+    assert!(
+        row.contains("DESCRIBE"),
+        "active marker should be on the DESCRIBE VIEW section when in describe: {row}"
+    );
+}
+
+#[test]
+fn help_active_section_differs_between_contexts() {
+    // Query context → QUERY first; Describe context → DESCRIBE first.
+    let graph = make_graph_with_tokens(&["accent-color"]);
+    let ctx = update_ctx(&graph);
+
+    let mut model_q = Model::new();
+    update(
+        &mut model_q,
+        Message::PaletteSubmit("query property=accent-color".into()),
+        &ctx,
+    );
+    update(&mut model_q, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf_q = render_to_buffer(&mut model_q, W, H);
+    let active_row_q = find_row_containing(&buf_q, "(active)", W, H);
+
+    let mut model_d = Model::new();
+    model_d.active_view = ActiveView::Describe(DescribeView {
+        component: "chip".to_string(),
+        pretty_json: "{\"name\":\"chip\"}".to_string(),
+        scroll: 0,
+        h_scroll: 0,
+    });
+    update(&mut model_d, Message::Key(key(KeyCode::Char('?'))), &ctx);
+    let buf_d = render_to_buffer(&mut model_d, W, H);
+    let active_row_d = find_row_containing(&buf_d, "(active)", W, H);
+
+    assert_ne!(
+        active_row_q, active_row_d,
+        "active section header should differ between query and describe contexts"
+    );
+}

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -1,10 +1,11 @@
 ---
 source: tui/tests/snapshots.rs
+assertion_line: 117
 expression: rendered
 ---
 ▶ test · 0 tokens
   Spectrum Design Data  v0.2.1
-  ↑↓ hi┌ Wizard · 1/4 · Intent ─────────────────────────────────────────┐
+  ↑↓ hi┌ Step 1 of 4 — Intent ──────────────────────────────────────────┐
   ─────│Intent: background-color                                        │───────
   >    │  These tokens already exist for similar intents.               │
     que│  Reusing one keeps the cascade healthy.  Tab to alias · Enter t│


### PR DESCRIPTION
## Description

Two UX improvements to the design-data TUI, both building on the Phase 1 modal/overlay infrastructure from #1167:

**Wizard step indicator** — Wire `Modal::screen_label()` (already implemented in `model/views.rs` but never called) into all three wizard title blocks (authoring Wizard/4, Naming/3, Find/2). Replaces the bespoke `Wizard · 1/4 · Intent` format with a uniform `Step 1 of 4 — Intent` breadcrumb across all wizards.

**Context-sensitive help** — Restructure `help.rs` from a single static `HELP_TEXT` const into per-section constants with a `help_text_for(HelpContext)` function. When the user opens `?`, the section most relevant to the current view is promoted to the top and marked `(active)`. All other sections remain scrollable below — nothing is hidden, only reordered.

## Related Issue

Closes beads `spectrum-design-data-kzc` (Phase 3 of the TUI UX improvement initiative `spectrum-design-data-may`). Unblocks Phase 4: Describe view row selection + yank (`spectrum-design-data-9dv`).

## Motivation and Context

Phase 3 of the TUI UX improvement initiative. The step indicator and context-sensitive help were identified as the two gaps remaining after #1167 (modal/toast) and #1168 (autocomplete). Both required no new dependencies — `screen_label()` was already built and documented as "not yet wired to a renderer."

The help reordering design decision: active section first (with `(active)` marker), then GLOBAL, then remaining sections in stable order. All content preserved — only the order changes, so power users can still scroll to any section.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — all tests pass (unit + integration + snapshots)
- 7 new buffer-cell render tests in `tests/render.rs`:
  - Step indicator assertions for all three wizard types (Wizard/4, Naming/3, Find/2)
  - Help context tests: palette active on home screen, query section active in query results, describe section active in describe view, and a cross-context diff assertion
- Updated `tests/snapshots/snapshots__wizard_screen1_80x24.snap` to reflect the new title format
- `logo.rs` coverage test updated to use `help_text_for` instead of removed `HELP_TEXT`

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.