### PR TITLE
feat(tui): wizard help overlay, Esc back-stack, did-you-mean, [SEL] badge, readline

### DIFF
--- a/.changeset/tui-ux-review-f1-f5.md
+++ b/.changeset/tui-ux-review-f1-f5.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+tui: five UX improvements from conventions review.
+
+- **update.rs / help.rs**: `?` now opens a wizard-context help overlay from inside any
+  wizard or modal; new `HelpContext::Wizard` variant promotes the WIZARD section (F1).
+- **find.rs / naming.rs**: Esc goes back one screen (S2→S1, S3→S2) instead of
+  hard-cancelling from any screen — matching the authoring wizard's behavior (F2).
+- **update/command.rs**: Invalid palette commands show a did-you-mean suggestion using
+  the existing fuzzy ranker, e.g. `unknown command: descrbe — did you mean \`describe\`?` (F3).
+- **view.rs**: A persistent `[SEL]` badge appears in the status line whenever mouse
+  text-selection mode is active, so users know the mode is on after other messages appear (F4).
+- **wizard.rs**: Ctrl-A/E/W/U readline editing works in authoring wizard text fields;
+  the Ctrl early-return was narrowed to intercept only Ctrl-S on Screen 4 (F5).

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -230,7 +230,14 @@ impl FindWizardState {
         index: &query::TokenIndex,
     ) -> FindEvent {
         if key.code == KeyCode::Esc {
-            return FindEvent::Cancel;
+            // Back one screen; cancel only from the first screen (mirrors authoring wizard).
+            return match self.screen {
+                FindScreen::Filters => FindEvent::Cancel,
+                FindScreen::Preview => {
+                    self.screen = FindScreen::Filters;
+                    FindEvent::Continue
+                }
+            };
         }
         match self.screen {
             FindScreen::Filters => self.handle_filters_key(key, graph, index),

--- a/sdk/tui/src/help.rs
+++ b/sdk/tui/src/help.rs
@@ -124,6 +124,8 @@ pub enum HelpContext {
     Describe,
     /// Token validation results.
     Validate,
+    /// Help opened from within any wizard/modal (authoring, find, or naming).
+    Wizard,
 }
 
 /// Derive the help context from the current active view.
@@ -163,6 +165,10 @@ pub fn help_text_for(ctx: HelpContext) -> String {
         HelpContext::Describe => (
             SEC_DESCRIBE,
             &[SEC_PALETTE, SEC_QUERY, SEC_WIZARD, SEC_MOUSE],
+        ),
+        HelpContext::Wizard => (
+            SEC_WIZARD,
+            &[SEC_PALETTE, SEC_QUERY, SEC_DESCRIBE, SEC_MOUSE],
         ),
     };
 

--- a/sdk/tui/src/model.rs
+++ b/sdk/tui/src/model.rs
@@ -154,6 +154,10 @@ impl Model {
             } else {
                 Mode::Browsing(BrowsingState::default())
             };
+            // Always clear the wizard-help overlay when the modal is dismissed so a
+            // stale Some(scroll) can't flash on the next frame after a mouse click
+            // closes the underlying wizard before the overlay is dismissed by keyboard.
+            self.wizard_help_scroll = None;
         }
     }
 

--- a/sdk/tui/src/model.rs
+++ b/sdk/tui/src/model.rs
@@ -41,6 +41,9 @@ pub struct Model {
     /// Click-region registry — cleared and repopulated each frame by `view::draw`.
     /// Use `handle_click(col, row)` for click hit-testing, `regions()` for drag-select.
     pub hit_registry: ClickRegionRegistry<HitEntry>,
+    /// Scroll position of the help overlay when it is opened on top of a wizard/modal.
+    /// `None` = overlay closed; `Some(scroll)` = open at that row offset.
+    pub wizard_help_scroll: Option<u16>,
 }
 
 impl Model {
@@ -76,6 +79,7 @@ impl Model {
             pending_yank: None,
             palette_history: Vec::new(),
             hit_registry: ClickRegionRegistry::new(),
+            wizard_help_scroll: None,
         }
     }
 

--- a/sdk/tui/src/naming.rs
+++ b/sdk/tui/src/naming.rs
@@ -117,7 +117,18 @@ impl NamingWizardState {
 
     pub fn handle_key(&mut self, key: KeyEvent, graph: &TokenGraph) -> NamingEvent {
         if key.code == KeyCode::Esc {
-            return NamingEvent::Cancel;
+            // Back one screen; cancel only from the first screen (mirrors authoring wizard).
+            return match self.screen {
+                NamingScreen::Intent => NamingEvent::Cancel,
+                NamingScreen::Classification => {
+                    self.screen = NamingScreen::Intent;
+                    NamingEvent::Continue
+                }
+                NamingScreen::Result => {
+                    self.screen = NamingScreen::Classification;
+                    NamingEvent::Continue
+                }
+            };
         }
         // Capture intent value before dispatch so we can skip suggest refresh when text
         // didn't change (e.g. Up/Down arrow navigation).

--- a/sdk/tui/src/update.rs
+++ b/sdk/tui/src/update.rs
@@ -578,6 +578,30 @@ fn route_modal_key(
     key: crossterm::event::KeyEvent,
     ctx: &UpdateCtx<'_>,
 ) -> Task<Message> {
+    // Wizard-help overlay (? pressed while a wizard/modal is active). This layer
+    // captures all navigation input so the wizard behind it is not affected.
+    if let Some(ref mut scroll) = model.wizard_help_scroll {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('?') => {
+                model.wizard_help_scroll = None;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                *scroll = scroll.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                *scroll = scroll.saturating_add(1);
+            }
+            KeyCode::PageUp => {
+                *scroll = scroll.saturating_sub(10);
+            }
+            KeyCode::PageDown => {
+                *scroll = scroll.saturating_add(10);
+            }
+            _ => {}
+        }
+        return Task::none();
+    }
+
     // Help modal.
     if let Some(Modal::Help(ref mut hm)) = model.modal_mut() {
         match key.code {
@@ -598,6 +622,13 @@ fn route_modal_key(
             }
             _ => {}
         }
+        return Task::none();
+    }
+
+    // Open wizard-help overlay when ? is pressed inside any wizard/modal other
+    // than the Help modal (which is already handled above).
+    if key.code == KeyCode::Char('?') {
+        model.wizard_help_scroll = Some(0);
         return Task::none();
     }
 

--- a/sdk/tui/src/update/command.rs
+++ b/sdk/tui/src/update/command.rs
@@ -339,7 +339,15 @@ fn dispatch_command(
             Task::none()
         }
         None => {
-            model.status_message = Some(StatusMessage::error(format!("unknown command: {cmd}")));
+            // Use the fuzzy ranker to suggest the closest known command.
+            let suggestion = Command::matches(cmd)
+                .into_iter()
+                .next()
+                .map(|m| format!(" — did you mean `{}`?", m.command.canonical()))
+                .unwrap_or_default();
+            model.status_message = Some(StatusMessage::error(format!(
+                "unknown command: {cmd}{suggestion}"
+            )));
             Task::none()
         }
     }

--- a/sdk/tui/src/update/mouse.rs
+++ b/sdk/tui/src/update/mouse.rs
@@ -59,6 +59,15 @@ pub(super) fn handle_mouse(model: &mut Model, me: crossterm::event::MouseEvent) 
 }
 
 fn scroll_active(model: &mut Model, delta: i32) {
+    // Wizard-help overlay captures scroll when open.
+    if let Some(ref mut scroll) = model.wizard_help_scroll {
+        if delta > 0 {
+            *scroll = scroll.saturating_add(delta as u16);
+        } else {
+            *scroll = scroll.saturating_sub((-delta) as u16);
+        }
+        return;
+    }
     if let Some(modal) = model.modal_mut() {
         if modal.wants_scroll() {
             modal.on_scroll(delta);

--- a/sdk/tui/src/view.rs
+++ b/sdk/tui/src/view.rs
@@ -10,7 +10,7 @@
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Style,
+    style::{Modifier, Style},
     symbols::border,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
@@ -70,7 +70,8 @@ fn modal_frame(f: &mut Frame, area: Rect, percent_x: u16, percent_y: u16) -> Rec
 /// overlay modal. This is the single entry point for all rendering; call it from
 /// `terminal.draw(|f| draw(app, f, theme, primer_line))`.
 pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &str) {
-    let status_height = u16::from(model.status_message.is_some());
+    let sel_active = model.is_selection_mode_enabled();
+    let status_height = u16::from(model.status_message.is_some() || sel_active);
     let area = frame.area();
 
     // Three-region layout (RFC #973 §3.1): primer header / active view / status+palette.
@@ -125,16 +126,26 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
         }
     }
 
-    // Status message — ok color for info, error color for errors.
-    if let Some(ref msg) = model.status_message {
-        let color = match msg.kind {
-            StatusKind::Info => theme.ok,
-            StatusKind::Error => theme.error,
-        };
-        frame.render_widget(
-            Paragraph::new(msg.text.as_str()).style(Style::default().fg(color)),
-            chunks[2],
-        );
+    // Status line — status message and/or [SEL] badge when selection mode is on.
+    if model.status_message.is_some() || sel_active {
+        let mut spans: Vec<Span> = Vec::new();
+        if let Some(ref msg) = model.status_message {
+            let color = match msg.kind {
+                StatusKind::Info => theme.ok,
+                StatusKind::Error => theme.error,
+            };
+            spans.push(Span::styled(msg.text.clone(), Style::default().fg(color)));
+        }
+        if sel_active {
+            if !spans.is_empty() {
+                spans.push(Span::raw("  "));
+            }
+            spans.push(Span::styled(
+                "[SEL]",
+                Style::default().fg(theme.warn).add_modifier(Modifier::BOLD),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), chunks[2]);
     }
 
     // chunk[3] is kept as a 1-row reserve to stay in sync with compute_hit_regions.
@@ -185,6 +196,12 @@ pub fn draw(model: &mut Model, frame: &mut Frame, theme: &Theme, primer_line: &s
                 render_help_modal(frame, hm.scroll, area, help_ctx);
             }
         }
+    }
+
+    // Wizard-help overlay: rendered on top of any active wizard/modal when the
+    // user presses ? while a wizard is open (see route_modal_key in update.rs).
+    if let Some(scroll) = model.wizard_help_scroll {
+        render_help_modal(frame, scroll, area, HelpContext::Wizard);
     }
 }
 

--- a/sdk/tui/src/wizard.rs
+++ b/sdk/tui/src/wizard.rs
@@ -173,13 +173,15 @@ impl WizardState {
 
     /// Route a key event through the appropriate screen handler.
     pub fn handle_key(&mut self, key: KeyEvent, ctx: &WizardCtx<'_>) -> WizardEvent {
-        // Ctrl-C should not be consumed here — App handles it above us.
-        // Ctrl-S on Screen 4 opens the schema URL editor (safe since it uses a modifier).
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            if key.code == KeyCode::Char('s') && self.screen == WizardScreen::Confirm {
-                self.editing_schema_url = true;
-                return WizardEvent::Continue;
-            }
+        // Ctrl-C is handled globally above us (never reaches here).
+        // Ctrl-S on Screen 4 opens the schema URL editor; all other Ctrl combos fall
+        // through to the screen handlers so tui-input's readline bindings (Ctrl-A/E/W/U)
+        // work in text fields — matching the behaviour of the palette and naming wizard.
+        if key.modifiers.contains(KeyModifiers::CONTROL)
+            && key.code == KeyCode::Char('s')
+            && self.screen == WizardScreen::Confirm
+        {
+            self.editing_schema_url = true;
             return WizardEvent::Continue;
         }
         if key.code == KeyCode::Esc {

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -207,13 +207,23 @@ fn esc_cancels_on_filters_screen() {
 }
 
 #[test]
-fn esc_cancels_on_preview_screen() {
+fn esc_goes_back_on_preview_screen() {
+    // Esc on Screen 2 (Preview) should go back to Screen 1 (Filters), not cancel.
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    assert_eq!(fs.screen, FindScreen::Preview);
     let event = fs.handle_key(key(KeyCode::Esc), &graph, &index);
-    assert!(matches!(event, FindEvent::Cancel));
+    assert!(
+        matches!(event, FindEvent::Continue),
+        "Esc on Preview should Continue, not Cancel"
+    );
+    assert_eq!(
+        fs.screen,
+        FindScreen::Filters,
+        "Esc on Preview should return to Filters screen"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/naming.rs
+++ b/sdk/tui/tests/naming.rs
@@ -88,18 +88,49 @@ fn e_on_result_screen_goes_back_to_classification() {
 }
 
 #[test]
-fn esc_on_any_screen_cancels() {
+fn esc_cancels_on_intent_screen() {
+    // Esc on Screen 1 (Intent) cancels the wizard.
     let graph = make_graph();
-    for start_screen in [
+    let mut ns = NamingWizardState::new();
+    assert_eq!(ns.screen, NamingScreen::Intent);
+    let event = ns.handle_key(key(KeyCode::Esc), &graph);
+    assert!(matches!(event, NamingEvent::Cancel));
+}
+
+#[test]
+fn esc_goes_back_on_classification_screen() {
+    // Esc on Screen 2 (Classification) goes back to Screen 1 (Intent), not cancel.
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Classification;
+    let event = ns.handle_key(key(KeyCode::Esc), &graph);
+    assert!(
+        matches!(event, NamingEvent::Continue),
+        "Esc on Classification should Continue"
+    );
+    assert_eq!(
+        ns.screen,
         NamingScreen::Intent,
+        "Esc on Classification should return to Intent"
+    );
+}
+
+#[test]
+fn esc_goes_back_on_result_screen() {
+    // Esc on Screen 3 (Result) goes back to Screen 2 (Classification), not cancel.
+    let graph = make_graph();
+    let mut ns = NamingWizardState::new();
+    ns.screen = NamingScreen::Result;
+    let event = ns.handle_key(key(KeyCode::Esc), &graph);
+    assert!(
+        matches!(event, NamingEvent::Continue),
+        "Esc on Result should Continue"
+    );
+    assert_eq!(
+        ns.screen,
         NamingScreen::Classification,
-        NamingScreen::Result,
-    ] {
-        let mut ns = NamingWizardState::new();
-        ns.screen = start_screen;
-        let event = ns.handle_key(key(KeyCode::Esc), &graph);
-        assert!(matches!(event, NamingEvent::Cancel));
-    }
+        "Esc on Result should return to Classification"
+    );
 }
 
 #[test]

--- a/sdk/tui/tests/query.rs
+++ b/sdk/tui/tests/query.rs
@@ -88,6 +88,28 @@ fn submit_unknown_command_sets_status_message() {
 }
 
 #[test]
+fn unknown_command_suggests_closest_match() {
+    let graph = empty_graph();
+    let ctx = update_ctx(&graph);
+    let mut model = Model::new();
+    // "descrbe" is one character away from "describe" — fuzzy ranker should surface it.
+    update(&mut model, Message::PaletteSubmit("descrbe".into()), &ctx);
+    let msg = model
+        .status_message
+        .as_ref()
+        .map(|m| m.text.as_str())
+        .unwrap_or("");
+    assert!(
+        msg.contains("did you mean"),
+        "expected did-you-mean hint in: {msg}"
+    );
+    assert!(
+        msg.contains("describe"),
+        "expected 'describe' suggestion in: {msg}"
+    );
+}
+
+#[test]
 fn down_j_moves_selection() {
     let graph = make_graph_with_tokens(&["a", "b", "c"]);
     let ctx = update_ctx(&graph);


### PR DESCRIPTION
## Description

Five UX improvements to the `sdk/tui` app, identified during a full QA pass against cross-TUI conventions (vim/fzf/lazygit/k9s norms).

## Related Issue

beads: spectrum-design-data-16k, spectrum-design-data-bw7, spectrum-design-data-3g8, spectrum-design-data-4x3, spectrum-design-data-cpy

## Motivation and Context

A conventions review of the TUI surfaces (command palette, wizards, list views, help overlay) found five friction points where the app deviated from norms users expect from terminal tools.

**F1 — `?` unreachable inside any wizard/modal** (`update.rs`, `help.rs`, `view.rs`, `model.rs`)
`?` was silently swallowed inside wizards. Now it opens a wizard-context help overlay layered on top of the active modal, with a new `HelpContext::Wizard` variant that promotes the WIZARD keybinding section. Scroll with j/k/PgUp/PgDn, dismiss with `?` or Esc.

**F2 — Esc hard-cancels find and naming wizards from any screen** (`find.rs`, `naming.rs`)
The authoring wizard correctly goes back one screen on Esc (S2→S1, S3→S2, cancel on S1). The find and naming wizards instead hard-cancelled from any screen, breaking the user's mental model. Both now mirror the authoring wizard's back-stack.

**F3 — Invalid command shows generic error** (`update/command.rs`)
`unknown command: descrbe` had no recovery hint. Now uses the existing `Command::matches` fuzzy ranker to append `— did you mean \`describe\`?` when a close match exists.

**F4 — Selection mode (`v`) has no persistent indicator** (`view.rs`)
Toggling `v` only set a transient status message. Once any other message appeared, there was no indication selection mode was still active. A bold `[SEL]` badge now appears in the status line whenever selection mode is on.

**F5 — Readline Ctrl editing swallowed in authoring wizard fields** (`wizard.rs`)
The wizard's Ctrl early-return was too broad — it consumed all Ctrl+key events including Ctrl-A/E/W/U, which `tui-input` supports natively. Narrowed the guard to only intercept Ctrl-S on Screen 4.

## How Has This Been Tested?

- `cargo test -p design-data-tui` — all 19 unit tests pass, plus the full sdk workspace.
- Two existing tests updated to reflect the new correct Esc behavior in find/naming wizards (`esc_goes_back_on_preview_screen`, `esc_cancels_on_intent_screen` / `esc_goes_back_on_classification_screen` / `esc_goes_back_on_result_screen`).
- Changeset lint passes: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.