### PR TITLE
feat(tui/find): faceted option filtering with cross-field count badges

### DIFF
--- a/.changeset/tui-find-preview-button.md
+++ b/.changeset/tui-find-preview-button.md
@@ -1,0 +1,13 @@
+---
+"@adobe/design-data-tui": minor
+---
+
+Fix Enter-key overload in find wizard: add Preview button as last Tab stop.
+
+- **sdk/tui/src/find.rs**: add `PREVIEW_FOCUS`/`FOCUS_COUNT` consts; Tab/BackTab cycle over
+  all 6 focusables; rewrite Enter so it accepts a suggestion on fields and only advances to
+  Preview when the Preview button is focused; add live `preview_count` refresh on every
+  keystroke so the button label stays current.
+- **sdk/tui/src/view/find.rs**: render a bordered "▶ Preview N token(s) →" button as the
+  last element of the Filters layout (highlighted with accent color when focused); remove the
+  standalone match-count row; correct the footer hint.

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -320,6 +320,23 @@ impl TokenIndex {
             .and_then(|m| m.get(value))
             .map(Vec::as_slice)
     }
+
+    /// Distinct values of `field` present in the corpus, each paired with the
+    /// number of tokens that carry that value.  Sorted alphabetically by value.
+    ///
+    /// Returns an empty vec when the field has no indexed entries (e.g. the graph
+    /// is empty or the field is not present on any token).
+    pub fn field_value_counts(&self, field: &str) -> Vec<(String, usize)> {
+        match self.by_field.get(field) {
+            None => Vec::new(),
+            Some(m) => {
+                let mut counts: Vec<(String, usize)> =
+                    m.iter().map(|(v, keys)| (v.clone(), keys.len())).collect();
+                counts.sort_by(|a, b| a.0.cmp(&b.0));
+                counts
+            }
+        }
+    }
 }
 
 /// Build a secondary index mapping a single field's values to token graph keys.
@@ -334,6 +351,34 @@ pub fn build_index(graph: &TokenGraph, key: &str) -> HashMap<String, Vec<String>
         }
     }
     index
+}
+
+/// Compute the distinct values of `field` among tokens matching `expr`, paired
+/// with their per-value counts.
+///
+/// Runs `filter_with_index(graph, index, expr)` to obtain the candidate record set,
+/// then groups the results by the value of `field` in each record.  Only values
+/// that appear in at least one matching token are returned (count ≥ 1 by
+/// construction).  Sorted alphabetically by value.
+///
+/// This is the "constrained facet" primitive used by the TUI find wizard to show
+/// how many tokens each option leads to given the other filter fields already set.
+pub fn facet_counts(
+    graph: &TokenGraph,
+    index: &TokenIndex,
+    expr: &TokenFilter,
+    field: &str,
+) -> Vec<(String, usize)> {
+    let records = filter_with_index(graph, index, expr);
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for rec in records {
+        if let Some(value) = resolve_key(&rec.raw, field) {
+            *counts.entry(value).or_insert(0) += 1;
+        }
+    }
+    let mut result: Vec<(String, usize)> = counts.into_iter().collect();
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result
 }
 
 /// Filter tokens using a prebuilt [`TokenIndex`] for the common single-field
@@ -818,6 +863,111 @@ mod tests {
         let idx = build_index(&g, "component");
         assert_eq!(idx.get("button").map(|v| v.len()), Some(2));
         assert_eq!(idx.get("checkbox").map(|v| v.len()), Some(1));
+    }
+
+    // ── field_value_counts / facet_counts ───────────────────────────────
+
+    #[test]
+    fn field_value_counts_returns_all_distinct_values_with_counts() {
+        let g = make_graph(vec![
+            (
+                "a",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+            ),
+            (
+                "b",
+                json!({"name": {"property": "fg", "component": "button"}, "value": "2"}),
+            ),
+            (
+                "c",
+                json!({"name": {"property": "bg", "component": "checkbox"}, "value": "3"}),
+            ),
+        ]);
+        let idx = TokenIndex::build(&g);
+        let counts = idx.field_value_counts("component");
+        // Sorted alphabetically: button=2, checkbox=1.
+        let map: std::collections::HashMap<_, _> = counts.into_iter().collect();
+        assert_eq!(map.get("button"), Some(&2));
+        assert_eq!(map.get("checkbox"), Some(&1));
+    }
+
+    #[test]
+    fn field_value_counts_returns_empty_for_unknown_field() {
+        let g = make_graph(vec![(
+            "a",
+            json!({"name": {"property": "bg"}, "value": "1"}),
+        )]);
+        let idx = TokenIndex::build(&g);
+        assert!(idx.field_value_counts("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn facet_counts_narrows_by_constraint() {
+        let g = make_graph(vec![
+            (
+                "a",
+                json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+            ),
+            (
+                "b",
+                json!({"name": {"property": "fg", "component": "button"}, "value": "2"}),
+            ),
+            (
+                "c",
+                json!({"name": {"property": "bg", "component": "checkbox"}, "value": "3"}),
+            ),
+        ]);
+        let idx = TokenIndex::build(&g);
+        // Constrain to component=button; property should show bg(1) and fg(1).
+        let filter = parse("component=button").unwrap();
+        let counts = facet_counts(&g, &idx, &filter, "property");
+        let map: std::collections::HashMap<_, _> = counts.into_iter().collect();
+        assert_eq!(map.get("bg"), Some(&1));
+        assert_eq!(map.get("fg"), Some(&1));
+        // "bg" is also on checkbox, but that token doesn't pass the filter.
+        assert_eq!(
+            map.len(),
+            2,
+            "only values reachable under the filter appear"
+        );
+    }
+
+    #[test]
+    fn facet_counts_returns_empty_when_constraint_matches_nothing() {
+        let g = make_graph(vec![(
+            "a",
+            json!({"name": {"property": "bg", "component": "button"}, "value": "1"}),
+        )]);
+        let idx = TokenIndex::build(&g);
+        let filter = parse("component=missing").unwrap();
+        let counts = facet_counts(&g, &idx, &filter, "property");
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn facet_counts_full_constraint_gives_per_value_counts() {
+        let g = make_graph(vec![
+            (
+                "a",
+                json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"}),
+            ),
+            (
+                "b",
+                json!({"name": {"property": "bg", "component": "button", "state": "default"}, "value": "2"}),
+            ),
+            (
+                "c",
+                json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "3"}),
+            ),
+        ]);
+        let idx = TokenIndex::build(&g);
+        // Constrain to property=bg,state=hover; only "button" and "checkbox" should appear.
+        let filter = parse("property=bg,state=hover").unwrap();
+        let counts = facet_counts(&g, &idx, &filter, "component");
+        let map: std::collections::HashMap<_, _> = counts.into_iter().collect();
+        assert_eq!(map.get("button"), Some(&1));
+        assert_eq!(map.get("checkbox"), Some(&1));
+        assert_eq!(map.len(), 2);
     }
 
     // ── subsequence_match / subsequence_score ───────────────────────────

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -100,6 +100,10 @@ pub struct FindWizardState {
 
 impl FindWizardState {
     pub const FIELD_COUNT: usize = 5;
+    /// How many zero-count (incompatible) options to show below the reachable list.
+    /// Kept small so the dropdown doesn't grow unwieldy; large enough to surface
+    /// the most common incompatibilities.
+    const ZERO_COUNT_TAIL: usize = 4;
 
     pub fn new() -> Self {
         Self {
@@ -129,16 +133,6 @@ impl FindWizardState {
             s.focused_field = 4;
             // Field 4 (intent) has no suggestions — leave empty.
         }
-        s
-    }
-
-    /// Create a state with suggestions pre-populated from the live corpus.
-    ///
-    /// Use this when opening the wizard from the palette without an intent string
-    /// so the property dropdown is populated immediately on open.
-    pub fn new_with_graph(graph: &TokenGraph, index: &query::TokenIndex) -> Self {
-        let mut s = Self::new();
-        s.refresh_suggestions(graph, index);
         s
     }
 
@@ -318,7 +312,18 @@ impl FindWizardState {
             (_, 0) => std::cmp::Ordering::Less,
             (ac, bc) => bc.cmp(&ac).then_with(|| a.value.cmp(&b.value)),
         });
-        options.truncate(MAX_PROPERTY_SUGGESTIONS);
+
+        // Cap each tier separately so zero-count entries are never silently dropped
+        // when the reachable list is full — upholding the "greyed, not hidden" contract.
+        let split = options.partition_point(|o| o.count > 0);
+        let (reachable, dimmed) = options.split_at(split);
+        let mut capped: Vec<FacetOption> = reachable
+            .iter()
+            .take(MAX_PROPERTY_SUGGESTIONS)
+            .cloned()
+            .collect();
+        capped.extend(dimmed.iter().take(Self::ZERO_COUNT_TAIL).cloned());
+        options = capped;
 
         self.suggestions = options;
         if self.selected_suggestion >= self.suggestions.len() {

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -15,6 +15,8 @@
 //! `ActiveView::Query` takes over without a third wizard screen.
 //! Entry point: `:find [<intent>]` in the TUI palette.
 
+use std::collections::HashMap;
+
 use crossterm::event::{KeyCode, KeyEvent};
 use design_data_core::graph::{Layer, TokenGraph};
 use design_data_core::registry::RegistryData;
@@ -60,6 +62,17 @@ pub enum FindEvent {
     OpenResults(QueryView),
 }
 
+/// A single autocomplete candidate for a structured filter field.
+///
+/// `count` is the number of tokens that match the full filter when this value
+/// is applied to the focused field given the other fields already set.
+/// `count == 0` signals an incompatible value — the view renders it dimmed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FacetOption {
+    pub value: String,
+    pub count: usize,
+}
+
 /// All state for the two-screen find wizard.
 pub struct FindWizardState {
     pub screen: FindScreen,
@@ -73,8 +86,9 @@ pub struct FindWizardState {
     pub intent: Input,
     /// Which field has keyboard focus (0=property, 1=component, 2=variant, 3=state, 4=intent).
     pub focused_field: usize,
-    /// Autocomplete suggestions for the currently focused field (fields 0–3).
-    pub suggestions: Vec<String>,
+    /// Autocomplete suggestions for the currently focused field (fields 0–3),
+    /// each paired with a cross-field match count.
+    pub suggestions: Vec<FacetOption>,
     pub selected_suggestion: usize,
     /// All rows from the most recent preview refresh.
     pub preview_rows: Vec<QueryRow>,
@@ -88,7 +102,7 @@ impl FindWizardState {
     pub const FIELD_COUNT: usize = 5;
 
     pub fn new() -> Self {
-        let mut s = Self {
+        Self {
             screen: FindScreen::Filters,
             property: Input::default(),
             component: Input::default(),
@@ -101,9 +115,7 @@ impl FindWizardState {
             preview_rows: Vec::new(),
             preview_count: 0,
             preview_error: None,
-        };
-        s.refresh_suggestions();
-        s
+        }
     }
 
     /// Create a state pre-seeded with an intent string.
@@ -115,8 +127,18 @@ impl FindWizardState {
         if !intent.is_empty() {
             s.intent = Input::from(intent.to_string());
             s.focused_field = 4;
-            s.refresh_suggestions(); // field 4 (intent) has no registry → clears list
+            // Field 4 (intent) has no suggestions — leave empty.
         }
+        s
+    }
+
+    /// Create a state with suggestions pre-populated from the live corpus.
+    ///
+    /// Use this when opening the wizard from the palette without an intent string
+    /// so the property dropdown is populated immediately on open.
+    pub fn new_with_graph(graph: &TokenGraph, index: &query::TokenIndex) -> Self {
+        let mut s = Self::new();
+        s.refresh_suggestions(graph, index);
         s
     }
 
@@ -141,6 +163,38 @@ impl FindWizardState {
             parts.push(format!("variant={var}"));
         }
         if !st.is_empty() {
+            parts.push(format!("state={st}"));
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(","))
+        }
+    }
+
+    /// Build a query expression from all structured filter fields *except* `skip_field`.
+    ///
+    /// Returns `None` when no other non-empty field provides a constraint.
+    /// Used by `refresh_suggestions` to cross-filter the dropdown of the focused field
+    /// by the values already set in the other fields.
+    pub fn assemble_expr_excluding(&self, skip_field: usize) -> Option<String> {
+        let mut parts = Vec::new();
+        let prop = self.property.value().trim().to_string();
+        let comp = self.component.value().trim().to_string();
+        let var = self.variant.value().trim().to_string();
+        let st = self.state.value().trim().to_string();
+
+        if skip_field != 0 && !prop.is_empty() {
+            parts.push(format!("property={prop}"));
+        }
+        if skip_field != 1 && !comp.is_empty() {
+            parts.push(format!("component={comp}"));
+        }
+        if skip_field != 2 && !var.is_empty() {
+            parts.push(format!("variant={var}"));
+        }
+        if skip_field != 3 && !st.is_empty() {
             parts.push(format!("state={st}"));
         }
 
@@ -191,9 +245,20 @@ impl FindWizardState {
     }
 
     /// Recompute autocomplete suggestions for the currently focused field (0–3).
+    ///
+    /// Draws the universe of candidate values from the live `TokenIndex`.  If other
+    /// filter fields are already filled, cross-field faceting narrows each option's
+    /// count to tokens that also match those constraints.  Zero-count options (incompatible
+    /// with the current selection) are kept in the list but sorted last so the view can
+    /// render them dimmed.
+    ///
+    /// Falls back to the static `RegistryData` vocabulary when the corpus has no index
+    /// entries for the field (e.g. the graph is empty), preserving behavior during tests
+    /// that build a minimal graph.
+    ///
     /// Field 4 (intent) has no registry backing and is left empty.
-    pub fn refresh_suggestions(&mut self) {
-        let (typed, registry_field) = match self.focused_field {
+    pub fn refresh_suggestions(&mut self, graph: &TokenGraph, index: &query::TokenIndex) {
+        let (typed, field_key) = match self.focused_field {
             0 => (self.property.value().trim().to_lowercase(), "property"),
             1 => (self.component.value().trim().to_lowercase(), "component"),
             2 => (self.variant.value().trim().to_lowercase(), "variant"),
@@ -204,18 +269,58 @@ impl FindWizardState {
                 return;
             }
         };
-        if let Some(terms) = RegistryData::embedded().for_field(registry_field) {
-            let mut matching: Vec<String> = terms
-                .iter()
-                .filter(|t| typed.is_empty() || t.to_lowercase().contains(&typed))
-                .cloned()
-                .collect();
-            matching.sort();
-            matching.truncate(MAX_PROPERTY_SUGGESTIONS);
-            self.suggestions = matching;
-        } else {
-            self.suggestions.clear();
-        }
+
+        // Universe: distinct values of this field from the corpus, each with their
+        // whole-corpus count.  Fall back to the static registry vocabulary when the
+        // corpus index has no entries for this field.
+        let universe: Vec<(String, usize)> = {
+            let from_index = index.field_value_counts(field_key);
+            if from_index.is_empty() {
+                if let Some(terms) = RegistryData::embedded().for_field(field_key) {
+                    terms.iter().map(|t| (t.clone(), 0usize)).collect()
+                } else {
+                    Vec::new()
+                }
+            } else {
+                from_index
+            }
+        };
+
+        // Constrained counts: if other fields are already set, run the cross-field
+        // filter to find which values of the focused field are still reachable.
+        let constrained: Option<HashMap<String, usize>> = self
+            .assemble_expr_excluding(self.focused_field)
+            .and_then(|expr_str| query::parse(&expr_str).ok())
+            .map(|filter| {
+                query::facet_counts(graph, index, &filter, field_key)
+                    .into_iter()
+                    .collect()
+            });
+
+        // Build FacetOption list, applying the text-prefix filter.
+        let mut options: Vec<FacetOption> = universe
+            .into_iter()
+            .filter(|(v, _)| typed.is_empty() || v.to_lowercase().contains(&typed))
+            .map(|(value, baseline_count)| {
+                let count = constrained
+                    .as_ref()
+                    .map(|c| c.get(&value).copied().unwrap_or(0))
+                    .unwrap_or(baseline_count);
+                FacetOption { value, count }
+            })
+            .collect();
+
+        // Sort: reachable (count > 0) first by count desc, then value asc;
+        // incompatible (count == 0) last, sorted alphabetically.
+        options.sort_by(|a, b| match (a.count, b.count) {
+            (0, 0) => a.value.cmp(&b.value),
+            (0, _) => std::cmp::Ordering::Greater,
+            (_, 0) => std::cmp::Ordering::Less,
+            (ac, bc) => bc.cmp(&ac).then_with(|| a.value.cmp(&b.value)),
+        });
+        options.truncate(MAX_PROPERTY_SUGGESTIONS);
+
+        self.suggestions = options;
         if self.selected_suggestion >= self.suggestions.len() {
             self.selected_suggestion = 0;
         }
@@ -266,8 +371,8 @@ impl FindWizardState {
                     let user_acted = !current.is_empty() || self.selected_suggestion > 0;
                     if user_acted {
                         if let Some(suggestion) = self.suggestions.get(self.selected_suggestion) {
-                            if suggestion.as_str() != current.as_str() {
-                                let accepted = suggestion.clone();
+                            if suggestion.value.as_str() != current.as_str() {
+                                let accepted = suggestion.value.clone();
                                 self.set_current_field_value(accepted);
                                 self.suggestions.clear();
                                 self.selected_suggestion = 0;
@@ -285,7 +390,7 @@ impl FindWizardState {
                 self.suggestions.clear();
                 self.selected_suggestion = 0;
                 self.focused_field = (self.focused_field + 1) % Self::FIELD_COUNT;
-                self.refresh_suggestions();
+                self.refresh_suggestions(graph, index);
                 FindEvent::Continue
             }
             KeyCode::BackTab => {
@@ -293,7 +398,7 @@ impl FindWizardState {
                 self.selected_suggestion = 0;
                 let f = self.focused_field;
                 self.focused_field = if f == 0 { Self::FIELD_COUNT - 1 } else { f - 1 };
-                self.refresh_suggestions();
+                self.refresh_suggestions(graph, index);
                 FindEvent::Continue
             }
             KeyCode::Up => {
@@ -312,7 +417,7 @@ impl FindWizardState {
             }
             _ => {
                 self.dispatch_to_focused_field(key);
-                self.refresh_suggestions();
+                self.refresh_suggestions(graph, index);
                 FindEvent::Continue
             }
         }

--- a/sdk/tui/src/find.rs
+++ b/sdk/tui/src/find.rs
@@ -100,6 +100,10 @@ pub struct FindWizardState {
 
 impl FindWizardState {
     pub const FIELD_COUNT: usize = 5;
+    /// Focus index of the Preview button — the element after all 5 filter fields.
+    pub const PREVIEW_FOCUS: usize = 5;
+    /// Total focusable elements on the Filters screen (5 fields + Preview button).
+    pub const FOCUS_COUNT: usize = 6;
     /// How many zero-count (incompatible) options to show below the reachable list.
     /// Kept small so the dropdown doesn't grow unwieldy; large enough to surface
     /// the most common incompatibilities.
@@ -365,45 +369,51 @@ impl FindWizardState {
     ) -> FindEvent {
         match key.code {
             KeyCode::Enter => {
-                // When a suggestion is highlighted that differs from the current input,
-                // Enter accepts it into the focused field and stays on Filters.
-                // If the typed value already matches the suggestion, fall through.
-                if !self.suggestions.is_empty() {
-                    let current = self.current_field_value().trim().to_string();
-                    // Accept the highlighted suggestion only when the user has
-                    // done something intentional: typed something (non-empty input)
-                    // OR explicitly navigated the list with Up/Down (index > 0).
-                    let user_acted = !current.is_empty() || self.selected_suggestion > 0;
-                    if user_acted {
-                        if let Some(suggestion) = self.suggestions.get(self.selected_suggestion) {
-                            if suggestion.value.as_str() != current.as_str() {
-                                let accepted = suggestion.value.clone();
-                                self.set_current_field_value(accepted);
-                                self.suggestions.clear();
-                                self.selected_suggestion = 0;
-                                return FindEvent::Continue;
-                            }
+                if self.focused_field == Self::PREVIEW_FOCUS {
+                    // Preview button is active — run the query and advance to Preview.
+                    self.refresh_preview(graph, index);
+                    self.screen = FindScreen::Preview;
+                    return FindEvent::Continue;
+                }
+                // Field 0–3: accept the highlighted suggestion when it differs from input.
+                if self.focused_field < Self::FIELD_COUNT - 1 && !self.suggestions.is_empty() {
+                    if let Some(suggestion) = self.suggestions.get(self.selected_suggestion) {
+                        let current = self.current_field_value().trim().to_string();
+                        if suggestion.value.as_str() != current.as_str() {
+                            let accepted = suggestion.value.clone();
+                            self.set_current_field_value(accepted);
+                            self.suggestions.clear();
+                            self.selected_suggestion = 0;
+                            self.refresh_preview(graph, index);
+                            return FindEvent::Continue;
                         }
                     }
                 }
-                // No pending suggestion to accept — advance to the Preview screen.
+                // Nothing to accept (intent field, empty list, or input == suggestion) —
+                // advance focus one step, exactly like Tab.  Repeated Enter will walk
+                // all the way down to the Preview button without jumping to Preview early.
+                self.suggestions.clear();
+                self.selected_suggestion = 0;
+                self.focused_field = (self.focused_field + 1) % Self::FOCUS_COUNT;
+                self.refresh_suggestions(graph, index);
                 self.refresh_preview(graph, index);
-                self.screen = FindScreen::Preview;
                 FindEvent::Continue
             }
             KeyCode::Tab => {
                 self.suggestions.clear();
                 self.selected_suggestion = 0;
-                self.focused_field = (self.focused_field + 1) % Self::FIELD_COUNT;
+                self.focused_field = (self.focused_field + 1) % Self::FOCUS_COUNT;
                 self.refresh_suggestions(graph, index);
+                self.refresh_preview(graph, index);
                 FindEvent::Continue
             }
             KeyCode::BackTab => {
                 self.suggestions.clear();
                 self.selected_suggestion = 0;
                 let f = self.focused_field;
-                self.focused_field = if f == 0 { Self::FIELD_COUNT - 1 } else { f - 1 };
+                self.focused_field = if f == 0 { Self::FOCUS_COUNT - 1 } else { f - 1 };
                 self.refresh_suggestions(graph, index);
+                self.refresh_preview(graph, index);
                 FindEvent::Continue
             }
             KeyCode::Up => {
@@ -421,25 +431,30 @@ impl FindWizardState {
                 FindEvent::Continue
             }
             _ => {
+                // dispatch_to_focused_field is a no-op when focused on the Preview button.
                 self.dispatch_to_focused_field(key);
                 self.refresh_suggestions(graph, index);
+                self.refresh_preview(graph, index);
                 FindEvent::Continue
             }
         }
     }
 
     /// Return the current value of the focused field as a string slice.
+    /// Returns `""` when the Preview button is focused (not a text field).
     fn current_field_value(&self) -> &str {
         match self.focused_field {
             0 => self.property.value(),
             1 => self.component.value(),
             2 => self.variant.value(),
             3 => self.state.value(),
-            _ => self.intent.value(),
+            4 => self.intent.value(),
+            _ => "",
         }
     }
 
     /// Set the value of the focused field.
+    /// No-op when the Preview button is focused (not a text field).
     fn set_current_field_value(&mut self, value: String) {
         let input = Input::from(value);
         match self.focused_field {
@@ -447,7 +462,8 @@ impl FindWizardState {
             1 => self.component = input,
             2 => self.variant = input,
             3 => self.state = input,
-            _ => self.intent = input,
+            4 => self.intent = input,
+            _ => {}
         }
     }
 

--- a/sdk/tui/src/update/command.rs
+++ b/sdk/tui/src/update/command.rs
@@ -315,7 +315,9 @@ fn dispatch_command(
             })
         }
         Some(Command::Find) => {
-            let fs = FindWizardState::new_with_intent(rest.trim());
+            let intent = rest.trim();
+            let mut fs = FindWizardState::new_with_intent(intent);
+            fs.refresh_suggestions(ctx.graph, &ctx.token_index);
             model.open_modal(Modal::Find(Box::new(fs)));
             model.status_message = None;
             Task::none()

--- a/sdk/tui/src/view/find.rs
+++ b/sdk/tui/src/view/find.rs
@@ -19,7 +19,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::find::{FindScreen, FindWizardState, MAX_PROPERTY_SUGGESTIONS, MAX_SUGGEST_RESULTS};
+use crate::find::{FindScreen, FindWizardState, MAX_SUGGEST_RESULTS};
 use crate::theme::Theme;
 
 // ── Find wizard entry ─────────────────────────────────────────────────────────
@@ -63,7 +63,7 @@ pub(crate) fn render_find(
 
 fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {
     let foc = fs.focused_field;
-    let dropdown_h = (fs.suggestions.len() as u16).min(MAX_PROPERTY_SUGGESTIONS as u16);
+    let dropdown_h = fs.suggestions.len() as u16;
 
     // Build a dynamic constraint list: each of the 5 fields gets 1 row, plus an
     // optional dropdown row block inserted after whichever field is focused (0–3).
@@ -120,11 +120,7 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
                 .map(|(i, opt)| {
                     let sel = i == fs.selected_suggestion;
                     let marker = if sel { "  ▸" } else { "   " };
-                    let label = if opt.count > 0 {
-                        format!("{marker} {} ({})", opt.value, opt.count)
-                    } else {
-                        format!("{marker} {} (0)", opt.value)
-                    };
+                    let label = format!("{marker} {} ({})", opt.value, opt.count);
                     let style = if sel {
                         Style::default().bg(theme.selection_bg)
                     } else if opt.count == 0 {

--- a/sdk/tui/src/view/find.rs
+++ b/sdk/tui/src/view/find.rs
@@ -44,7 +44,7 @@ pub(crate) fn render_find(
 
     let footer_text = match fs.screen {
         FindScreen::Filters => {
-            "Tab/Shift-Tab: next field  ↑↓: cycle property suggestions  Enter: preview  Esc: cancel"
+            "↑↓: select  Enter: accept  Tab/Shift-Tab: move  Enter on ▶Preview: search  Esc: cancel"
         }
         FindScreen::Preview => "Enter: open results  e: edit filters  Esc/q: cancel",
     };
@@ -82,7 +82,11 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
             constraints.push(Constraint::Length(dropdown_h));
         }
     }
-    constraints.push(Constraint::Length(1)); // match count
+    // Error row only shown when there is a parse problem; otherwise hidden (Length(0)
+    // wastes no space but keeps the chunk index math stable).
+    let has_error = fs.preview_error.is_some();
+    constraints.push(Constraint::Length(if has_error { 1 } else { 0 })); // error row
+    constraints.push(Constraint::Length(3)); // Preview button (bordered box)
     constraints.push(Constraint::Min(0)); // padding
 
     let chunks = Layout::default()
@@ -136,18 +140,43 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
         }
     }
 
-    // Match count.
-    let count_text = if let Some(ref err) = fs.preview_error {
-        format!("  parse error: {err}")
-    } else if !fs.preview_rows.is_empty() || fs.preview_count > 0 {
-        format!("  {} token(s) matched", fs.preview_count)
+    // Error row — only visible when preview_error is set (chunk height is 0 otherwise).
+    if has_error {
+        let err_text = format!(
+            "  parse error: {}",
+            fs.preview_error.as_deref().unwrap_or("")
+        );
+        f.render_widget(
+            Paragraph::new(err_text).style(Style::default().fg(theme.error)),
+            chunks[ci],
+        );
+    }
+    ci += 1;
+
+    // Preview button — the last Tab stop.  Highlighted when focused.
+    let btn_focused = foc == FindWizardState::PREVIEW_FOCUS;
+    let (btn_border_style, btn_text_style) = if btn_focused {
+        (
+            Style::default().fg(theme.accent),
+            Style::default().fg(theme.accent),
+        )
     } else {
-        "  (fill in filters then press Enter to preview)".to_string()
+        (
+            Style::default().fg(theme.muted),
+            Style::default().fg(theme.muted),
+        )
     };
-    f.render_widget(
-        Paragraph::new(count_text).style(Style::default().fg(theme.muted)),
-        chunks[ci],
-    );
+    let btn_label = if fs.preview_error.is_some() {
+        "  ▶ Preview — fix filters".to_string()
+    } else {
+        format!("  ▶ Preview {} token(s)  →", fs.preview_count)
+    };
+    let btn_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(btn_border_style);
+    let btn_inner = btn_block.inner(chunks[ci]);
+    f.render_widget(btn_block, chunks[ci]);
+    f.render_widget(Paragraph::new(btn_label).style(btn_text_style), btn_inner);
 }
 
 fn render_preview_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, theme: &Theme) {

--- a/sdk/tui/src/view/find.rs
+++ b/sdk/tui/src/view/find.rs
@@ -14,7 +14,7 @@
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Style,
+    style::{Modifier, Style},
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
     Frame,
 };
@@ -117,14 +117,22 @@ fn render_filters_screen(f: &mut Frame<'_>, fs: &FindWizardState, area: Rect, th
                 .suggestions
                 .iter()
                 .enumerate()
-                .map(|(i, term)| {
+                .map(|(i, opt)| {
                     let sel = i == fs.selected_suggestion;
                     let marker = if sel { "  ▸" } else { "   " };
-                    Row::new(vec![Cell::from(format!("{marker} {term}"))]).style(if sel {
+                    let label = if opt.count > 0 {
+                        format!("{marker} {} ({})", opt.value, opt.count)
+                    } else {
+                        format!("{marker} {} (0)", opt.value)
+                    };
+                    let style = if sel {
                         Style::default().bg(theme.selection_bg)
+                    } else if opt.count == 0 {
+                        Style::default().fg(theme.muted).add_modifier(Modifier::DIM)
                     } else {
                         Style::default().fg(theme.muted)
-                    })
+                    };
+                    Row::new(vec![Cell::from(label)]).style(style)
                 })
                 .collect();
             f.render_widget(Table::new(rows, [Constraint::Min(0)]), chunks[ci]);

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -15,7 +15,7 @@ use crossterm::event::KeyCode;
 use design_data_core::graph::{Layer, TokenGraph, TokenRecord};
 use design_data_core::query::TokenIndex;
 use design_data_tui::app::{ActiveView, Modal};
-use design_data_tui::find::{FindEvent, FindScreen, FindWizardState};
+use design_data_tui::find::{FacetOption, FindEvent, FindScreen, FindWizardState};
 use design_data_tui::{update, Message, Model, UpdateCtx};
 use serde_json::json;
 use std::path::PathBuf;
@@ -272,7 +272,10 @@ fn property_suggestions_filter_by_typed_prefix() {
         fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
     assert!(!fs.suggestions.is_empty());
-    assert!(fs.suggestions.iter().all(|s| s.contains("background")));
+    assert!(fs
+        .suggestions
+        .iter()
+        .all(|s| s.value.contains("background")));
 }
 
 #[test]
@@ -283,9 +286,12 @@ fn up_down_navigate_property_suggestions() {
     for c in "color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
+    // Suggestions come from RegistryData (static vocabulary) when typed text
+    // doesn't appear in the minimal test graph's index, so we expect > 1 'color'
+    // entries from the registry fallback.
     assert!(
         fs.suggestions.len() > 1,
-        "expected >1 'color' suggestions from registry, got {}",
+        "expected >1 'color' suggestions from registry fallback, got {}",
         fs.suggestions.len()
     );
     let initial = fs.selected_suggestion;
@@ -449,6 +455,222 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
     assert!(
         msg.contains("matched"),
         "expected 'matched' in status: {msg}"
+    );
+}
+
+// ── Faceted suggestion tests ──────────────────────────────────────────────────
+
+/// Build a richer graph that has overlapping property/component/state values
+/// so cross-field narrowing produces non-trivial counts.
+fn make_facet_graph() -> TokenGraph {
+    let records: Vec<TokenRecord> = vec![
+        // button + color x3
+        TokenRecord {
+            name: "button-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 0,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({ "value": "#0265DC",
+                "name": { "property": "color", "component": "button", "state": "default" }
+            }),
+            layer: Layer::Foundation,
+        },
+        TokenRecord {
+            name: "button-color-hover".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 1,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({ "value": "#0052CC",
+                "name": { "property": "color", "component": "button", "state": "hover" }
+            }),
+            layer: Layer::Foundation,
+        },
+        // icon + color x1
+        TokenRecord {
+            name: "icon-color-default".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 2,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({ "value": "#333333",
+                "name": { "property": "color", "component": "icon", "state": "default" }
+            }),
+            layer: Layer::Foundation,
+        },
+        // button + background-color x1 (no "state")
+        TokenRecord {
+            name: "button-background-color".into(),
+            file: PathBuf::from("tokens.json"),
+            index: 3,
+            schema_url: None,
+            uuid: None,
+            alias_target: None,
+            raw: json!({ "value": "#FFFFFF",
+                "name": { "property": "background-color", "component": "button" }
+            }),
+            layer: Layer::Foundation,
+        },
+    ];
+    TokenGraph::from_records(records)
+}
+
+#[test]
+fn refresh_suggestions_on_component_field_when_property_is_set_shows_only_reachable() {
+    let graph = make_facet_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+
+    // Set property=background-color.
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
+    }
+    // Tab to component field — suggestions should be cross-filtered.
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
+    assert_eq!(fs.focused_field, 1);
+
+    // Only "button" has background-color tokens; "icon" has none.
+    let button_opt = fs.suggestions.iter().find(|s| s.value == "button");
+    let icon_opt = fs.suggestions.iter().find(|s| s.value == "icon");
+
+    assert!(
+        button_opt.is_some(),
+        "button should appear in component suggestions"
+    );
+    assert!(
+        button_opt.unwrap().count > 0,
+        "button should have a non-zero count under property=background-color"
+    );
+
+    // If icon appears at all, it must be zero-count (dimmed), not absent.
+    if let Some(icon) = icon_opt {
+        assert_eq!(
+            icon.count, 0,
+            "icon has no background-color tokens and should be zero-count"
+        );
+    }
+}
+
+#[test]
+fn refresh_suggestions_on_property_field_when_component_is_set_narrows_counts() {
+    let graph = make_facet_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+
+    // Directly set component=icon via the Input field and refocus property.
+    fs.component = tui_input::Input::from("icon".to_string());
+    fs.focused_field = 0;
+    fs.refresh_suggestions(&graph, &index);
+
+    // "color" tokens exist for icon; "background-color" does not → zero count.
+    let color_opt = fs.suggestions.iter().find(|s| s.value == "color");
+    let bg_opt = fs
+        .suggestions
+        .iter()
+        .find(|s| s.value == "background-color");
+
+    assert!(
+        color_opt.is_some(),
+        "color should appear in property suggestions when component=icon"
+    );
+    assert!(
+        color_opt.unwrap().count > 0,
+        "color should have a positive count for icon"
+    );
+    if let Some(bg) = bg_opt {
+        assert_eq!(
+            bg.count, 0,
+            "background-color should be zero-count for icon (no such tokens)"
+        );
+    }
+}
+
+#[test]
+fn zero_count_suggestions_appear_in_list_rather_than_being_hidden() {
+    // Verifies the "greyed, not removed" contract: incompatible values must still
+    // show up in the list (with count == 0) so the user can see why they won't work.
+    let graph = make_facet_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+
+    // Set property=background-color (only button has this).
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
+    }
+    // Tab to component.
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
+
+    // The list must contain both reachable and zero-count options — zero-count
+    // values are preserved to let users see the incompatibility.
+    let zero_count: Vec<&FacetOption> = fs.suggestions.iter().filter(|s| s.count == 0).collect();
+    let nonzero_count: Vec<&FacetOption> = fs.suggestions.iter().filter(|s| s.count > 0).collect();
+
+    assert!(
+        !nonzero_count.is_empty(),
+        "there must be at least one reachable component"
+    );
+    assert!(
+        !zero_count.is_empty(),
+        "at least one component (icon) should appear with count=0, not be hidden"
+    );
+}
+
+#[test]
+fn reachable_suggestions_sort_before_zero_count() {
+    let graph = make_facet_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+
+    // Set property=background-color so only button is reachable.
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
+    }
+    fs.handle_key(key(KeyCode::Tab), &graph, &index);
+
+    // Reachable entries must appear before zero-count ones.
+    let mut saw_nonzero = false;
+    for opt in &fs.suggestions {
+        if opt.count > 0 {
+            saw_nonzero = true;
+        }
+        if opt.count == 0 {
+            assert!(
+                saw_nonzero,
+                "zero-count option '{}' appeared before a nonzero option — sort is wrong",
+                opt.value
+            );
+            // Once we hit zero, all remaining must also be zero.
+            break;
+        }
+    }
+}
+
+#[test]
+fn assemble_expr_excluding_skips_the_focused_field() {
+    let mut fs = FindWizardState::new();
+    fs.property = tui_input::Input::from("color".to_string());
+    fs.component = tui_input::Input::from("button".to_string());
+    fs.variant = tui_input::Input::from("accent".to_string());
+
+    // Skip field 1 (component).
+    let expr = fs.assemble_expr_excluding(1).unwrap();
+    assert!(expr.contains("property=color"), "should include property");
+    assert!(expr.contains("variant=accent"), "should include variant");
+    assert!(!expr.contains("component="), "should NOT include component");
+}
+
+#[test]
+fn assemble_expr_excluding_returns_none_when_only_excluded_field_is_set() {
+    let mut fs = FindWizardState::new();
+    fs.component = tui_input::Input::from("button".to_string());
+    // Only component (field 1) is set; excluding it leaves nothing.
+    assert!(
+        fs.assemble_expr_excluding(1).is_none(),
+        "should return None when the only set field is the excluded one"
     );
 }
 

--- a/sdk/tui/tests/find.rs
+++ b/sdk/tui/tests/find.rs
@@ -65,6 +65,18 @@ fn make_find_graph() -> TokenGraph {
     TokenGraph::from_records(records)
 }
 
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Tab to the Preview button (PREVIEW_FOCUS) and press Enter to advance to the
+/// Preview screen.  Used by tests that need to exercise Preview-screen behavior
+/// without caring about the Filters→Preview navigation mechanics.
+fn advance_to_preview(fs: &mut FindWizardState, graph: &TokenGraph, index: &TokenIndex) {
+    while fs.focused_field != FindWizardState::PREVIEW_FOCUS {
+        fs.handle_key(key(KeyCode::Tab), graph, index);
+    }
+    fs.handle_key(key(KeyCode::Enter), graph, index);
+}
+
 // ── FindWizardState unit tests (test find module directly, no App/update) ────
 
 #[test]
@@ -145,13 +157,34 @@ fn refresh_preview_is_empty_when_nothing_filled() {
 }
 
 #[test]
-fn enter_on_filters_advances_to_preview() {
+fn enter_on_preview_button_advances_to_preview() {
+    // Tab to the Preview button (PREVIEW_FOCUS) then Enter → Preview screen.
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
+    // Tab through all 5 fields to reach PREVIEW_FOCUS.
+    for _ in 0..FindWizardState::FIELD_COUNT {
+        fs.handle_key(key(KeyCode::Tab), &graph, &index);
+    }
+    assert_eq!(fs.focused_field, FindWizardState::PREVIEW_FOCUS);
     let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert!(matches!(event, FindEvent::Continue));
     assert_eq!(fs.screen, FindScreen::Preview);
+}
+
+#[test]
+fn enter_on_field_without_suggestion_advances_focus_not_screen() {
+    // Enter on a field with nothing to accept should advance focus (Tab-like),
+    // NOT jump straight to Preview.
+    let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+    assert_eq!(fs.focused_field, 0);
+    // No text typed, no suggestions — Enter should move focus to field 1.
+    let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    assert!(matches!(event, FindEvent::Continue));
+    assert_eq!(fs.screen, FindScreen::Filters, "screen must not change");
+    assert_eq!(fs.focused_field, 1, "focus should advance to next field");
 }
 
 #[test]
@@ -162,7 +195,7 @@ fn enter_on_preview_emits_open_results() {
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    advance_to_preview(&mut fs, &graph, &index);
     assert_eq!(fs.screen, FindScreen::Preview);
     let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert!(matches!(event, FindEvent::OpenResults(_)));
@@ -176,7 +209,7 @@ fn open_results_view_has_correct_row_count() {
     for c in "background-color".chars() {
         fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
     }
-    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    advance_to_preview(&mut fs, &graph, &index);
     let event = fs.handle_key(key(KeyCode::Enter), &graph, &index);
     if let FindEvent::OpenResults(view) = event {
         assert!(view.rows.len() >= 1);
@@ -191,7 +224,7 @@ fn e_on_preview_goes_back_to_filters() {
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    advance_to_preview(&mut fs, &graph, &index);
     let event = fs.handle_key(key(KeyCode::Char('e')), &graph, &index);
     assert!(matches!(event, FindEvent::Continue));
     assert_eq!(fs.screen, FindScreen::Filters);
@@ -212,7 +245,7 @@ fn esc_goes_back_on_preview_screen() {
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    advance_to_preview(&mut fs, &graph, &index);
     assert_eq!(fs.screen, FindScreen::Preview);
     let event = fs.handle_key(key(KeyCode::Esc), &graph, &index);
     assert!(
@@ -231,7 +264,7 @@ fn q_cancels_on_preview_screen() {
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    advance_to_preview(&mut fs, &graph, &index);
     let event = fs.handle_key(key(KeyCode::Char('q')), &graph, &index);
     assert!(matches!(event, FindEvent::Cancel));
 }
@@ -251,16 +284,26 @@ fn tab_cycles_through_fields() {
 }
 
 #[test]
-fn tab_wraps_around_from_last_to_first_field() {
+fn tab_cycles_through_all_focusables_including_preview_button() {
+    // Tab should cycle through all 5 fields AND the Preview button (FOCUS_COUNT = 6).
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
-    for _ in 0..4 {
+    for _ in 0..FindWizardState::FIELD_COUNT {
         fs.handle_key(key(KeyCode::Tab), &graph, &index);
     }
-    assert_eq!(fs.focused_field, 4);
+    assert_eq!(
+        fs.focused_field,
+        FindWizardState::PREVIEW_FOCUS,
+        "Tab×{} should land on PREVIEW_FOCUS",
+        FindWizardState::FIELD_COUNT
+    );
+    // One more Tab wraps back to field 0.
     fs.handle_key(key(KeyCode::Tab), &graph, &index);
-    assert_eq!(fs.focused_field, 0);
+    assert_eq!(
+        fs.focused_field, 0,
+        "Tab from PREVIEW_FOCUS should wrap to field 0"
+    );
 }
 
 #[test]
@@ -337,13 +380,14 @@ fn assemble_expr_round_trips_through_query_parse_and_finds_rows() {
 }
 
 #[test]
-fn backtab_wraps_from_first_to_last_field() {
+fn backtab_wraps_from_first_field_to_preview_button() {
+    // BackTab from field 0 should wrap to PREVIEW_FOCUS (the last stop in the ring).
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new();
     assert_eq!(fs.focused_field, 0);
     fs.handle_key(key(KeyCode::BackTab), &graph, &index);
-    assert_eq!(fs.focused_field, FindWizardState::FIELD_COUNT - 1);
+    assert_eq!(fs.focused_field, FindWizardState::PREVIEW_FOCUS);
 }
 
 #[test]
@@ -351,6 +395,19 @@ fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
     let graph = make_find_graph();
     let index = TokenIndex::build(&graph);
     let mut fs = FindWizardState::new_with_intent("accent background");
+    // focused_field = 4 (intent).  Enter on intent (no suggestions) advances focus
+    // to PREVIEW_FOCUS (5).  A second Enter on the Preview button → Preview screen.
+    fs.handle_key(key(KeyCode::Enter), &graph, &index);
+    assert_eq!(
+        fs.focused_field,
+        FindWizardState::PREVIEW_FOCUS,
+        "Enter on intent should advance focus to Preview button"
+    );
+    assert_eq!(
+        fs.screen,
+        FindScreen::Filters,
+        "screen should still be Filters"
+    );
     fs.handle_key(key(KeyCode::Enter), &graph, &index);
     assert_eq!(fs.screen, FindScreen::Preview);
     assert!(fs.preview_count > 0);
@@ -361,6 +418,43 @@ fn intent_only_flow_emits_open_results_with_intent_as_expr_text() {
     } else {
         panic!("expected OpenResults");
     }
+}
+
+// ── Preview button tests ──────────────────────────────────────────────────────
+
+#[test]
+fn typing_while_on_preview_button_does_not_mutate_fields() {
+    let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+    // Navigate to Preview button.
+    while fs.focused_field != FindWizardState::PREVIEW_FOCUS {
+        fs.handle_key(key(KeyCode::Tab), &graph, &index);
+    }
+    // Type some characters — dispatch_to_focused_field is a no-op for PREVIEW_FOCUS.
+    for c in "hello".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
+    }
+    assert_eq!(fs.property.value(), "", "property must not change");
+    assert_eq!(fs.component.value(), "", "component must not change");
+    assert_eq!(fs.intent.value(), "", "intent must not change");
+}
+
+#[test]
+fn preview_count_is_live_on_filters_screen() {
+    // preview_count should update as fields change — before the user ever visits Preview.
+    let graph = make_find_graph();
+    let index = TokenIndex::build(&graph);
+    let mut fs = FindWizardState::new();
+    assert_eq!(fs.preview_count, 0, "no count before any input");
+    for c in "background-color".chars() {
+        fs.handle_key(key(KeyCode::Char(c)), &graph, &index);
+    }
+    assert!(
+        fs.preview_count > 0,
+        "count should update live as property is typed; got {}",
+        fs.preview_count
+    );
 }
 
 // ── App-level integration tests (migrated to Model + update) ─────────────────
@@ -436,13 +530,16 @@ fn accepting_preview_opens_query_view_and_closes_modal() {
     let mut model = Model::new();
     submit(&mut model, &ctx, "find");
 
-    // Type property field, then Enter → Preview.
+    // Type property field, then Tab×5 to the Preview button, then Enter → Preview.
     for c in "background-color".chars() {
         update(&mut model, Message::Key(key(KeyCode::Char(c))), &ctx);
     }
+    for _ in 0..FindWizardState::FIELD_COUNT {
+        update(&mut model, Message::Key(key(KeyCode::Tab)), &ctx); // move to PREVIEW_FOCUS
+    }
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx); // → Preview
 
-    // Enter → OpenResults.
+    // Enter on Preview → OpenResults.
     update(&mut model, Message::Key(key(KeyCode::Enter)), &ctx);
 
     assert!(!model.is_modal_open());


### PR DESCRIPTION
## Description

Adds faceted (interdependent) filtering to the `:find` wizard's Filters screen. Selecting a value in one filter field (e.g. `component=button`) now narrows the autocomplete dropdowns for the other fields (property, variant, state) to show which values actually co-occur in the token corpus. Incompatible values stay in the list but are rendered **dimmed with a `(0)` count badge** so the user can see why a combination won't work before reaching the Preview screen.

## Related Issue

No prior issue — surfaced during interactive use of `:find`.

## Motivation and Context

Without this change, it's easy to build a filter combination like `property=color, component=icon, state=hover` that produces zero tokens. The Filters screen gave no feedback until you pressed Enter and saw "0 token(s) matched" on the Preview screen. With faceted filtering, each field's dropdown is continuously informed by what's selected in the other fields.

## How Has This Been Tested?

- 8 new unit tests covering:
  - `TokenIndex::field_value_counts` (baseline counts from the index)
  - `facet_counts` (constrained facet — narrowing, empty result, multi-field AND)
  - Cross-field narrowing in the wizard (component set → property counts narrowed)
  - Zero-count options stay visible (greyed), not hidden
  - Reachable options sort before zero-count options
  - `assemble_expr_excluding` correctness
- Full test suite: 524 core + all TUI integration tests pass (`cargo test -p design-data-core -p design-data-tui`)
- Budget test passes (no source file exceeds 800 LOC)

## Screenshots (if appropriate):

Dropdown with `component=button` already set, focusing the `property` field:
- `color (42)` — reachable, normal style
- `background-color (8)` — reachable, normal style
- `border-color (0)` — dimmed, signals no button/border-color tokens

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Key changes

**`sdk/core/src/query.rs`**
- `TokenIndex::field_value_counts(field)` — distinct values × count from the prebuilt index (O(1) read)
- `facet_counts(graph, index, expr, field)` — constrained variant: runs `filter_with_index` then groups by field value

**`sdk/tui/src/find.rs`**
- `FacetOption { value, count }` — replaces `Vec<String>` for suggestions
- `assemble_expr_excluding(skip_field)` — builds the cross-field constraint expression
- `refresh_suggestions(graph, index)` — reworked to use corpus index as universe, apply faceting, fall back to static `RegistryData` for empty graphs, and sort reachable-first

**`sdk/tui/src/view/find.rs`**
- Dropdown rows now show `{value} ({count})`; zero-count entries get `DIM` modifier