### PR TITLE
docs(demo): refresh demo materials for TUI feature drift (#1157–#1173)

### DIFF
--- a/sdk/tui/DEMO.md
+++ b/sdk/tui/DEMO.md
@@ -63,12 +63,12 @@ search them like a database."*
 ### Beat 2 — Cascade resolution (45 s)
 
 **Talking point:** "Every token participates in a cascade — like CSS specificity but
-for design. Let's see who wins for `accent-background-color-default` in dark mode."
+for design. Let's see who wins for `accent-background-color` in dark mode."
 
-| Keys                                                                        | Action       |
-| --------------------------------------------------------------------------- | ------------ |
-| `:`                                                                         | Open palette |
-| `resolve property=accent-background-color-default,colorScheme=dark` `Enter` | Run resolve  |
+| Keys                                                                | Action       |
+| ------------------------------------------------------------------- | ------------ |
+| `:`                                                                 | Open palette |
+| `resolve property=accent-background-color,colorScheme=dark` `Enter` | Run resolve  |
 
 Expected: table with ★ / Name / Value / File / Layer / Spec columns. One row has ★
 in the first column — that's the winning token for this mode combination.
@@ -109,7 +109,9 @@ diff preview — it's an alias, not a net-new value.
 
 *"One keystroke, and the cascade stays healthy."*
 
-**Esc** to cancel (we'll create a real one next).
+**Esc** to back-navigate (Esc now steps back one screen at a time — press Esc four
+times to cancel from Confirm: Confirm → Values → Classification → Intent → cancel).
+This is a good moment to narrate the back-navigation feature.
 
 ***
 
@@ -233,17 +235,18 @@ Quit and relaunch against the real dataset for the rest of the demo.
 
 * `:query property=*background*` `Enter` — narrows the table to tokens whose
   property matches the `*background*` glob (any `query` expression works here).
-* `:find background` `Enter` — opens the Find wizard seeded with that intent for
-  interactive name lookup.
-* `/` `btnbg` — opens **live fuzzy-find**: the table re-ranks on every keystroke
-  using fzf-style subsequence matching (`btnbg` matches `button-background`), with
-  the header reading `Fuzzy: /btnbg`. `Enter` keeps the filtered results; `Esc`
-  restores the view that was on screen before you opened the palette. Pick a
-  needle that actually hits tokens in your dataset so the live narrowing reads
-  clearly on camera — `btnbg` is just an example.
+* `:find` `Enter` — opens the **Find wizard** at the Filters screen
+  (`Step 1 of 2 — Filters`). Five fields: property, component, variant, state,
+  free-text intent. As you type, **cross-field count badges** update next to
+  every option — showing how many tokens match the full combination. Tab through
+  the fields to the Preview button; Enter to run the query; Esc from Preview
+  returns to Filters; Esc from Filters cancels.
+* `:find background` `Enter` — same wizard, pre-seeded with "background" as the
+  intent field. Good for intent-first lookup.
 
-*"`:` is the structured command surface — `query` for predicate filtering and `find`
-for guided lookup — while `/` is incremental fuzzy search over token names. Tab
+*"`:query` is predicate filtering (glob expressions, structured fields). `:find`
+is guided lookup with live count feedback — use it when you want to explore what
+values are available for a field before committing to an expression. Tab
 autocomplete and Up/Down history work throughout the `:` palette."*
 
 ***

--- a/sdk/tui/README.md
+++ b/sdk/tui/README.md
@@ -54,15 +54,18 @@ drops you into an interactive session. Press `?` for the full keymap.
 
 ## Commands
 
-Open the palette with `:` (command mode) or `/` (fuzzy-find mode).
+Open the palette with `:` and type a command name. Press `Tab` to autocomplete
+(fuzzy match with highlighted characters). Press `?` at any point to open the
+context-sensitive help overlay.
 
-| Command                                           | Description                                                                                                |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `:query <expr>`                                   | Filter tokens. Glob-style: `background-color/*`, `accent-*`                                                |
-| `:resolve property=<name>[,<mode-set>=<mode>...]` | Show cascade resolution for a property with optional mode overrides. The ★ column marks the winning token. |
-| `:describe <component>`                           | Inspect a component schema (JSON, scrollable).                                                             |
-| `:validate`                                       | Validate all loaded tokens against their `$schema`. Shows Sev / Rule / Token / Message.                    |
-| `:new [<intent>]`                                 | Open the four-screen token authoring wizard.                                                               |
+| Command                                           | Description                                                                                                                                    |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:query <expr>`                                   | Filter tokens. Glob-style: `background-color/*`, `accent-*`                                                                                    |
+| `:resolve property=<name>[,<mode-set>=<mode>...]` | Show cascade resolution for a property with optional mode overrides. The ★ column marks the winning token.                                     |
+| `:describe <component>`                           | Inspect a component schema (JSON, scrollable). Alias: `:component`.                                                                            |
+| `:validate`                                       | Validate all loaded tokens against their `$schema`. Findings are **grouped by rule** with expand/collapse. Shows Sev / Rule / Token / Message. |
+| `:find [<intent>]`                                | Open the two-screen **find wizard** (Filters → Preview). Five structured fields with cross-field count badges; free-text intent search.        |
+| `:new [<intent>]`                                 | Open the four-screen token authoring wizard. Alias: `:create`.                                                                                 |
 
 ***
 
@@ -99,54 +102,61 @@ Relaunch without `--no-resume-wizard` to restore.
 
 ### Palette
 
-| Key       | Action                    |
-| --------- | ------------------------- |
-| `:`       | Open command mode         |
-| `/`       | Open fuzzy-find mode      |
-| `Esc`     | Cancel / close palette    |
-| `Enter`   | Dispatch command          |
-| `Tab`     | Autocomplete command name |
-| `↑` / `↓` | Recall palette history    |
+| Key       | Action                                               |
+| --------- | ---------------------------------------------------- |
+| `:`       | Open palette in command mode                         |
+| `Esc`     | Cancel / close palette                               |
+| `Enter`   | Dispatch command                                     |
+| `Tab`     | Fuzzy-autocomplete command name (highlights matches) |
+| `↑` / `↓` | Recall palette history                               |
 
 ### List views (query / resolve / validate)
 
-| Key          | Action                                    |
-| ------------ | ----------------------------------------- |
-| `↑` / `k`    | Move selection up                         |
-| `↓` / `j`    | Move selection down                       |
-| Scroll wheel | Move selection                            |
-| Click row    | Select that row                           |
-| `y`          | Yank selected name / message to clipboard |
-| `Esc`        | Return to empty view                      |
+| Key          | Action                                               |
+| ------------ | ---------------------------------------------------- |
+| `↑` / `k`    | Move selection up                                    |
+| `↓` / `j`    | Move selection down                                  |
+| `g`          | Jump to top                                          |
+| `G`          | Jump to bottom                                       |
+| Scroll wheel | Move selection                                       |
+| Click row    | Select that row                                      |
+| `y`          | Yank selected name / message to clipboard            |
+| `Enter`      | (validate view) Expand / collapse the selected group |
+| `Esc`        | Return to empty view                                 |
 
 ### Describe view
 
-| Key             | Action               |
-| --------------- | -------------------- |
-| `↑` / `k`       | Scroll up one line   |
-| `↓` / `j`       | Scroll down one line |
-| `PgUp` / `PgDn` | Scroll 10 lines      |
-| Scroll wheel    | Scroll body          |
-| `Esc`           | Return to empty view |
+| Key             | Action                                |
+| --------------- | ------------------------------------- |
+| `↑` / `k`       | Scroll up one line                    |
+| `↓` / `j`       | Scroll down one line                  |
+| `←` / `h`       | Scroll left (horizontal scroll)       |
+| `→` / `l`       | Scroll right (horizontal scroll)      |
+| `PgUp` / `PgDn` | Scroll 10 lines                       |
+| Scroll wheel    | Scroll body                           |
+| `y`             | Yank selected row to clipboard        |
+| `Y`             | Yank full component JSON to clipboard |
+| `Esc`           | Return to empty view                  |
 
 ### Wizard
 
-| Screen           | Key                 | Action                                       |
-| ---------------- | ------------------- | -------------------------------------------- |
-| 1 Intent         | `↑`/`↓`             | Navigate suggestions                         |
-| 1 Intent         | `Tab`               | Reuse top suggestion (alias path → Screen 4) |
-| 1 Intent         | `Enter`             | Proceed to Screen 2                          |
-| 2 Classification | `Tab` / `Shift-Tab` | Move between fields                          |
-| 2 Classification | `←` / `→`           | Cycle layer                                  |
-| 2 Classification | `+`                 | Add a name field                             |
-| 3 Values         | `a`                 | Set row kind to Alias                        |
-| 3 Values         | `l`                 | Set row kind to Literal                      |
-| 3 Values         | `e`                 | Edit active row value                        |
-| 4 Confirm        | Type                | Enter rationale                              |
-| 4 Confirm        | `↑`/`↓` / Scroll    | Scroll diff preview                          |
-| 4 Confirm        | `Ctrl+S`            | Edit `$schema` URL                           |
-| 4 Confirm        | `Enter`             | Submit                                       |
-| All              | `Esc`               | Cancel wizard                                |
+| Screen           | Key                 | Action                                                           |
+| ---------------- | ------------------- | ---------------------------------------------------------------- |
+| 1 Intent         | `↑`/`↓`             | Navigate suggestions                                             |
+| 1 Intent         | `Tab`               | Reuse top suggestion (alias path → Screen 4)                     |
+| 1 Intent         | `Enter`             | Proceed to Screen 2                                              |
+| 2 Classification | `Tab` / `Shift-Tab` | Move between fields                                              |
+| 2 Classification | `←` / `→`           | Cycle layer                                                      |
+| 2 Classification | `+`                 | Add a name field                                                 |
+| 3 Values         | `a`                 | Set row kind to Alias                                            |
+| 3 Values         | `l`                 | Set row kind to Literal                                          |
+| 3 Values         | `e`                 | Edit active row value                                            |
+| 4 Confirm        | Type                | Enter rationale                                                  |
+| 4 Confirm        | `↑`/`↓` / Scroll    | Scroll diff preview                                              |
+| 4 Confirm        | `Ctrl+S`            | Edit `$schema` URL                                               |
+| 4 Confirm        | `Enter`             | Submit                                                           |
+| 1 Intent         | `Esc`               | Cancel wizard                                                    |
+| 2–4 Any          | `Esc`               | Go back one screen (Confirm→Values→Classification→Intent→cancel) |
 
 ### Mouse
 

--- a/tools/demo/auto/beats/A.beats.sh
+++ b/tools/demo/auto/beats/A.beats.sh
@@ -9,11 +9,12 @@
 # Beat table from presentation/RECORDING.md:
 #   A1  :query background-color/* Enter — scroll j/k Esc              marker after
 #   A2  :resolve property=accent-background-color,colorScheme=dark Enter Esc  marker after
-#   A3  :describe button Enter — scroll j/k/PgDn Esc                  marker after
-#   A4  / accentbg — fuzzy find, j/k, Enter                           marker after
+#   A3  :describe button Enter — scroll j/k/PgDn, y yank, Esc         marker after
+#   A4  :find — Filters screen, type property filter, Tab to Preview   marker after
 #
 # Note: A1 (browser visualizer) is out of scope; TUI covers A2 (:resolve dark),
-# A3 (:describe button), A4 (/ fuzzy find). The TUI :query is shown as a bonus beat.
+# A3 (:describe button), A4 (:find wizard with faceted filtering). The TUI :query
+# is shown as a bonus beat.
 #
 # Source this file; call run_beats_A SESSION_NAME MODE CAST_PATH REPO_ROOT
 # The orchestrator is responsible for starting and ending the rmux session.
@@ -61,16 +62,39 @@ run_beats_A() {
   wait_for    "$session" "(button|Button|anatomy|role|state)" 30
   assert_contains "$session" "(button|Button|anatomy|role|state)" "A3: describe button view present"
   sleep 1
+  # y yanks the selected row to clipboard (showcases #1170).
+  send_keys "$session" "y"
+  sleep 0.3
   send_keys "$session" "Escape"
   sleep 0.5
 
-  # ── A4: / fuzzy find ──────────────────────────────────────────────────────
-  echo "  beat A4: TUI / fuzzy find" >&2
-  type_keys    "$session" "/accentbg"
-  wait_for    "$session" "(Fuzzy|accent-background|accentbg)" 15
-  assert_contains "$session" "(Fuzzy|accent-background|accentbg)" "A4: fuzzy find active"
+  # ── A4: :find wizard (faceted filtering) ─────────────────────────────────
+  echo "  beat A4: TUI :find wizard" >&2
+  type_keys    "$session" ":find"
+  send_keys   "$session" "Enter"
+  # Wait for find wizard Filters screen (modal title: "Step 1 of 2 — Filters").
+  wait_for    "$session" "(Step 1 of 2|Filters)" 15
+  assert_contains "$session" "(Step 1 of 2|Filters)" "A4: find wizard Filters screen"
+  # Type a filter in the property field (field 0, auto-focused). Count badges update live.
+  type_keys    "$session" "background-color"
+  sleep 1
+  # Tab through all 5 fields (property=0, component=1, variant=2, state=3, intent=4)
+  # to reach the Preview button (index 5).
+  send_keys "$session" "Tab"
+  send_keys "$session" "Tab"
+  send_keys "$session" "Tab"
+  send_keys "$session" "Tab"
+  send_keys "$session" "Tab"
   sleep 0.5
+  # Enter on the Preview button → advance to Preview screen.
   send_keys "$session" "Enter"
+  wait_for    "$session" "(Step 2 of 2|Preview)" 15
+  assert_contains "$session" "(Step 2 of 2|Preview)" "A4: find wizard Preview screen"
+  sleep 0.5
+  # Esc from Preview → back to Filters; second Esc → cancel find wizard.
+  send_keys "$session" "Escape"
+  sleep 0.3
+  send_keys "$session" "Escape"
   sleep 0.5
 
   # ── exit TUI ──────────────────────────────────────────────────────────────
@@ -87,12 +111,12 @@ run_beats_A() {
     # Use screen-header strings: each only appears in its specific view, so
     # the markers land at the right timestamps and in the right order.
     # TUI headers (verified with capture-pane):
-    #   Resolve view: "Resolve: accent-background-color" in the dialog title
-    #   Describe view: "Describe: button" in the dialog title
-    #   Fuzzy find:    "Fuzzy:" in the header line (only while fuzzy mode is active)
+    #   Resolve view:    "Resolve: accent-background-color" in the dialog title
+    #   Describe view:   "Describe: button" in the dialog title
+    #   Find Filters:    "Step 1 of 2 — Filters" in the find wizard modal title
     printf 'A2 resolved value\tResolve:\n' >> "$sentinel_file"
     printf 'A3 describe button\tDescribe:\n' >> "$sentinel_file"
-    printf 'A4 fuzzy find\tFuzzy\n' >> "$sentinel_file"
+    printf 'A4 find wizard\tFilters\n' >> "$sentinel_file"
     local tmp_marked="${cast_path%.cast}.marked.cast"
     inject_markers "$cast_path" "$tmp_marked" "$sentinel_file"
     mv "$tmp_marked" "$cast_path"

--- a/tools/demo/auto/beats/B.beats.sh
+++ b/tools/demo/auto/beats/B.beats.sh
@@ -10,16 +10,20 @@
 #   B1  :new accent background Enter → reuse banner → Tab (alias path → Confirm diff) Esc
 #   B2  :new custom brand overlay Enter → Classification → Values → Confirm → Esc
 #
-# Actual wizard screens (verified with rmux capture-pane):
-#   Screen 1 (Intent):         "Wizard · 1/4 · Intent"  — palette Enter advances here
-#   Screen 2 (Classification): "Wizard · 2/4 · Classification", Layer:, Property:, Preview:
-#   Screen 3 (Values):         "Wizard · 3/4 · Values",  Mode combo, Kind, alias rows
-#   Screen 4 (Confirm/Submit): "Wizard · 4/4 · ..."
+# Actual wizard screens (verified with rmux capture-pane, updated for #1169/#1172):
+#   Screen 1 (Intent):         "Step 1 of 4 — Intent"   — palette Enter advances here
+#   Screen 2 (Classification): "Step 2 of 4 — Classification", Layer:, Property:, Preview:
+#   Screen 3 (Values):         "Step 3 of 4 — Values",  mode-combo rows, Kind, alias rows
+#   Screen 4 (Confirm/Submit): "Step 4 of 4 — Confirm", Rationale, Diff preview
+#
+# Esc in the wizard back-navigates one screen (#1160/#1172):
+#   Screens 2/3/4 → go_back() one step; Screen 1 → cancel.
+#   To cancel from Screen 4: press Esc four times (4→3→2→1→cancel).
 #
 # B1: ":new accent background" shows Screen 1 (Intent) with existing matches.
-#     Tab from Screen 1 → reuse (alias path) → Screen 4 (Confirm). Esc cancels.
+#     Tab from Screen 1 → reuse (alias path) → Screen 4 (Confirm). 4×Esc to cancel.
 # B2: ":new custom brand overlay" → Screen 1 → Enter → Screen 2 → Enter → Screen 3
-#     → Enter → Screen 4 → Esc (cancel without writing).
+#     → Enter → Screen 4 → 4×Esc (back-navigate to cancel without writing).
 #
 # Source this file; call run_beats_B SESSION_NAME MODE CAST_PATH REPO_ROOT
 # The orchestrator is responsible for starting and ending the rmux session.
@@ -51,14 +55,20 @@ run_beats_B() {
   echo "  beat B1: TUI :new accent background" >&2
   type_keys    "$session" ":new accent background"
   send_keys   "$session" "Enter"
-  # Wizard opens at Screen 1 (Intent): "Wizard · 1/4 · Intent"
-  wait_for    "$session" "(1/4|Intent|Wizard)" 30
-  assert_contains "$session" "(1/4|Intent|Wizard)" "B1: wizard Screen 1 (Intent) visible"
+  # Wizard opens at Screen 1 (Intent): "Step 1 of 4 — Intent"
+  wait_for    "$session" "(Step 1 of 4|Intent)" 30
+  assert_contains "$session" "(Step 1 of 4|Intent)" "B1: wizard Screen 1 (Intent) visible"
   sleep 1
   # Tab from Screen 1 → reuse selected (alias path, jumps to Confirm / Screen 4).
   send_keys "$session" "Tab"
   sleep 1
-  # Esc cancels without writing.
+  # Esc back-navigates one screen at a time (4→3→2→1→cancel).
+  send_keys "$session" "Escape"
+  sleep 0.5
+  send_keys "$session" "Escape"
+  sleep 0.5
+  send_keys "$session" "Escape"
+  sleep 0.5
   send_keys "$session" "Escape"
   sleep 0.8
 
@@ -70,27 +80,33 @@ run_beats_B() {
   type_keys    "$session" ":new custom brand overlay"
   send_keys   "$session" "Enter"
   # Wizard opens at Screen 1 (Intent) again.
-  wait_for    "$session" "(1/4|Intent|Wizard)" 30
+  wait_for    "$session" "(Step 1 of 4|Intent)" 30
   sleep 1
-  # Enter → Screen 2 (Classification): "Wizard · 2/4 · Classification"
+  # Enter → Screen 2 (Classification): "Step 2 of 4 — Classification"
   send_keys "$session" "Enter"
   sleep 1
-  wait_for    "$session" "(2/4|Classification)" 30
-  assert_contains "$session" "(2/4|Classification|Layer:|Property:)" "B2: Screen 2 (Classification) visible"
+  wait_for    "$session" "(Step 2 of 4|Classification)" 30
+  assert_contains "$session" "(Step 2 of 4|Classification|Layer:|Property:)" "B2: Screen 2 (Classification) visible"
   sleep 1
-  # Enter → Screen 3 (Values): "Wizard · 3/4 · Values"
+  # Enter → Screen 3 (Values): "Step 3 of 4 — Values"
   send_keys "$session" "Enter"
   sleep 1
-  wait_for  "$session" "(3/4|Mode combo|Values)" 30
-  assert_contains "$session" "(3/4|Mode combo|Values)" "B2: Screen 3 (Values) visible"
+  wait_for  "$session" "(Step 3 of 4|Values)" 30
+  assert_contains "$session" "(Step 3 of 4|Values)" "B2: Screen 3 (Values) visible"
   sleep 1
-  # Enter → Screen 4 (Confirm/Submit).
+  # Enter → Screen 4 (Confirm/Submit): "Step 4 of 4 — Confirm"
   send_keys "$session" "Enter"
   sleep 1
-  wait_for  "$session" "(4/4|Confirm|Submit|rationale)" 30
-  assert_contains "$session" "(4/4|Confirm|Submit|rationale)" "B2: Screen 4 (Confirm) visible"
+  wait_for  "$session" "(Step 4 of 4|Confirm|rationale)" 30
+  assert_contains "$session" "(Step 4 of 4|Confirm|rationale)" "B2: Screen 4 (Confirm) visible"
   sleep 1
-  # Esc cancels without writing to disk (no --allow-write flag).
+  # Esc back-navigates one screen at a time (4→3→2→1→cancel). No write (no --allow-write).
+  send_keys "$session" "Escape"
+  sleep 0.5
+  send_keys "$session" "Escape"
+  sleep 0.5
+  send_keys "$session" "Escape"
+  sleep 0.5
   send_keys "$session" "Escape"
   sleep 0.5
 
@@ -106,9 +122,9 @@ run_beats_B() {
   if [[ "$mode" == "record" && -n "$cast_path" && -f "$cast_path" ]]; then
     sentinel_file="$(mktemp)"
     # B1: Screen 1 (Intent) visible after :new accent background
-    printf 'B1 wizard intent screen\t(1/4|Intent|Wizard)\n' >> "$sentinel_file"
+    printf 'B1 wizard intent screen\t(Step 1 of 4|Intent)\n' >> "$sentinel_file"
     # B2: Classification screen (Screen 2) — most distinctive visual for this beat
-    printf 'B2 classification step\t(2/4|Classification)\n' >> "$sentinel_file"
+    printf 'B2 classification step\t(Step 2 of 4|Classification)\n' >> "$sentinel_file"
     local tmp_marked="${cast_path%.cast}.marked.cast"
     inject_markers "$cast_path" "$tmp_marked" "$sentinel_file"
     mv "$tmp_marked" "$cast_path"

--- a/tools/demo/presentation/RECORDING.md
+++ b/tools/demo/presentation/RECORDING.md
@@ -46,7 +46,7 @@ bash tools/demo/auto/auto-demo.sh A --record --docker
 ```
 
 **Demos A, B, C** — beat markers are injected by anchoring to sentinel text patterns
-in the cast's output events (the TUI view headers: `Resolve:`, `Describe:`, `Fuzzy`).
+in the cast's output events (the TUI view headers: `Resolve:`, `Describe:`, `Filters`).
 These land on asciinema's own clock regardless of `--idle-time-limit` compression.
 
 **Demo D** — uses **Claude Code hooks** for reliable beat detection and marker timing:
@@ -125,38 +125,53 @@ passing explicit `markers` timestamps in the slide's `playerProps`.
 
 Deterministic. \~2–2.5 min. Launch the TUI as above, then:
 
-> **Re-record needed:** the committed `A-find.cast` is a placeholder with markers
-> for A1–A3 only. Add the A4 fuzzy-find beat (and its marker) when you record the
-> real cast, or the deck's `pauseOnMarkers` won't stop for it.
+| Beat | Keystrokes                                                                                                                                                                                                                           | Marker after |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| A1   | `:` `query background-color/*` `Enter` — scroll `j`/`k`, then `Esc`                                                                                                                                                                  | yes          |
+| A2   | `:` `resolve property=accent-background-color,colorScheme=dark` `Enter`, then `Esc`                                                                                                                                                  | yes          |
+| A3   | `:` `describe button` `Enter` — scroll with `j`/`k` / `PgDn`, press `y` to yank a row, then `Esc`                                                                                                                                    | yes          |
+| A4   | `:` `find` `Enter` → Filters screen (title: `Step 1 of 2 — Filters`); type `background-color` in the property field; Tab×5 to the Preview button; `Enter` → Preview screen; `Esc` back to Filters; `Esc` again to cancel find wizard | yes          |
 
-| Beat | Keystrokes                                                                                                                                            | Marker after |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| A1   | `:` `query background-color/*` `Enter` — scroll `j`/`k`, then `Esc`                                                                                   | yes          |
-| A2   | `:` `resolve property=accent-background-color-default,colorScheme=dark` `Enter`, then `Esc`                                                           | yes          |
-| A3   | `:` `describe button` `Enter` — scroll with `j`/`k` / `PgDn`, then `Esc`                                                                              | yes          |
-| A4   | `/` `accentbg` — live fuzzy filter (table re-ranks on every keystroke), `j`/`k` to move, `Enter` to keep results (or `Esc` to restore the prior view) | yes          |
+`:find` is the **structured find wizard** (two screens: Filters → Preview). The Filters
+screen shows five input fields (property, component, variant, state, free-text intent)
+with **cross-field count badges** updating live as you type — showing how many tokens
+match the filter combination for each option. `:query` is complementary: unguided
+glob/predicate filtering without count feedback. Use `:find` when you want to explore
+what values exist for a field; use `:query` for precise expression-based filtering.
 
-`/` and `:` are complementary, so show both: `/` is **live fuzzy-find** (fzf-style
-subsequence match — `accentbg` finds `accent-background-…`, re-ranked per
-keystroke, header reads `Fuzzy: /accentbg`), while `:query` is structured
-predicate filtering. `Enter` commits the fuzzy results; `Esc` restores the view
-that was on screen before you opened the palette.
+**Optional A5 beat — help overlay + g/G + `?`** (add to your take if time permits):
+From any result view, press `?` to open the context-sensitive help overlay; press `?`
+or `Esc` to close. Press `g` to jump to the top of a list, `G` to jump to the bottom.
+No automated sentinel — drop a manual `Ctrl+\` marker when the overlay is open.
 
 ## Demo B — Name a new token (`public/casts/B-name.cast`)
 
 \~2.5 min. Fresh TUI launch (clean draft).
 
-| Beat | Keystrokes                                                                                                                                                                                                                    | Marker after |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| B1   | `:` `new accent background` `Enter` → reuse banner fires → **Tab** (alias path → Confirm diff) → `Esc`                                                                                                                        | yes          |
-| B2   | `:` `new custom brand overlay` `Enter` → `Enter` (Classification: `←`/`→` layer, Tab to property, `+` name field) → `Enter` (Values: `a`/`l`, `e` to edit a row) → `Enter` (Confirm: type rationale, watch live diff) → `Esc` | yes          |
+Wizard screen titles now read **`Step N of 4 — <Name>`** (e.g. `Step 1 of 4 — Intent`).
+`Esc` **back-navigates** one screen at a time (Screens 2/3/4 → previous screen;
+Screen 1 → cancel). To cancel from the Confirm screen, press `Esc` four times.
 
-The Confirm diff now serializes **every mode-combo row** as a `sets` block
-(fixed; previously only the first row was written) — so the multi-mode story is
-honest on camera. The diff also emits a structured `name` object (property +
-name fields), matching what the MCP authoring session writes, so the TUI and
-agent paths produce identical token shapes. Only add `--allow-write` for a
-deliberate "write to disk" take.
+| Beat | Keystrokes                                                                                                                                                                                                                      | Marker after |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| B1   | `:` `new accent background` `Enter` → reuse banner fires → **Tab** (alias path → Confirm diff) → `Esc`×4 to cancel (showcases back-navigation)                                                                                  | yes          |
+| B2   | `:` `new custom brand overlay` `Enter` → `Enter` (Classification: `←`/`→` layer, Tab to property, `+` name field) → `Enter` (Values: `a`/`l`, `e` to edit a row) → `Enter` (Confirm: type rationale, watch live diff) → `Esc`×4 | yes          |
+
+The Confirm diff serializes **every mode-combo row** as a `sets` block and emits a
+structured `name` object — the TUI and agent paths produce identical token shapes.
+Only add `--allow-write` for a "write to disk" take.
+
+**Optional B3 beat — `:validate` with grouped findings** (manual-only; add if the
+dataset has validation errors, or use `tools/demo/broken-token-example.tokens.json`):
+Re-launch the TUI on the broken-token file:
+
+```bash
+design-data tools/demo/broken-token-example.tokens.json --theme spectrum
+```
+
+Then: `:validate` `Enter` → findings grouped by rule (`×N ▶`); `Enter` to expand a
+group (shows individual tokens); `y` to yank the selected token name to clipboard.
+No automated sentinel — drop a manual `Ctrl+\` marker when the grouped view is open.
 
 ## Demo C — Deterministic agent companion (`public/casts/C-suggest.cast`, optional)
 

--- a/tools/demo/presentation/slides.md
+++ b/tools/demo/presentation/slides.md
@@ -54,18 +54,21 @@ deterministic — query, resolve, describe. No model involved.
 Beat A1 — `:query background-color/*` filters ~4,166 tokens into a Name / Value /
 File / Layer table. The TUI loads the whole corpus in about a second.
 
-Beat A2 — `:resolve property=accent-background-color-default,colorScheme=dark`
+Beat A2 — `:resolve property=accent-background-color,colorScheme=dark`
 shows the cascade winner (★) and a Spec specificity column. Same idea as CSS
 specificity, but deterministic and auditable.
 
 Beat A3 — `:describe button` pulls the component schema straight from the spec
-bundle: anatomy, states, accessibility role, token bindings.
+bundle: anatomy, states, accessibility role, token bindings. Press `y` to yank
+any selected row to the clipboard.
 
-Beat A4 — `/accentbg` is live fuzzy-find: the table re-ranks on every keystroke
-with fzf-style subsequence matching (the header reads `Fuzzy: /accentbg`). Enter
-keeps the filtered results; Esc restores the previous view. So `:` is the
-structured surface (`query`/`find`) and `/` is incremental name search — show
-both.
+Beat A4 — `:find` opens the two-screen **find wizard** (Filters → Preview).
+The Filters screen shows five input fields (property, component, variant, state,
+free-text intent). As you type in a field, **cross-field count badges** update
+on every other option — showing how many tokens match the full filter when that
+value is applied. Tab to the Preview button and Enter to see results; Esc steps
+back one screen at a time. `:query` is complementary — unguided glob/predicate
+filtering for when you already know the expression.
 -->
 
 ***
@@ -93,18 +96,20 @@ which keeps the cascade coherent.
 <!--
 Beat B1 — `:new accent background`. The reuse banner fires because a high-
 confidence match exists (threshold 0.35). One Tab takes the alias path straight
-to the Confirm diff — a reference, not a duplicate value.
+to the Confirm diff — a reference, not a duplicate value. Press Esc to
+back-navigate one screen at a time (new #1160/#1172 behavior — show this!):
+Confirm → Values → Classification → Intent → cancel.
 
 Beat B2 — `:new custom brand overlay` is a genuinely novel intent, so no banner.
 Walk the four screens: Intent → Classification (layer, property, name fields,
-live preview) → Values (one row per mode combination, alias or literal) →
-Confirm (rationale required, live diff).
+live preview; screen title reads `Step 2 of 4 — Classification`) → Values (one
+row per mode combination, alias or literal) → Confirm (rationale required,
+live diff). Esc×4 to cancel.
 
-Note the Confirm diff serializes EVERY mode-combo row as a `sets` block — we
-just fixed a bug where only the first row was written. The multi-mode story is
-honest on camera now. The diff also emits a structured `name` object (property +
-name fields), so the TUI writes the same token shape as the MCP authoring
-session — the wizard and agent paths are at parity.
+The Confirm diff serializes EVERY mode-combo row as a `sets` block and emits a
+structured `name` object (property + name fields), so the TUI writes the same
+token shape as the MCP authoring session — the wizard and agent paths are at
+parity.
 -->
 
 ***


### PR DESCRIPTION
## Description

Refreshes all demo materials to match the current TUI after ~10 feature PRs (#1157–#1173) landed since the last update (early June / #1107–#1113), leaving the demo partly broken and out of date.

**No TUI source changes** — `/` fuzzy-find removal is treated as intentional (superseded by the `:find` wizard).

## Related Issue

N/A — maintenance follow-up to #1157–#1173.

## Motivation and Context

The demo recording scripts (`auto-demo.sh A/B`) had three broken areas:

1. **A4 beat broken**: `/accentbg` fuzzy-find no longer exists in the TUI (`QueryView::fuzzy` is never constructed, no `/` key handler). The `Fuzzy` marker sentinel would never anchor.
2. **B wizard sentinels stale**: Screen titles changed from `Wizard · N/4 · <Name>` to `Step N of 4 — <Name>` (#1169/#1172). The `N/4` regex fallbacks survived but comments/markers were wrong.
3. **B Esc behavior wrong**: Esc now back-navigates one screen at a time (#1160/#1172) instead of canceling. A single Esc from Screen 4 (Confirm) only steps to Screen 3 — the old beats left the wizard open after "cancel".

Also refreshes documentation to document new features: `:find` wizard + faceted count badges (#1173), `:validate` grouping (#1165), `g`/`G` jump (#1164), `y`/`Y` yank (#1170), `h`/`l` horizontal scroll (#1166), Esc back-navigation (#1160/#1172), fuzzy palette autocomplete (#1168).

## How Has This Been Tested?

- Beat scripts (`A.beats.sh`, `B.beats.sh`) reviewed against current TUI source (`sdk/tui/src/find.rs`, `model/views.rs`, `wizard.rs`) for sentinel accuracy
- `remark` linter passed on all four `.md` files (pre-commit hook)
- Re-recording (`moon run demo:auto-record`) and CI verify (`moon run demo:auto-verify`) should be run after merge on a machine with `rmux` + `asciinema` + CLI pre-built

## Screenshots (if appropriate):

N/A — documentation/script changes only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.