### PR TITLE
feat(ai): add version metadata to agent skills and surface designDataVersion in MCP primer

### DIFF
--- a/.changeset/version-metadata-ai-tools.md
+++ b/.changeset/version-metadata-ai-tools.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data-skill": minor
+"@adobe/design-data-agent-mcp": minor
+"@adobe/s2-docs-mcp": minor
+---
+
+Add version metadata to agent skills; surface dataset provenance in MCP primer output.
+
+- **design-data/SKILL.md**: add `metadata.version` and `metadata.designDataVersion`
+  to frontmatter (agentskills.io spec `metadata` block).
+- **design-data-agent/SKILL.md**: add `metadata.version` to frontmatter.
+- **s2-docs/SKILL.md**: add `metadata.version` to frontmatter.
+- **design-data-mcp primer**: return `provenance` object (includes `designDataVersion`).
+- **design-data-agent-mcp primer**: return `provenance` for dataset version metrics.
+- **skill-version.test.js** (all three packages): AVA tests assert SKILL.md
+  `metadata.version` stays in sync with `package.json` on every version bump.

--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -30,6 +30,8 @@
     "design-data:legacy-output",
     "design-data-glue:ci",
     "design-data-agent-mcp:test",
+    "design-data-skill:test",
+    "s2-docs-mcp:test",
     "token-naming-audit:ci"
   ],
   "excludedFromCI": [

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -27,6 +27,7 @@ projects:
   token-naming-audit: "tools/token-naming-audit"
   demo: "tools/demo"
   design-data-glue: "tools/design-data"
+  design-data-skill: "tools/design-data-skill"
   s2-docs-to-document-blocks: "tools/s2-docs-to-document-blocks"
 vcs:
   manager: "git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,7 +609,11 @@ importers:
         specifier: ^6.0.1
         version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
-  tools/design-data-skill: {}
+  tools/design-data-skill:
+    devDependencies:
+      ava:
+        specifier: ^6.0.1
+        version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
   tools/diff-generator:
     dependencies:
@@ -681,6 +685,10 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)
+    devDependencies:
+      ava:
+        specifier: ^6.0.1
+        version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
 
   tools/s2-docs-to-document-blocks:
     dependencies:

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-tui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1229,7 +1229,7 @@ fn run_primer(
         }),
         data_source::Provenance::Embedded { version } => serde_json::json!({
             "source": "embedded",
-            "tokensVersion": version,
+            "designDataVersion": version,
         }),
     };
 

--- a/sdk/core/src/primer.rs
+++ b/sdk/core/src/primer.rs
@@ -67,7 +67,7 @@ pub struct PrimerData {
 ///
 /// `provenance` is surface-specific:
 /// - CLI derives it from `data_source::Provenance` (in-repo, config, cache, embedded).
-/// - WASM uses `{ "source": "embedded", "tokensVersion": EMBEDDED_DATA_VERSION }`
+/// - WASM uses `{ "source": "embedded", "designDataVersion": EMBEDDED_DATA_VERSION }`
 ///   for the embedded dataset, or `{ "source": "in-memory" }` for `fromTokens`.
 pub fn build(graph: &TokenGraph, provenance: serde_json::Value) -> PrimerData {
     let mode_sets: Vec<PrimerModeSet> = graph

--- a/sdk/tui/tests/snapshots/snapshots__home_view_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__home_view_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.2.1
+  Spectrum Design Data  v0.3.0
   ↑↓ history/list · Tab complete · Enter run · Esc back · Ctrl+C quit
   ──────────────────────────────────────────────────────────────────────────────
   >

--- a/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.2.1
+  Spectrum Design Data  v0.3.0
   ↑↓ history/list · Tab complete · Enter run · Esc back · Ctrl+C quit
   ──────────────────────────────────────────────────────────────────────────────
   > :

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -4,7 +4,7 @@ assertion_line: 117
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.2.1
+  Spectrum Design Data  v0.3.0
   ↑↓ hi┌ Step 1 of 4 — Intent ──────────────────────────────────────────┐
   ─────│Intent: background-color                                        │───────
   >    │  These tokens already exist for similar intents.               │

--- a/sdk/wasm/src/dataset.rs
+++ b/sdk/wasm/src/dataset.rs
@@ -182,14 +182,14 @@ impl Dataset {
     /// For in-memory datasets (`Dataset.fromTokens()`), both are empty / null.
     ///
     /// `provenance.source` is:
-    /// - `"embedded"` when created via `Dataset.embedded()` (includes `tokensVersion`)
+    /// - `"embedded"` when created via `Dataset.embedded()` (includes `designDataVersion`)
     /// - `"in-memory"` when created via `Dataset.fromTokens()`
     pub fn primer(&self) -> Result<JsValue, JsValue> {
         let provenance = match self.source {
             DatasetSource::Embedded => {
                 serde_json::json!({
                     "source": "embedded",
-                    "tokensVersion": primer::EMBEDDED_DATA_VERSION,
+                    "designDataVersion": primer::EMBEDDED_DATA_VERSION,
                 })
             }
             DatasetSource::InMemory => serde_json::json!({ "source": "in-memory" }),

--- a/sdk/wasm/test/parity.test.js
+++ b/sdk/wasm/test/parity.test.js
@@ -509,9 +509,9 @@ test("Dataset.embedded().primer() returns expected payload shape", (t) => {
     "provenance.source should be 'embedded'",
   );
   t.is(
-    typeof p.provenance.tokensVersion,
+    typeof p.provenance.designDataVersion,
     "string",
-    "provenance.tokensVersion should be a string",
+    "provenance.designDataVersion should be a string",
   );
 });
 

--- a/tools/design-data-agent-mcp/skills/design-data/SKILL.md
+++ b/tools/design-data-agent-mcp/skills/design-data/SKILL.md
@@ -4,6 +4,9 @@ description: >
   Validate, query, resolve, diff, and author spec-conformant design tokens and components using the
   design-data MCP tools against a local dataset. Use when the user asks about design tokens, a design
   system, token lookup, spec-conformance, drift detection, or token authoring on custom data.
+metadata:
+  author: adobe
+  version: "1.6.6"
 when_to_use: >
   Trigger on: design system, design tokens, spec-conformant, drift, validate tokens, token
   authoring, custom dataset, DESIGN_DATA_PATH, design-data validate, design-data diff,

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -84,6 +84,9 @@ export function createReadTools() {
         const ds = await getDataset();
         const { provenance } = ds.primer();
         return {
+          // top-level source is the legacy skill-contract field; provenance.source
+          // duplicates it intentionally — provenance is the richer metrics object
+          // and consumers should prefer it going forward.
           source: "embedded",
           tokenCount: ds.tokenCount(),
           modeSets: {

--- a/tools/design-data-agent-mcp/src/tools/read.js
+++ b/tools/design-data-agent-mcp/src/tools/read.js
@@ -77,10 +77,12 @@ export function createReadTools() {
         // shape uses keyed objects (matching the sibling design-data-mcp), which agents
         // and the SKILL.md skill prompt consume by key name. Skill contract:
         // tokenCount, modeSets.{colorScheme,scale,contrast}, components[],
-        // taxonomyFields.{indexed,advisory}. CLI-only fields (specVersion, manifest,
-        // provenance) are not present — no SKILL.md reference or consumer relies on them.
+        // taxonomyFields.{indexed,advisory}. provenance is included for metrics:
+        // for the embedded dataset it carries designDataVersion (@adobe/spectrum-design-data
+        // version baked in at wasm build time); for custom datasets the source differs.
         const wasm = await getWasm();
         const ds = await getDataset();
+        const { provenance } = ds.primer();
         return {
           source: "embedded",
           tokenCount: ds.tokenCount(),
@@ -95,6 +97,7 @@ export function createReadTools() {
           },
           components: wasm.getFieldValues("component") ?? [],
           properties: wasm.getFieldValues("property") ?? [],
+          provenance,
         };
       },
     },

--- a/tools/design-data-agent-mcp/test/read.test.js
+++ b/tools/design-data-agent-mcp/test/read.test.js
@@ -43,6 +43,24 @@ test("primer returns expected top-level keys", async (t) => {
   t.true(result.components.length > 0, "components should be non-empty");
   t.true(Array.isArray(result.properties), "properties is an array");
   t.is(result.source, "embedded");
+  // provenance carries designDataVersion for metrics (the @adobe/spectrum-design-data
+  // version baked into the wasm at build time)
+  t.truthy(result.provenance, "provenance should be present");
+  t.is(
+    result.provenance.source,
+    "embedded",
+    "provenance.source should be 'embedded'",
+  );
+  t.is(
+    typeof result.provenance.designDataVersion,
+    "string",
+    "provenance.designDataVersion should be a string",
+  );
+  t.regex(
+    result.provenance.designDataVersion,
+    /^\d+\.\d+\.\d+/,
+    "provenance.designDataVersion should look like a semver",
+  );
 });
 
 test("primer does not require a CLI binary (no runCli import)", async (t) => {

--- a/tools/design-data-agent-mcp/test/skill-version.test.js
+++ b/tools/design-data-agent-mcp/test/skill-version.test.js
@@ -20,30 +20,36 @@ import { join, dirname } from "path";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 
-/** Parse a metadata field value from a SKILL.md file's YAML frontmatter. */
-function parseSkillVersion(skillPath) {
+/**
+ * Parse a metadata field value from a SKILL.md YAML frontmatter block.
+ * Matches the first `fieldName: "value"` line under the metadata: key.
+ * Assumes fieldName does not collide with a top-level YAML key of the same name.
+ */
+function parseMetadataField(skillPath, fieldName) {
   const content = readFileSync(skillPath, "utf-8");
   // Extract content between the first two --- delimiters
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) throw new Error(`No YAML frontmatter found in ${skillPath}`);
   const frontmatter = match[1];
-  // Extract metadata.version — expects the form: `  version: "x.y.z"`
-  const versionMatch = frontmatter.match(
-    /^\s*version:\s*["']?([^"'\r\n]+)["']?\s*$/m,
+  // Extract metadata.<fieldName> — expects: `  fieldName: "x.y.z"`
+  const re = new RegExp(
+    `^\\s*${fieldName}:\\s*["']?([^"'\\r\\n]+)["']?\\s*$`,
+    "m",
   );
-  if (!versionMatch) {
+  const valueMatch = frontmatter.match(re);
+  if (!valueMatch) {
     throw new Error(
-      `metadata.version not found in frontmatter of ${skillPath}`,
+      `metadata.${fieldName} not found in frontmatter of ${skillPath}`,
     );
   }
-  return versionMatch[1].trim();
+  return valueMatch[1].trim();
 }
 
 test("SKILL.md metadata.version matches package.json version", (t) => {
   const skillPath = join(root, "skills", "design-data", "SKILL.md");
   const pkgPath = join(root, "package.json");
 
-  const skillVersion = parseSkillVersion(skillPath);
+  const skillVersion = parseMetadataField(skillPath, "version");
   const { version: pkgVersion } = JSON.parse(readFileSync(pkgPath, "utf-8"));
 
   t.is(

--- a/tools/design-data-agent-mcp/test/skill-version.test.js
+++ b/tools/design-data-agent-mcp/test/skill-version.test.js
@@ -1,0 +1,55 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Asserts that the skill SKILL.md metadata.version matches the package.json
+ * version, so a changeset bump fails CI until the frontmatter is updated.
+ */
+
+import test from "ava";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Parse a metadata field value from a SKILL.md file's YAML frontmatter. */
+function parseSkillVersion(skillPath) {
+  const content = readFileSync(skillPath, "utf-8");
+  // Extract content between the first two --- delimiters
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) throw new Error(`No YAML frontmatter found in ${skillPath}`);
+  const frontmatter = match[1];
+  // Extract metadata.version — expects the form: `  version: "x.y.z"`
+  const versionMatch = frontmatter.match(
+    /^\s*version:\s*["']?([^"'\r\n]+)["']?\s*$/m,
+  );
+  if (!versionMatch) {
+    throw new Error(
+      `metadata.version not found in frontmatter of ${skillPath}`,
+    );
+  }
+  return versionMatch[1].trim();
+}
+
+test("SKILL.md metadata.version matches package.json version", (t) => {
+  const skillPath = join(root, "skills", "design-data", "SKILL.md");
+  const pkgPath = join(root, "package.json");
+
+  const skillVersion = parseSkillVersion(skillPath);
+  const { version: pkgVersion } = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  t.is(
+    skillVersion,
+    pkgVersion,
+    `SKILL.md metadata.version "${skillVersion}" must match package.json version "${pkgVersion}". ` +
+      `Update skills/design-data/SKILL.md when bumping the package version.`,
+  );
+});

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -119,6 +119,10 @@ export function createDesignDataTools() {
             }
           : null;
 
+        // Provenance carries source + designDataVersion (the @adobe/spectrum-design-data
+        // package version baked into the wasm at build time via EMBEDDED_DATA_VERSION).
+        const { provenance } = ds.primer();
+
         return {
           source: "embedded",
           tokenCount: ds.tokenCount(),
@@ -134,6 +138,7 @@ export function createDesignDataTools() {
           components: wasm.getFieldValues("component") ?? [],
           properties: wasm.getFieldValues("property") ?? [],
           guidelines: guidelinesSummary,
+          provenance,
         };
       },
     },

--- a/tools/design-data-mcp/src/tools/design-data.js
+++ b/tools/design-data-mcp/src/tools/design-data.js
@@ -124,6 +124,9 @@ export function createDesignDataTools() {
         const { provenance } = ds.primer();
 
         return {
+          // top-level source is the legacy skill-contract field; provenance.source
+          // duplicates it intentionally — provenance is the richer metrics object
+          // and consumers should prefer it going forward.
           source: "embedded",
           tokenCount: ds.tokenCount(),
           modeSets: {

--- a/tools/design-data-mcp/test/design-data.test.js
+++ b/tools/design-data-mcp/test/design-data.test.js
@@ -215,3 +215,28 @@ test("design-data-guideline-list category is not required", (t) => {
   const schema = tools["design-data-guideline-list"].inputSchema;
   t.falsy(schema.required, "category should not be required");
 });
+
+// ── design-data-primer provenance ────────────────────────────────────────────
+
+test("design-data-primer returns provenance with designDataVersion", async (t) => {
+  const tools = Object.fromEntries(
+    createDesignDataTools().map((tool) => [tool.name, tool]),
+  );
+  const result = await tools["design-data-primer"].handler({});
+  t.truthy(result.provenance, "provenance should be present");
+  t.is(
+    result.provenance.source,
+    "embedded",
+    "provenance.source should be 'embedded'",
+  );
+  t.is(
+    typeof result.provenance.designDataVersion,
+    "string",
+    "provenance.designDataVersion should be a string",
+  );
+  t.regex(
+    result.provenance.designDataVersion,
+    /^\d+\.\d+\.\d+/,
+    "provenance.designDataVersion should look like a semver",
+  );
+});

--- a/tools/design-data-skill/ava.config.js
+++ b/tools/design-data-skill/ava.config.js
@@ -1,0 +1,15 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+export default {
+  files: ["test/**/*.test.js"],
+  verbose: true,
+  environmentVariables: { NODE_ENV: "test" },
+};

--- a/tools/design-data-skill/moon.yml
+++ b/tools/design-data-skill/moon.yml
@@ -1,0 +1,20 @@
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+$schema: "https://moonrepo.dev/schemas/project.json"
+layer: tool
+tasks:
+  test:
+    command: [pnpm, ava]
+    platform: node
+    inputs:
+      - "skills/**/*"
+      - "test/**/*.js"
+      - "ava.config.js"
+      - "package.json"

--- a/tools/design-data-skill/package.json
+++ b/tools/design-data-skill/package.json
@@ -31,6 +31,15 @@
     "design-tokens",
     "design-data"
   ],
+  "scripts": {
+    "test": "ava"
+  },
+  "devDependencies": {
+    "ava": "^6.0.1"
+  },
+  "engines": {
+    "node": ">=20.12.0"
+  },
   "author": "Adobe",
   "license": "Apache-2.0"
 }

--- a/tools/design-data-skill/skills/design-data/SKILL.md
+++ b/tools/design-data-skill/skills/design-data/SKILL.md
@@ -6,6 +6,10 @@ description: >
   token values, component options, naming conventions, or wants to
   validate/explore design-token data. Also triggers when a .design-data.toml
   config is involved or the user mentions the design-data CLI.
+metadata:
+  author: adobe
+  version: "1.2.0"
+  designDataVersion: "0.7.0"
 when_to_use: >
   Trigger on: token names (color, spacing, typography, dimension), "which token",
   "Spectrum component options", validate tokens, design-data primer, query tokens,

--- a/tools/design-data-skill/test/skill-version.test.js
+++ b/tools/design-data-skill/test/skill-version.test.js
@@ -1,0 +1,80 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Asserts that the skill SKILL.md metadata.version matches the package.json
+ * version, so a changeset bump fails CI until the frontmatter is updated.
+ */
+
+import test from "ava";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Parse a metadata field value from a SKILL.md file's YAML frontmatter. */
+function parseMetadataField(skillPath, fieldName) {
+  const content = readFileSync(skillPath, "utf-8");
+  // Extract content between the first two --- delimiters
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) throw new Error(`No YAML frontmatter found in ${skillPath}`);
+  const frontmatter = match[1];
+  // Extract metadata.<fieldName> — expects: `  fieldName: "x.y.z"`
+  const re = new RegExp(
+    `^\\s*${fieldName}:\\s*["']?([^"'\\r\\n]+)["']?\\s*$`,
+    "m",
+  );
+  const valueMatch = frontmatter.match(re);
+  if (!valueMatch) {
+    throw new Error(
+      `metadata.${fieldName} not found in frontmatter of ${skillPath}`,
+    );
+  }
+  return valueMatch[1].trim();
+}
+
+const skillPath = join(root, "skills", "design-data", "SKILL.md");
+
+test("SKILL.md metadata.version matches package.json version", (t) => {
+  const pkgPath = join(root, "package.json");
+
+  const skillVersion = parseMetadataField(skillPath, "version");
+  const { version: pkgVersion } = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  t.is(
+    skillVersion,
+    pkgVersion,
+    `SKILL.md metadata.version "${skillVersion}" must match package.json version "${pkgVersion}". ` +
+      `Update skills/design-data/SKILL.md when bumping the package version.`,
+  );
+});
+
+test("SKILL.md metadata.designDataVersion matches @adobe/spectrum-design-data package version", (t) => {
+  // designDataVersion reflects the @adobe/spectrum-design-data snapshot served by this skill.
+  // Update it when @adobe/spectrum-design-data is bumped.
+  const dataPath = join(
+    root,
+    "..",
+    "..",
+    "packages",
+    "design-data",
+    "package.json",
+  );
+  const designDataVersion = parseMetadataField(skillPath, "designDataVersion");
+  const { version: dataVersion } = JSON.parse(readFileSync(dataPath, "utf-8"));
+
+  t.is(
+    designDataVersion,
+    dataVersion,
+    `SKILL.md metadata.designDataVersion "${designDataVersion}" must match @adobe/spectrum-design-data ` +
+      `version "${dataVersion}". Update skills/design-data/SKILL.md when the data package bumps.`,
+  );
+});

--- a/tools/s2-docs-mcp/ava.config.js
+++ b/tools/s2-docs-mcp/ava.config.js
@@ -1,0 +1,15 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+export default {
+  files: ["test/**/*.test.js"],
+  verbose: true,
+  environmentVariables: { NODE_ENV: "test" },
+};

--- a/tools/s2-docs-mcp/moon.yml
+++ b/tools/s2-docs-mcp/moon.yml
@@ -5,6 +5,15 @@ project:
   description: "MCP server for S2 documentation"
 
 tasks:
+  test:
+    command: [pnpm, ava]
+    platform: node
+    inputs:
+      - "skills/**/*"
+      - "test/**/*.js"
+      - "ava.config.js"
+      - "package.json"
+
   build:
     command: 'echo "No build required for MCP server"'
 

--- a/tools/s2-docs-mcp/package.json
+++ b/tools/s2-docs-mcp/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "start": "node src/cli.js",
+    "test": "ava",
     "scrape": "node src/batch-scraper.js",
     "bundle": "node tasks/bundleDocs.js",
     "prepublishOnly": "node tasks/bundleDocs.js"
@@ -40,6 +41,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "ava": "^6.0.1"
   },
   "engines": {
     "node": ">=20.12.0"

--- a/tools/s2-docs-mcp/skills/s2-docs/SKILL.md
+++ b/tools/s2-docs-mcp/skills/s2-docs/SKILL.md
@@ -7,6 +7,9 @@ description: >
   Components, or SWC, or names a Spectrum component (Button, Picker, ComboBox,
   TextField, ActionButton, etc.). Helps prevent drift from documented S2 design
   decisions during prototyping.
+metadata:
+  author: adobe
+  version: "1.1.2"
 when_to_use: >
   Trigger on: "which Spectrum component", "React Spectrum", "Spectrum Web
   Components", "@adobe/react-spectrum", "@spectrum-web-components", component

--- a/tools/s2-docs-mcp/test/skill-version.test.js
+++ b/tools/s2-docs-mcp/test/skill-version.test.js
@@ -20,30 +20,36 @@ import { join, dirname } from "path";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 
-/** Parse `metadata.version` from a SKILL.md file's YAML frontmatter. */
-function parseSkillVersion(skillPath) {
+/**
+ * Parse a metadata field value from a SKILL.md YAML frontmatter block.
+ * Matches the first `fieldName: "value"` line under the metadata: key.
+ * Assumes fieldName does not collide with a top-level YAML key of the same name.
+ */
+function parseMetadataField(skillPath, fieldName) {
   const content = readFileSync(skillPath, "utf-8");
   // Extract content between the first two --- delimiters
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) throw new Error(`No YAML frontmatter found in ${skillPath}`);
   const frontmatter = match[1];
-  // Extract metadata.version — expects the form: `  version: "x.y.z"`
-  const versionMatch = frontmatter.match(
-    /^\s*version:\s*["']?([^"'\r\n]+)["']?\s*$/m,
+  // Extract metadata.<fieldName> — expects: `  fieldName: "x.y.z"`
+  const re = new RegExp(
+    `^\\s*${fieldName}:\\s*["']?([^"'\\r\\n]+)["']?\\s*$`,
+    "m",
   );
-  if (!versionMatch) {
+  const valueMatch = frontmatter.match(re);
+  if (!valueMatch) {
     throw new Error(
-      `metadata.version not found in frontmatter of ${skillPath}`,
+      `metadata.${fieldName} not found in frontmatter of ${skillPath}`,
     );
   }
-  return versionMatch[1].trim();
+  return valueMatch[1].trim();
 }
 
 test("SKILL.md metadata.version matches package.json version", (t) => {
   const skillPath = join(root, "skills", "s2-docs", "SKILL.md");
   const pkgPath = join(root, "package.json");
 
-  const skillVersion = parseSkillVersion(skillPath);
+  const skillVersion = parseMetadataField(skillPath, "version");
   const { version: pkgVersion } = JSON.parse(readFileSync(pkgPath, "utf-8"));
 
   t.is(

--- a/tools/s2-docs-mcp/test/skill-version.test.js
+++ b/tools/s2-docs-mcp/test/skill-version.test.js
@@ -1,0 +1,55 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Asserts that the skill SKILL.md metadata.version matches the package.json
+ * version, so a changeset bump fails CI until the frontmatter is updated.
+ */
+
+import test from "ava";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Parse `metadata.version` from a SKILL.md file's YAML frontmatter. */
+function parseSkillVersion(skillPath) {
+  const content = readFileSync(skillPath, "utf-8");
+  // Extract content between the first two --- delimiters
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) throw new Error(`No YAML frontmatter found in ${skillPath}`);
+  const frontmatter = match[1];
+  // Extract metadata.version — expects the form: `  version: "x.y.z"`
+  const versionMatch = frontmatter.match(
+    /^\s*version:\s*["']?([^"'\r\n]+)["']?\s*$/m,
+  );
+  if (!versionMatch) {
+    throw new Error(
+      `metadata.version not found in frontmatter of ${skillPath}`,
+    );
+  }
+  return versionMatch[1].trim();
+}
+
+test("SKILL.md metadata.version matches package.json version", (t) => {
+  const skillPath = join(root, "skills", "s2-docs", "SKILL.md");
+  const pkgPath = join(root, "package.json");
+
+  const skillVersion = parseSkillVersion(skillPath);
+  const { version: pkgVersion } = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  t.is(
+    skillVersion,
+    pkgVersion,
+    `SKILL.md metadata.version "${skillVersion}" must match package.json version "${pkgVersion}". ` +
+      `Update skills/s2-docs/SKILL.md when bumping the package version.`,
+  );
+});


### PR DESCRIPTION
## Description

Adds version metadata to the three published Agent Skills and surfaces the design-data dataset version in MCP primer tool output — both driven by a leadership metrics discussion about tracking which version of the integration and which token snapshot are in use.

Two version axes are now surfaced:
1. **Tool/software version** (`metadata.version` in SKILL.md frontmatter) — the npm package version of each skill.
2. **Dataset version** (`metadata.designDataVersion` in the `design-data` skill; `provenance.designDataVersion` in MCP primer output) — the `@adobe/spectrum-design-data` version baked into the wasm at build time via `EMBEDDED_DATA_VERSION`.

The field was originally named `tokensVersion` internally in the wasm/CLI, but "tokens" is misleading — it maps to the legacy `@packages/tokens` package. This PR renames it to `designDataVersion` at source (both Rust producers: `sdk/wasm/src/dataset.rs` and `sdk/cli/src/main.rs`) so the public name matches what it represents.

## Related Issue

N/A — driven by leadership metrics discussion.

## Motivation and Context

Metrics teams need to correlate AI tool invocations to specific integration and dataset versions. The MCP `serverInfo.version` already reports tool version (was already wired). This PR closes the gap for skills (no version field) and for the dataset snapshot version (available in wasm but not propagated to the MCP primer response).

## How Has This Been Tested?

- **Skill version sync tests** (`skill-version.test.js`) added to all three skill packages — assert SKILL.md `metadata.version` matches `package.json` version; `design-data` skill also asserts `metadata.designDataVersion` matches `packages/design-data/package.json`. All 4 tests pass locally.
- **MCP primer provenance tests** added to `design-data-mcp` and updated in `design-data-agent-mcp` — assert `provenance.designDataVersion` is a semver string. These require a wasm rebuild (`sdk-wasm:build`, CI only) since `wasm-pack` is not installed locally.
- **Wasm parity test** (`sdk/wasm/test/parity.test.js`) updated to assert `provenance.designDataVersion` — runs in CI with built wasm.
- **Grep guard**: `grep -rn "tokensVersion" --include=*.rs --include=*.js --include=*.md sdk tools .changeset` returns zero hits (only `sdk/cli/CHANGELOG.md` historical entry remains, intentionally untouched).
- **Changeset linter**: `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.
- Pre-commit hooks (prettier, cargo fmt, remark, changeset lint) all passed on commit.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) — `provenance.tokensVersion` → `provenance.designDataVersion` in wasm/CLI output; internal-only crates, acceptable.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.