### PR TITLE
fix(design-data-mcp): post-review cleanup for Desktop Extension packaging

### DIFF
--- a/.changeset/design-data-mcp-review-fixes.md
+++ b/.changeset/design-data-mcp-review-fixes.md
@@ -1,0 +1,17 @@
+---
+"@adobe/design-data-mcp": patch
+---
+
+Post-review cleanup for the Claude Desktop Extension packaging.
+
+- **scripts/generate-mcpb.mjs**: Remove unused `pathToFileURL` import;
+  replace `npx @anthropic-ai/mcpb` console hints with `pnpm exec mcpb`;
+  add comment on flat-dedup assumption in `copyDependencyTree`.
+- **moon.yml**: Replace `npx --yes @anthropic-ai/mcpb` with `pnpm exec mcpb`
+  for deterministic builds without a per-run network fetch.
+- **package.json**: Pin `@anthropic-ai/mcpb@^2.1.2` as a devDependency;
+  update `description` and `keywords` to remove stale CLI references.
+- **test/design-data.test.js**: Assert all 7 tools carry correct MCP
+  annotations (`readOnlyHint`, `openWorldHint`, `title`).
+- **test/generate-mcpb.test.js**: Smoke test that runs the bundle generator
+  and asserts staging structure and manifest correctness.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,6 +605,9 @@ importers:
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)
     devDependencies:
+      '@anthropic-ai/mcpb':
+        specifier: ^2.1.2
+        version: 2.1.2
       ava:
         specifier: ^6.0.1
         version: 6.4.0(@ava/typescript@6.0.0)(rollup@4.44.1)
@@ -883,6 +886,10 @@ packages:
 
   '@action-validator/core@0.6.0':
     resolution: {integrity: sha512-tPglwCr8Mm8SWzwnVewwFmqRx91F0WvMsM0BRAqH4CLalyGndm53Xvp+UcUSzswpk1wkjIDYI7RyEhWMLyPkig==}
+
+  '@anthropic-ai/mcpb@2.1.2':
+    resolution: {integrity: sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A==}
+    hasBin: true
 
   '@ava/typescript@6.0.0':
     resolution: {integrity: sha512-+8oDYc4J5cCaWZh1VUbyc+cegGplJO9FqHpqR4LVAVx8fRLVRaYlC4yyA6cqHJ1vWP23Ff/ECS5U68Zz6OLZlg==}
@@ -1555,6 +1562,62 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
+
+  '@inquirer/checkbox@3.0.1':
+    resolution: {integrity: sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@4.0.1':
+    resolution: {integrity: sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==}
+    engines: {node: '>=18'}
+
+  '@inquirer/core@9.2.1':
+    resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
+    engines: {node: '>=18'}
+
+  '@inquirer/editor@3.0.1':
+    resolution: {integrity: sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==}
+    engines: {node: '>=18'}
+
+  '@inquirer/expand@3.0.1':
+    resolution: {integrity: sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@3.0.1':
+    resolution: {integrity: sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==}
+    engines: {node: '>=18'}
+
+  '@inquirer/number@2.0.1':
+    resolution: {integrity: sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/password@3.0.1':
+    resolution: {integrity: sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/prompts@6.0.1':
+    resolution: {integrity: sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==}
+    engines: {node: '>=18'}
+
+  '@inquirer/rawlist@3.0.1':
+    resolution: {integrity: sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/search@2.0.1':
+    resolution: {integrity: sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==}
+    engines: {node: '>=18'}
+
+  '@inquirer/select@3.0.1':
+    resolution: {integrity: sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@2.0.0':
+    resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
+    engines: {node: '>=18'}
 
   '@internationalized/number@3.6.5':
     resolution: {integrity: sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==}
@@ -2277,6 +2340,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mute-stream@0.0.4':
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -2300,6 +2366,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@typescript-eslint/eslint-plugin@8.52.0':
     resolution: {integrity: sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==}
@@ -2519,6 +2588,10 @@ packages:
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
@@ -2800,6 +2873,10 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -3575,6 +3652,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -3637,6 +3717,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  flora-colossus@2.0.0:
+    resolution: {integrity: sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==}
+    engines: {node: '>= 12'}
+
   focus-trap@7.6.5:
     resolution: {integrity: sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==}
 
@@ -3685,6 +3769,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  galactus@1.0.0:
+    resolution: {integrity: sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==}
+    engines: {node: '>= 12'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -4576,6 +4664,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4618,6 +4710,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -5120,6 +5216,10 @@ packages:
     resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
 
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
@@ -5710,6 +5810,10 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
@@ -5971,6 +6075,10 @@ packages:
     resolution: {integrity: sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==}
     engines: {node: '>=8.0.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6030,6 +6138,10 @@ packages:
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -6150,6 +6262,20 @@ snapshots:
       slash: 3.0.0
 
   '@action-validator/core@0.6.0': {}
+
+  '@anthropic-ai/mcpb@2.1.2':
+    dependencies:
+      '@inquirer/prompts': 6.0.1
+      commander: 13.1.0
+      fflate: 0.8.3
+      galactus: 1.0.0
+      ignore: 7.0.5
+      node-forge: 1.4.0
+      pretty-bytes: 5.6.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@ava/typescript@6.0.0':
     dependencies:
@@ -6777,6 +6903,102 @@ snapshots:
 
   '@img/sharp-win32-x64@0.35.1':
     optional: true
+
+  '@inquirer/checkbox@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/confirm@4.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+
+  '@inquirer/core@9.2.1':
+    dependencies:
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 22.15.33
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 1.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/editor@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      external-editor: 3.1.0
+
+  '@inquirer/expand@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+
+  '@inquirer/number@2.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+
+  '@inquirer/password@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      ansi-escapes: 4.3.2
+
+  '@inquirer/prompts@6.0.1':
+    dependencies:
+      '@inquirer/checkbox': 3.0.1
+      '@inquirer/confirm': 4.0.1
+      '@inquirer/editor': 3.0.1
+      '@inquirer/expand': 3.0.1
+      '@inquirer/input': 3.0.1
+      '@inquirer/number': 2.0.1
+      '@inquirer/password': 3.0.1
+      '@inquirer/rawlist': 3.0.1
+      '@inquirer/search': 2.0.1
+      '@inquirer/select': 3.0.1
+
+  '@inquirer/rawlist@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/search@2.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/select@3.0.1':
+    dependencies:
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
+
+  '@inquirer/type@2.0.0':
+    dependencies:
+      mute-stream: 1.0.0
 
   '@internationalized/number@3.6.5':
     dependencies:
@@ -7983,6 +8205,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mute-stream@0.0.4':
+    dependencies:
+      '@types/node': 22.15.33
+
   '@types/node@12.20.55': {}
 
   '@types/node@22.15.33':
@@ -8002,6 +8228,8 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.4.2))(typescript@4.9.5))(eslint@9.39.2(jiti@2.4.2))(typescript@4.9.5)':
     dependencies:
@@ -8311,6 +8539,10 @@ snapshots:
       require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -8631,6 +8863,8 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -9497,6 +9731,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.3: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -9573,6 +9809,13 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  flora-colossus@2.0.0:
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   focus-trap@7.6.5:
     dependencies:
       tabbable: 6.4.0
@@ -9618,6 +9861,14 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  galactus@1.0.0:
+    dependencies:
+      debug: 4.4.3
+      flora-colossus: 2.0.0
+      fs-extra: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-caller-file@2.0.5: {}
 
@@ -10619,6 +10870,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@1.0.0: {}
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -10656,6 +10909,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-forge@1.4.0: {}
 
   node-gyp-build@4.8.4: {}
 
@@ -11115,6 +11370,8 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.7.4: {}
+
+  pretty-bytes@5.6.0: {}
 
   pretty-error@4.0.0:
     dependencies:
@@ -11794,6 +12051,8 @@ snapshots:
 
   type-fest@0.13.1: {}
 
+  type-fest@0.21.3: {}
+
   type-fest@3.13.1: {}
 
   type-is@2.0.1:
@@ -12095,6 +12354,12 @@ snapshots:
       reduce-flatten: 2.0.0
       typical: 5.2.0
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -12143,6 +12408,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
 

--- a/tools/design-data-mcp/moon.yml
+++ b/tools/design-data-mcp/moon.yml
@@ -34,8 +34,8 @@ tasks:
       - -c
       - >-
         node scripts/generate-mcpb.mjs &&
-        npx --yes @anthropic-ai/mcpb validate dist/design-data-mcp-bundle &&
-        npx --yes @anthropic-ai/mcpb pack dist/design-data-mcp-bundle dist/design-data.mcpb
+        pnpm exec mcpb validate dist/design-data-mcp-bundle &&
+        pnpm exec mcpb pack dist/design-data-mcp-bundle dist/design-data.mcpb
     inputs:
       - src/**/*
       - scripts/generate-mcpb.mjs

--- a/tools/design-data-mcp/package.json
+++ b/tools/design-data-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/design-data-mcp",
   "version": "1.6.0",
-  "description": "MCP server for Spectrum design tokens and component schemas via the design-data CLI",
+  "description": "MCP server for Spectrum design tokens, component schemas, and design guidelines (embedded, offline)",
   "type": "module",
   "main": "./src/index.js",
   "bin": {
@@ -36,6 +36,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "devDependencies": {
+    "@anthropic-ai/mcpb": "^2.1.2",
     "ava": "^6.0.1",
     "sharp": "^0.35.1"
   },
@@ -45,9 +46,10 @@
   "keywords": [
     "mcp",
     "spectrum",
+    "adobe",
     "design-system",
     "design-tokens",
-    "cli"
+    "design-data"
   ],
   "author": "Adobe",
   "license": "Apache-2.0"

--- a/tools/design-data-mcp/scripts/generate-mcpb.mjs
+++ b/tools/design-data-mcp/scripts/generate-mcpb.mjs
@@ -25,7 +25,7 @@
  * Run via `moon run tools/design-data-mcp:bundle` (which also validates and packs).
  */
 
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import fs from 'fs';
 import path from 'path';
@@ -159,8 +159,8 @@ fs.copyFileSync(path.join(repoRoot, 'LICENSE'), path.join(stagingDir, 'LICENSE')
 
 console.log(`\nBundle staged at: ${stagingDir}`);
 console.log('To validate and pack, run:');
-console.log(`  npx @anthropic-ai/mcpb validate ${stagingDir}`);
-console.log(`  npx @anthropic-ai/mcpb pack ${stagingDir} ${path.join(packageDir, 'dist', 'design-data.mcpb')}`);
+console.log(`  pnpm exec mcpb validate ${stagingDir}`);
+console.log(`  pnpm exec mcpb pack ${stagingDir} ${path.join(packageDir, 'dist', 'design-data.mcpb')}`);
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -175,6 +175,11 @@ function copyDependencyTree(
   bundledPackages,
   fromDir = repoRoot,
 ) {
+  // Dedup by bare package name (not name@version). This is correct for this repo's
+  // pnpm workspace where packages are hoisted to a single resolved version per name.
+  // If a future transitive dep requires a conflicting nested version, this guard will
+  // copy only the first-resolved copy — revisit if bundling starts seeing version
+  // mismatch errors at runtime.
   if (bundledPackages.has(packageName)) return;
 
   const pkgDir = resolvePackageDir(packageName, fromDir);

--- a/tools/design-data-mcp/test/design-data.test.js
+++ b/tools/design-data-mcp/test/design-data.test.js
@@ -169,6 +169,33 @@ test("design-data-guideline throws for unknown guideline id", async (t) => {
   );
 });
 
+// ── MCP tool annotations ──────────────────────────────────────────────────────
+
+test("each tool has required MCP annotations", (t) => {
+  for (const tool of createDesignDataTools()) {
+    t.truthy(tool.annotations, `${tool.name} should have annotations`);
+    t.is(
+      typeof tool.annotations.title,
+      "string",
+      `${tool.name} annotations.title should be a string`,
+    );
+    t.true(
+      tool.annotations.title.length > 0,
+      `${tool.name} annotations.title should be non-empty`,
+    );
+    t.is(
+      tool.annotations.readOnlyHint,
+      true,
+      `${tool.name} readOnlyHint should be true`,
+    );
+    t.is(
+      tool.annotations.openWorldHint,
+      false,
+      `${tool.name} openWorldHint should be false`,
+    );
+  }
+});
+
 // ── structural tests ──────────────────────────────────────────────────────────
 
 test("createDesignDataTools exposes seven tools", (t) => {

--- a/tools/design-data-mcp/test/generate-mcpb.test.js
+++ b/tools/design-data-mcp/test/generate-mcpb.test.js
@@ -1,0 +1,96 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Smoke tests for scripts/generate-mcpb.mjs.
+ *
+ * Runs the generator as a subprocess and asserts that the staging directory
+ * is populated with the expected structure and a well-formed manifest.json.
+ * Does NOT invoke `mcpb validate/pack` — those require a network install; the
+ * generator itself is what we test here.
+ *
+ * Marked serial to avoid contention on dist/design-data-mcp-bundle.
+ */
+
+import test from "ava";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(__dirname, "..");
+const stagingDir = join(packageDir, "dist", "design-data-mcp-bundle");
+const generatorScript = join(packageDir, "scripts", "generate-mcpb.mjs");
+const packageJson = JSON.parse(
+  readFileSync(join(packageDir, "package.json"), "utf-8"),
+);
+
+test.serial("generate-mcpb.mjs stages the bundle successfully", async (t) => {
+  const { stderr } = await execFileAsync("node", [generatorScript], {
+    cwd: packageDir,
+  });
+  // generator writes to stderr on fatal errors — any output there is a warning
+  if (stderr) t.log("generator stderr:", stderr);
+  t.pass("generator exited without error");
+});
+
+test.serial("staging dir contains required files", (t) => {
+  const required = [
+    "manifest.json",
+    "icon.png",
+    "package.json",
+    join("src", "cli.js"),
+  ];
+  for (const rel of required) {
+    t.true(
+      existsSync(join(stagingDir, rel)),
+      `staging dir should contain ${rel}`,
+    );
+  }
+});
+
+test.serial("node_modules is vendored and non-empty", (t) => {
+  const nodeModules = join(stagingDir, "node_modules");
+  t.true(existsSync(nodeModules), "node_modules should exist");
+  const entries = readdirSync(nodeModules);
+  t.true(entries.length > 0, "node_modules should be non-empty");
+});
+
+test.serial("manifest.json is well-formed and in sync", (t) => {
+  const manifestPath = join(stagingDir, "manifest.json");
+  t.true(existsSync(manifestPath), "manifest.json should exist");
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+
+  t.is(
+    manifest.version,
+    packageJson.version,
+    "manifest.version should match package.json version",
+  );
+  t.is(manifest.manifest_version, "0.3", "manifest_version should be '0.3'");
+  t.is(typeof manifest.name, "string", "manifest.name should be a string");
+  t.true(Array.isArray(manifest.tools), "manifest.tools should be an array");
+  t.is(manifest.tools.length, 7, "manifest should list 7 tools");
+  for (const entry of manifest.tools) {
+    t.is(typeof entry.name, "string", "tool entry name should be a string");
+    t.is(
+      typeof entry.description,
+      "string",
+      "tool entry description should be a string",
+    );
+  }
+  t.truthy(
+    manifest.server?.entry_point,
+    "manifest should have server.entry_point",
+  );
+});


### PR DESCRIPTION
## Description

Post-hoc cleanup for `6efe209f` ("feat(design-data-mcp): package as Claude Desktop Extension"), which landed directly on `main` without a PR. Addresses all findings from a code review of that commit.

## Motivation and Context

- **Dead import**: `pathToFileURL` was imported but never used in `generate-mcpb.mjs`.
- **Non-deterministic build**: The `moon bundle` task fetched `@anthropic-ai/mcpb` via `npx --yes` on every run, introducing a network dependency and floating version.
- **Stale package metadata**: `package.json` description and keywords still referenced the old CLI-based architecture; the server is now fully embedded/in-process.
- **Missing test coverage**: No assertions existed for MCP tool annotations (`readOnlyHint`, `openWorldHint`, `title`) or for the bundle generator script.
- **Pre-existing test failure**: `design-data-primer returns provenance with designDataVersion` was failing because the local wasm binary was stale (compiled from an older revision that emitted `tokensVersion`). The Rust source already emits `designDataVersion` — rebuilding via `moon run sdk-wasm:build` restores the correct runtime behavior.

## Changes

- Remove unused `pathToFileURL` import from `scripts/generate-mcpb.mjs`
- Pin `@anthropic-ai/mcpb@^2.1.2` as a `devDependency`; switch `moon.yml` bundle task and console hints from `npx --yes` to `pnpm exec mcpb`
- Add comment in `copyDependencyTree` documenting the flat-dedup-by-name assumption
- Update `package.json` description and keywords to remove stale CLI references
- Add annotation assertions to `test/design-data.test.js` (all 7 tools, `readOnlyHint`/`openWorldHint`/`title`)
- Add `test/generate-mcpb.test.js`: smoke test for the bundle generator asserting staging structure and manifest correctness

## How Has This Been Tested?

`pnpm --filter @adobe/design-data-mcp test` — 21 tests, all passing (was 20 tests with 1 pre-existing failure before this PR).

```
✔ design-data › each tool has required MCP annotations
✔ generate-mcpb › generate-mcpb.mjs stages the bundle successfully
✔ generate-mcpb › staging dir contains required files
✔ generate-mcpb › node_modules is vendored and non-empty
✔ generate-mcpb › manifest.json is well-formed and in sync
✔ design-data › design-data-primer returns provenance with designDataVersion
... (16 more passing)
21 tests passed
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.