### PR TITLE
feat: Update small and extra small vertical base & accessory paddings

### DIFF
--- a/.changeset/20260624-5eeadcd1.md
+++ b/.changeset/20260624-5eeadcd1.md
@@ -1,0 +1,45 @@
+---
+"@adobe/spectrum-tokens": patch
+---
+
+## Token sync from Spectrum Tokens Studio
+
+**Original implementer:** @NateBaldwinDesign
+
+### Design motivation
+
+Web Design / Figma Arch teams agree to revert recent updates to component heights for small and extra small sizes back to their original height values in S2 (prior to layout token refactor)
+
+|  Size | Current | Update (this PR) |
+|------|--------|------------------|
+| Small | 26px | 24px |
+| Extra small | 22px | 20px |
+
+### Token changes
+
+
+## Tokens Changed (4)
+**Original Branch:** `main`
+**New Branch:** `tokens-sync/patch-spectrum2-from-main`
+
+  
+### Updated (4)
+  
+
+<details open><summary><strong>Updated Properties (4)</strong></summary>
+  
+- `accessory-gap-extra-small`
+	- `value`: `4px` -> `3px`
+- `accessory-gap-small`
+	- `value`: `5px` -> `4px`
+- `base-padding-vertical-extra-small`
+	- `value`: `4px` -> `3px`
+- `base-padding-vertical-small`
+	- `value`: `5px` -> `4px`
+</details>
+
+
+### References
+
+- Tokens Studio PR: https://github.com/adobe/spectrum-tokens-studio-data/pull/312
+- Spectrum Tokens PR: https://github.com/adobe/spectrum-design-data/pull/1186

--- a/.changeset/20260624-design-data-layout-sync.md
+++ b/.changeset/20260624-design-data-layout-sync.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Sync layout token values from Spectrum Tokens Studio (#1186).
+
+- **tokens/layout.tokens.json**: revert small/extra-small accessory-gap and
+  base-padding-vertical to original S2 values (accessory-gap-extra-small 4→3px,
+  accessory-gap-small 5→4px, base-padding-vertical-extra-small 4→3px,
+  base-padding-vertical-small 5→4px).

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -76,7 +76,7 @@
       "property": "accessory-gap-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "4px",
+    "value": "3px",
     "uuid": "c4071c28-33df-4461-a05c-2a1b1c295d5e",
     "description": "Spacing between child elements for accessory elements at extra-small size"
   },
@@ -103,7 +103,7 @@
       "property": "accessory-gap-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "5px",
+    "value": "4px",
     "uuid": "843d1518-7aa6-4d60-968e-b71ebbfcd88e",
     "description": "Spacing between child elements for accessory elements at small size"
   },
@@ -519,7 +519,7 @@
       "property": "base-padding-vertical-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "4px",
+    "value": "3px",
     "uuid": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47",
     "description": "Vertical internal spacing for base UI elements at extra-small size"
   },
@@ -546,7 +546,7 @@
       "property": "base-padding-vertical-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "5px",
+    "value": "4px",
     "uuid": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d",
     "description": "Vertical internal spacing for base UI elements at small size"
   },

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -49,9 +49,9 @@
   },
   "accessory-gap-extra-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "4px",
-    "uuid": "c4071c28-33df-4461-a05c-2a1b1c295d5e",
-    "description": "Spacing between child elements for accessory elements at extra-small size"
+    "value": "3px",
+    "description": "Spacing between child elements for accessory elements at extra-small size",
+    "uuid": "c4071c28-33df-4461-a05c-2a1b1c295d5e"
   },
   "accessory-gap-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -67,9 +67,9 @@
   },
   "accessory-gap-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "5px",
-    "uuid": "843d1518-7aa6-4d60-968e-b71ebbfcd88e",
-    "description": "Spacing between child elements for accessory elements at small size"
+    "value": "4px",
+    "description": "Spacing between child elements for accessory elements at small size",
+    "uuid": "843d1518-7aa6-4d60-968e-b71ebbfcd88e"
   },
   "accessory-item-padding-2x-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -349,9 +349,9 @@
   },
   "base-padding-vertical-extra-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "4px",
-    "uuid": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47",
-    "description": "Vertical internal spacing for base UI elements at extra-small size"
+    "value": "3px",
+    "description": "Vertical internal spacing for base UI elements at extra-small size",
+    "uuid": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47"
   },
   "base-padding-vertical-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -367,9 +367,9 @@
   },
   "base-padding-vertical-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "value": "5px",
-    "uuid": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d",
-    "description": "Vertical internal spacing for base UI elements at small size"
+    "value": "4px",
+    "description": "Vertical internal spacing for base UI elements at small size",
+    "uuid": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d"
   },
   "border-width-100": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",


### PR DESCRIPTION
## Token updates from Spectrum Tokens Studio Data

**Original implementer:** [@NateBaldwinDesign](https://github.com/NateBaldwinDesign)

**Source PR**: [#312 Update small and extra small vertical base & accessory paddings](https://github.com/adobe/spectrum-tokens-studio-data/pull/312)

**Automated sync via**: [GitHub Actions run](https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/28122035712)

### Source description

## Description
Updated vertical padding and accessory gaps for small and extra small sizes. Result of this update will ensure small components are 24px tall and extra small components are 20px tall.

## Motivation and context
Web Design / Figma Arch teams agree to revert recent updates to component heights for small and extra small sizes back to their original height values in S2 (prior to layout token refactor)

|  Size | Current | Update (this PR) |
|------|--------|------------------|
| Small | 26px | 24px |
| Extra small | 22px | 20px |

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>

---

Created by Action: https://github.com/adobe/spectrum-tokens-studio-data/actions/runs/28122035712
