### PR TITLE
feat(write): add cascade token write path (Phase B / B1)

### DIFF
--- a/sdk/core/src/write.rs
+++ b/sdk/core/src/write.rs
@@ -136,11 +136,10 @@ pub fn write_token(
         is_override,
     } = input;
 
-    // Inject rationale into the token object if supplied.
+    // Inject rationale into the token object if supplied, overwriting any prior value.
     if let Some(ref r) = rationale {
         if let Some(obj) = token.as_object_mut() {
-            obj.entry("rationale")
-                .or_insert_with(|| Value::String(r.clone()));
+            obj.insert("rationale".into(), Value::String(r.clone()));
         }
     }
 
@@ -220,6 +219,10 @@ fn read_legacy_file(path: &Path) -> Result<Map<String, Value>, CoreError> {
 
 /// Serialize `value` as pretty-printed JSON with a trailing newline and write to `path`.
 /// Creates parent directories if needed.
+///
+/// Uses a write-to-temp-then-rename sequence so a crash between truncation and completion
+/// cannot leave the file in an invalid state.  The temp file sits next to the target
+/// (same directory) so that `rename` is an atomic same-filesystem move on POSIX.
 fn write_json_file(path: &Path, value: &Value) -> Result<(), CoreError> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
@@ -227,7 +230,9 @@ fn write_json_file(path: &Path, value: &Value) -> Result<(), CoreError> {
         }
     }
     let json = serde_json::to_string_pretty(value)?;
-    std::fs::write(path, json + "\n")?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, json + "\n")?;
+    std::fs::rename(&tmp, path)?;
     Ok(())
 }
 
@@ -261,8 +266,8 @@ fn read_cascade_file(path: &Path) -> Result<Vec<Value>, CoreError> {
 ///
 /// Matching priority:
 /// 1. `uuid` string equality — both sides must expose a `"uuid"` string field.
-/// 2. `name` object equality — both sides must expose a `"name"` object; compared as
-///    JSON value equality (all key/value pairs must match exactly).
+/// 2. `name` equality — covers both structured name objects (normal case) and plain
+///    string names (SPEC-017 escape hatch); compared as JSON value equality.
 ///
 /// Array order is preserved (cascade tie-breaking depends on it, see token-format.md §ordering).
 fn upsert_in_cascade_array(arr: &mut Vec<Value>, token: Value) -> bool {
@@ -280,9 +285,10 @@ fn upsert_in_cascade_array(arr: &mut Vec<Value>, token: Value) -> bool {
         }
     }
 
-    // 2. Name-object equality fallback (for tokens that lack a uuid yet).
+    // 2. Name equality fallback (for tokens that lack a uuid yet).
+    //    Handles both structured name objects and SPEC-017 plain-string names.
     if let Some(n) = name {
-        if n.is_object() {
+        if n.is_object() || n.is_string() {
             if let Some(pos) = arr
                 .iter()
                 .position(|e| e.get("name").map(|en| en == n).unwrap_or(false))
@@ -331,11 +337,10 @@ pub fn write_cascade_token(
         rationale,
     } = input;
 
-    // Inject rationale into the token object if supplied.
+    // Inject rationale into the token object if supplied, overwriting any prior value.
     if let Some(ref r) = rationale {
         if let Some(obj) = token.as_object_mut() {
-            obj.entry("rationale")
-                .or_insert_with(|| Value::String(r.clone()));
+            obj.insert("rationale".into(), Value::String(r.clone()));
         }
     }
 
@@ -1096,6 +1101,76 @@ mod cascade_tests {
         assert!(replaced, "name-object fallback should find the match");
         assert_eq!(arr.len(), 1, "should update in place, not append");
         assert_eq!(arr[0]["value"].as_str(), Some("rgb(240, 240, 0)"));
+    }
+
+    #[test]
+    fn write_cascade_token_overwrites_existing_rationale() {
+        // Write a token that already carries a rationale field, then re-write it
+        // with a different rationale.  The caller-supplied value must win.
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        let uuid = "11111111-aaaa-4aaa-8aaa-000000000001";
+        // First write — token already embeds "rationale": "old".
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "cyan" },
+                    "value": "rgb(0, 255, 255)",
+                    "uuid": uuid,
+                    "rationale": "old"
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .unwrap();
+
+        // Second write — caller passes rationale: Some("corrected").
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "cyan" },
+                    "value": "rgb(0, 255, 255)",
+                    "uuid": uuid,
+                    "rationale": "old"
+                }),
+                target: target.clone(),
+                rationale: Some("corrected".into()),
+            },
+            &registry,
+        )
+        .unwrap();
+
+        let text = std::fs::read_to_string(&target).unwrap();
+        let doc: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            doc[0]["rationale"].as_str(),
+            Some("corrected"),
+            "caller-supplied rationale must overwrite existing value"
+        );
+    }
+
+    #[test]
+    fn upsert_in_cascade_array_string_name_no_duplicate() {
+        // SPEC-017 string-named token with no uuid must be updated in place, not appended.
+        let mut arr = vec![json!({
+            "name": "checkout-bg",
+            "value": "rgb(255, 255, 255)"
+            // no uuid
+        })];
+        let updated = json!({
+            "name": "checkout-bg",
+            "value": "rgb(240, 240, 240)"
+        });
+        let replaced = upsert_in_cascade_array(&mut arr, updated);
+        assert!(replaced, "string-name fallback should find the match");
+        assert_eq!(arr.len(), 1, "must update in place, not append");
+        assert_eq!(arr[0]["value"].as_str(), Some("rgb(240, 240, 240)"));
     }
 
     #[test]

--- a/sdk/core/src/write.rs
+++ b/sdk/core/src/write.rs
@@ -231,6 +231,134 @@ fn write_json_file(path: &Path, value: &Value) -> Result<(), CoreError> {
     Ok(())
 }
 
+// ── Cascade write path ────────────────────────────────────────────────────────
+
+/// Read a cascade token file into a `Vec<Value>` array, or return an empty vec if the
+/// file does not exist.
+///
+/// # Errors
+///
+/// Returns `Err` when:
+/// - The file exists but cannot be read or parsed as JSON.
+/// - The JSON root is not an array (cascade format requires a top-level array).
+fn read_cascade_file(path: &Path) -> Result<Vec<Value>, CoreError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text = std::fs::read_to_string(path)?;
+    let root: Value = serde_json::from_str(&text)?;
+    match root {
+        Value::Array(arr) => Ok(arr),
+        _ => Err(CoreError::ParseError(format!(
+            "{}: cascade token file root must be a JSON array",
+            path.display()
+        ))),
+    }
+}
+
+/// Upsert `token` into `arr`, returning `true` when an existing element was replaced
+/// and `false` when the token was appended.
+///
+/// Matching priority:
+/// 1. `uuid` string equality — both sides must expose a `"uuid"` string field.
+/// 2. `name` object equality — both sides must expose a `"name"` object; compared as
+///    JSON value equality (all key/value pairs must match exactly).
+///
+/// Array order is preserved (cascade tie-breaking depends on it, see token-format.md §ordering).
+fn upsert_in_cascade_array(arr: &mut Vec<Value>, token: Value) -> bool {
+    let uuid = token.get("uuid").and_then(|v| v.as_str());
+    let name = token.get("name");
+
+    // 1. UUID match — primary identity for cascade tokens.
+    if let Some(u) = uuid {
+        if let Some(pos) = arr
+            .iter()
+            .position(|e| e.get("uuid").and_then(|v| v.as_str()) == Some(u))
+        {
+            arr[pos] = token;
+            return true;
+        }
+    }
+
+    // 2. Name-object equality fallback (for tokens that lack a uuid yet).
+    if let Some(n) = name {
+        if n.is_object() {
+            if let Some(pos) = arr
+                .iter()
+                .position(|e| e.get("name").map(|en| en == n).unwrap_or(false))
+            {
+                arr[pos] = token;
+                return true;
+            }
+        }
+    }
+
+    arr.push(token);
+    false
+}
+
+/// Input for the `write_cascade_token` operation.
+pub struct WriteCascadeTokenInput {
+    /// Full token object — MUST include `$schema`, `uuid`, and `name`.
+    pub token: Value,
+    /// Target `*.tokens.json` file path (cascade format: JSON array).  Created if absent.
+    pub target: PathBuf,
+    /// Optional rationale string.  Recorded in the token's inline `rationale` field.
+    pub rationale: Option<String>,
+}
+
+/// Validate, upsert, and write a token to a cascade `*.tokens.json` file.
+///
+/// The target file root MUST be a JSON array (cascade format).  If the file does not
+/// exist it is created as a single-element array.  Identity is resolved by `uuid` first,
+/// then `name`-object equality — the first match is updated in place, preserving array order.
+///
+/// # Errors
+///
+/// Returns `Err` when:
+/// - The token object is missing `$schema`.
+/// - The `$schema` URL is not in the registry.
+/// - The token fails structural JSON Schema validation.
+/// - The existing target file root is not a JSON array.
+/// - File I/O fails.
+pub fn write_cascade_token(
+    input: WriteCascadeTokenInput,
+    registry: &SchemaRegistry,
+) -> Result<WriteTokenResult, CoreError> {
+    let WriteCascadeTokenInput {
+        mut token,
+        target,
+        rationale,
+    } = input;
+
+    // Inject rationale into the token object if supplied.
+    if let Some(ref r) = rationale {
+        if let Some(obj) = token.as_object_mut() {
+            obj.entry("rationale")
+                .or_insert_with(|| Value::String(r.clone()));
+        }
+    }
+
+    // Layer-1 validation against the token's $schema.
+    let label = token
+        .get("uuid")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<no-uuid>");
+    validate_token_object(label, &token, registry)?;
+
+    // Read existing cascade array (or start fresh).
+    let mut arr = read_cascade_file(&target)?;
+
+    // Upsert the token into the array and write back.
+    upsert_in_cascade_array(&mut arr, token);
+    write_json_file(&target, &Value::Array(arr))?;
+
+    Ok(WriteTokenResult {
+        written_to: target,
+        product_context_updated: false,
+    })
+}
+
 /// Update (or create) `product-context.json` to record the written token's rationale.
 ///
 /// For overrides (`is_override = true`): appends/updates an entry in `overrides[]`.
@@ -711,5 +839,293 @@ mod tests {
         assert_eq!(tokens.len(), 1, "upsert must not duplicate the entry");
         assert_eq!(tokens[0]["value"].as_str(), Some("rgb(2, 2, 2)"));
         assert_eq!(tokens[0]["rationale"].as_str(), Some("updated rationale"));
+    }
+}
+
+#[cfg(test)]
+mod cascade_tests {
+    use super::*;
+    use crate::graph::TokenGraph;
+    use crate::schema::SchemaRegistry;
+    use serde_json::json;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn cascade_registry() -> SchemaRegistry {
+        let schemas = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../packages/tokens/schemas");
+        SchemaRegistry::load_legacy_token_schemas(&schemas).expect("schemas load")
+    }
+
+    // ── write_cascade_token ───────────────────────────────────────────────────
+
+    #[test]
+    fn write_cascade_token_creates_array_file() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        let result = write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "black" },
+                    "value": "rgb(0, 0, 0)",
+                    "uuid": "aaaaaaaa-0001-4001-8001-000000000001"
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .expect("write_cascade_token should succeed");
+
+        assert!(target.exists(), "target file should be created");
+        let text = std::fs::read_to_string(&target).unwrap();
+        let doc: Value = serde_json::from_str(&text).unwrap();
+        let arr = doc.as_array().expect("root must be a JSON array");
+        assert_eq!(arr.len(), 1, "single-element array");
+        assert_eq!(arr[0]["value"].as_str(), Some("rgb(0, 0, 0)"));
+        assert!(!result.product_context_updated);
+    }
+
+    #[test]
+    fn write_cascade_token_upserts_by_uuid_no_duplicate() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        // Write initial token.
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "black" },
+                    "value": "rgb(0, 0, 0)",
+                    "uuid": "aaaaaaaa-0001-4001-8001-000000000001"
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .unwrap();
+
+        // Upsert same UUID with a new value — must update in place, not append.
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "black" },
+                    "value": "rgb(1, 1, 1)",
+                    "uuid": "aaaaaaaa-0001-4001-8001-000000000001"
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .unwrap();
+
+        let text = std::fs::read_to_string(&target).unwrap();
+        let doc: Value = serde_json::from_str(&text).unwrap();
+        let arr = doc.as_array().expect("root must be a JSON array");
+        assert_eq!(arr.len(), 1, "upsert must not duplicate the entry");
+        assert_eq!(
+            arr[0]["value"].as_str(),
+            Some("rgb(1, 1, 1)"),
+            "value should be updated"
+        );
+    }
+
+    #[test]
+    fn write_cascade_token_appends_distinct_tokens() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "blue" },
+                    "value": "rgb(0, 0, 255)",
+                    "uuid": "bbbbbbbb-0002-4002-8002-000000000002"
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .unwrap();
+
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "red" },
+                    "value": "rgb(255, 0, 0)",
+                    "uuid": "cccccccc-0003-4003-8003-000000000003"
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .unwrap();
+
+        let text = std::fs::read_to_string(&target).unwrap();
+        let doc: Value = serde_json::from_str(&text).unwrap();
+        let arr = doc.as_array().expect("root must be a JSON array");
+        assert_eq!(arr.len(), 2, "two distinct tokens should both be present");
+    }
+
+    #[test]
+    fn write_cascade_token_errors_on_non_array_root() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        // Seed target with a legacy object root (not an array).
+        std::fs::write(&target, r#"{"key":{"value":"bad"}}"#).unwrap();
+
+        let result = write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "black" },
+                    "value": "rgb(0, 0, 0)",
+                    "uuid": "aaaaaaaa-0001-4001-8001-000000000001"
+                }),
+                target,
+                rationale: None,
+            },
+            &registry,
+        );
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("array"), "error should mention array: {msg}");
+    }
+
+    #[test]
+    fn write_cascade_token_injects_rationale() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "green" },
+                    "value": "rgb(0, 128, 0)",
+                    "uuid": "dddddddd-0004-4004-8004-000000000004"
+                }),
+                target: target.clone(),
+                rationale: Some("brand refresh".into()),
+            },
+            &registry,
+        )
+        .unwrap();
+
+        let text = std::fs::read_to_string(&target).unwrap();
+        let doc: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            doc[0]["rationale"].as_str(),
+            Some("brand refresh"),
+            "rationale should be injected into the token"
+        );
+    }
+
+    #[test]
+    fn write_cascade_token_reload_roundtrip() {
+        // Write a token, reload via TokenGraph::from_json_dir, confirm recovery.
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test.tokens.json");
+        let registry = cascade_registry();
+
+        let token_uuid = "eeeeeeee-0005-4005-8005-000000000005";
+        write_cascade_token(
+            WriteCascadeTokenInput {
+                token: json!({
+                    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
+                    "name": { "property": "color", "colorFamily": "purple" },
+                    "value": "rgb(128, 0, 128)",
+                    "uuid": token_uuid
+                }),
+                target: target.clone(),
+                rationale: None,
+            },
+            &registry,
+        )
+        .unwrap();
+
+        // Reload the directory via the cascade graph reader.
+        let graph =
+            TokenGraph::from_json_dir(dir.path()).expect("TokenGraph::from_json_dir should load");
+        let record = graph
+            .tokens
+            .values()
+            .find(|r| r.uuid.as_deref() == Some(token_uuid));
+        assert!(
+            record.is_some(),
+            "token should be found in graph after reload"
+        );
+        let r = record.unwrap();
+        assert_eq!(
+            r.raw["value"].as_str(),
+            Some("rgb(128, 0, 128)"),
+            "value should round-trip through write → reload"
+        );
+    }
+
+    // ── upsert_in_cascade_array (unit) ────────────────────────────────────────
+
+    #[test]
+    fn upsert_in_cascade_array_name_fallback_when_no_uuid() {
+        let mut arr = vec![json!({
+            "name": { "property": "color", "colorFamily": "yellow" },
+            "value": "rgb(255, 255, 0)"
+            // no uuid
+        })];
+        let updated = json!({
+            "name": { "property": "color", "colorFamily": "yellow" },
+            "value": "rgb(240, 240, 0)"
+        });
+        let replaced = upsert_in_cascade_array(&mut arr, updated);
+        assert!(replaced, "name-object fallback should find the match");
+        assert_eq!(arr.len(), 1, "should update in place, not append");
+        assert_eq!(arr[0]["value"].as_str(), Some("rgb(240, 240, 0)"));
+    }
+
+    #[test]
+    fn upsert_in_cascade_array_uuid_wins_over_name() {
+        // Two elements: one matching by name, one matching by UUID.
+        // The UUID match should win.
+        let uuid_target = "ffffffff-0006-4006-8006-000000000006";
+        let mut arr = vec![
+            json!({
+                "name": { "property": "color", "colorFamily": "orange" },
+                "value": "original-by-name",
+                "uuid": "11111111-0001-0001-0001-000000000001"
+            }),
+            json!({
+                "name": { "property": "color", "colorFamily": "teal" },
+                "value": "original-by-uuid",
+                "uuid": uuid_target
+            }),
+        ];
+        // Token shares name with element[0] but UUID with element[1].
+        let token = json!({
+            "name": { "property": "color", "colorFamily": "orange" },
+            "value": "updated",
+            "uuid": uuid_target
+        });
+        let replaced = upsert_in_cascade_array(&mut arr, token);
+        assert!(replaced, "should find a match");
+        assert_eq!(arr.len(), 2, "no new element added");
+        // element[1] should be updated (UUID match), element[0] unchanged.
+        assert_eq!(arr[0]["value"].as_str(), Some("original-by-name"));
+        assert_eq!(arr[1]["value"].as_str(), Some("updated"));
     }
 }


### PR DESCRIPTION
## Description

Adds the cascade token write primitives to `sdk/core/src/write.rs` as Phase B sub-task B1. This is the foundational layer that all remaining Phase B work (lifecycle ops, catalog-aware classification, CLI/TUI/MCP surfaces) builds on.

**New public API:**
- `WriteCascadeTokenInput` — input struct carrying `token`, `target` (`*.tokens.json` path), and optional `rationale`
- `write_cascade_token(input, registry)` — validate (Layer-1 schema), upsert into the cascade array, write back

**Internal helpers:**
- `read_cascade_file(path)` — parses the JSON array root; errors if root is not an array
- `upsert_in_cascade_array(arr, token)` — UUID match (primary identity) → replace in place; `name`-object equality fallback → replace in place; else append. Array order preserved (cascade tie-breaking depends on it).

## Related Issue

Closes #spectrum-design-data-122.1 (Phase B sub-bead B1). Part of the larger Phase B initiative tracked under spectrum-design-data-122 (unblocks Phase C / `-1vr` and Phase D / `-ye1`).

## Motivation and Context

The shipped authoring tooling (RFC #973) writes tokens to legacy flat-object files (`foundation.json` / `platform.json` / `product.json`). The canonical corpus is now the cascade format: 8 `*.tokens.json` files under `packages/design-data/tokens/`, each a JSON array of self-describing token objects identified by `uuid` with an inline structured `name` object. The SDK already _reads_ cascade files; this PR adds the write side.

The contract is ratified in `packages/design-data-spec/spec/authoring-workflow.md` (§scheduled-promotion, L47-51): `write_token` escalates RECOMMENDED→MUST for cascade targets once Phase B ships.

## How Has This Been Tested?

8 new unit tests in `sdk/core/src/write.rs::cascade_tests`:

| Test | What it verifies |
|---|---|
| `write_cascade_token_creates_array_file` | New file created as a JSON array |
| `write_cascade_token_upserts_by_uuid_no_duplicate` | Re-write same UUID updates in place, no duplication |
| `write_cascade_token_appends_distinct_tokens` | Distinct UUIDs both land in the array |
| `write_cascade_token_errors_on_non_array_root` | Legacy object file rejected with clear error |
| `write_cascade_token_injects_rationale` | `rationale` field written into token object |
| `write_cascade_token_reload_roundtrip` | Write then reload via `TokenGraph::from_json_dir` — value round-trips exactly |
| `upsert_in_cascade_array_name_fallback_when_no_uuid` | Name-object equality used when no UUID present |
| `upsert_in_cascade_array_uuid_wins_over_name` | UUID match takes priority over coincidental name match |

532 core lib tests pass, 0 failures. `moon run sdk:test` (full workspace) passes. Pre-existing clippy warnings in `graph.rs` are unchanged and pre-date this PR.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)