### PR TITLE
chore(tooling): commit code-intelligence tool configs as team-standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,11 @@ graphify-out/
 **/graphify-out/
 .ferrograph
 **/.ferrograph
+
+# Scout: commit scout.config.yaml only; ignore per-machine runtime/index state
+.scout/installation-id
+.scout/models/
+.scout/search/
 tools/token-mapping-analyzer/output/
 
 # demo video pipeline rendered artifacts (re-buildable from manifests).

--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,6 @@ sdk/wasm/pkg/
 .claude/settings.local.json
 .claude/worktrees/
 **/.claude/
-.mcp.json
 
 # test temporary directories
 temp-*

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "tuiwright": {
+      "command": "tuiwright",
+      "args": ["--config", "${PWD}/tuiwright.toml"]
+    },
+    "figma": {
+      "type": "http",
+      "url": "http://127.0.0.1:3845/mcp"
+    },
+    "design-data": {
+      "command": "npx",
+      "args": ["-y", "@adobe/design-data-agent-mcp"],
+      "env": {
+        "DESIGN_DATA_BIN": "${PWD}/sdk/target/release/design-data",
+        "DESIGN_DATA_PATH": "packages/design-data/tokens",
+        "DESIGN_DATA_COMPONENTS": "packages/design-data/components",
+        "DESIGN_DATA_FIELDS": "packages/design-data/fields"
+      }
+    },
+    "scout": {
+      "command": "scout",
+      "args": ["mcp"]
+    },
+    "ferrograph": {
+      "command": "ferrograph",
+      "args": ["mcp"],
+      "cwd": "${PWD}/sdk"
+    }
+  }
+}

--- a/.scout/scout.config.yaml
+++ b/.scout/scout.config.yaml
@@ -1,0 +1,19 @@
+# Scout per-repo config template.
+#
+# Seeded into `<repo>/.scout/scout.config.yaml` by `scout attach` when the
+# repo has no config yet.  Templates here only carry the repo-specific
+# ignore / dampen / boost / tune overrides; defaults for
+# repository/markdown/ranking/index/projects are filled in at load time.
+ignore:
+  - "**/CHANGELOG.md"
+  - "**/CHANGELOG*"
+  - "**/CHANGES.md"
+  - "**/HISTORY.md"
+  - "sdk/target/**" # build artifacts (379k+ .o/.rmeta/.d files)
+  - "**/*.timestamp" # cargo incremental timestamp files
+  - "pnpm-lock.yaml" # 400 KB lockfile, low retrieval value
+
+dampen:
+  - factor: 0.3
+    patterns:
+      - "**/package.json"

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,132 @@
+# the name by which the project can be referenced within Serena
+project_name: "spectrum-design-data"
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+  - typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,13 @@ License: Apache-2.0.
 
 ## Code Intelligence Tools (MCP)
 
-Two MCP servers are configured alongside tuiwright/figma/design-data:
+Five MCP servers are configured in `.mcp.json` (committed, portable — uses `${PWD}` for
+repo-relative paths):
 
 * **Scout** — fuzzy front door for the whole repo. Use for: semantic search over tokens/schemas/docs, cross-package references ("what uses this token?"), doc knowledge graph, "find code about X" across TS/JS/JSON/Rust.
 * **Ferrograph** — precise back end for `sdk/` Rust crates only. Use for: exact call graph, blast radius ("what breaks if I change this?"), dead code, ownership/`&`/`&mut`/`unsafe` edges, raw Datalog queries. Deterministic — no LLM tokens, no approximations.
+* **tuiwright** — TUI snapshot/headless testing for the product TUI. Requires a one-time install: `cargo install --path <path-to-tuiwright-source>/crates/tuiwright-mcp` (source at <https://github.com/GarthDB/tuiwright>).
+* **design-data** — query token/component data from the local SDK build via `@adobe/design-data-agent-mcp`.
+* **figma** — Figma desktop plugin bridge (must have the Figma desktop app running).
 
 **Routing rule:** when asking a Rust structural question (impact, callers, dead code), prefer ferrograph's answer over Scout's — it's exact. For everything else (tokens, docs, TS, "what is X"), use Scout. The two cover different ground and complement each other.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,12 @@ License: Apache-2.0.
 * `async/await` over `.then()` chains
 * Template literals for interpolation
 * Full patterns and anti-patterns → `.claude/rules/javascript.md` (loads when JS/TS files are open)
+
+## Code Intelligence Tools (MCP)
+
+Two MCP servers are configured alongside tuiwright/figma/design-data:
+
+* **Scout** — fuzzy front door for the whole repo. Use for: semantic search over tokens/schemas/docs, cross-package references ("what uses this token?"), doc knowledge graph, "find code about X" across TS/JS/JSON/Rust.
+* **Ferrograph** — precise back end for `sdk/` Rust crates only. Use for: exact call graph, blast radius ("what breaks if I change this?"), dead code, ownership/`&`/`&mut`/`unsafe` edges, raw Datalog queries. Deterministic — no LLM tokens, no approximations.
+
+**Routing rule:** when asking a Rust structural question (impact, callers, dead code), prefer ferrograph's answer over Scout's — it's exact. For everything else (tokens, docs, TS, "what is X"), use Scout. The two cover different ground and complement each other.

--- a/tuiwright.toml
+++ b/tuiwright.toml
@@ -1,0 +1,10 @@
+# {} is substituted with the NDJSON replay file path at runtime
+headless_snapshot = "sdk/target/release/design-data packages/design-data/tokens --components packages/design-data/components --replay {} --snapshot-ansi"
+
+[launch]
+command = "sdk/target/release/design-data"
+args = ["packages/design-data/tokens", "--components", "packages/design-data/components"]
+
+[size]
+cols = 120
+rows = 36


### PR DESCRIPTION
## Description

Commits configuration for five code-intelligence MCP tools (Scout, Serena, Ferrograph, tuiwright, design-data) as team-standard tooling. Previously these were gitignored as machine-specific; this PR makes the shareable configs tracked and portable.

## Related Issue

No issue — tooling setup, not a product change.

## Motivation and Context

These tools (Scout for semantic search, Ferrograph for Rust call-graph analysis, Serena for project context, tuiwright for TUI snapshot testing, design-data MCP for token queries) are useful for any contributor working on this repo. Committing the configs lets teammates get the same setup without manual reverse-engineering.

The `.mcp.json` previously had hardcoded absolute paths (`/Users/garthdb/…`); those are replaced with `${PWD}/…` so the file works on any machine.

## How Has This Been Tested?

- `git add --dry-run --verbose` confirmed no runtime/index state (`.serena/cache/`, `.scout/installation-id`, etc.) was swept in.
- `git check-ignore` verified the new `.scout/` gitignore rules correctly exclude per-machine state while allowing `scout.config.yaml`.
- tuiwright binary installed via `cargo install …/crates/tuiwright-mcp` and confirmed in PATH at `~/.cargo/bin/tuiwright`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.