### PR TITLE
feat(authoring): Phase C — create/edit authoring for non-token data categories

### DIFF
--- a/.changeset/c1-non-token-authoring.md
+++ b/.changeset/c1-non-token-authoring.md
@@ -1,0 +1,11 @@
+---
+"@adobe/design-data-agent-mcp": minor
+"@adobe/spectrum-design-data": patch
+---
+
+feat(authoring): Phase C — create/edit authoring for non-token data categories.
+
+- **tools/design-data-agent-mcp**: adds `data_create` and `data_edit` MCP tools for
+  components, fields, registry, mode-sets, and guidelines; delegate to the CLI.
+- **packages/design-data/AUTHORING.md**: documents the new `design-data data create|edit`
+  CLI commands and the `data_create`/`data_edit` MCP tools.

--- a/packages/design-data/AUTHORING.md
+++ b/packages/design-data/AUTHORING.md
@@ -282,6 +282,40 @@ For questions or feedback:
 * Content Strategists: Jess Sattell, Kari Brookmyer
 * GitHub: [Spectrum Design Data Discussions](https://github.com/adobe/spectrum-design-data/discussions)
 
+## CLI Authoring Commands (Phase C)
+
+All five non-token data categories can be created or edited using the `design-data data`
+command. The command validates the JSON document against the category schema before writing.
+
+```bash
+# Create a new file (fails if <name>.json already exists)
+design-data data create --category <category> --file path/to/doc.json
+
+# Edit an existing file (fails if <name>.json does not exist)
+design-data data edit --category <category> --file path/to/doc.json
+
+# Read from stdin
+cat doc.json | design-data data create --category mode-sets --file -
+```
+
+**`--category`** is one of: `components`, `fields`, `registry`, `mode-sets`, `guidelines`.
+
+The document must include the required fields for its category (e.g. `name`, `$schema`,
+`specVersion`). The output filename is derived from the `name` field (or `type` for registry).
+
+**After editing `fields/` or `registry/`**, run:
+
+```bash
+moon run sdk:codegen && moon run sdk:codegen-check
+```
+
+to keep the embedded Rust registry in sync.
+
+### MCP tools
+
+When using `design-data-agent-mcp`, the equivalent tools are `data_create` and `data_edit`.
+Both accept a `document` object and `category` string, and delegate to the CLI above.
+
 ## Related Resources
 
 * [Spectrum Naming and Definition Writing Guide](https://wiki.corp.adobe.com/display/AdobeDesign/Spectrum+Design+System%3A+Naming+and+definition+writing+guide)

--- a/sdk/cli/src/data.rs
+++ b/sdk/cli/src/data.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! `data` subcommand — create/edit non-token data categories.
+//!
+//! All output is JSON written to stdout; exit code 1 on error.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Subcommand;
+use design_data_core::authoring::data_object::{write_data_object, DataCategory, DataWriteMode};
+
+// ── Clap types ────────────────────────────────────────────────────────────────
+
+/// Non-token data categories.
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub enum CategoryArg {
+    Components,
+    Fields,
+    Registry,
+    #[value(name = "mode-sets")]
+    ModeSets,
+    Guidelines,
+}
+
+impl From<CategoryArg> for DataCategory {
+    fn from(a: CategoryArg) -> Self {
+        match a {
+            CategoryArg::Components => DataCategory::Components,
+            CategoryArg::Fields => DataCategory::Fields,
+            CategoryArg::Registry => DataCategory::Registry,
+            CategoryArg::ModeSets => DataCategory::ModeSets,
+            CategoryArg::Guidelines => DataCategory::Guidelines,
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DataCommand {
+    /// Create a new data object (fails if the file already exists).
+    Create {
+        /// Category to create in.
+        #[arg(long, value_enum)]
+        category: CategoryArg,
+        /// JSON file to read, or `-` for stdin.
+        #[arg(long, value_name = "FILE")]
+        file: String,
+        /// Dataset root (default: current directory).
+        #[arg(long, value_name = "DIR")]
+        dataset: Option<PathBuf>,
+        /// design-data-spec schemas dir (default: probed from dataset root).
+        #[arg(long, value_name = "DIR")]
+        spec_schemas: Option<PathBuf>,
+    },
+    /// Edit an existing data object (fails if the file does not exist).
+    Edit {
+        /// Category to edit in.
+        #[arg(long, value_enum)]
+        category: CategoryArg,
+        /// JSON file to read, or `-` for stdin.
+        #[arg(long, value_name = "FILE")]
+        file: String,
+        /// Dataset root (default: current directory).
+        #[arg(long, value_name = "DIR")]
+        dataset: Option<PathBuf>,
+        /// design-data-spec schemas dir (default: probed from dataset root).
+        #[arg(long, value_name = "DIR")]
+        spec_schemas: Option<PathBuf>,
+    },
+}
+
+// ── Dispatch ──────────────────────────────────────────────────────────────────
+
+pub fn run(cmd: DataCommand) -> ExitCode {
+    match run_inner(cmd) {
+        Ok(json) => {
+            println!("{json}");
+            ExitCode::SUCCESS
+        }
+        Err(msg) => {
+            eprintln!("data error: {msg}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_inner(cmd: DataCommand) -> Result<String, String> {
+    let (category, file, dataset, spec_schemas, mode) = match cmd {
+        DataCommand::Create {
+            category,
+            file,
+            dataset,
+            spec_schemas,
+        } => (category, file, dataset, spec_schemas, DataWriteMode::Create),
+        DataCommand::Edit {
+            category,
+            file,
+            dataset,
+            spec_schemas,
+        } => (category, file, dataset, spec_schemas, DataWriteMode::Edit),
+    };
+
+    // Read document from file or stdin.
+    let json_text = if file == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| format!("failed to read stdin: {e}"))?;
+        buf
+    } else {
+        std::fs::read_to_string(&file).map_err(|e| format!("failed to read {file}: {e}"))?
+    };
+
+    let doc: serde_json::Value =
+        serde_json::from_str(&json_text).map_err(|e| format!("invalid JSON: {e}"))?;
+
+    let dataset_root = dataset.unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+    let schemas_dir = spec_schemas
+        .or_else(|| probe_spec_schemas(&dataset_root))
+        .ok_or_else(|| {
+            "design-data-spec schemas not found; pass --spec-schemas <DIR>".to_string()
+        })?;
+
+    let result = write_data_object(&dataset_root, &schemas_dir, category.into(), mode, &doc)
+        .map_err(|e| e.to_string())?;
+
+    serde_json::to_string_pretty(&result).map_err(|e| format!("serialize result: {e}"))
+}
+
+/// Probe common spec-schemas locations relative to the dataset root and cwd.
+fn probe_spec_schemas(dataset_root: &std::path::Path) -> Option<PathBuf> {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let candidates = [
+        dataset_root.join("../design-data-spec/schemas"),
+        cwd.join("packages/design-data-spec/schemas"),
+        cwd.join("../packages/design-data-spec/schemas"),
+        cwd.join("../design-data-spec/schemas"),
+    ];
+    candidates
+        .into_iter()
+        .find(|c| c.join("field.schema.json").is_file())
+}

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -14,6 +14,7 @@ use std::process::ExitCode;
 use chrono::Utc;
 
 mod authoring;
+mod data;
 mod format;
 mod lifecycle;
 
@@ -335,6 +336,11 @@ enum Commands {
     ModeSet {
         #[command(subcommand)]
         cmd: lifecycle::ModeSetCommand,
+    },
+    /// Create or edit non-token data objects (components, fields, registry, mode-sets, guidelines)
+    Data {
+        #[command(subcommand)]
+        cmd: data::DataCommand,
     },
     /// Launch the interactive TUI (same as running with no arguments)
     Tui(TuiArgs),
@@ -1785,6 +1791,9 @@ fn main() -> ExitCode {
         }
         Commands::ModeSet { cmd } => {
             return lifecycle::run_mode_set(cmd);
+        }
+        Commands::Data { cmd } => {
+            return data::run(cmd);
         }
         Commands::Tui(_) => unreachable!("handled above"),
     };

--- a/sdk/core/src/authoring/data_object.rs
+++ b/sdk/core/src/authoring/data_object.rs
@@ -132,6 +132,20 @@ pub fn write_data_object(
         })?
         .to_string();
 
+    // Reject names that would traverse out of the category directory.
+    {
+        use std::path::Component;
+        let p = std::path::Path::new(&name);
+        let safe = p.components().count() == 1
+            && p.components().all(|c| matches!(c, Component::Normal(_)));
+        if !safe {
+            return Err(CoreError::ParseError(format!(
+                "invalid {}: {:?} — must be a plain filename with no path separators",
+                m.name_field, name
+            )));
+        }
+    }
+
     let target_dir = dataset_root.join(m.subdir);
     let target = target_dir.join(format!("{name}.json"));
 
@@ -227,7 +241,7 @@ mod tests {
     #[test]
     fn create_fails_on_schema_violation() {
         // mode-set missing required "default" field
-        let (_dir, result) = run(
+        let (dir, result) = run(
             DataCategory::ModeSets,
             DataWriteMode::Create,
             json!({
@@ -238,8 +252,7 @@ mod tests {
             }),
         );
         assert!(matches!(result, Err(CoreError::ParseError(_))));
-        // ponytail: also assert nothing was written
-        // (dir still around, but the file should not exist)
+        assert!(!dir.path().join("mode-sets/bad-mode-set.json").exists());
     }
 
     #[test]
@@ -323,6 +336,23 @@ mod tests {
         )
         .expect("edit should succeed");
         assert_eq!(r.name, "editable");
+    }
+
+    #[test]
+    fn create_rejects_path_traversal_in_name() {
+        // A name like "../evil" must not traverse out of the category dir.
+        let (_dir, result) = run(
+            DataCategory::ModeSets,
+            DataWriteMode::Create,
+            json!({
+                "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+                "specVersion": "1.0.0-draft",
+                "name": "../evil",
+                "modes": ["a"],
+                "default": "a"
+            }),
+        );
+        assert!(matches!(result, Err(CoreError::ParseError(_))));
     }
 
     #[test]

--- a/sdk/core/src/authoring/data_object.rs
+++ b/sdk/core/src/authoring/data_object.rs
@@ -1,0 +1,348 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! Create / edit authoring for non-token data categories:
+//! components, fields, registry, mode-sets, guidelines.
+//!
+//! All five categories are one-JSON-object-per-file, so create/edit reduces to:
+//! validate the document (Layer 1, JSON Schema), write `<category-dir>/<name>.json`.
+//! No UUID resolution, no array upsert, no cascade layering — see Phase B for tokens.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::schema::SchemaRegistry;
+use crate::write::write_json_file;
+use crate::CoreError;
+
+// ── Category registration ─────────────────────────────────────────────────────
+
+/// A non-token data category that can be created or edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataCategory {
+    Components,
+    Fields,
+    Registry,
+    ModeSets,
+    Guidelines,
+}
+
+struct CategoryMeta {
+    /// Subdirectory under the dataset root.
+    subdir: &'static str,
+    /// Schema filename under `spec_schemas_dir`.
+    schema_file: &'static str,
+    /// JSON field used as the canonical name / filename slug.
+    name_field: &'static str,
+    /// Whether mutations here require `moon run sdk:codegen` to stay in sync.
+    needs_codegen: bool,
+}
+
+fn meta(cat: DataCategory) -> CategoryMeta {
+    match cat {
+        DataCategory::Components => CategoryMeta {
+            subdir: "components",
+            schema_file: "component.schema.json",
+            name_field: "name",
+            needs_codegen: false,
+        },
+        DataCategory::Fields => CategoryMeta {
+            subdir: "fields",
+            schema_file: "field.schema.json",
+            name_field: "name",
+            needs_codegen: true,
+        },
+        DataCategory::Registry => CategoryMeta {
+            subdir: "registry",
+            schema_file: "registry-value.json",
+            name_field: "type",
+            needs_codegen: true,
+        },
+        DataCategory::ModeSets => CategoryMeta {
+            subdir: "mode-sets",
+            schema_file: "mode-set.schema.json",
+            name_field: "name",
+            needs_codegen: false,
+        },
+        DataCategory::Guidelines => CategoryMeta {
+            subdir: "guidelines",
+            schema_file: "guideline.schema.json",
+            name_field: "name",
+            needs_codegen: false,
+        },
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Whether to create a new file or overwrite an existing one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataWriteMode {
+    /// Fails if the target file already exists.
+    Create,
+    /// Fails if the target file does not exist.
+    Edit,
+}
+
+/// Result of a successful [`write_data_object`] call.
+#[derive(Debug, Serialize)]
+pub struct DataWriteResult {
+    pub written_to: PathBuf,
+    pub category: String,
+    pub name: String,
+    /// Non-empty when the caller should run `moon run sdk:codegen` + `sdk:codegen-check`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codegen_required: Option<String>,
+}
+
+/// Validate and write a non-token data object to `<dataset_root>/<category>/<name>.json`.
+///
+/// # Errors
+/// - `CoreError::ParseError` if the document is not valid JSON, is missing its name
+///   field, fails Layer 1 schema validation, or violates the create/edit existence check.
+/// - `CoreError::Io` on file read/write failure.
+pub fn write_data_object(
+    dataset_root: &Path,
+    spec_schemas_dir: &Path,
+    category: DataCategory,
+    mode: DataWriteMode,
+    doc: &Value,
+) -> Result<DataWriteResult, CoreError> {
+    let m = meta(category);
+
+    // Extract name from document.
+    let name = doc
+        .get(m.name_field)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            CoreError::ParseError(format!(
+                "document is missing required string field {:?}",
+                m.name_field
+            ))
+        })?
+        .to_string();
+
+    let target_dir = dataset_root.join(m.subdir);
+    let target = target_dir.join(format!("{name}.json"));
+
+    // Enforce create / edit existence semantics.
+    match mode {
+        DataWriteMode::Create if target.exists() => {
+            return Err(CoreError::ParseError(format!(
+                "{}/{name}.json already exists — use edit to overwrite",
+                m.subdir
+            )));
+        }
+        DataWriteMode::Edit if !target.exists() => {
+            return Err(CoreError::ParseError(format!(
+                "{}/{name}.json does not exist — use create to create it",
+                m.subdir
+            )));
+        }
+        _ => {}
+    }
+
+    // Layer 1: validate against the category JSON schema (pre-write, nothing written yet).
+    let schema_path = spec_schemas_dir.join(m.schema_file);
+    let errors = SchemaRegistry::validate_value_against_schema_file(doc, &schema_path)?;
+    if !errors.is_empty() {
+        return Err(CoreError::ParseError(format!(
+            "schema validation failed for {}/{name}.json:\n{}",
+            m.subdir,
+            errors.join("\n")
+        )));
+    }
+
+    // Write.
+    std::fs::create_dir_all(&target_dir)?;
+    write_json_file(&target, doc)?;
+
+    Ok(DataWriteResult {
+        written_to: target,
+        category: m.subdir.to_string(),
+        name,
+        codegen_required: if m.needs_codegen {
+            Some("run `moon run sdk:codegen && moon run sdk:codegen-check` to keep the embedded Rust registry in sync".to_string())
+        } else {
+            None
+        },
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn spec_schemas_dir() -> PathBuf {
+        // Resolve relative to this source file's location in the workspace.
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest.join("../../packages/design-data-spec/schemas")
+    }
+
+    fn run(
+        cat: DataCategory,
+        mode: DataWriteMode,
+        doc: Value,
+    ) -> (TempDir, Result<DataWriteResult, CoreError>) {
+        let dir = TempDir::new().unwrap();
+        let result = write_data_object(dir.path(), &spec_schemas_dir(), cat, mode, &doc);
+        (dir, result)
+    }
+
+    #[test]
+    fn create_valid_mode_set() {
+        let (_dir, result) = run(
+            DataCategory::ModeSets,
+            DataWriteMode::Create,
+            json!({
+                "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+                "specVersion": "1.0.0-draft",
+                "name": "test-modes",
+                "modes": ["a", "b"],
+                "default": "a",
+                "description": "test"
+            }),
+        );
+        let r = result.expect("create should succeed");
+        assert_eq!(r.name, "test-modes");
+        assert!(r.written_to.exists());
+        assert!(r.codegen_required.is_none());
+    }
+
+    #[test]
+    fn create_fails_on_schema_violation() {
+        // mode-set missing required "default" field
+        let (_dir, result) = run(
+            DataCategory::ModeSets,
+            DataWriteMode::Create,
+            json!({
+                "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+                "specVersion": "1.0.0-draft",
+                "name": "bad-mode-set",
+                "modes": ["a", "b"]
+            }),
+        );
+        assert!(matches!(result, Err(CoreError::ParseError(_))));
+        // ponytail: also assert nothing was written
+        // (dir still around, but the file should not exist)
+    }
+
+    #[test]
+    fn create_fails_when_file_exists() {
+        let doc = json!({
+            "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+            "specVersion": "1.0.0-draft",
+            "name": "dup",
+            "modes": ["a"],
+            "default": "a"
+        });
+        let dir = TempDir::new().unwrap();
+        let schemas = spec_schemas_dir();
+        write_data_object(
+            dir.path(),
+            &schemas,
+            DataCategory::ModeSets,
+            DataWriteMode::Create,
+            &doc,
+        )
+        .expect("first create should succeed");
+        let second = write_data_object(
+            dir.path(),
+            &schemas,
+            DataCategory::ModeSets,
+            DataWriteMode::Create,
+            &doc,
+        );
+        assert!(matches!(second, Err(CoreError::ParseError(_))));
+    }
+
+    #[test]
+    fn edit_fails_when_file_missing() {
+        let (_dir, result) = run(
+            DataCategory::ModeSets,
+            DataWriteMode::Edit,
+            json!({
+                "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+                "specVersion": "1.0.0-draft",
+                "name": "nonexistent",
+                "modes": ["a"],
+                "default": "a"
+            }),
+        );
+        assert!(matches!(result, Err(CoreError::ParseError(_))));
+    }
+
+    #[test]
+    fn edit_succeeds_when_file_exists() {
+        let doc_v1 = json!({
+            "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+            "specVersion": "1.0.0-draft",
+            "name": "editable",
+            "modes": ["a"],
+            "default": "a"
+        });
+        let doc_v2 = json!({
+            "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/mode-set.schema.json",
+            "specVersion": "1.0.0-draft",
+            "name": "editable",
+            "modes": ["a", "b"],
+            "default": "b",
+            "description": "updated"
+        });
+        let dir = TempDir::new().unwrap();
+        let schemas = spec_schemas_dir();
+        write_data_object(
+            dir.path(),
+            &schemas,
+            DataCategory::ModeSets,
+            DataWriteMode::Create,
+            &doc_v1,
+        )
+        .expect("create should succeed");
+        let r = write_data_object(
+            dir.path(),
+            &schemas,
+            DataCategory::ModeSets,
+            DataWriteMode::Edit,
+            &doc_v2,
+        )
+        .expect("edit should succeed");
+        assert_eq!(r.name, "editable");
+    }
+
+    #[test]
+    fn fields_create_signals_codegen() {
+        let (_dir, result) = run(
+            DataCategory::Fields,
+            DataWriteMode::Create,
+            json!({
+                "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+                "specVersion": "1.0.0-draft",
+                "name": "test-field",
+                "description": "A test field.",
+                "kind": "semantic",
+                "validation": "advisory",
+                "serialization": { "position": 99 },
+                "required": false,
+                "valueType": "string"
+            }),
+        );
+        let r = result.expect("create should succeed");
+        assert!(r.codegen_required.is_some());
+    }
+}

--- a/sdk/core/src/authoring/mod.rs
+++ b/sdk/core/src/authoring/mod.rs
@@ -9,7 +9,9 @@
 // governing permissions and limitations under the License.
 
 //! Token authoring — wizard DTOs and MCP session state machine (RFC #973 Q4).
+//! Also contains [`data_object`] for non-token category authoring (Phase C).
 
+pub mod data_object;
 pub mod draft;
 pub mod lifecycle;
 pub mod mode_set;

--- a/tools/design-data-agent-mcp/src/cli.js
+++ b/tools/design-data-agent-mcp/src/cli.js
@@ -11,7 +11,7 @@
 import { spawn } from "child_process";
 import { config } from "./config.js";
 
-export function runCli(args, { timeout = 10_000 } = {}) {
+export function runCli(args, { timeout = 10_000, stdin } = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn(config.bin, args, {
       // Anchor the CLI's working directory to the resolved data root so its own
@@ -19,8 +19,12 @@ export function runCli(args, { timeout = 10_000 } = {}) {
       // even when Claude Code launched the server from a monorepo subdirectory.
       cwd: config.dataRoot,
       // isolates CLI stdout from the MCP JSON-RPC stream on the parent's stdout
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: [stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
     });
+    if (stdin != null) {
+      proc.stdin.write(stdin);
+      proc.stdin.end();
+    }
     let stdout = "";
     let stderr = "";
     proc.stdout.on("data", (d) => {

--- a/tools/design-data-agent-mcp/src/index.js
+++ b/tools/design-data-agent-mcp/src/index.js
@@ -19,6 +19,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { createAuthoringTools } from "./tools/authoring.js";
+import { createDataTools } from "./tools/data.js";
 import { createReadTools } from "./tools/read.js";
 import { createValidateTools } from "./tools/validate.js";
 import { createDiffTools } from "./tools/diff.js";
@@ -31,6 +32,7 @@ export function createAllTools() {
     ...createDiffTools(),
     ...createWriteTools(),
     ...createAuthoringTools(),
+    ...createDataTools(),
   ];
 }
 

--- a/tools/design-data-agent-mcp/src/tools/data.js
+++ b/tools/design-data-agent-mcp/src/tools/data.js
@@ -1,0 +1,158 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * create/edit tools for non-token data categories (components, fields, registry,
+ * mode-sets, guidelines) — Phase C authoring surface.
+ *
+ * All operations delegate to `design-data data create|edit`, which validates
+ * against the JSON schema before writing. Output is byte-identical to the CLI.
+ *
+ * CLI surface used:
+ *   design-data data create --category <c> --file -  [--dataset <dir>] [--spec-schemas <dir>]
+ *   design-data data edit   --category <c> --file -  [--dataset <dir>] [--spec-schemas <dir>]
+ */
+
+import { resolve } from "path";
+import { runCli } from "../cli.js";
+import { config } from "../config.js";
+
+const CATEGORIES = [
+  "components",
+  "fields",
+  "registry",
+  "mode-sets",
+  "guidelines",
+];
+
+/** Run CLI, throw on non-zero exit, return parsed JSON. */
+async function runJson(args, stdin, { timeout = 30_000 } = {}) {
+  const { exitCode, stdout, stderr } = await runCli(args, { timeout, stdin });
+  if (exitCode !== 0)
+    throw new Error(stderr || `design-data ${args[0]} exited ${exitCode}`);
+  return JSON.parse(stdout);
+}
+
+/**
+ * Build the base args for a data create/edit call, resolving dataset root and
+ * spec schemas dir from config / env.
+ */
+function baseArgs(subcommand, category, datasetOverride, specSchemasOverride) {
+  const dataset =
+    datasetOverride ??
+    // Strip trailing /tokens from DESIGN_DATA_PATH to get the dataset root.
+    config.dataPath?.replace(/\/tokens\/?$/, "") ??
+    resolve(config.dataRoot, "packages/design-data");
+
+  const args = [
+    "data",
+    subcommand,
+    "--category",
+    category,
+    "--file",
+    "-",
+    "--dataset",
+    dataset,
+  ];
+
+  const specSchemas =
+    specSchemasOverride ??
+    (process.env.DESIGN_DATA_SPEC_SCHEMAS
+      ? resolve(process.env.DESIGN_DATA_SPEC_SCHEMAS)
+      : null);
+  if (specSchemas) args.push("--spec-schemas", specSchemas);
+
+  return { args, dataset };
+}
+
+export function createDataTools() {
+  return [
+    {
+      name: "data_create",
+      description:
+        "Create a new non-token data object (component, field, registry entry, mode-set, or " +
+        "guideline). Validates the JSON document against the category schema before writing. " +
+        "Fails if the file already exists — use data_edit to overwrite.",
+      inputSchema: {
+        type: "object",
+        required: ["category", "document"],
+        properties: {
+          category: {
+            type: "string",
+            enum: CATEGORIES,
+            description: "Data category to create in.",
+          },
+          document: {
+            type: "object",
+            description:
+              "Full JSON document to write. Must include the category's required fields " +
+              "(e.g. `name`, `$schema`, `specVersion`). The filename is derived from the `name` field.",
+            additionalProperties: true,
+          },
+          dataset: {
+            type: "string",
+            description:
+              "Path to the dataset root (packages/design-data). Defaults to DESIGN_DATA_PATH minus /tokens.",
+          },
+          spec_schemas: {
+            type: "string",
+            description:
+              "Path to the design-data-spec schemas dir. Defaults to DESIGN_DATA_SPEC_SCHEMAS or auto-probed.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({ category, document, dataset, spec_schemas }) {
+        const { args } = baseArgs("create", category, dataset, spec_schemas);
+        return runJson(args, JSON.stringify(document));
+      },
+    },
+
+    {
+      name: "data_edit",
+      description:
+        "Replace an existing non-token data object with a new JSON document. Validates the " +
+        "document against the category schema before writing. Fails if the file does not exist " +
+        "— use data_create to create it. Edit is a full document replace, not a patch.",
+      inputSchema: {
+        type: "object",
+        required: ["category", "document"],
+        properties: {
+          category: {
+            type: "string",
+            enum: CATEGORIES,
+            description: "Data category to edit in.",
+          },
+          document: {
+            type: "object",
+            description:
+              "Full replacement JSON document. The `name` field must match the existing file.",
+            additionalProperties: true,
+          },
+          dataset: {
+            type: "string",
+            description:
+              "Path to the dataset root (packages/design-data). Defaults to DESIGN_DATA_PATH minus /tokens.",
+          },
+          spec_schemas: {
+            type: "string",
+            description:
+              "Path to the design-data-spec schemas dir. Defaults to DESIGN_DATA_SPEC_SCHEMAS or auto-probed.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler({ category, document, dataset, spec_schemas }) {
+        const { args } = baseArgs("edit", category, dataset, spec_schemas);
+        return runJson(args, JSON.stringify(document));
+      },
+    },
+  ];
+}

--- a/tools/design-data-agent-mcp/src/tools/data.js
+++ b/tools/design-data-agent-mcp/src/tools/data.js
@@ -45,10 +45,14 @@ async function runJson(args, stdin, { timeout = 30_000 } = {}) {
  * spec schemas dir from config / env.
  */
 function baseArgs(subcommand, category, datasetOverride, specSchemasOverride) {
+  // Only use config.dataPath when it ends in /tokens — the bare-cwd fallback
+  // (anchorPath(".")) does not end in tokens and must not be stripped.
+  const dataPathTokens = config.dataPath?.match(/^(.*?)\/tokens\/?$/)
+    ? config.dataPath.replace(/\/tokens\/?$/, "")
+    : null;
   const dataset =
     datasetOverride ??
-    // Strip trailing /tokens from DESIGN_DATA_PATH to get the dataset root.
-    config.dataPath?.replace(/\/tokens\/?$/, "") ??
+    dataPathTokens ??
     resolve(config.dataRoot, "packages/design-data");
 
   const args = [

--- a/tools/design-data-agent-mcp/test/index.test.js
+++ b/tools/design-data-agent-mcp/test/index.test.js
@@ -54,9 +54,9 @@ test("server initializes", (t) => {
   t.truthy(server);
 });
 
-test("server exposes 25 tools", (t) => {
+test("server exposes 27 tools", (t) => {
   const tools = createAllTools();
-  t.is(tools.length, 25);
+  t.is(tools.length, 27);
 });
 
 test("starts when launched via the real file path", async (t) => {


### PR DESCRIPTION
## Description

Adds `design-data data create|edit` CLI commands and matching `data_create`/`data_edit` MCP tools for all five non-token data categories: **components**, **fields**, **registry**, **mode-sets**, and **guidelines**.

This is Phase C of the A→E authoring initiative (A = spec ratification, B = token authoring engine — both merged). Phases A and B landed in #1198/#1200.

## Related Issue

Closes beads `spectrum-design-data-1vr` (Phase C: Authoring tooling for non-token data).

## Motivation and Context

"Everything Spectrum data, via tooling" requires every data category to be authorable. Before this PR, all five non-token categories were hand-edited JSON with no tooling and no pre-write validation gate.

**Key design decision:** one generic command pair (`data create/edit --category <c>`) rather than five bespoke commands. The five categories are all one-JSON-object-per-file, so they need none of the token wizard/cascade/UUID machinery — create/edit reduces to: *validate the document, write `<category>/<name>.json`*.

## How Has This Been Tested?

- `moon run sdk:test` — all Rust tests pass, including 6 new unit tests in `data_object.rs` covering create/edit success and rejection paths for mode-sets and fields
- `pnpm --filter @adobe/design-data-agent-mcp test` — all 45 MCP tests pass; tool count updated 25→27
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset passes
- Layer-1 pre-write gate verified: feeding a mode-set without `default`, or a guideline with bad schema, returns an error and writes nothing

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (`packages/design-data/AUTHORING.md`).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## What's in this PR

| File | Role |
|---|---|
| `sdk/core/src/authoring/data_object.rs` | `write_data_object` + `DataCategory` enum + 5-category registration table + 6 unit tests |
| `sdk/cli/src/data.rs` | `DataCommand` (create/edit), `--file -` stdin support, schema probing, JSON stdout |
| `sdk/cli/src/main.rs` | `Data` variant in `Commands` + dispatch |
| `tools/design-data-agent-mcp/src/tools/data.js` | `data_create` + `data_edit` MCP tools (CLI shell-out) |
| `tools/design-data-agent-mcp/src/cli.js` | `stdin` option added to `runCli` |
| `tools/design-data-agent-mcp/src/index.js` | `createDataTools()` registered |
| `packages/design-data/AUTHORING.md` | CLI + MCP authoring docs |
| `.changeset/c1-non-token-authoring.md` | minor for MCP, patch for design-data |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)