### PR TITLE
feat(tokens): phase D — decompose density field (ye1.2)

### DIFF
--- a/.changeset/ye1-2-density-decompose.md
+++ b/.changeset/ye1-2-density-decompose.md
@@ -1,0 +1,9 @@
+---
+"@adobe/spectrum-tokens": minor
+---
+
+Phase D: decompose density field in 2 layout-component tokens (ye1.2).
+
+- **packages/design-data/tokens/layout-component.tokens.json**: decomposed 2 tokens —
+  `height-compact` → `height` + `density: compact` and `spacing-spacious` → `spacing` +
+  `density: spacious`; Rust roundtrip verified clean.

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -2960,7 +2960,8 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "height-compact"
+      "property": "height",
+      "density": "compact"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
@@ -13109,7 +13110,8 @@
   {
     "name": {
       "component": "swatch-group",
-      "property": "spacing-spacious"
+      "property": "spacing",
+      "density": "spacious"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",


### PR DESCRIPTION
## Description

Decomposes the `density` taxonomy field out of free-text `property` slugs into the structured `name.density` field for 2 tokens in `layout-component.tokens.json`:

- `property: "height-compact"` → `property: "height", density: "compact"`
- `property: "spacing-spacious"` → `property: "spacing", density: "spacious"`

This is the first field migration after the Phase D generic infrastructure landed in #1202–#1204 (field-agnostic `apply.js`, catalog-driven `naming.rs` serializer, opt-in `excludeFromLegacyKey` flag). It validates that the generic pipeline works for non-size fields before batching the remaining 10.

## Related Issue

Closes spectrum-design-data-ye1.2 (child of epic ye1: Phase D taxonomy decomposition)

## Motivation and Context

13 of 24 name-object fields remain unpopulated across 4,180 tokens. Phase D migrates them incrementally, field by field, with roundtrip gates to prevent key collapse (the failure mode found in the ye1.1 pilot where `legacy-output` ran before `roundtrip-verify`).

## How Has This Been Tested?

1. `design-data:roundtrip-verify` (Rust CLI) run **before** `legacy-output` — clean. Confirms Rust serializer reconstructs the same legacy key from `property: "height"` + `density: "compact"` as it did from `property: "height-compact"`.
2. `design-data:legacy-output` regenerated — `packages/tokens/src/` byte-identical (density serializes back into the legacy key, no downstream impact).
3. `design-data:roundtrip-verify` run again post-regeneration — clean.
4. `design-data:validate` — no new errors (pre-existing SPEC-043 warnings unaffected).
5. Changeset linter passes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.