### PR TITLE
feat(tokens): phase D — decompose alignment field (ye1.6)

### DIFF
--- a/.changeset/ye1-6-alignment-decompose.md
+++ b/.changeset/ye1-6-alignment-decompose.md
@@ -1,0 +1,8 @@
+---
+"@adobe/design-data": minor
+---
+
+Decompose alignment from property into structured field (closes ye1.6).
+
+- **packages/design-data/tokens/typography.tokens.json**: extract `alignment` from baked
+  property slugs (3 tokens: text-align-center/end/start).

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -3418,7 +3418,8 @@
   },
   {
     "name": {
-      "property": "text-align-center"
+      "property": "text-align",
+      "alignment": "center"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "center",
@@ -3426,7 +3427,8 @@
   },
   {
     "name": {
-      "property": "text-align-end"
+      "property": "text-align",
+      "alignment": "end"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "end",
@@ -3434,7 +3436,8 @@
   },
   {
     "name": {
-      "property": "text-align-start"
+      "property": "text-align",
+      "alignment": "start"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "start",


### PR DESCRIPTION
## Description

Decomposes the `alignment` taxonomy field out of baked `property` slugs. 3 tokens in
`typography.tokens.json` are affected:

```diff
-  "property": "text-align-center"
+  "property": "text-align",
+  "alignment": "center"
```

Same for `end` and `start`.

**Shape and contrast findings (no data changes):**
- `shape`: 0 HIGH-confidence candidates. Shape terms appear in property slugs but fail
  the re-serialization guard due to ambiguity.
- `contrast`: excluded by design (`excludeFromLegacyKey: true` in the field catalog) —
  it's a mode-set selector with no value registry. Tracked separately in 9rm for a
  decision on whether to flip the flag or leave it excluded.

## Related Issue

Closes ye1.6 (beads). Part of Phase D taxonomy decomposition (ye1).

## Motivation and Context

SPEC-009/SPEC-043: taxonomy concepts should live in structured fields. `apply.js` only
writes tokens that pass all four guards: HIGH confidence, JS roundtrip, non-empty
property, and re-serialization identity.

## How Has This Been Tested?

- `apply.js --field alignment` dry-run: 3 tokens, re-serialization verified
- `apply.js --field shape`: 0 candidates (no data change needed)
- `design-data migrate roundtrip-verify packages/tokens/src` → **Roundtrip OK**
- `design-data migrate legacy-verify` → **Legacy output OK** (byte-identical)
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` → clean

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
