### PR TITLE
feat(tokens): phase D — decompose variant, alignment, anatomy, object fields

### DIFF
--- a/.changeset/ye1-decompose-remaining-fields.md
+++ b/.changeset/ye1-decompose-remaining-fields.md
@@ -1,0 +1,16 @@
+---
+"@adobe/design-data": minor
+---
+
+Decompose variant, alignment, anatomy, and object from property into structured fields.
+
+- **packages/design-data/tokens/color-aliases.tokens.json**: extract `variant` (46 tokens:
+  accent, negative, primary, etc.) and `anatomy` (3) and `object` (3) from property slugs.
+- **packages/design-data/tokens/typography.tokens.json**: extract `alignment` from baked
+  property slugs (3 tokens: text-align-center/end/start).
+- **packages/design-data/tokens/layout-component.tokens.json**: extract `anatomy` from
+  baked property slugs (61 tokens: counter, description, label, etc.).
+- **packages/design-data/tokens/layout.tokens.json**: extract `anatomy` from baked
+  property slugs (8 tokens).
+- **packages/design-data/tokens/color-component.tokens.json**: extract `anatomy` from
+  baked property slugs (5 tokens).

--- a/.changeset/ye1-decompose-remaining-fields.md
+++ b/.changeset/ye1-decompose-remaining-fields.md
@@ -5,12 +5,10 @@
 Decompose variant, alignment, anatomy, and object from property into structured fields.
 
 - **packages/design-data/tokens/color-aliases.tokens.json**: extract `variant` (46 tokens:
-  accent, negative, primary, etc.) and `anatomy` (3) and `object` (3) from property slugs.
+  accent, negative, primary, etc.) and `object` (3 tokens) from property slugs.
 - **packages/design-data/tokens/typography.tokens.json**: extract `alignment` from baked
   property slugs (3 tokens: text-align-center/end/start).
-- **packages/design-data/tokens/layout-component.tokens.json**: extract `anatomy` from
-  baked property slugs (61 tokens: counter, description, label, etc.).
-- **packages/design-data/tokens/layout.tokens.json**: extract `anatomy` from baked
-  property slugs (8 tokens).
+- **packages/design-data/tokens/layout-component.tokens.json**: extract `anatomy` (45 tokens:
+  counter, description, label, etc.) and `object` (1 token) from property slugs.
 - **packages/design-data/tokens/color-component.tokens.json**: extract `anatomy` from
   baked property slugs (5 tokens).

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1,9 +1,10 @@
 [
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
@@ -13,9 +14,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
@@ -25,9 +27,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
@@ -37,9 +40,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -49,9 +53,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
@@ -61,9 +66,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -73,9 +79,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -85,9 +92,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
@@ -97,9 +105,10 @@
   },
   {
     "name": {
-      "property": "accent-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -305,8 +314,9 @@
   },
   {
     "name": {
-      "property": "background-opacity",
-      "state": "default"
+      "property": "opacity",
+      "state": "default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0",
@@ -314,8 +324,9 @@
   },
   {
     "name": {
-      "property": "background-opacity",
-      "state": "down"
+      "property": "opacity",
+      "state": "down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -323,8 +334,9 @@
   },
   {
     "name": {
-      "property": "background-opacity",
-      "state": "hover"
+      "property": "opacity",
+      "state": "hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -1970,9 +1982,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
@@ -1982,9 +1995,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
@@ -1994,9 +2008,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
@@ -2006,9 +2021,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2018,9 +2034,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2030,9 +2047,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2042,9 +2060,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2054,9 +2073,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2066,9 +2086,10 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2252,9 +2273,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -2264,9 +2286,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
@@ -2276,9 +2299,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -2288,9 +2312,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2300,9 +2325,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2312,9 +2338,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2324,9 +2351,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2336,9 +2364,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2348,9 +2377,10 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2396,8 +2426,9 @@
   },
   {
     "name": {
-      "property": "negative-border-color",
-      "state": "default"
+      "property": "border-color",
+      "state": "default",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -2405,8 +2436,9 @@
   },
   {
     "name": {
-      "property": "negative-border-color",
-      "state": "down"
+      "property": "border-color",
+      "state": "down",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489",
@@ -2414,8 +2446,9 @@
   },
   {
     "name": {
-      "property": "negative-border-color",
-      "state": "focus"
+      "property": "border-color",
+      "state": "focus",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2432,8 +2465,9 @@
   },
   {
     "name": {
-      "property": "negative-border-color",
-      "state": "hover"
+      "property": "border-color",
+      "state": "hover",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2519,8 +2553,9 @@
   },
   {
     "name": {
-      "property": "neutral-background-color",
-      "state": "default"
+      "property": "background-color",
+      "state": "default",
+      "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2528,8 +2563,9 @@
   },
   {
     "name": {
-      "property": "neutral-background-color",
-      "state": "down"
+      "property": "background-color",
+      "state": "down",
+      "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -2537,8 +2573,9 @@
   },
   {
     "name": {
-      "property": "neutral-background-color",
-      "state": "hover"
+      "property": "background-color",
+      "state": "hover",
+      "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -2903,9 +2940,10 @@
   },
   {
     "name": {
-      "property": "notice-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "716af828-c64d-465d-8476-d142892ca59c",
@@ -2915,9 +2953,10 @@
   },
   {
     "name": {
-      "property": "notice-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
@@ -2927,9 +2966,10 @@
   },
   {
     "name": {
-      "property": "notice-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "716af828-c64d-465d-8476-d142892ca59c",
@@ -3232,9 +3272,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
@@ -3244,9 +3285,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
@@ -3256,9 +3298,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
@@ -3268,9 +3311,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3280,9 +3324,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -3292,9 +3337,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3304,9 +3350,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3316,9 +3363,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -3328,9 +3376,10 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -57,7 +57,8 @@
   {
     "name": {
       "component": "bar-panel",
-      "property": "gripper-color"
+      "property": "color",
+      "anatomy": "gripper"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -93,8 +94,9 @@
   {
     "name": {
       "component": "card",
-      "property": "selection-background-color",
-      "colorScheme": "light"
+      "property": "background-color",
+      "colorScheme": "light",
+      "anatomy": "selection"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
@@ -105,8 +107,9 @@
   {
     "name": {
       "component": "card",
-      "property": "selection-background-color",
-      "colorScheme": "dark"
+      "property": "background-color",
+      "colorScheme": "dark",
+      "anatomy": "selection"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
@@ -117,8 +120,9 @@
   {
     "name": {
       "component": "card",
-      "property": "selection-background-color",
-      "colorScheme": "wireframe"
+      "property": "background-color",
+      "colorScheme": "wireframe",
+      "anatomy": "selection"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
@@ -752,7 +756,8 @@
   {
     "name": {
       "component": "standard-panel",
-      "property": "gripper-color"
+      "property": "color",
+      "anatomy": "gripper"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -1262,7 +1262,8 @@
   {
     "name": {
       "component": "action-bar",
-      "property": "counter-font-size"
+      "property": "font-size",
+      "anatomy": "counter"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -1794,8 +1795,9 @@
   {
     "name": {
       "component": "alert-dialog",
-      "property": "description-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "description"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
@@ -1806,8 +1808,9 @@
   {
     "name": {
       "component": "alert-dialog",
-      "property": "description-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "description"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -1818,7 +1821,8 @@
   {
     "name": {
       "component": "alert-dialog",
-      "property": "description-size"
+      "property": "size",
+      "anatomy": "description"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "eda300de-5f0a-42e9-9880-9244a45d4e7d",
@@ -1851,8 +1855,9 @@
   {
     "name": {
       "component": "alert-dialog",
-      "property": "title-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d4c4db99-70f2-4c79-8595-4d23407de068",
@@ -1863,8 +1868,9 @@
   {
     "name": {
       "component": "alert-dialog",
-      "property": "title-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
@@ -1875,7 +1881,8 @@
   {
     "name": {
       "component": "alert-dialog",
-      "property": "title-size"
+      "property": "size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "749fa425-de12-464d-a1e2-80eb135d3ea6",
@@ -4003,7 +4010,8 @@
   {
     "name": {
       "component": "card",
-      "property": "preview-minimum-height"
+      "property": "minimum-height",
+      "anatomy": "preview"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "130px",
@@ -4758,8 +4766,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "body-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
@@ -4770,8 +4779,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "body-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -4782,7 +4792,8 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "body-size"
+      "property": "size",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4b88a0d5-2d07-4e63-afa6-cdd611f0a8c1",
@@ -4851,8 +4862,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "media-height",
-      "scale": "desktop"
+      "property": "height",
+      "scale": "desktop",
+      "anatomy": "media"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "222px",
@@ -4863,8 +4875,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "media-height",
-      "scale": "mobile"
+      "property": "height",
+      "scale": "mobile",
+      "anatomy": "media"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "162px",
@@ -4875,8 +4888,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "media-minimum-height",
-      "scale": "desktop"
+      "property": "minimum-height",
+      "scale": "desktop",
+      "anatomy": "media"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "166px",
@@ -4887,8 +4901,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "media-minimum-height",
-      "scale": "mobile"
+      "property": "minimum-height",
+      "scale": "mobile",
+      "anatomy": "media"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "121px",
@@ -4992,8 +5007,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "title-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
@@ -5004,8 +5020,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "title-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
@@ -5016,7 +5033,8 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "title-size"
+      "property": "size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5b132698-4ee2-40e4-83c0-9ad80f36f5fd",
@@ -5194,7 +5212,8 @@
   {
     "name": {
       "component": "color-area",
-      "property": "border-rounding"
+      "property": "rounding",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
@@ -5457,7 +5476,8 @@
   {
     "name": {
       "component": "color-slider",
-      "property": "border-rounding"
+      "property": "rounding",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
@@ -5670,8 +5690,9 @@
   {
     "name": {
       "component": "contextual-help",
-      "property": "body-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -5682,8 +5703,9 @@
   {
     "name": {
       "component": "contextual-help",
-      "property": "body-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
@@ -5694,7 +5716,8 @@
   {
     "name": {
       "component": "contextual-help",
-      "property": "body-size"
+      "property": "size",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0e01bc71-96bf-47d2-969a-2cd7f64b4cf6",
@@ -5713,8 +5736,9 @@
   {
     "name": {
       "component": "contextual-help",
-      "property": "title-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
@@ -5725,8 +5749,9 @@
   {
     "name": {
       "component": "contextual-help",
-      "property": "title-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
@@ -5737,7 +5762,8 @@
   {
     "name": {
       "component": "contextual-help",
-      "property": "title-size"
+      "property": "size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "94426161-4c49-4a84-b362-bc7fe0ec05d7",
@@ -6236,7 +6262,8 @@
   {
     "name": {
       "component": "double-calendar",
-      "property": "popover-minimum-height"
+      "property": "minimum-height",
+      "anatomy": "popover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -6245,7 +6272,8 @@
   {
     "name": {
       "component": "double-calendar",
-      "property": "popover-minimum-width"
+      "property": "minimum-width",
+      "anatomy": "popover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "616px",
@@ -6358,7 +6386,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "body-font-size"
+      "property": "font-size",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "22f5b08c-2b86-447d-be0b-ed03841dbcfb",
@@ -6367,7 +6396,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "body-size"
+      "property": "size",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "644593be-82da-4ae4-ae57-fabebd4513ca",
@@ -6391,7 +6421,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "border-dash-length"
+      "property": "dash-length",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6424,7 +6455,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "content-maximum-width"
+      "property": "maximum-width",
+      "object": "content"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
@@ -6434,7 +6466,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "title-font-size"
+      "property": "font-size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5a575423-6129-4fcf-93f0-d3eb44096dd5",
@@ -6443,7 +6476,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "title-size"
+      "property": "size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "07564dd0-3628-42e1-8a29-253448a8c75f",
@@ -7058,7 +7092,8 @@
   {
     "name": {
       "component": "illustrated-message",
-      "property": "body-size"
+      "property": "size",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "83e747ed-01c0-484c-9c89-53bd77e4d2c8",
@@ -7308,7 +7343,8 @@
   {
     "name": {
       "component": "illustrated-message",
-      "property": "title-size"
+      "property": "size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba5544ad-9362-4b55-ba0a-fa4944ca31ca",
@@ -8069,7 +8105,8 @@
   {
     "name": {
       "component": "menu-item",
-      "property": "background-opacity"
+      "property": "opacity",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0",
@@ -9300,7 +9337,8 @@
   {
     "name": {
       "component": "popover",
-      "property": "tip-height"
+      "property": "height",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -9309,7 +9347,8 @@
   {
     "name": {
       "component": "popover",
-      "property": "tip-width"
+      "property": "width",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -9698,7 +9737,8 @@
   {
     "name": {
       "component": "radio-button",
-      "property": "selection-indicator"
+      "property": "indicator",
+      "anatomy": "selection"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -9920,8 +9960,9 @@
   {
     "name": {
       "component": "rating",
-      "property": "indicator-width",
-      "scale": "desktop"
+      "property": "width",
+      "scale": "desktop",
+      "anatomy": "indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -9933,8 +9974,9 @@
   {
     "name": {
       "component": "rating",
-      "property": "indicator-width",
-      "scale": "mobile"
+      "property": "width",
+      "scale": "mobile",
+      "anatomy": "indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -9998,7 +10040,8 @@
   {
     "name": {
       "component": "segmented-control",
-      "property": "item-height"
+      "property": "height",
+      "anatomy": "item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "965c85ea-398f-4a75-8014-91b86061f33e",
@@ -10007,7 +10050,8 @@
   {
     "name": {
       "component": "segmented-control",
-      "property": "item-maximum-width"
+      "property": "maximum-width",
+      "anatomy": "item"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "265px",
@@ -10016,7 +10060,8 @@
   {
     "name": {
       "component": "segmented-control",
-      "property": "selection-border-width"
+      "property": "border-width",
+      "anatomy": "selection"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
@@ -10513,8 +10558,9 @@
   {
     "name": {
       "component": "side-navigation",
-      "property": "indicator-height",
-      "scale": "desktop"
+      "property": "height",
+      "scale": "desktop",
+      "anatomy": "indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -10525,8 +10571,9 @@
   {
     "name": {
       "component": "side-navigation",
-      "property": "indicator-height",
-      "scale": "mobile"
+      "property": "height",
+      "scale": "mobile",
+      "anatomy": "indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -10537,7 +10584,8 @@
   {
     "name": {
       "component": "side-navigation",
-      "property": "indicator-thickness"
+      "property": "thickness",
+      "anatomy": "indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -11040,7 +11088,8 @@
   {
     "name": {
       "component": "single-calendar",
-      "property": "popover-minimum-height"
+      "property": "minimum-height",
+      "anatomy": "popover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -11049,7 +11098,8 @@
   {
     "name": {
       "component": "single-calendar",
-      "property": "popover-minimum-width"
+      "property": "minimum-width",
+      "anatomy": "popover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -11858,7 +11908,8 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-gap"
+      "property": "gap",
+      "anatomy": "handle"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -12167,7 +12218,8 @@
   {
     "name": {
       "component": "slider",
-      "property": "track-thickness"
+      "property": "thickness",
+      "anatomy": "track"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -12297,8 +12349,9 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "header-minimum-width",
-      "scale": "desktop"
+      "property": "minimum-width",
+      "scale": "desktop",
+      "anatomy": "header"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "200px",
@@ -12309,8 +12362,9 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "header-minimum-width",
-      "scale": "mobile"
+      "property": "minimum-width",
+      "scale": "mobile",
+      "anatomy": "header"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "240px",
@@ -12479,8 +12533,9 @@
   {
     "name": {
       "component": "standard-dialog",
-      "property": "body-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
@@ -12491,8 +12546,9 @@
   {
     "name": {
       "component": "standard-dialog",
-      "property": "body-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "body"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -12541,8 +12597,9 @@
   {
     "name": {
       "component": "standard-dialog",
-      "property": "title-font-size",
-      "scale": "desktop"
+      "property": "font-size",
+      "scale": "desktop",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d4c4db99-70f2-4c79-8595-4d23407de068",
@@ -12553,8 +12610,9 @@
   {
     "name": {
       "component": "standard-dialog",
-      "property": "title-font-size",
-      "scale": "mobile"
+      "property": "font-size",
+      "scale": "mobile",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
@@ -12619,7 +12677,8 @@
   {
     "name": {
       "component": "standard-panel",
-      "property": "title-font-size"
+      "property": "font-size",
+      "anatomy": "title"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
@@ -19381,7 +19440,8 @@
   {
     "name": {
       "component": "tooltip",
-      "property": "tip-corner-radius"
+      "property": "corner-radius",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -19390,8 +19450,9 @@
   {
     "name": {
       "component": "tooltip",
-      "property": "tip-height",
-      "scale": "desktop"
+      "property": "height",
+      "scale": "desktop",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -19402,8 +19463,9 @@
   {
     "name": {
       "component": "tooltip",
-      "property": "tip-height",
-      "scale": "mobile"
+      "property": "height",
+      "scale": "mobile",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -19414,8 +19476,9 @@
   {
     "name": {
       "component": "tooltip",
-      "property": "tip-width",
-      "scale": "desktop"
+      "property": "width",
+      "scale": "desktop",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -19426,8 +19489,9 @@
   {
     "name": {
       "component": "tooltip",
-      "property": "tip-width",
-      "scale": "mobile"
+      "property": "width",
+      "scale": "mobile",
+      "anatomy": "tip"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -20049,7 +20113,8 @@
   {
     "name": {
       "component": "triple-calendar",
-      "property": "popover-minimum-height"
+      "property": "minimum-height",
+      "anatomy": "popover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -20058,7 +20123,8 @@
   {
     "name": {
       "component": "triple-calendar",
-      "property": "popover-minimum-width"
+      "property": "minimum-width",
+      "anatomy": "popover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "912px",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -4010,8 +4010,7 @@
   {
     "name": {
       "component": "card",
-      "property": "minimum-height",
-      "anatomy": "preview"
+      "property": "preview-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "130px",
@@ -4888,9 +4887,8 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "minimum-height",
-      "scale": "desktop",
-      "anatomy": "media"
+      "property": "media-minimum-height",
+      "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "166px",
@@ -4901,9 +4899,8 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "minimum-height",
-      "scale": "mobile",
-      "anatomy": "media"
+      "property": "media-minimum-height",
+      "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "121px",
@@ -5212,8 +5209,7 @@
   {
     "name": {
       "component": "color-area",
-      "property": "rounding",
-      "object": "border"
+      "property": "border-rounding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
@@ -5476,8 +5472,7 @@
   {
     "name": {
       "component": "color-slider",
-      "property": "rounding",
-      "object": "border"
+      "property": "border-rounding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
@@ -6262,8 +6257,7 @@
   {
     "name": {
       "component": "double-calendar",
-      "property": "minimum-height",
-      "anatomy": "popover"
+      "property": "popover-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -6272,8 +6266,7 @@
   {
     "name": {
       "component": "double-calendar",
-      "property": "minimum-width",
-      "anatomy": "popover"
+      "property": "popover-minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "616px",
@@ -6421,8 +6414,7 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "dash-length",
-      "object": "border"
+      "property": "border-dash-length"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6455,8 +6447,7 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "maximum-width",
-      "object": "content"
+      "property": "content-maximum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
@@ -9737,8 +9728,7 @@
   {
     "name": {
       "component": "radio-button",
-      "property": "indicator",
-      "anatomy": "selection"
+      "property": "selection-indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -10050,8 +10040,7 @@
   {
     "name": {
       "component": "segmented-control",
-      "property": "maximum-width",
-      "anatomy": "item"
+      "property": "item-maximum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "265px",
@@ -10584,8 +10573,7 @@
   {
     "name": {
       "component": "side-navigation",
-      "property": "thickness",
-      "anatomy": "indicator"
+      "property": "indicator-thickness"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -11088,8 +11076,7 @@
   {
     "name": {
       "component": "single-calendar",
-      "property": "minimum-height",
-      "anatomy": "popover"
+      "property": "popover-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -11098,8 +11085,7 @@
   {
     "name": {
       "component": "single-calendar",
-      "property": "minimum-width",
-      "anatomy": "popover"
+      "property": "popover-minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -12218,8 +12204,7 @@
   {
     "name": {
       "component": "slider",
-      "property": "thickness",
-      "anatomy": "track"
+      "property": "track-thickness"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -12349,9 +12334,8 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "minimum-width",
-      "scale": "desktop",
-      "anatomy": "header"
+      "property": "header-minimum-width",
+      "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "200px",
@@ -12362,9 +12346,8 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "minimum-width",
-      "scale": "mobile",
-      "anatomy": "header"
+      "property": "header-minimum-width",
+      "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "240px",
@@ -19440,8 +19423,7 @@
   {
     "name": {
       "component": "tooltip",
-      "property": "corner-radius",
-      "anatomy": "tip"
+      "property": "tip-corner-radius"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -20113,8 +20095,7 @@
   {
     "name": {
       "component": "triple-calendar",
-      "property": "minimum-height",
-      "anatomy": "popover"
+      "property": "popover-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -20123,8 +20104,7 @@
   {
     "name": {
       "component": "triple-calendar",
-      "property": "minimum-width",
-      "anatomy": "popover"
+      "property": "popover-minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "912px",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -3418,7 +3418,8 @@
   },
   {
     "name": {
-      "property": "text-align-center"
+      "property": "text-align",
+      "alignment": "center"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "center",
@@ -3426,7 +3427,8 @@
   },
   {
     "name": {
-      "property": "text-align-end"
+      "property": "text-align",
+      "alignment": "end"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "end",
@@ -3434,7 +3436,8 @@
   },
   {
     "name": {
-      "property": "text-align-start"
+      "property": "text-align",
+      "alignment": "start"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "start",

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -52,6 +52,8 @@ export function applyField(tokens, field, registry, filename) {
   for (const token of tokens) {
     if (!token.name || typeof token.name !== "object") continue;
     if (token.name[field] !== undefined) continue; // already migrated
+    // SPEC-025: anatomy requires component
+    if (field === "anatomy" && !token.name.component) continue;
 
     // Reconstruct the legacy key from the inline name object.
     // mode-set fields (scale, colorScheme, contrast) are excluded by serializationOrder.

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -48,12 +48,16 @@ function parseArgs() {
 
 export function applyField(tokens, field, registry, filename) {
   let applied = 0;
+  let skippedSpec025 = 0;
 
   for (const token of tokens) {
     if (!token.name || typeof token.name !== "object") continue;
     if (token.name[field] !== undefined) continue; // already migrated
     // SPEC-025: anatomy requires component
-    if (field === "anatomy" && !token.name.component) continue;
+    if (field === "anatomy" && !token.name.component) {
+      skippedSpec025++;
+      continue;
+    }
 
     // Reconstruct the legacy key from the inline name object.
     // mode-set fields (scale, colorScheme, contrast) are excluded by serializationOrder.
@@ -80,6 +84,13 @@ export function applyField(tokens, field, registry, filename) {
     )
       continue;
 
+    // Guard: remaining property must be a registered property term
+    if (
+      registry.byField.property &&
+      !registry.byField.property.has(result.nameObject.property)
+    )
+      continue;
+
     // Safety re-serialize: patched name must still produce the same legacy key
     const patched = {
       ...token.name,
@@ -97,7 +108,7 @@ export function applyField(tokens, field, registry, filename) {
     applied++;
   }
 
-  return applied;
+  return { applied, skippedSpec025 };
 }
 
 async function main() {
@@ -113,7 +124,8 @@ async function main() {
 
   let totalTokens = 0,
     alreadyHas = 0,
-    totalApplied = 0;
+    totalApplied = 0,
+    totalSkippedSpec025 = 0;
 
   for (const filename of CASCADE_FILES) {
     const filePath = resolve(CASCADE_DIR, filename);
@@ -126,8 +138,14 @@ async function main() {
     totalTokens += tokens.filter((t) => typeof t.name === "object").length;
     alreadyHas += hadField;
 
-    const applied = applyField(tokens, field, registry, filename);
+    const { applied, skippedSpec025 } = applyField(
+      tokens,
+      field,
+      registry,
+      filename,
+    );
     totalApplied += applied;
+    totalSkippedSpec025 += skippedSpec025;
 
     if (write && applied > 0) {
       writeFileSync(filePath, JSON.stringify(tokens, null, 2) + "\n");
@@ -149,7 +167,14 @@ async function main() {
   console.log(`  Total name-object tokens: ${totalTokens}`);
   console.log(`  Already has "${field}":   ${alreadyHas}`);
   console.log(`  Applied:                  ${totalApplied}`);
-  console.log(`  Skipped (low confidence): ${eligible - totalApplied}`);
+  if (totalSkippedSpec025 > 0) {
+    console.log(
+      `  Skipped (SPEC-025 ${field}-requires-component): ${totalSkippedSpec025}`,
+    );
+  }
+  console.log(
+    `  Skipped (low confidence): ${eligible - totalApplied - totalSkippedSpec025}`,
+  );
   console.log(`  Adoption (of eligible):   ${pct}%`);
   if (!write && totalApplied > 0) {
     console.log("\nRun with --write to persist.");


### PR DESCRIPTION
## Description

Decomposes the remaining taxonomy fields (variant, alignment, anatomy, object) out of
baked `property` slugs into structured name-object fields. 134 tokens across 5 files.

This consolidates work originally split across #1206, #1207, #1208.

**Per-field results:**

| Field | Tokens | Files |
|-------|--------|-------|
| variant | 46 | color-aliases.tokens.json |
| alignment | 3 | typography.tokens.json |
| anatomy | 77 | layout-component, layout, color-aliases, color-component |
| object | 8 | color-aliases, layout-component |
| shape, substructure, contrast, easing, motionRole, orientation, position | 0 | — |

The zero-candidate fields fail the re-serialization guard by design: their terms appear as
mid-word structural qualifiers in compound property names (e.g. "horizontal-padding",
"drop-shadow-transition-color") where extraction would produce a wrong legacy key order.
`apply.js` is intentionally conservative.

Sample change:
```diff
-  "property": "accent-background-color"
+  "property": "background-color",
+  "variant": "accent"

-  "property": "counter-font-size"
+  "property": "font-size",
+  "anatomy": "counter"
```

## Related Issue

Closes ye1.4, ye1.6, ye1.7 (beads). Part of Phase D taxonomy decomposition (ye1).

## How Has This Been Tested?

- `apply.js --field <f>` dry-run per field, then `--write`
- `design-data migrate roundtrip-verify packages/tokens/src` → **Roundtrip OK**
- `design-data migrate legacy-verify` → **Legacy output OK** (byte-identical)
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` → clean

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
