### PR TITLE
feat(tokens): phase D — register atomic property terms + phase E stale-ref cleanup

### DIFF
--- a/.changeset/ye1-3-atomic-property-terms.md
+++ b/.changeset/ye1-3-atomic-property-terms.md
@@ -1,0 +1,9 @@
+---
+"@adobe/design-data": minor
+---
+
+Register four atomic property terms in property-terms.json.
+
+- **packages/design-data/registry/property-terms.json**: add `minimum-width`,
+  `minimum-height`, `maximum-width`, `thickness` — atomic CSS/design-system abstractions
+  present in 103 layout-component tokens; apply.js registry guards now accept them.

--- a/packages/design-data/CLAUDE.md
+++ b/packages/design-data/CLAUDE.md
@@ -32,8 +32,8 @@ moon run design-data:test    # AVA tests for the Node utilities in this package
 
 ## Key Relationships
 
-* `sdk/core` embeds data from `packages/tokens/src/*.json` and
-  `packages/design-data/{mode-sets,components,fields}/*.json` at compile time.
+* `sdk/core` embeds data from `packages/design-data/tokens/*.tokens.json` and
+  `packages/design-data/{mode-sets,components,fields,guidelines}/*.json` at compile time.
   After editing JSON here, run `moon run sdk:codegen-check` to verify the Rust side is in sync.
 * `packages/design-data-spec` validates schemas against the token JSON in this package.
 * The `design-data` MCP (`tools/design-data-agent-mcp/`) reads from `tokens/` at runtime.

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -207,6 +207,26 @@
       "id": "line-height-multiplier",
       "label": "Line Height Multiplier",
       "description": "Unitless line-height ratio (multiplier), distinct from the absolute px line-height paired with a specific font-size tier"
+    },
+    {
+      "id": "minimum-width",
+      "label": "Minimum Width",
+      "description": "CSS min-width constraint (design-system abstraction)"
+    },
+    {
+      "id": "minimum-height",
+      "label": "Minimum Height",
+      "description": "CSS min-height constraint (design-system abstraction)"
+    },
+    {
+      "id": "maximum-width",
+      "label": "Maximum Width",
+      "description": "CSS max-width constraint (design-system abstraction)"
+    },
+    {
+      "id": "thickness",
+      "label": "Thickness",
+      "description": "Stroke or line thickness (design-system abstraction; not a standard CSS property)"
     }
   ]
 }

--- a/sdk/CLAUDE.md
+++ b/sdk/CLAUDE.md
@@ -33,7 +33,7 @@ run `moon run sdk:codegen` first or the check will fail.
 * **Rust toolchain**: pinned in `sdk/rust-toolchain.toml` — don't override it
 * **Crates are internal-only** for now — not published to crates.io
 * **Embedded data**: `core` embeds token snapshots at compile time; changes to
-  `packages/tokens/src/*.json`, `packages/design-data/**/*.json`, etc. invalidate the build
+  `packages/design-data/tokens/*.tokens.json`, `packages/design-data/{mode-sets,components,fields,guidelines}/*.json`, etc. invalidate the build
 * **WASM**: `sdk/wasm/` has a separate `Cargo.toml` and is also in the pnpm workspace
   via `sdk/tui/` (the TUI's npm package wraps the Rust binary)
 * **`sdk/target/` is \~29 GB** — never read into it; it's gitignored

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -52,12 +52,12 @@ All subcommands accept `--help` for full flag documentation.
 Validate a token file or directory against JSON Schemas (Layer 1) and relational catalog rules (Layer 2).
 
 ```bash
-design-data validate packages/tokens/src
-design-data validate packages/tokens/src --strict
-design-data validate packages/tokens/src --format json
+design-data validate packages/design-data/tokens
+design-data validate packages/design-data/tokens --strict
+design-data validate packages/design-data/tokens --format json
 
 # Optional overrides
-design-data validate packages/tokens/src \
+design-data validate packages/design-data/tokens \
   --schema-path packages/design-data-spec \
   --exceptions-path naming-exceptions.json \
   --mode-sets-path packages/design-data/mode-sets \
@@ -69,7 +69,7 @@ design-data validate packages/tokens/src \
 Resolve a single token property to its final value for a given mode context.
 
 ```bash
-design-data resolve background-color-default packages/tokens/src \
+design-data resolve background-color-default packages/design-data/tokens \
   --color-scheme light \
   --scale desktop \
   --contrast regular
@@ -80,7 +80,7 @@ design-data resolve background-color-default packages/tokens/src \
 Compare two token datasets and report additions, removals, and changes.
 
 ```bash
-design-data diff packages/tokens/src packages/tokens-next/src
+design-data diff packages/design-data/tokens packages/tokens-next/src
 design-data diff old/ new/ --filter "component=button"
 design-data diff old/ new/ --format json
 ```
@@ -90,9 +90,9 @@ design-data diff old/ new/ --format json
 List tokens matching a filter expression.
 
 ```bash
-design-data query packages/tokens/src --filter "component=button,state=hover"
-design-data query packages/tokens/src --filter "component=button" --count
-design-data query packages/tokens/src --filter "component=button" --format json
+design-data query packages/design-data/tokens --filter "component=button,state=hover"
+design-data query packages/design-data/tokens --filter "component=button" --count
+design-data query packages/design-data/tokens --filter "component=button" --format json
 ```
 
 ### migrate
@@ -100,8 +100,8 @@ design-data query packages/tokens/src --filter "component=button" --format json
 Snapshot and backward-compatibility helpers.
 
 ```bash
-design-data migrate snapshot packages/tokens/src --output golden.json
-design-data migrate verify  packages/tokens/src --snapshot golden.json
+design-data migrate snapshot packages/design-data/tokens --output golden.json
+design-data migrate verify  packages/design-data/tokens --snapshot golden.json
 design-data migrate convert input/ --output output/
 design-data migrate legacy-output input/ --output output/
 design-data migrate add-uuids input/ --output output/
@@ -113,8 +113,8 @@ design-data migrate roundtrip-verify packages/tokens/src
 Build a portable `.redb` cache asset from a token dataset (for WASM web tools or offline distribution).
 
 ```bash
-design-data cache-build packages/tokens/src -o index.redb
-design-data cache-build packages/tokens/src \
+design-data cache-build packages/design-data/tokens -o index.redb
+design-data cache-build packages/design-data/tokens \
   --mode-sets-path packages/design-data/mode-sets \
   --components-path packages/design-data/components \
   -o index.redb
@@ -163,8 +163,8 @@ design-data figma export --file-key <KEY> --output figma-vars.json
 Emit a structural overview of the dataset — useful as context at the start of an agent session.
 
 ```bash
-design-data primer packages/tokens/src
-design-data primer packages/tokens/src --format json
+design-data primer packages/design-data/tokens
+design-data primer packages/design-data/tokens --format json
 ```
 
 ### component

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1616,6 +1616,26 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "line-height-multiplier",
       "label": "Line Height Multiplier",
       "description": "Unitless line-height ratio (multiplier), distinct from the absolute px line-height paired with a specific font-size tier"
+    },
+    {
+      "id": "minimum-width",
+      "label": "Minimum Width",
+      "description": "CSS min-width constraint (design-system abstraction)"
+    },
+    {
+      "id": "minimum-height",
+      "label": "Minimum Height",
+      "description": "CSS min-height constraint (design-system abstraction)"
+    },
+    {
+      "id": "maximum-width",
+      "label": "Maximum Width",
+      "description": "CSS max-width constraint (design-system abstraction)"
+    },
+    {
+      "id": "thickness",
+      "label": "Thickness",
+      "description": "Stroke or line thickness (design-system abstraction; not a standard CSS property)"
     }
   ]
 }

--- a/sdk/moon.yml
+++ b/sdk/moon.yml
@@ -46,13 +46,14 @@ tasks:
       - "@globs(sources)"
       - "core/src/registry_data.rs"
       # Embedded snapshot sources — invalidate the build when token data changes.
-      - "/packages/tokens/src/*.json"
+      - "/packages/design-data/tokens/*.tokens.json"
       - "/packages/tokens/schemas/**/*.json"
       - "/packages/tokens/naming-exceptions.json"
       - "/packages/tokens/manifest.json"
       - "/packages/design-data/mode-sets/*.json"
       - "/packages/design-data/components/*.json"
       - "/packages/design-data/fields/*.json"
+      - "/packages/design-data/guidelines/*.json"
     deps:
       - codegen-check
   test:
@@ -64,13 +65,14 @@ tasks:
       - "@globs(sources)"
       - "core/src/registry_data.rs"
       # Embedded snapshot sources — re-run tests when token data changes.
-      - "/packages/tokens/src/*.json"
+      - "/packages/design-data/tokens/*.tokens.json"
       - "/packages/tokens/schemas/**/*.json"
       - "/packages/tokens/naming-exceptions.json"
       - "/packages/tokens/manifest.json"
       - "/packages/design-data/mode-sets/*.json"
       - "/packages/design-data/components/*.json"
       - "/packages/design-data/fields/*.json"
+      - "/packages/design-data/guidelines/*.json"
     deps:
       - codegen-check
   fmt:


### PR DESCRIPTION
## Description

Two bounded cleanup tasks closing out the Phase D backlog audit and Phase E stale reference work.

**1. Register atomic property terms (ye1.3 / beads-1n3)**

The apply.js registry guard (`registry.byField.property.has()`) added in #1210 prevents future unregistered `property` writes, but an audit found 103 existing tokens carrying 4 atomic values not yet in `property-terms.json`:

- `minimum-width` (40 tokens)
- `minimum-height` (25 tokens)
- `maximum-width` (20 tokens)
- `thickness` (18 tokens)

These are genuine CSS/design-system abstractions that survive decomposition unchanged — not compound values to split. Added them to the registry, regenerated `registry_data.rs`.

**2. Fix stale `packages/tokens/src` references (phase E / beads-7rp)**

`sdk/moon.yml` build/test inputs still listed `/packages/tokens/src/*.json` as a dependency, but `embedded.rs` has embedded from `packages/design-data/tokens/*.tokens.json` (cascade format) since the Phase D pilot. Also added the missing `guidelines/*.json` glob (embedded but not tracked as a moon input).

Updated:
- `sdk/moon.yml`: cascade-format token glob + guidelines glob
- `sdk/CLAUDE.md`: correct embedded-data path description
- `packages/design-data/CLAUDE.md`: correct embedded-data path description
- `sdk/README.md`: all CLI examples updated to `packages/design-data/tokens` (except `roundtrip-verify`, which correctly takes the legacy `packages/tokens/src` path)

## Related Issue

Closes beads spectrum-design-data-1n3, spectrum-design-data-7rp, spectrum-design-data-9rm (contrast: confirmed leave excluded, no code change needed).

## Motivation and Context

Phase D decomposition tooling is complete but the registry guard was blocking future apply runs on layout-component tokens. These 4 terms unblock those runs.

The stale moon.yml inputs meant moon wouldn't invalidate SDK builds when cascade-format tokens changed — a latent correctness gap.

## How Has This Been Tested?

- `cargo test --workspace` — 617 tests pass, 0 failures
- `design-data migrate roundtrip-verify packages/tokens/src` — Roundtrip OK
- `moon run sdk:codegen-check` — passes after regeneration
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — 10 valid, 0 warnings

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.