### PR TITLE
feat(tokens): phase D — decompose component color props into colorFamily + colorRole

### DIFF
--- a/.changeset/ye1-color-family-role-decompose.md
+++ b/.changeset/ye1-color-family-role-decompose.md
@@ -1,0 +1,19 @@
+---
+"@adobe/spectrum-design-data": minor
+"token-mapping-analyzer": patch
+---
+
+Decompose component color properties into colorFamily + colorRole fields (closes beads #72c).
+
+- **packages/design-data/fields/colorRole.json**: new `colorRole` field
+  (position 16, scope color, excludeFromLegacyKey).
+- **packages/design-data/registry/color-roles.json**: new registry —
+  `primary` and `background` role values.
+- **packages/design-data/tokens/icons.tokens.json**: 187 tokens atomized
+  (`color-blue-primary` → `property:color` + `colorFamily:blue` + `colorRole:primary`).
+- **sdk/core/src/naming.rs**: color-domain branch extended for component color
+  tokens (`{component}-{property}-{colorFamily?}-{colorRole?}-{state?}`).
+- **tools/token-mapping-analyzer/src/migrate-color-role.js**: new migration
+  script for multi-field color property decomposition.
+- **tools/token-mapping-analyzer/src/decomposer.js**: `serialize()` gains
+  JS-parity color-domain branches matching the Rust serializer.

--- a/packages/design-data/fields/colorRole.json
+++ b/packages/design-data/fields/colorRole.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "colorRole",
+  "description": "Semantic role of a color token within a component (e.g. primary, background). Used alongside colorFamily for component-scoped color tokens. Excluded from the legacy key; the serializer emits it via the explicit component-color branch.",
+  "kind": "semantic",
+  "registry": "packages/design-data/registry/color-roles.json",
+  "validation": "advisory",
+  "serialization": {
+    "position": 16
+  },
+  "scope": "color",
+  "required": false,
+  "valueType": "string",
+  "excludeFromLegacyKey": true
+}

--- a/packages/design-data/registry/color-roles.json
+++ b/packages/design-data/registry/color-roles.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "color-role",
+  "description": "Semantic roles for component-scoped color tokens. Assigned via the `colorRole` name-object field alongside `colorFamily` (e.g. colorFamily=blue + colorRole=primary → the primary blue color for a component).",
+  "values": [
+    {
+      "id": "primary",
+      "label": "Primary",
+      "description": "Primary color role — the main foreground color for an element"
+    },
+    {
+      "id": "background",
+      "label": "Background",
+      "description": "Background color role — fill or surface color behind an element"
+    }
+  ]
+}

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -2,8 +2,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -14,8 +16,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
@@ -26,8 +30,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -38,9 +44,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -51,9 +59,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -64,9 +74,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -77,9 +89,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
@@ -90,9 +104,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
@@ -103,9 +119,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
@@ -116,9 +134,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
@@ -129,9 +149,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -142,9 +164,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-blue-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "blue"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
@@ -155,8 +179,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
@@ -167,8 +193,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bd1ec088-5fc2-44c1-ba00-949b6bcfee0c",
@@ -179,8 +207,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
@@ -191,9 +221,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -204,9 +236,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6f87ea74-5734-40c1-ab34-b284e0f75b1b",
@@ -217,9 +251,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -230,9 +266,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
@@ -243,9 +281,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -256,9 +296,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3a775c3b-5910-40eb-ad7e-a6c6badd05a9",
@@ -269,9 +311,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -282,9 +326,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -295,9 +341,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-brown-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "brown"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -308,8 +356,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cfa877de-79f8-493f-898d-ceb70a12f64e",
@@ -320,8 +370,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e8b68c0f-5e9f-47c0-b844-35032c46aeee",
@@ -332,8 +384,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cfa877de-79f8-493f-898d-ceb70a12f64e",
@@ -344,9 +398,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
@@ -357,9 +413,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
@@ -370,9 +428,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
@@ -383,9 +443,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
@@ -396,9 +458,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bd5d2127-7c7e-428c-bded-4638ab7094a5",
@@ -409,9 +473,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
@@ -422,9 +488,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
@@ -435,9 +503,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2184d450-2711-4e31-bb52-ee71e4fee3a5",
@@ -448,9 +518,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-celery-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "celery"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
@@ -461,8 +533,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
@@ -473,8 +547,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dba5cb03-a980-48bd-8b35-99dd063763e0",
@@ -485,8 +561,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
@@ -497,9 +575,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
@@ -510,9 +590,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
@@ -523,9 +605,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
@@ -536,9 +620,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9131b099-6865-4e54-b364-acb3891737f1",
@@ -549,9 +635,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e6cff881-8cb4-4b7b-883d-0aa00dc3efdb",
@@ -562,9 +650,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9131b099-6865-4e54-b364-acb3891737f1",
@@ -575,9 +665,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f50abb60-7047-4e92-a48c-627d98eb85d3",
@@ -588,9 +680,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "20c271df-6e71-4082-b953-d8bf938ff286",
@@ -601,9 +695,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-chartreuse-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "chartreuse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f50abb60-7047-4e92-a48c-627d98eb85d3",
@@ -614,8 +710,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cinnamon-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "cinnamon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
@@ -626,8 +724,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cinnamon-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "cinnamon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3527fc94-a410-4933-bbb7-bedecd37e477",
@@ -638,8 +738,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cinnamon-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "cinnamon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
@@ -650,8 +752,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cinnamon-primary",
-      "state": "default"
+      "property": "color",
+      "state": "default",
+      "colorRole": "primary",
+      "colorFamily": "cinnamon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -660,8 +764,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cinnamon-primary",
-      "state": "down"
+      "property": "color",
+      "state": "down",
+      "colorRole": "primary",
+      "colorFamily": "cinnamon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee0dc73e-8a68-4b2a-80f2-a0262016ec38",
@@ -670,8 +776,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cinnamon-primary",
-      "state": "hover"
+      "property": "color",
+      "state": "hover",
+      "colorRole": "primary",
+      "colorFamily": "cinnamon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -680,8 +788,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cyan-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "cyan"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba6486c3-b48d-4d4e-952e-c179db5671df",
@@ -692,8 +802,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cyan-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "cyan"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "61be07be-d428-4fe9-8e79-96df63980556",
@@ -704,8 +816,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cyan-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "cyan"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba6486c3-b48d-4d4e-952e-c179db5671df",
@@ -716,8 +830,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cyan-primary",
-      "state": "default"
+      "property": "color",
+      "state": "default",
+      "colorRole": "primary",
+      "colorFamily": "cyan"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
@@ -726,8 +842,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cyan-primary",
-      "state": "down"
+      "property": "color",
+      "state": "down",
+      "colorRole": "primary",
+      "colorFamily": "cyan"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2dd3bb3-e7c6-42fe-b7d6-6e25ee1b5b0f",
@@ -736,8 +854,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-cyan-primary",
-      "state": "hover"
+      "property": "color",
+      "state": "hover",
+      "colorRole": "primary",
+      "colorFamily": "cyan"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -764,7 +884,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-background"
+      "property": "color",
+      "colorRole": "background",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
@@ -773,9 +895,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -786,9 +910,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1149f4f6-5cd0-4792-9dad-189c2a75a542",
@@ -799,9 +925,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -812,9 +940,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
@@ -825,9 +955,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -838,9 +970,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3ffd0b97-3692-400d-b6d6-9147b6028fbe",
@@ -851,9 +985,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0f412425-de6f-48f1-9d0f-0310d933d244",
@@ -864,9 +1000,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -877,9 +1015,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-fuchsia-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "fuchsia"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0f412425-de6f-48f1-9d0f-0310d933d244",
@@ -890,8 +1030,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-green-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "green"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7c7c0136-2623-468d-a12f-678d21973613",
@@ -902,8 +1044,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-green-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "green"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6673709d-2154-4189-ad4f-e6867ecfe744",
@@ -914,8 +1058,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-green-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "green"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7c7c0136-2623-468d-a12f-678d21973613",
@@ -926,8 +1072,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-green-primary",
-      "state": "default"
+      "property": "color",
+      "state": "default",
+      "colorRole": "primary",
+      "colorFamily": "green"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
@@ -936,8 +1084,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-green-primary",
-      "state": "down"
+      "property": "color",
+      "state": "down",
+      "colorRole": "primary",
+      "colorFamily": "green"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
@@ -946,8 +1096,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-green-primary",
-      "state": "hover"
+      "property": "color",
+      "state": "hover",
+      "colorRole": "primary",
+      "colorFamily": "green"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
@@ -956,8 +1108,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
@@ -968,8 +1122,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ed49ef2-25c7-44a5-86e2-8f57a2b5b07e",
@@ -980,8 +1136,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
@@ -992,9 +1150,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -1005,9 +1165,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e011bc2f-8a2a-46cb-a758-e53f0ce3a2ac",
@@ -1018,9 +1180,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -1031,9 +1195,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
@@ -1044,9 +1210,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -1057,9 +1225,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c1e41827-eb48-415a-bd6f-f4cb3d4ef5bb",
@@ -1070,9 +1240,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
@@ -1083,9 +1255,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -1096,9 +1270,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-indigo-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "indigo"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7e4d3279-2b61-46f6-8eb3-7636f564f591",
@@ -1128,7 +1304,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-background"
+      "property": "color",
+      "colorRole": "background",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
@@ -1137,9 +1315,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -1150,9 +1330,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8f76d9bd-a0b8-4756-a08d-4db3c787c4c9",
@@ -1163,9 +1345,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -1176,9 +1360,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
@@ -1189,9 +1375,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -1202,9 +1390,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03d47c47-99f0-4ed3-a275-7659dee3ca8e",
@@ -1215,9 +1405,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "66f59c7d-f12b-4b8b-a472-c196deec527c",
@@ -1228,9 +1420,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -1241,9 +1435,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-magenta-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "magenta"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "66f59c7d-f12b-4b8b-a472-c196deec527c",
@@ -1254,8 +1450,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -1266,8 +1464,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
@@ -1278,8 +1478,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -1290,9 +1492,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -1303,9 +1507,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -1316,9 +1522,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -1329,9 +1537,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -1342,9 +1552,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
@@ -1355,9 +1567,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -1368,9 +1582,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bed559d1-c097-40ad-8d3a-2866198832c2",
@@ -1381,9 +1597,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
@@ -1394,9 +1612,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-orange-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "orange"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bed559d1-c097-40ad-8d3a-2866198832c2",
@@ -1407,7 +1627,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-background"
+      "property": "color",
+      "colorRole": "background",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
@@ -1416,9 +1638,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -1429,9 +1653,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dc6e56ee-3f71-48fd-9ffc-bbe65fa27ab9",
@@ -1442,9 +1668,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -1455,9 +1683,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
@@ -1468,9 +1698,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -1481,9 +1713,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c937f1fd-146d-4558-a42d-c8aafc5f4589",
@@ -1494,9 +1728,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -1507,9 +1743,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -1520,9 +1758,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-pink-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "pink"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -1533,8 +1773,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-primary",
-      "state": "default"
+      "property": "color",
+      "state": "default",
+      "colorRole": "primary"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "43ca4c0d-7803-4e8e-b444-26fe70d5304c",
@@ -1543,8 +1784,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-primary",
-      "state": "down"
+      "property": "color",
+      "state": "down",
+      "colorRole": "primary"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf169d95-e427-4665-a983-c24727dbfa60",
@@ -1553,8 +1795,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-primary",
-      "state": "hover"
+      "property": "color",
+      "state": "hover",
+      "colorRole": "primary"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d236bdc5-037b-4838-8401-8a0d5136936c",
@@ -1563,7 +1806,9 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-background"
+      "property": "color",
+      "colorRole": "background",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
@@ -1572,9 +1817,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -1585,9 +1832,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3d17ea49-0cf8-4df4-80e0-0b8dd5ec7e3e",
@@ -1598,9 +1847,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -1611,9 +1862,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
@@ -1624,9 +1877,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -1637,9 +1892,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bd31f22a-d6c5-4ec6-a40b-cec88d085734",
@@ -1650,9 +1907,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
@@ -1663,9 +1922,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -1676,9 +1937,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-purple-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "purple"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6f0335da-6c21-4946-9a67-e6e908cc2aaa",
@@ -1689,8 +1952,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -1701,8 +1966,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
@@ -1713,8 +1980,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -1725,9 +1994,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -1738,9 +2009,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
@@ -1751,9 +2024,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -1764,9 +2039,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5485c698-0ea9-47d7-b81d-43f0647c4078",
@@ -1777,9 +2054,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -1790,9 +2069,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5485c698-0ea9-47d7-b81d-43f0647c4078",
@@ -1803,9 +2084,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
@@ -1816,9 +2099,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -1829,9 +2114,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-red-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "red"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
@@ -1842,8 +2129,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-seafoam-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "seafoam"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
@@ -1854,8 +2143,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-seafoam-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "seafoam"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "63882463-c739-495b-b164-317ebcf97e35",
@@ -1866,8 +2157,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-seafoam-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "seafoam"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
@@ -1878,8 +2171,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-seafoam-primary",
-      "state": "default"
+      "property": "color",
+      "state": "default",
+      "colorRole": "primary",
+      "colorFamily": "seafoam"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
@@ -1888,8 +2183,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-seafoam-primary",
-      "state": "down"
+      "property": "color",
+      "state": "down",
+      "colorRole": "primary",
+      "colorFamily": "seafoam"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "487ae86b-24c7-4587-87b0-008fca574e84",
@@ -1898,8 +2195,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-seafoam-primary",
-      "state": "hover"
+      "property": "color",
+      "state": "hover",
+      "colorRole": "primary",
+      "colorFamily": "seafoam"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
@@ -1908,8 +2207,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
@@ -1920,8 +2221,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ac14b55-357e-43a0-85f3-c41a8f3697c8",
@@ -1932,8 +2235,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
@@ -1944,9 +2249,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
@@ -1957,9 +2264,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -1970,9 +2279,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5d1179ae-dde0-4133-b97e-5d1c3001e2d3",
@@ -1983,9 +2294,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -1996,9 +2309,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e8bb1260-f417-4fae-823e-7a1b3e8f4f86",
@@ -2009,9 +2324,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -2022,9 +2339,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -2035,9 +2354,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -2048,9 +2369,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-silver-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "silver"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -2061,8 +2384,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7720aa32-deea-454b-a593-f1234e638565",
@@ -2073,8 +2398,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1327ec82-3f65-4706-a664-11e46294ffd2",
@@ -2085,8 +2412,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7720aa32-deea-454b-a593-f1234e638565",
@@ -2097,9 +2426,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3cf57594-3174-4192-ab62-b854b1562748",
@@ -2110,9 +2441,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -2123,9 +2456,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3cf57594-3174-4192-ab62-b854b1562748",
@@ -2136,9 +2471,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -2149,9 +2486,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "eba4bafc-0f66-4dd1-8007-d25121e79a4b",
@@ -2162,9 +2501,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -2175,9 +2516,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -2188,9 +2531,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -2201,9 +2546,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-turquoise-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "turquoise"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -2214,8 +2561,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-background",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "colorRole": "background",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
@@ -2226,8 +2575,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-background",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "colorRole": "background",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -2238,8 +2589,10 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-background",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "colorRole": "background",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "34318bf7-de9b-46a0-8bc1-29b154d89cb8",
@@ -2250,9 +2603,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -2263,9 +2618,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af877bd7-9943-454e-b83e-5597e381190a",
@@ -2276,9 +2633,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -2289,9 +2648,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
@@ -2302,9 +2663,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0fcda0a7-23be-4467-9f9d-1fc9eab938ce",
@@ -2315,9 +2678,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
@@ -2328,9 +2693,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8f90e008-a466-4477-ab93-1a55a644f52e",
@@ -2341,9 +2708,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2558f6d-b45c-4662-a4a9-e34acd060c1d",
@@ -2354,9 +2723,11 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-yellow-primary",
+      "property": "color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "colorRole": "primary",
+      "colorFamily": "yellow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8f90e008-a466-4477-ab93-1a55a644f52e",

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -165,22 +165,56 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
 
     let name: &Map<String, Value> = name_val.as_object()?;
 
-    // Color-domain serialization: {variant?}-{colorFamily}-{scaleIndex?}
-    // `property` ("color") is implicit for palette tokens and omitted from the key.
-    if let Some(color_family) = name.get("colorFamily").and_then(|v| v.as_str()) {
-        let mut parts: Vec<String> = Vec::new();
-        if let Some(v) = name.get("variant").and_then(|v| v.as_str()) {
-            parts.push(v.to_string());
+    // Color-domain serialization — two sub-cases distinguished by component presence.
+    //
+    //   Palette ramp (no component): {variant?}-{colorFamily}-{scaleIndex?}
+    //   `property` ("color") is implicit and omitted from the key.
+    //   e.g. {colorFamily:"blue", scaleIndex:100} → "blue-100"
+    //
+    //   Component color (component + colorFamily and/or colorRole):
+    //   {component}-{property}-{colorFamily?}-{colorRole?}-{state?}
+    //   `property` is always "color". Explicit ordering avoids the position-walk trap
+    //   where state@12 < colorFamily@17 would produce the wrong segment order.
+    //   e.g. {component:"icon", property:"color", colorFamily:"blue", colorRole:"primary",
+    //         state:"default"} → "icon-color-blue-primary-default"
+    let color_family = name.get("colorFamily").and_then(|v| v.as_str());
+    let color_role = name.get("colorRole").and_then(|v| v.as_str());
+    let component = name.get("component").and_then(|v| v.as_str());
+
+    if let Some(cf) = color_family {
+        if component.is_none() {
+            // Palette ramp: no component, property implicit.
+            let mut parts: Vec<String> = Vec::new();
+            if let Some(v) = name.get("variant").and_then(|v| v.as_str()) {
+                parts.push(v.to_string());
+            }
+            parts.push(cf.to_string());
+            if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
+                parts.push(i.to_string());
+            }
+            return Some(parts.join("-"));
         }
-        parts.push(color_family.to_string());
-        if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
-            parts.push(i.to_string());
+    }
+
+    // Component color: component present AND at least one of colorFamily/colorRole.
+    if component.is_some() && (color_family.is_some() || color_role.is_some()) {
+        let property = name.get("property").and_then(|v| v.as_str())?;
+        let mut parts: Vec<String> = Vec::new();
+        parts.push(component.unwrap().to_string());
+        parts.push(property.to_string());
+        if let Some(cf) = color_family {
+            parts.push(cf.to_string());
+        }
+        if let Some(cr) = color_role {
+            parts.push(cr.to_string());
+        }
+        if let Some(st) = name.get("state").and_then(|v| v.as_str()) {
+            parts.push(st.to_string());
         }
         return Some(parts.join("-"));
     }
 
     let property = name.get("property").and_then(|v| v.as_str())?;
-    let component = name.get("component").and_then(|v| v.as_str());
 
     // Thin-format detection: `property` already begins with `{component}-`.
     // In the thin cascade format the full legacy key is stored in `property`; component is
@@ -206,7 +240,7 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     //
     // Currently excluded fields, grouped by reason (see each field's JSON for per-field notes):
     //   Mode-set selectors (not part of the legacy name): colorScheme, scale, contrast
-    //   Color-domain (handled by colorFamily branch above): colorFamily
+    //   Color-domain (handled by color-domain branch above): colorFamily, colorRole
     //   Integer scale (already embedded in `property`; would double-emit): scaleIndex
     //   Legacy metadata annotations (value already embedded in `property` for all current
     //     tokens): weight, family, style, structure — if any joins Phase D decomposition,
@@ -541,5 +575,59 @@ mod tests {
             !key.contains("italic"),
             "style must not appear in legacy key"
         );
+    }
+
+    // ── Component color branch (colorRole) ───────────────────────────────────
+
+    #[test]
+    fn extract_key_component_color_with_family_and_role() {
+        // Component + colorFamily + colorRole → explicit {component}-{property}-{colorFamily}-{colorRole}-{state?}
+        let name = json!({
+            "component": "icon",
+            "property": "color",
+            "colorFamily": "blue",
+            "colorRole": "primary",
+            "state": "default"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("icon-color-blue-primary-default")
+        );
+    }
+
+    #[test]
+    fn extract_key_component_color_background_no_state() {
+        let name = json!({
+            "component": "icon",
+            "property": "color",
+            "colorFamily": "red",
+            "colorRole": "background"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("icon-color-red-background")
+        );
+    }
+
+    #[test]
+    fn extract_key_component_color_role_only_no_family() {
+        // colorRole present, no colorFamily (e.g. "color-primary" → no hue)
+        let name = json!({
+            "component": "icon",
+            "property": "color",
+            "colorRole": "primary",
+            "state": "default"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("icon-color-primary-default")
+        );
+    }
+
+    #[test]
+    fn extract_key_palette_ramp_unaffected_by_component_color_branch() {
+        // Palette ramp (no component) still uses the short form.
+        let name = json!({"property": "color", "colorFamily": "blue", "scaleIndex": 700});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("blue-700"));
     }
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1979,6 +1979,24 @@ const STATES_JSON: &str = r##"{
   ]
 }
 "##;
+const COLOR_ROLES_JSON: &str = r##"{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "color-role",
+  "description": "Semantic roles for component-scoped color tokens. Assigned via the `colorRole` name-object field alongside `colorFamily` (e.g. colorFamily=blue + colorRole=primary → the primary blue color for a component).",
+  "values": [
+    {
+      "id": "primary",
+      "label": "Primary",
+      "description": "Primary color role — the main foreground color for an element"
+    },
+    {
+      "id": "background",
+      "label": "Background",
+      "description": "Background color role — fill or surface color behind an element"
+    }
+  ]
+}
+"##;
 const COLOR_FAMILIES_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "color-family",
@@ -2402,7 +2420,7 @@ const CATEGORIES_JSON: &str = r##"{
 }
 "##;
 
-pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "property", "orientation", "position", "size", "density", "shape", "state", "colorFamily", "family", "weight", "style", "motionRole", "easing", "alignment"];
+pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "family", "weight", "style", "motionRole", "easing", "alignment"];
 
 pub(crate) fn build_registry_map(
 ) -> std::collections::HashMap<String, std::collections::HashSet<String>> {
@@ -2420,6 +2438,7 @@ pub(crate) fn build_registry_map(
     map.insert("density".to_string(), parse_registry(DENSITIES_JSON));
     map.insert("shape".to_string(), parse_registry(SHAPES_JSON));
     map.insert("state".to_string(), parse_registry(STATES_JSON));
+    map.insert("colorRole".to_string(), parse_registry(COLOR_ROLES_JSON));
     map.insert("colorFamily".to_string(), parse_registry(COLOR_FAMILIES_JSON));
     map.insert("family".to_string(), parse_registry(TYPOGRAPHY_FAMILIES_JSON));
     map.insert("weight".to_string(), parse_registry(TYPOGRAPHY_WEIGHTS_JSON));
@@ -2447,6 +2466,7 @@ pub(crate) fn build_token_name_map(
     map.insert("density".to_string(), parse_token_name_map(DENSITIES_JSON));
     map.insert("shape".to_string(), parse_token_name_map(SHAPES_JSON));
     map.insert("state".to_string(), parse_token_name_map(STATES_JSON));
+    map.insert("colorRole".to_string(), parse_token_name_map(COLOR_ROLES_JSON));
     map.insert("colorFamily".to_string(), parse_token_name_map(COLOR_FAMILIES_JSON));
     map.insert("family".to_string(), parse_token_name_map(TYPOGRAPHY_FAMILIES_JSON));
     map.insert("weight".to_string(), parse_token_name_map(TYPOGRAPHY_WEIGHTS_JSON));
@@ -2475,6 +2495,7 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "colorScheme", position: 13, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "scale", position: 14, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "contrast", position: 15, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "colorRole", position: 16, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "colorFamily", position: 17, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "family", position: 18, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "weight", position: 19, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },

--- a/sdk/core/src/validate/rules/spec042.rs
+++ b/sdk/core/src/validate/rules/spec042.rs
@@ -35,7 +35,7 @@ pub struct Rule;
 /// Authoritative source: `packages/design-data/fields/*.json` `scope` property.
 fn field_domain(field: &str) -> Option<&'static str> {
     match field {
-        "colorFamily" => Some("color"),
+        "colorFamily" | "colorRole" => Some("color"),
         "family" | "weight" | "style" => Some("typography"),
         "motionRole" | "easing" => Some("motion"),
         _ => None,

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -182,10 +182,16 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     }
   }
 
-  // Sort by: longer matches first, then by field priority
+  // Sort by: longer matches first, then by field priority.
+  // Fields not in fieldPriority (e.g. colorFamily, colorRole, weight) get Infinity
+  // so they sort AFTER all listed fields, not before them (indexOf returns -1 otherwise).
+  const priority = (f) => {
+    const i = fieldPriority.indexOf(f);
+    return i === -1 ? Infinity : i;
+  };
   positionMatches.sort((a, b) => {
     if (b.length !== a.length) return b.length - a.length;
-    return fieldPriority.indexOf(a.field) - fieldPriority.indexOf(b.field);
+    return priority(a.field) - priority(b.field);
   });
 
   // Greedily assign matches, skipping conflicts
@@ -377,9 +383,15 @@ export function serialize(
     return parts.join("-");
   }
 
-  // Component color: component + (colorFamily and/or colorRole)
+  // Component color: component + (colorFamily and/or colorRole) AND property === "color".
+  // The property guard prevents this branch from firing when colorRole terms (e.g. "background",
+  // "primary") match a non-color token via the decomposer, which would drop other fields.
   // → {component}-{property}-{colorFamily?}-{colorRole?}-{state?}
-  if (component && (colorFamily || colorRole)) {
+  if (
+    component &&
+    (colorFamily || colorRole) &&
+    nameObject.property === "color"
+  ) {
     const parts = [component, nameObject.property];
     if (colorFamily) parts.push(tokenNameMap[colorFamily] || colorFamily);
     if (colorRole) parts.push(tokenNameMap[colorRole] || colorRole);

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -348,6 +348,13 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
  * Uses tokenNameMap to output long-form aliases (e.g., xl → extra-large)
  * for legacy compatibility.
  *
+ * Color-domain tokens use explicit ordering that mirrors the Rust naming.rs
+ * color-domain branch, bypassing the position-ordered general walk (which
+ * would mis-order state@12 before colorFamily@17):
+ *   palette ramp (no component): {variant?}-{colorFamily}-{scaleIndex?}
+ *   component color (component + colorFamily/colorRole):
+ *     {component}-{property}-{colorFamily?}-{colorRole?}-{state?}
+ *
  * @param {object} nameObject
  * @param {object} tokenNameMap - id → tokenName for legacy alias expansion
  * @param {string[]} [serializationOrder] - ordered field names from field catalog
@@ -357,6 +364,31 @@ export function serialize(
   tokenNameMap = {},
   serializationOrder = FALLBACK_SERIALIZATION_ORDER,
 ) {
+  const { colorFamily, colorRole, component } = nameObject;
+
+  // Palette ramp: colorFamily present, no component → {variant?}-{colorFamily}-{scaleIndex?}
+  if (colorFamily && !component) {
+    const parts = [];
+    if (nameObject.variant)
+      parts.push(tokenNameMap[nameObject.variant] || nameObject.variant);
+    parts.push(tokenNameMap[colorFamily] || colorFamily);
+    if (nameObject.scaleIndex != null)
+      parts.push(String(nameObject.scaleIndex));
+    return parts.join("-");
+  }
+
+  // Component color: component + (colorFamily and/or colorRole)
+  // → {component}-{property}-{colorFamily?}-{colorRole?}-{state?}
+  if (component && (colorFamily || colorRole)) {
+    const parts = [component, nameObject.property];
+    if (colorFamily) parts.push(tokenNameMap[colorFamily] || colorFamily);
+    if (colorRole) parts.push(tokenNameMap[colorRole] || colorRole);
+    if (nameObject.state)
+      parts.push(tokenNameMap[nameObject.state] || nameObject.state);
+    return parts.join("-");
+  }
+
+  // General path (non-color tokens)
   const parts = [];
   for (const field of serializationOrder) {
     if (nameObject[field]) {

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -237,6 +237,53 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     }
   }
 
+  // Phase 4.5: Color-domain promotion
+  // colorFamily/colorRole have Infinity priority so they don't steal segments
+  // from object, size, etc. in non-color tokens. But when context confirms a
+  // color domain, matched variant/object fields are promoted to the color taxonomy.
+  //
+  //   Palette ramp (scaleIndex + no component):
+  //     variant:"blue" → colorFamily:"blue"
+  //   Component color (property:"color" + component):
+  //     variant:<hue>  → colorFamily:<hue>, then object:<role> → colorRole:<role>
+  //     variant:<role> → colorRole:<role>  (no-hue tokens, e.g. color-primary)
+  {
+    const hueSet = registry.byField["colorFamily"] || new Set();
+    const roleSet = registry.byField["colorRole"] || new Set();
+
+    // Palette ramp: scaleIndex assigned, no component
+    if (
+      nameObject.scaleIndex !== undefined &&
+      nameObject.component === undefined
+    ) {
+      if (nameObject.variant !== undefined && hueSet.has(nameObject.variant)) {
+        nameObject.colorFamily = nameObject.variant;
+        delete nameObject.variant;
+      }
+    }
+
+    // Component color: property === "color" + component present
+    if (nameObject.property === "color" && nameObject.component !== undefined) {
+      if (nameObject.variant !== undefined && hueSet.has(nameObject.variant)) {
+        // Hue in variant → promote to colorFamily; also promote object → colorRole alongside it
+        nameObject.colorFamily = nameObject.variant;
+        delete nameObject.variant;
+        if (nameObject.object !== undefined && roleSet.has(nameObject.object)) {
+          nameObject.colorRole = nameObject.object;
+          delete nameObject.object;
+        }
+      } else if (
+        nameObject.variant !== undefined &&
+        roleSet.has(nameObject.variant) &&
+        !hueSet.has(nameObject.variant)
+      ) {
+        // Role in variant (no hue) → promote to colorRole (e.g. icon-color-primary-default)
+        nameObject.colorRole = nameObject.variant;
+        delete nameObject.variant;
+      }
+    }
+  }
+
   // Phase 5: Check for -to- spacing pattern
   const toIndex = segments.indexOf("to");
   if (toIndex > 0 && !matched[toIndex]) {

--- a/tools/token-mapping-analyzer/src/migrate-color-role.js
+++ b/tools/token-mapping-analyzer/src/migrate-color-role.js
@@ -1,0 +1,234 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * Migrate component-scoped compound color properties to atomic fields.
+ *
+ * Usage: node src/migrate-color-role.js [--write]
+ *
+ * Tokens whose name.property matches "color-<hue>-<role>" or "color-<role>"
+ * (where hue ∈ color-families registry, role ∈ color-roles registry) are
+ * rewritten to:
+ *   property: "color", colorFamily: hue (if present), colorRole: role
+ *
+ * The JS serialize() (which mirrors the Rust color-domain branch) must
+ * reproduce the original legacy key for every migrated token — fail loud if not.
+ * Edge cases (color-inverse, color-area-margin) are reported and skipped.
+ * Dry-run by default; --write to persist.
+ *
+ * ponytail: dedicated script because apply.js is one-field-per-run and the
+ * intermediate state (color-blue after pulling colorFamily) is not a registered
+ * property term, so sequential apply runs can't do the 3-field split atomically.
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { loadRegistries } from "./registry-index.js";
+import { serialize } from "./decomposer.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../..");
+const CASCADE_DIR = resolve(REPO_ROOT, "packages/design-data/tokens");
+
+const CASCADE_FILES = readdirSync(CASCADE_DIR)
+  .filter((f) => f.endsWith(".tokens.json"))
+  .sort();
+
+function parseArgs() {
+  return { write: process.argv.includes("--write") };
+}
+
+/**
+ * Decompose "color-<hue>-<role>" or "color-<role>" from property.
+ * Returns { colorFamily, colorRole } or null if it doesn't match.
+ * Fails loudly if the pattern matches but hue/role aren't registered.
+ */
+function parseColorProperty(property, hueSet, roleSet) {
+  if (!property.startsWith("color-")) return null;
+  const rest = property.slice("color-".length);
+  const segs = rest.split("-");
+
+  if (segs.length === 1) {
+    // color-<role>  (no hue — e.g. color-primary)
+    const role = segs[0];
+    if (!roleSet.has(role)) return null; // not a registered role → skip
+    return { colorFamily: null, colorRole: role };
+  }
+
+  if (segs.length === 2) {
+    // color-<hue>-<role>  (e.g. color-blue-primary)
+    const [hue, role] = segs;
+    if (!hueSet.has(hue)) return null; // not a registered hue → edge case, skip
+    if (!roleSet.has(role)) {
+      // hue matched but role is unrecognized — warn (could be a gap in the registry)
+      process.stderr.write(
+        `WARN: recognized hue "${hue}" but unrecognized role "${role}" in "${property}" — skipping\n`,
+      );
+      return null;
+    }
+    return { colorFamily: hue, colorRole: role };
+  }
+
+  return null; // 3+ segments (e.g. color-inverse-background) — skip
+}
+
+export function migrateColorRole(tokens, hueSet, roleSet, registry, filename) {
+  let applied = 0;
+  const skipped = [];
+
+  for (const token of tokens) {
+    if (!token.name || typeof token.name !== "object") continue;
+    if (!token.name.component) continue; // only component-scoped tokens
+    if (
+      token.name.colorFamily !== undefined ||
+      token.name.colorRole !== undefined
+    )
+      continue; // already migrated
+
+    const property = token.name.property;
+    if (!property || !property.startsWith("color-")) continue;
+
+    const parsed = parseColorProperty(property, hueSet, roleSet);
+    if (!parsed) {
+      // Unrecognized compound: flag as skipped for reporting
+      skipped.push({
+        file: filename,
+        property,
+        name: JSON.stringify(token.name),
+      });
+      continue;
+    }
+
+    const { colorFamily, colorRole } = parsed;
+
+    // Build the patched name object
+    const patched = { ...token.name, property: "color", colorRole };
+    if (colorFamily) patched.colorFamily = colorFamily;
+
+    // Safety: JS serialize() must reproduce the original legacy key exactly.
+    // This mirrors the Rust extract_legacy_key gate.
+    const originalKey = serialize(
+      token.name,
+      registry.tokenNameMap,
+      registry.serializationOrder,
+    );
+    const patchedKey = serialize(
+      patched,
+      registry.tokenNameMap,
+      registry.serializationOrder,
+    );
+    if (originalKey !== patchedKey) {
+      throw new Error(
+        `Roundtrip mismatch in ${filename}:\n` +
+          `  original: ${JSON.stringify(token.name)} → "${originalKey}"\n` +
+          `  patched:  ${JSON.stringify(patched)} → "${patchedKey}"\n` +
+          `  Aborting — fix the JS serialize() color-domain branch first.`,
+      );
+    }
+
+    // Apply
+    token.name.property = "color";
+    token.name.colorRole = colorRole;
+    if (colorFamily) token.name.colorFamily = colorFamily;
+    applied++;
+  }
+
+  return { applied, skipped };
+}
+
+async function main() {
+  const { write } = parseArgs();
+  const registry = loadRegistries();
+
+  // Build hue and role sets from the registries
+  const hueSet = registry.byField["colorFamily"] || new Set();
+  const roleSet = registry.byField["colorRole"] || new Set();
+
+  if (hueSet.size === 0) {
+    console.error("colorFamily registry is empty — run sdk:codegen");
+    process.exit(1);
+  }
+  if (roleSet.size === 0) {
+    console.error(
+      "colorRole registry is empty — ensure colorRole.json + color-roles.json exist",
+    );
+    process.exit(1);
+  }
+
+  let totalApplied = 0;
+  const allSkipped = [];
+  const hueSeen = new Map(),
+    roleSeen = new Map();
+
+  for (const filename of CASCADE_FILES) {
+    const filePath = resolve(CASCADE_DIR, filename);
+    const tokens = JSON.parse(readFileSync(filePath, "utf-8"));
+
+    const { applied, skipped } = migrateColorRole(
+      tokens,
+      hueSet,
+      roleSet,
+      registry,
+      filename,
+    );
+    totalApplied += applied;
+    allSkipped.push(...skipped);
+
+    // Track distinct hues/roles actually migrated
+    for (const token of tokens) {
+      if (!token.name?.colorRole) continue;
+      const cf = token.name.colorFamily;
+      const cr = token.name.colorRole;
+      if (cf) hueSeen.set(cf, (hueSeen.get(cf) || 0) + 1);
+      roleSeen.set(cr, (roleSeen.get(cr) || 0) + 1);
+    }
+
+    if (write && applied > 0) {
+      writeFileSync(filePath, JSON.stringify(tokens, null, 2) + "\n");
+    }
+    if (applied > 0) {
+      console.log(`  ${filename}: ${applied} applied`);
+    }
+  }
+
+  console.log(
+    `\n=== colorFamily + colorRole migration${write ? " (WROTE)" : " (dry run)"} ===`,
+  );
+  console.log(`  Applied: ${totalApplied}`);
+  if (hueSeen.size > 0) {
+    console.log(
+      `  Hues:    ${[...hueSeen.entries()].map(([k, n]) => `${k}:${n}`).join("  ")}`,
+    );
+  }
+  if (roleSeen.size > 0) {
+    console.log(
+      `  Roles:   ${[...roleSeen.entries()].map(([k, n]) => `${k}:${n}`).join("  ")}`,
+    );
+  }
+  if (allSkipped.length > 0) {
+    console.log(
+      `\n  Skipped (unrecognized compound, manual follow-up needed): ${allSkipped.length}`,
+    );
+    for (const s of allSkipped) {
+      console.log(`    [${s.file}] property="${s.property}" — ${s.name}`);
+    }
+  }
+  if (!write && totalApplied > 0) {
+    console.log("\nRun with --write to persist.");
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -136,3 +136,64 @@ test("processes all tokens without errors", (t) => {
   t.truthy(result.confidence);
   t.truthy(result.nameObject);
 });
+
+// ── colorFamily / colorRole promotion regression tests ───────────────────────
+
+test("promotes variant hue → colorFamily for palette ramp tokens (scaleIndex + no component)", (t) => {
+  // "blue" would match variant (priority) before colorFamily (Infinity).
+  // Phase 4.5 promotes it because scaleIndex is present and there is no component.
+  const result = decompose("blue-700", {}, registry, "test");
+  t.is(result.nameObject.colorFamily, "blue");
+  t.is(result.nameObject.variant, undefined);
+  t.is(result.nameObject.scaleIndex, "700");
+  t.true(result.roundtrips);
+});
+
+test("promotes variant hue + retains colorRole for component color tokens", (t) => {
+  // "blue" wins variant priority over colorFamily; "primary" goes to colorRole
+  // since variant is already taken. Phase 4.5 promotes blue → colorFamily.
+  const result = decompose(
+    "icon-color-blue-primary-default",
+    { component: "icon" },
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.colorFamily, "blue");
+  t.is(result.nameObject.colorRole, "primary");
+  t.is(result.nameObject.variant, undefined);
+  t.is(result.nameObject.property, "color");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("promotes variant hue + object role for component color tokens (background role)", (t) => {
+  // "blue" → variant → promoted to colorFamily. "background" → object (priority)
+  // → promoted to colorRole alongside the hue promotion.
+  const result = decompose(
+    "icon-color-blue-background",
+    { component: "icon" },
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.colorFamily, "blue");
+  t.is(result.nameObject.colorRole, "background");
+  t.is(result.nameObject.variant, undefined);
+  t.is(result.nameObject.object, undefined);
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("does not promote non-color tokens: variant/object unaffected when property is not color", (t) => {
+  // "accent" is not in colorFamily registry; "content" is not in colorRole registry.
+  // No promotion should occur even though property === "color".
+  const result = decompose(
+    "accent-content-color-default",
+    {},
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.variant, "accent");
+  t.is(result.nameObject.object, "content");
+  t.is(result.nameObject.colorFamily, undefined);
+  t.is(result.nameObject.colorRole, undefined);
+});

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -18,14 +18,17 @@ test.before(() => {
 });
 
 test("decomposes simple variant-object-property-state token", (t) => {
+  // "background-color" is a registered 2-seg compound property term, so
+  // "accent-background-color-default" would collapse to property:background-color.
+  // Use "content" (object registry, no compound overlap) to test the full split.
   const result = decompose(
-    "accent-background-color-default",
+    "accent-content-color-default",
     {},
     registry,
     "test",
   );
   t.is(result.nameObject.variant, "accent");
-  t.is(result.nameObject.object, "background");
+  t.is(result.nameObject.object, "content");
   t.is(result.nameObject.property, "color");
   t.is(result.nameObject.state, "default");
   t.is(result.confidence, "HIGH");
@@ -86,10 +89,11 @@ test("classifies typography weight terms as gaps", (t) => {
     registry,
     "test",
   );
+  // "emphasized" is unregistered → typography-weight gap
   const weightGap = result.gaps.find((g) => g.type === "typography-weight");
   t.truthy(weightGap);
-  const scriptGap = result.gaps.find((g) => g.type === "typography-script");
-  t.truthy(scriptGap);
+  // "cjk" is registered in the family registry → matched as family, not a gap
+  t.is(result.nameObject.family, "cjk");
 });
 
 test("matches key-focus as keyboard-focus state", (t) => {


### PR DESCRIPTION
## Description

Fully atomizes 187 component-scoped color tokens whose `name.property` carried compound values like `color-blue-primary`. Each token is now decomposed into three atomic fields: `property:"color"` + `colorFamily:"blue"` + `colorRole:"primary"`.

Adds a new `colorRole` field (the semantic role within a component: primary, background) alongside the existing `colorFamily` field (the hue family). The `colorFamily` field was previously only populated for palette ramp tokens (no component); this extends it to component color tokens as well.

## Related Issue

Beads #72c — Phase D: decompose component color props into colorFamily + colorRole (full atomization)

Follow-up filed as beads #2mh for 3 edge cases (color-inverse, color-area-margin) that require a design decision before automation.

## Motivation and Context

Phase D goal: every compound value in `name.property` should be decomposed into structured fields so tokens are queryable by individual dimensions. The 187 tokens in `icons.tokens.json` were the last significant block of undecomposed color properties.

The key design constraint: the general position-ordered serialization walk has `state` (pos 12) before `colorFamily` (pos 17), which would mis-order the legacy key (`icon-color-default-blue-primary` instead of `icon-color-blue-primary-default`). The fix is to route component color tokens through the explicit color-domain branch in `naming.rs` rather than the general walk, keeping both `colorFamily` and `colorRole` as `excludeFromLegacyKey: true`. The Rust and JS serializers now both implement this branch, closing the existing JS↔Rust trust-boundary gap for color tokens.

## How Has This Been Tested?

- `design-data migrate roundtrip-verify packages/tokens/src` — Roundtrip OK
- `design-data migrate legacy-verify --reference packages/tokens/src packages/design-data/tokens` — Legacy output OK (zero key changes across all 187 migrated tokens and all 971 existing palette tokens)
- `moon run sdk:test` — 4 new `naming::tests` covering the component color branch; all existing tests pass
- `moon run test` — full JS suite passes
- Changeset linter: `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.