### PR TITLE
feat(design-data): register color-handle/color-loupe components + color-area anatomy term

### DIFF
--- a/.changeset/e1-color-component-registry.md
+++ b/.changeset/e1-color-component-registry.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Register color-handle, color-loupe components and color-area anatomy term.
+
+- **packages/design-data/registry/components.json**: Add `color-handle` and
+  `color-loupe` entries backing existing refs in `color-component.tokens.json`.
+- **packages/design-data/registry/anatomy-terms.json**: Add `color-area`
+  anatomy term for the embedded gradient surface in color-wheel and relatives.
+- **sdk/core/src/registry_data.rs**: Regenerated via `sdk:codegen` to include
+  all three new entries.

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,9 @@ tools/token-mapping-analyzer/output/
 # demo video pipeline rendered artifacts (re-buildable from manifests).
 # Commit only curated, published assets under tools/demo/videos/published/.
 tools/demo/videos/out/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -484,6 +484,12 @@
       "usedIn": ["s2-docs"]
     },
     {
+      "id": "color-area",
+      "label": "Color Area",
+      "description": "The color-area component when used as an embedded anatomy part within another component (e.g. the color gradient area inside a color-wheel)",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "color-handle",
       "label": "Color Handle",
       "description": "Draggable handle element in color picker components (color-area, color-slider, color-wheel)",

--- a/packages/design-data/registry/components.json
+++ b/packages/design-data/registry/components.json
@@ -94,6 +94,16 @@
       "documentationUrl": "https://spectrum.adobe.com/page/color-slider/"
     },
     {
+      "id": "color-handle",
+      "label": "Color Handle",
+      "documentationUrl": "https://spectrum.adobe.com/page/color-handle/"
+    },
+    {
+      "id": "color-loupe",
+      "label": "Color Loupe",
+      "documentationUrl": "https://spectrum.adobe.com/page/color-loupe/"
+    },
+    {
       "id": "color-wheel",
       "label": "Color Wheel",
       "documentationUrl": "https://spectrum.adobe.com/page/color-wheel/"

--- a/packages/design-data/registry/components.json
+++ b/packages/design-data/registry/components.json
@@ -89,11 +89,6 @@
       "documentationUrl": "https://spectrum.adobe.com/page/color-area/"
     },
     {
-      "id": "color-slider",
-      "label": "Color Slider",
-      "documentationUrl": "https://spectrum.adobe.com/page/color-slider/"
-    },
-    {
       "id": "color-handle",
       "label": "Color Handle",
       "documentationUrl": "https://spectrum.adobe.com/page/color-handle/"
@@ -102,6 +97,11 @@
       "id": "color-loupe",
       "label": "Color Loupe",
       "documentationUrl": "https://spectrum.adobe.com/page/color-loupe/"
+    },
+    {
+      "id": "color-slider",
+      "label": "Color Slider",
+      "documentationUrl": "https://spectrum.adobe.com/page/color-slider/"
     },
     {
       "id": "color-wheel",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -381,6 +381,16 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/color-slider/"
     },
     {
+      "id": "color-handle",
+      "label": "Color Handle",
+      "documentationUrl": "https://spectrum.adobe.com/page/color-handle/"
+    },
+    {
+      "id": "color-loupe",
+      "label": "Color Loupe",
+      "documentationUrl": "https://spectrum.adobe.com/page/color-loupe/"
+    },
+    {
       "id": "color-wheel",
       "label": "Color Wheel",
       "documentationUrl": "https://spectrum.adobe.com/page/color-wheel/"
@@ -1118,6 +1128,12 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "label": "Segmented Control Item",
       "description": "Individual selectable item within a segmented-control component",
       "usedIn": ["s2-docs"]
+    },
+    {
+      "id": "color-area",
+      "label": "Color Area",
+      "description": "The color-area component when used as an embedded anatomy part within another component (e.g. the color gradient area inside a color-wheel)",
+      "usedIn": ["tokens"]
     },
     {
       "id": "color-handle",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -376,11 +376,6 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/color-area/"
     },
     {
-      "id": "color-slider",
-      "label": "Color Slider",
-      "documentationUrl": "https://spectrum.adobe.com/page/color-slider/"
-    },
-    {
       "id": "color-handle",
       "label": "Color Handle",
       "documentationUrl": "https://spectrum.adobe.com/page/color-handle/"
@@ -389,6 +384,11 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "color-loupe",
       "label": "Color Loupe",
       "documentationUrl": "https://spectrum.adobe.com/page/color-loupe/"
+    },
+    {
+      "id": "color-slider",
+      "label": "Color Slider",
+      "documentationUrl": "https://spectrum.adobe.com/page/color-slider/"
     },
     {
       "id": "color-wheel",


### PR DESCRIPTION
## Description

Registers three missing entries in the design-data registries that back existing token references in `color-component.tokens.json` and `layout-component.tokens.json`:

- `color-handle` and `color-loupe` as component registry entries
- `color-area` as an anatomy term (the embedded color-gradient surface used within color-wheel and related components)

`sdk/core/src/registry_data.rs` was regenerated via `moon run sdk:codegen` to include all three.

## Related Issue

No dedicated issue — discovered as part of the Phase D follow-up session; tokens referencing these IDs existed but the registry entries were absent.

## Motivation and Context

Without registry entries, any validation path that resolves `"component": "color-handle"` etc. against the registry fails to find a match. The anatomy term `color-area` fills the same gap for layout tokens that reference it as an embedded part.

## How Has This Been Tested?

- `moon run sdk:codegen-check` confirms `registry_data.rs` is up to date
- `moon run sdk:test` — 648 tests, 0 failures (codegen-check runs as a dependency)
- `pnpm --filter @adobe/spectrum-design-data test` — passing
- Changeset linted with `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — 0 errors, 0 warnings

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.