### PR TITLE
feat(design-data): register space-between property term + from/to endpoint fields

### DIFF
--- a/.changeset/04c1-space-between-endpoint-fields.md
+++ b/.changeset/04c1-space-between-endpoint-fields.md
@@ -1,0 +1,16 @@
+---
+"@adobe/spectrum-design-data": minor
+"@adobe/design-data-spec": minor
+---
+
+Phase D: register `space-between` property term and paired `from`/`to` endpoint fields.
+
+- **packages/design-data/registry/property-terms.json**: added `space-between` term for
+  {a}-to-{b} spacing tokens.
+- **packages/design-data/fields/from.json, to.json**: new paired semantic fields modeling a
+  space-between token's two endpoints; excluded from legacy-key catalog serialization pending
+  a dedicated `naming.rs` branch (04c.2).
+- **packages/design-data-spec/schemas/token.schema.json**: declared `from`/`to` on the
+  nameObject definition.
+- **packages/design-data-spec/rules/rules.yaml**: added SPEC-047 validating `from`/`to` values
+  against positions, generic anatomy terms, or the referenced component's declared anatomy.

--- a/packages/design-data-spec/conformance/invalid/SPEC-047/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-047/dataset.json
@@ -1,0 +1,25 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "accordion",
+        "property": "space-between",
+        "from": "top",
+        "to": "banana"
+      },
+      "value": "8px"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/accordion.json",
+      "name": "accordion",
+      "displayName": "Accordion",
+      "meta": {
+        "category": "containers",
+        "documentationUrl": "https://spectrum.adobe.com/page/accordion/"
+      },
+      "anatomy": [{ "name": "handle", "description": "Drag handle." }]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-047/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-047/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-047",
+      "severity": "error",
+      "message_pattern": ".*space-between endpoint.*banana.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-047/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-047/dataset.json
@@ -1,0 +1,25 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "component": "accordion",
+        "property": "space-between",
+        "from": "bottom",
+        "to": "handle"
+      },
+      "value": "8px"
+    }
+  ],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/accordion.json",
+      "name": "accordion",
+      "displayName": "Accordion",
+      "meta": {
+        "category": "containers",
+        "documentationUrl": "https://spectrum.adobe.com/page/accordion/"
+      },
+      "anatomy": [{ "name": "handle", "description": "Drag handle." }]
+    }
+  ]
+}

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -534,13 +534,13 @@ rules:
     layer: 2
     category: reference-integrity
     assert: >
-      When a token name-object has `property` "space-between", each of its `from`/`to`
-      values MUST be one of: an edge position (`positions.json`), a generic anatomy term
-      (`anatomy-terms.json`), or — when `component` is present and declares an `anatomy`
-      array — the `name` of a declared anatomy part on that component. Mirrors SPEC-020's
-      component→anatomy resolution, unioned with the position and generic-anatomy
-      vocabularies. Severity is advisory (warning) when the component declares no anatomy
-      array, since the position/generic-anatomy union still applies.
+      A token name-object with `property` "space-between" MUST carry both `from` and
+      `to` fields, and `from`/`to` MUST NOT appear unless `property` is "space-between".
+      Each of `from`/`to` MUST be one of: an edge position (`positions.json`), a generic
+      anatomy term (`anatomy-terms.json`), or — when `component` is present and declares
+      an `anatomy` array — the `name` of a declared anatomy part on that component.
+      Mirrors SPEC-020's component→anatomy resolution, unioned with the position and
+      generic-anatomy vocabularies.
     message: "Token '{token}' has space-between endpoint '{endpoint}' that is not a known position, anatomy term, or declared anatomy part on component '{component}'"
-    spec_ref: spec/token-format.md#space-between
+    spec_ref: spec/token-format.md#space-between-endpoints
     introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -527,3 +527,20 @@ rules:
     message: "Guideline '{name}' references '{ref}' which is not a known component or guideline"
     spec_ref: spec/guideline-format.md#related-references
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-047
+    name: space-between-endpoint-valid
+    severity: error
+    layer: 2
+    category: reference-integrity
+    assert: >
+      When a token name-object has `property` "space-between", each of its `from`/`to`
+      values MUST be one of: an edge position (`positions.json`), a generic anatomy term
+      (`anatomy-terms.json`), or — when `component` is present and declares an `anatomy`
+      array — the `name` of a declared anatomy part on that component. Mirrors SPEC-020's
+      component→anatomy resolution, unioned with the position and generic-anatomy
+      vocabularies. Severity is advisory (warning) when the component declares no anatomy
+      array, since the position/generic-anatomy union still applies.
+    message: "Token '{token}' has space-between endpoint '{endpoint}' that is not a known position, anatomy term, or declared anatomy part on component '{component}'"
+    spec_ref: spec/token-format.md#space-between
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -71,6 +71,14 @@
           "type": "string",
           "description": "Semantic: overall component shape (e.g. uniform)."
         },
+        "from": {
+          "type": "string",
+          "description": "Semantic: starting endpoint of a space-between measurement (e.g. top, edge, text). Paired with `to`; used with property `space-between`."
+        },
+        "to": {
+          "type": "string",
+          "description": "Semantic: ending endpoint of a space-between measurement (e.g. text, visual, control). Paired with `from`; used with property `space-between`."
+        },
         "colorScheme": {
           "type": "string",
           "description": "Mode set: color scheme mode (e.g. light, dark, wireframe)."

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -71,6 +71,25 @@ The table below lists all semantic fields. Fields marked with a scope are domain
 | `density`      | OPTIONAL | Density           | Space within or around component parts (e.g. `spacious`, `compact`).                                                                                                     |
 | `shape`        | OPTIONAL | Shape             | Relative to overall component shape (e.g. `uniform`).                                                                                                                    |
 | `scaleIndex`   | OPTIONAL | —                 | Numeric scale index appended at the end of the serialized name (e.g. `100`, `200`, `900`). Used by color palette, spacing, font-size, and motion duration tokens.        |
+| `from`         | OPTIONAL | —                 | Starting endpoint of a `space-between` measurement (e.g. `top`, `edge`, `text`). See [Space-between endpoints](#space-between-endpoints).                                |
+| `to`           | OPTIONAL | —                 | Ending endpoint of a `space-between` measurement (e.g. `text`, `visual`, `control`). See [Space-between endpoints](#space-between-endpoints).                            |
+
+#### Space-between endpoints
+
+A token whose `property` is **`space-between`** represents the spacing between two named endpoints (e.g. an edge and an anatomy part, or two anatomy parts) and **MUST** carry both the `from` and `to` fields; conversely, `from`/`to` **MUST NOT** appear unless `property` is `space-between` (rule `SPEC-047`).
+
+Each of `from`/`to` **MUST** be one of:
+
+* an edge position from `registry/positions.json` (e.g. `top`, `bottom`, `start`, `end`, `affixed`);
+* a generic anatomy term from `registry/anatomy-terms.json` (e.g. `text`, `icon`, `label`);
+* when `component` is present and declares an `anatomy` array, the `name` of a declared anatomy part on that component (e.g. `handle` on `accordion`).
+
+```json
+{ "name": { "component": "accordion", "property": "space-between", "from": "bottom", "to": "handle" },
+  "value": "8px" }
+```
+
+The `space-between` property term does not itself appear in the serialized legacy key; the key is reconstructed from the endpoints as `{component}-{from}-to-{to}` (e.g. `accordion-bottom-to-handle`).
 
 **Domain-scoped semantic fields** (only valid on the indicated token type):
 

--- a/packages/design-data/fields/from.json
+++ b/packages/design-data/fields/from.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "from",
+  "description": "Semantic: the starting endpoint of a space-between measurement (e.g. top, edge, text). Paired with `to`. Value MUST be an edge position, a generic anatomy term, or (when `component` is present) an anatomy part declared on that component — see SPEC-047.",
+  "kind": "semantic",
+  "registry": null,
+  "validation": "advisory",
+  "serialization": {
+    "position": 23
+  },
+  "scope": null,
+  "required": false,
+  "valueType": "string",
+  "excludeFromLegacyKey": true
+}

--- a/packages/design-data/fields/to.json
+++ b/packages/design-data/fields/to.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "to",
+  "description": "Semantic: the ending endpoint of a space-between measurement (e.g. text, visual, control). Paired with `from`. Value MUST be an edge position, a generic anatomy term, or (when `component` is present) an anatomy part declared on that component — see SPEC-047.",
+  "kind": "semantic",
+  "registry": null,
+  "validation": "advisory",
+  "serialization": {
+    "position": 24
+  },
+  "scope": null,
+  "required": false,
+  "valueType": "string",
+  "excludeFromLegacyKey": true
+}

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -227,6 +227,11 @@
       "id": "thickness",
       "label": "Thickness",
       "description": "Stroke or line thickness (design-system abstraction; not a standard CSS property)"
+    },
+    {
+      "id": "space-between",
+      "label": "Space Between",
+      "description": "Spacing between two named endpoints (e.g. an edge and an anatomy part, or two anatomy parts). The endpoints are carried by the paired `from`/`to` name-object fields, not by this term; the legacy key is reconstructed as {from}-to-{to} and omits this property term."
     }
   ]
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1652,6 +1652,11 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "thickness",
       "label": "Thickness",
       "description": "Stroke or line thickness (design-system abstraction; not a standard CSS property)"
+    },
+    {
+      "id": "space-between",
+      "label": "Space Between",
+      "description": "Spacing between two named endpoints (e.g. an edge and an anatomy part, or two anatomy parts). The endpoints are carried by the paired `from`/`to` name-object fields, not by this term; the legacy key is reconstructed as {from}-to-{to} and omits this property term."
     }
   ]
 }
@@ -2518,6 +2523,8 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "style", position: 20, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "motionRole", position: 21, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "easing", position: 22, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "from", position: 23, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "to", position: 24, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "alignment", position: 25, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "scaleIndex", position: 99, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
     ]

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -57,6 +57,7 @@ mod spec043;
 // `crate::validate::dataset_structure` and `validate::validate_dataset`.
 mod spec045;
 mod spec046;
+mod spec047;
 
 use std::collections::HashSet;
 
@@ -155,6 +156,7 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec043::Rule),
         Box::new(spec045::Rule),
         Box::new(spec046::Rule),
+        Box::new(spec047::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec047.rs
+++ b/sdk/core/src/validate/rules/spec047.rs
@@ -1,0 +1,211 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-047: space-between-endpoint-valid
+//!
+//! A token name-object with `property: "space-between"` MUST carry both `from`
+//! and `to` endpoint fields, and neither field may appear without it. Each
+//! endpoint value MUST be one of: an edge position (registry/positions.json),
+//! a generic anatomy term (registry/anatomy-terms.json), or — when `component`
+//! is present and declares an `anatomy` array — the `name` of a declared
+//! anatomy part on that component. Mirrors SPEC-020's component→anatomy
+//! resolution, unioned with the position and generic-anatomy vocabularies.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-047"
+    }
+
+    fn name(&self) -> &'static str {
+        "space-between-endpoint-valid"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        let position_vocab = ctx.registry.for_field("position");
+        let anatomy_vocab = ctx.registry.for_field("anatomy");
+
+        let comp_map: std::collections::HashMap<&str, &crate::graph::ComponentRecord> = ctx
+            .graph
+            .components
+            .iter()
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+
+        for t in ctx.graph.tokens.values() {
+            let Some(name_obj) = t.raw.get("name").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            let property = name_obj.get("property").and_then(|v| v.as_str());
+            let from = name_obj.get("from").and_then(|v| v.as_str());
+            let to = name_obj.get("to").and_then(|v| v.as_str());
+            let is_space_between = property == Some("space-between");
+
+            if !is_space_between {
+                if from.is_some() || to.is_some() {
+                    out.push(Diagnostic {
+                        file: t.file.clone(),
+                        token: Some(t.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!(
+                            "Token '{}' has a 'from'/'to' endpoint field but property is not 'space-between'",
+                            t.name
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
+                continue;
+            }
+
+            if from.is_none() || to.is_none() {
+                out.push(Diagnostic {
+                    file: t.file.clone(),
+                    token: Some(t.name.clone()),
+                    rule_id: Some(self.id().to_string()),
+                    severity: Severity::Error,
+                    message: format!(
+                        "Token '{}' has property 'space-between' but is missing 'from' and/or 'to'",
+                        t.name
+                    ),
+                    instance_path: None,
+                    schema_path: None,
+                });
+                continue;
+            }
+
+            let component = name_obj.get("component").and_then(|v| v.as_str());
+            let declared_parts: std::collections::HashSet<&str> = component
+                .and_then(|c| comp_map.get(c))
+                .and_then(|comp| comp.raw.get("anatomy"))
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|p| p.get("name").and_then(|n| n.as_str()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            for (field, endpoint) in [("from", from.unwrap()), ("to", to.unwrap())] {
+                let valid = position_vocab.is_some_and(|v| v.contains(endpoint))
+                    || anatomy_vocab.is_some_and(|v| v.contains(endpoint))
+                    || declared_parts.contains(endpoint);
+
+                if !valid {
+                    out.push(Diagnostic {
+                        file: t.file.clone(),
+                        token: Some(t.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!(
+                            "Token '{}' has space-between endpoint '{}' ('{endpoint}') that is not a known position, anatomy term, or declared anatomy part on component '{}'",
+                            t.name,
+                            field,
+                            component.unwrap_or("<none>")
+                        ),
+                        instance_path: Some(format!("/name/{field}")),
+                        schema_path: None,
+                    });
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::TokenGraph;
+    use crate::validate::relational::diagnostics_for_rule;
+
+    #[test]
+    fn edge_to_generic_anatomy_no_error() {
+        let g = TokenGraph::from_pairs(vec![(
+            "accordion-top-to-text".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "component": "accordion", "from": "top", "to": "text"}, "value": "8px"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
+    }
+
+    #[test]
+    fn component_declared_anatomy_endpoint_no_error() {
+        let mut g = TokenGraph::from_pairs(vec![(
+            "accordion-bottom-to-handle".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "component": "accordion", "from": "bottom", "to": "handle"}, "value": "8px"}),
+        )]);
+        g.components.push(crate::graph::ComponentRecord {
+            name: "accordion".into(),
+            file: PathBuf::from("accordion.json"),
+            raw: json!({"name": "accordion", "anatomy": [{"name": "handle"}]}),
+        });
+        assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
+    }
+
+    #[test]
+    fn unknown_endpoint_errors() {
+        let g = TokenGraph::from_pairs(vec![(
+            "widget-top-to-banana".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "from": "top", "to": "banana"}, "value": "8px"}),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-047");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, crate::report::Severity::Error);
+        assert!(diags[0].message.contains("banana"));
+    }
+
+    #[test]
+    fn missing_to_errors() {
+        let g = TokenGraph::from_pairs(vec![(
+            "widget-top".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "from": "top"}, "value": "8px"}),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-047");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("missing"));
+    }
+
+    #[test]
+    fn from_without_space_between_property_errors() {
+        let g = TokenGraph::from_pairs(vec![(
+            "widget-color".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "background-color", "from": "top"}, "value": "#fff"}),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-047");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("not 'space-between'"));
+    }
+
+    #[test]
+    fn unrelated_token_no_error() {
+        let g = TokenGraph::from_pairs(vec![(
+            "button-background-color".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "background-color", "component": "button"}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
+    }
+}


### PR DESCRIPTION
## Description

Resolves the `04c.1` design decision for the space-between (gap) decomposition epic (~781 `{a}-to-{b}` property values in `layout-component.tokens.json`, half the file).

Adopts paired endpoint fields over the two alternatives considered:
- **Chosen**: new `from`/`to` semantic fields, each constrained to a union domain (edge position, generic anatomy term, or a component's own declared anatomy part) — models both edge→anatomy and anatomy→anatomy gaps collision-free.
- Rejected reusing `position`+`anatomy`: only covers the edge→anatomy subset (~2/3) while still requiring the same new serializer work, for less coverage.
- Rejected atomic-peel-only: ships without Rust changes but defers modeling the endpoints at all.

The `naming.rs` branch that reconstructs the `{component}-{from}-to-{to}` legacy key is deferred to a follow-up (bead `04c.2`, now unblocked) — this PR only registers the data model.

## Related Issue

Beads: `spectrum-design-data-04c.1` (closed by this PR), unblocks `04c.2`/`04c.3`/`04c.4`. RFC #661 (taxonomy/glossary backbone).

## Motivation and Context

The `name` object had only one `anatomy` slot and one `position` slot, so anatomy→anatomy gap tokens (`text-to-visual`, `label-to-description`) collided under a single field with no way to distinguish the two endpoints. Endpoint decomposition requires this structural decision before any Rust or data migration can proceed.

## How Has This Been Tested?

- `moon run sdk:codegen` / `sdk:codegen-check` — registry_data.rs regenerated and verified in sync.
- `moon run sdk:test` — full Rust workspace suite green (621+ passed, 0 failed); confirms the new advisory fields don't affect existing serialization/validation.
- `moon run design-data-spec:check` — spec layout OK.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.