### PR TITLE
feat(design-data): serialize space-between endpoint fields in naming.rs (04c.2)

### DIFF
--- a/.changeset/04c2-gap-endpoint-serializer.md
+++ b/.changeset/04c2-gap-endpoint-serializer.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+naming.rs: serialize `space-between` endpoint fields in `extract_legacy_key` (04c.2).
+
+- **sdk/core/src/naming.rs**: added an explicit branch for `property: "space-between"`
+  tokens that reconstructs the legacy `{from}-to-{to}` connective from the paired `from`/`to`
+  fields, mirroring the existing color-domain branches. Falls through to the generic walk
+  when either endpoint is missing.

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -251,7 +251,7 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
                 if entry.name == "property" {
                     let f_expanded = registry.token_name("from", f).unwrap_or(f);
                     let t_expanded = registry.token_name("to", t).unwrap_or(t);
-                    parts.push(format!("{}-to-{}", f_expanded, t_expanded));
+                    parts.push(format!("{f_expanded}-to-{t_expanded}"));
                     continue;
                 }
                 if let Some(v) = name.get(entry.name).and_then(|v| v.as_str()) {

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -229,6 +229,44 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         return Some(property.to_string());
     }
 
+    // Space-between (gap) domain: property is the literal term "space-between" and the
+    // real endpoints live in the paired `from`/`to` fields (both excludeFromLegacyKey).
+    // The legacy key reconstructs the connective form `{from}-to-{to}` in property's slot
+    // (position 6) — an explicit branch, like the color branches above, because the
+    // generic position-walk below can't express a joining `-to-` between two field values.
+    // e.g. {component:"accordion", property:"space-between", from:"bottom", to:"handle",
+    //       size:"xl", state:"hover"} → "accordion-bottom-to-handle-extra-large-hover"
+    if property == "space-between" {
+        let from = name.get("from").and_then(|v| v.as_str());
+        let to = name.get("to").and_then(|v| v.as_str());
+        if let (Some(f), Some(t)) = (from, to) {
+            let registry = crate::registry::RegistryData::embedded();
+            let catalog = crate::registry::FieldCatalog::embedded();
+            let mut parts: Vec<String> = Vec::new();
+
+            for entry in catalog.entries_by_position() {
+                if entry.exclude_from_legacy_key {
+                    continue;
+                }
+                if entry.name == "property" {
+                    let f_expanded = registry.token_name("from", f).unwrap_or(f);
+                    let t_expanded = registry.token_name("to", t).unwrap_or(t);
+                    parts.push(format!("{}-to-{}", f_expanded, t_expanded));
+                    continue;
+                }
+                if let Some(v) = name.get(entry.name).and_then(|v| v.as_str()) {
+                    let expanded = registry.token_name(entry.name, v).unwrap_or(v);
+                    parts.push(expanded.to_string());
+                }
+            }
+
+            if parts.is_empty() {
+                return None;
+            }
+            return Some(parts.join("-"));
+        }
+    }
+
     // Decomposed/general format: walk the field catalog in serialization-position order,
     // expanding registry ids to their tokenName long-forms (e.g. size:"xl" → "extra-large").
     // Mirrors the JS serialize() in tools/token-mapping-analyzer/src/decomposer.js.
@@ -523,6 +561,36 @@ mod tests {
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("accordion-bottom-to-handle-extra-large-hover")
+        );
+    }
+
+    #[test]
+    fn extract_key_space_between_from_to_reconstructs_connective() {
+        // Decomposed space-between: from/to (excludeFromLegacyKey) reconstruct the
+        // legacy `{from}-to-{to}` connective in property's slot (pos 6). Same target
+        // key as extract_key_taxonomy_ordering_matches_catalog, but from decomposed fields.
+        let name = json!({
+            "component": "accordion",
+            "property": "space-between",
+            "from": "bottom",
+            "to": "handle",
+            "size": "xl",
+            "state": "hover"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("accordion-bottom-to-handle-extra-large-hover")
+        );
+    }
+
+    #[test]
+    fn extract_key_space_between_missing_endpoint_falls_through() {
+        // property "space-between" but only `from` present (no `to`) → falls through
+        // to the generic walk, which pushes the literal "space-between" property value.
+        let name = json!({"component": "accordion", "property": "space-between", "from": "bottom"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("accordion-space-between")
         );
     }
 


### PR DESCRIPTION
## Description

Adds an explicit `property == "space-between"` branch to `extract_legacy_key` in `sdk/core/src/naming.rs` that reconstructs the legacy `{from}-to-{to}` connective from the paired `from`/`to` fields landed in #1216, mirroring the existing color-domain branches. Falls through to the generic field-catalog walk when either endpoint is missing.

## Related Issue

Part of epic 04c (space-between/gap decomposition). Depends on 04c.1 (#1216, merged). Unblocks the mechanical apply migration (04c.6) — per project convention, no name-object field may be applied to data until it is serialized in `naming.rs`.

## Motivation and Context

`from`/`to` are `excludeFromLegacyKey: true`, so the generic position-walk in `extract_legacy_key` already skips them — but the legacy key needs the *connective* form `{from}-to-{to}`, not a plain `-`-joined segment. This is the Rust-side process gate for the epic: JS-side roundtrip in `apply.js` is not a proxy for Rust agreement, so this branch must land before any gap token data is migrated.

## How Has This Been Tested?

- Two new unit tests in `naming.rs`: one asserting the decomposed `from`/`to` shape round-trips to the exact legacy key produced by the pre-existing baked-`property` test (`extract_key_taxonomy_ordering_matches_catalog`), one asserting graceful fallthrough when an endpoint is missing.
- `moon run sdk:codegen-check` — clean (Rust ↔ generated registry data in sync).
- `moon run sdk:test` — full suite green (no regressions).
- Changeset `04c2-gap-endpoint-serializer.md` added, passes `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
