### PR TITLE
feat(design-data): register gap-endpoint vocabulary for space-between decomposition (04c.3)

### DIFF
--- a/.changeset/04c3-gap-endpoint-registry.md
+++ b/.changeset/04c3-gap-endpoint-registry.md
@@ -1,0 +1,20 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Register gap-endpoint vocabulary for space-between decomposition (closes 04c.3).
+
+- **packages/design-data/registry/positions.json**: Add edge-family positions
+  `edge`, `start-edge`, `end-edge`, `bottom-edge`.
+- **packages/design-data/registry/anatomy-terms.json**: Add generic anatomy
+  terms `content`, `visual`, `action`, `navigation`, `disclosure`,
+  `content-area`, `disclosure-indicator`, `disclosure-icon`, `drag-handle`,
+  `field-button`.
+- **packages/design-data/components/*.json**: Add component-scoped `anatomy[]`
+  parts for 14 components (action-bar, tree-view, tag, alert-banner,
+  number-field, slider, steplist, side-navigation, breadcrumbs, field-label,
+  menu, status-light, table, coach-mark).
+- **sdk/core/src/validate/rules/spec047.rs**: Retry unresolved endpoints by
+  stripping a registered position affix and validating the remainder as
+  anatomy, covering fused endpoints like `content-area-bottom`/`item-top`.
+- **sdk/core/src/registry_data.rs**: Regenerated via `sdk:codegen`.

--- a/docs/proposals/012-space-between-decompose.md
+++ b/docs/proposals/012-space-between-decompose.md
@@ -1,6 +1,9 @@
 # Proposal 012: Space-Between (Gap) Endpoint Decomposition — Triage
 
-**Status:** Triage complete (04c.4); registry/qualifier work follows in 04c.3/04c.5\
+**Status:** Triage complete (04c.4); 04c.5 closed as a no-op (no qualifiers found in gap
+tokens); 04c.3 registry/component-anatomy additions landed, including a SPEC-047 enhancement
+to resolve compound anatomy+position endpoints (bucket 3) by splitting on a registered
+position affix. 04c.6 (apply migration) remains.\
 **Affects:** 432 distinct `(component, property)` tuples / 725 `-to-` token occurrences across `packages/design-data/tokens/layout-component.tokens.json`\
 **Spec reference:** SPEC-047 (`space-between-endpoint-valid`), `fields/from.json`, `fields/to.json`
 
@@ -148,12 +151,39 @@ Every `UNKNOWN` above falls into one of four buckets — none silently resolved 
 
 3. **Compound anatomy+position endpoints** — a single term fuses an anatomy part with a position/row-scope and won't validate as one `from`/`to` value under SPEC-047's flat union: `card-edge`, `content-area-bottom/edge/top`, `column-header-row-bottom/top`, `row-bottom/top`, `row-checkbox`, `header-row-checkbox`, `menu-item-edge/top`, `item-top`, `item-label`, `top-text`/`bottom-text` (breadcrumbs), `pagination-text`. These need an explicit decision in 04c.3/04c.6: split into `{component-context}` + a plain position/anatomy pair, or accept as an atomic declared anatomy part on the owning component. Recommend the latter (smallest change) unless a term needs to compose with unrelated positions elsewhere.
 
-4. **Data-quality fix** — `end-edge-to-disclousure-icon` (picker) is a typo duplicate of the correctly-spelled `end-edge-to-disclosure-icon`; normalize to `disclosure-icon` during 04c.6's apply pass rather than registering the misspelling.
+4. **Data-quality fix** — `end-edge-to-disclousure-icon` (picker) is a typo duplicate of the correctly-spelled `end-edge-to-disclosure-icon`; normalize to `disclosure-icon` during 04c.6's apply pass rather than registering the misspelling. `card-edge-to-content` (card) is a second case in the same family: `card` already uses bare `edge` elsewhere (`edge-to-content`), so `card-edge` is a redundant self-referential prefix rather than new vocabulary — normalize to `edge` during 04c.6 instead of registering `card-edge`.
 
 No terms were flagged as padding-vs-gap semantic mismatches on inspection — the `edge-to-content`-shaped tokens are consistently used as true endpoint gaps (component edge → inner content), so `space-between` applies uniformly; no `property` exceptions to carve out.
 
+## 04c.3 resolution (registry additions)
+
+Bucket 1 landed in full as proposed. Bucket 2 shrank considerably: five terms used across
+multiple components — `content-area`, `disclosure-indicator`, `disclosure-icon`, `drag-handle`,
+`field-button` — were promoted to generic `anatomy-terms.json` rather than duplicated per
+component (this also sidesteps `stack-item` and `in-field-button`, which are referenced as
+`component` values in gap tokens but have no component definition file to hold a component-
+scoped `anatomy[]`). The remaining component-specific parts landed on their owning components:
+`action-group-area`/`item-counter` (action-bar), `action-area` (tree-view), `clear-icon`/
+`cross-icon` (tag), `alert-icon` (alert-banner), `in-field-stepper` (number-field), `text-field`
+(slider), `track-size` (steplist), `trailing-accessory-area` (side-navigation), `separator-icon`
+(breadcrumbs), `asterisk` (field-label), `item-label`/`menu-item` (menu), `visual-75/100/200/300`
+(status-light, registered as four distinct ids rather than a `variant`-qualified part — smallest
+change, no schema impact), `column-header-row`/`row`/`row-checkbox`/`header-row-checkbox`
+(table), `pagination-text` (coach-mark).
+
+Bucket 3 resolved via **split**, not atomic registration: SPEC-047 now retries an unresolved
+endpoint by stripping a registered position as a hyphen-bounded prefix or suffix and validating
+the remainder against the anatomy union (see `endpoint_resolves` in `spec047.rs`). This means
+`item-top` and `top-text`/`bottom-text` resolve with **no new registry entries at all** — `item`
+and `text` were already generic anatomy, `top`/`bottom` already positions. `content-area-bottom/
+edge/top`, `column-header-row-bottom/top`, and `row-bottom/top` resolve the same way once their
+base parts (`content-area`, `column-header-row`, `row`) are registered above. `row-checkbox` and
+`header-row-checkbox` don't fuse with a position (`checkbox` isn't one), so they're registered as
+atomic parts on `table` instead, per the doc's original recommendation for that sub-case.
+
 ## Next steps
 
-* **04c.3** — add the generic vocabulary (bucket 1) to `positions.json`/`anatomy-terms.json`; add component-specific parts (bucket 2) to each owning component's `anatomy[]`; decide the compound-endpoint pattern (bucket 3) and apply it consistently.
-* **04c.5** — qualifier handling (size/density/state suffixes) is already stripped cleanly by this pass; no new qualifier types surfaced beyond the ones already scoped in that bead.
-* **04c.6** — apply migration, including the `disclousure` → `disclosure` typo fix.
+* ~~**04c.3**~~ — done; see resolution above.
+* ~~**04c.5**~~ — closed as a no-op; no qualifiers found in the gap tokens.
+* **04c.6** — apply migration, including the `disclousure` → `disclosure` and `card-edge` → `edge`
+  data fixes.

--- a/packages/design-data/components/action-bar.json
+++ b/packages/design-data/components/action-bar.json
@@ -54,6 +54,16 @@
     }
   ],
   "options": { "isEmphasized": { "type": "boolean", "default": false } },
+  "anatomy": [
+    {
+      "name": "action-group-area",
+      "description": "Group of secondary action controls."
+    },
+    {
+      "name": "item-counter",
+      "description": "Badge showing a count of items or actions."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "action-bar-height", "context": "Height" },

--- a/packages/design-data/components/alert-banner.json
+++ b/packages/design-data/components/alert-banner.json
@@ -113,6 +113,12 @@
     },
     "isDismissible": { "type": "boolean", "default": false }
   },
+  "anatomy": [
+    {
+      "name": "alert-icon",
+      "description": "Icon indicating the alert's severity."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "workflow-icon-size-100", "context": "Icon asset" },

--- a/packages/design-data/components/breadcrumbs.json
+++ b/packages/design-data/components/breadcrumbs.json
@@ -141,6 +141,12 @@
       ]
     }
   },
+  "anatomy": [
+    {
+      "name": "separator-icon",
+      "description": "Icon separating breadcrumb items."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/coach-mark.json
+++ b/packages/design-data/components/coach-mark.json
@@ -111,6 +111,12 @@
       }
     }
   },
+  "anatomy": [
+    {
+      "name": "pagination-text",
+      "description": "Text indicating step position (e.g. '2 of 5')."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "coach-mark-width", "context": "Width" },

--- a/packages/design-data/components/field-label.json
+++ b/packages/design-data/components/field-label.json
@@ -80,6 +80,12 @@
     "isRequired": { "type": "boolean", "default": false },
     "isDisabled": { "type": "boolean", "default": false }
   },
+  "anatomy": [
+    {
+      "name": "asterisk",
+      "description": "Required-field indicator."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "component-height-75", "context": "Minimum height" },

--- a/packages/design-data/components/menu.json
+++ b/packages/design-data/components/menu.json
@@ -162,6 +162,16 @@
     "isUnavailable": { "type": "boolean", "default": false },
     "isDisabled": { "type": "boolean", "default": false }
   },
+  "anatomy": [
+    {
+      "name": "item-label",
+      "description": "Label text of a menu item."
+    },
+    {
+      "name": "menu-item",
+      "description": "A single row within the menu."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/number-field.json
+++ b/packages/design-data/components/number-field.json
@@ -179,6 +179,12 @@
       "description": "If true, hides in-field increment and decrement buttons (stepper)."
     }
   },
+  "anatomy": [
+    {
+      "name": "in-field-stepper",
+      "description": "Increment/decrement stepper embedded in the field."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "focus-+-hover", "trigger": "prop" },

--- a/packages/design-data/components/side-navigation.json
+++ b/packages/design-data/components/side-navigation.json
@@ -133,6 +133,12 @@
       ]
     }
   },
+  "anatomy": [
+    {
+      "name": "trailing-accessory-area",
+      "description": "Trailing area for accessory content such as counts or actions."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/slider.json
+++ b/packages/design-data/components/slider.json
@@ -135,6 +135,12 @@
     "isEditable": { "type": "boolean", "default": false },
     "isDisabled": { "type": "boolean", "default": false }
   },
+  "anatomy": [
+    {
+      "name": "text-field",
+      "description": "Editable numeric value field."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/status-light.json
+++ b/packages/design-data/components/status-light.json
@@ -89,6 +89,24 @@
       ]
     }
   },
+  "anatomy": [
+    {
+      "name": "visual-75",
+      "description": "Severity dot, 75 size variant."
+    },
+    {
+      "name": "visual-100",
+      "description": "Severity dot, 100 size variant."
+    },
+    {
+      "name": "visual-200",
+      "description": "Severity dot, 200 size variant."
+    },
+    {
+      "name": "visual-300",
+      "description": "Severity dot, 300 size variant."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "component-height-75", "context": "Height" },

--- a/packages/design-data/components/steplist.json
+++ b/packages/design-data/components/steplist.json
@@ -88,6 +88,12 @@
       "description": "The identifier or label of the currently active step."
     }
   },
+  "anatomy": [
+    {
+      "name": "track-size",
+      "description": "The connecting track between steps."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     {

--- a/packages/design-data/components/table.json
+++ b/packages/design-data/components/table.json
@@ -193,6 +193,24 @@
       }
     }
   },
+  "anatomy": [
+    {
+      "name": "column-header-row",
+      "description": "The header row containing column titles."
+    },
+    {
+      "name": "row",
+      "description": "A single data row."
+    },
+    {
+      "name": "row-checkbox",
+      "description": "Selection checkbox within a row."
+    },
+    {
+      "name": "header-row-checkbox",
+      "description": "Select-all checkbox within the column header row."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "chevron-100", "context": "Header icons" },

--- a/packages/design-data/components/tag.json
+++ b/packages/design-data/components/tag.json
@@ -59,6 +59,16 @@
     "isDisabled": { "type": "boolean", "default": false },
     "isReadOnly": { "type": "boolean", "default": false }
   },
+  "anatomy": [
+    {
+      "name": "clear-icon",
+      "description": "Icon affordance that removes the tag."
+    },
+    {
+      "name": "cross-icon",
+      "description": "Cross/X icon shown on the tag."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/tree-view.json
+++ b/packages/design-data/components/tree-view.json
@@ -165,6 +165,12 @@
       "values": [{ "value": "toggle" }, { "value": "replace" }]
     }
   },
+  "anatomy": [
+    {
+      "name": "action-area",
+      "description": "Trailing area containing item actions."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -740,6 +740,66 @@
       "label": "Progress Bar",
       "description": "Visual progress fill track indicating completion level",
       "usedIn": ["tokens", "component-schemas"]
+    },
+    {
+      "id": "content",
+      "label": "Content",
+      "description": "The main content area of a component",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "visual",
+      "label": "Visual",
+      "description": "A leading visual element such as an icon or thumbnail",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "action",
+      "label": "Action",
+      "description": "An interactive action affordance",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "navigation",
+      "label": "Navigation",
+      "description": "A navigation control or affordance",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "disclosure",
+      "label": "Disclosure",
+      "description": "An expand/collapse affordance",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "content-area",
+      "label": "Content area",
+      "description": "The container region that wraps a component's main content",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "disclosure-indicator",
+      "label": "Disclosure indicator",
+      "description": "A visual affordance showing expand/collapse state",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "disclosure-icon",
+      "label": "Disclosure icon",
+      "description": "An icon affordance showing expand/collapse state",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "drag-handle",
+      "label": "Drag handle",
+      "description": "A grip affordance for reordering an item via drag",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "field-button",
+      "label": "Field button",
+      "description": "A trigger button embedded within a text field or picker",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/registry/positions.json
+++ b/packages/design-data/registry/positions.json
@@ -27,6 +27,26 @@
       "id": "end",
       "label": "End",
       "description": "End position (right in LTR, left in RTL)"
+    },
+    {
+      "id": "edge",
+      "label": "Edge",
+      "description": "Outer boundary of an element"
+    },
+    {
+      "id": "start-edge",
+      "label": "Start edge",
+      "description": "Outer boundary at the start (left in LTR, right in RTL)"
+    },
+    {
+      "id": "end-edge",
+      "label": "End edge",
+      "description": "Outer boundary at the end (right in LTR, left in RTL)"
+    },
+    {
+      "id": "bottom-edge",
+      "label": "Bottom edge",
+      "description": "Outer boundary at the bottom"
     }
   ]
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1386,6 +1386,66 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "label": "Progress Bar",
       "description": "Visual progress fill track indicating completion level",
       "usedIn": ["tokens", "component-schemas"]
+    },
+    {
+      "id": "content",
+      "label": "Content",
+      "description": "The main content area of a component",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "visual",
+      "label": "Visual",
+      "description": "A leading visual element such as an icon or thumbnail",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "action",
+      "label": "Action",
+      "description": "An interactive action affordance",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "navigation",
+      "label": "Navigation",
+      "description": "A navigation control or affordance",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "disclosure",
+      "label": "Disclosure",
+      "description": "An expand/collapse affordance",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "content-area",
+      "label": "Content area",
+      "description": "The container region that wraps a component's main content",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "disclosure-indicator",
+      "label": "Disclosure indicator",
+      "description": "A visual affordance showing expand/collapse state",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "disclosure-icon",
+      "label": "Disclosure icon",
+      "description": "An icon affordance showing expand/collapse state",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "drag-handle",
+      "label": "Drag handle",
+      "description": "A grip affordance for reordering an item via drag",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "field-button",
+      "label": "Field button",
+      "description": "A trigger button embedded within a text field or picker",
+      "usedIn": ["tokens"]
     }
   ]
 }
@@ -1708,6 +1768,26 @@ const POSITIONS_JSON: &str = r##"{
       "id": "end",
       "label": "End",
       "description": "End position (right in LTR, left in RTL)"
+    },
+    {
+      "id": "edge",
+      "label": "Edge",
+      "description": "Outer boundary of an element"
+    },
+    {
+      "id": "start-edge",
+      "label": "Start edge",
+      "description": "Outer boundary at the start (left in LTR, right in RTL)"
+    },
+    {
+      "id": "end-edge",
+      "label": "End edge",
+      "description": "Outer boundary at the end (right in LTR, left in RTL)"
+    },
+    {
+      "id": "bottom-edge",
+      "label": "Bottom edge",
+      "description": "Outer boundary at the bottom"
     }
   ]
 }

--- a/sdk/core/src/validate/rules/spec047.rs
+++ b/sdk/core/src/validate/rules/spec047.rs
@@ -17,9 +17,51 @@
 //! is present and declares an `anatomy` array — the `name` of a declared
 //! anatomy part on that component. Mirrors SPEC-020's component→anatomy
 //! resolution, unioned with the position and generic-anatomy vocabularies.
+//!
+//! A compound endpoint (e.g. `content-area-bottom`, `top-text`) that doesn't
+//! match the flat union directly is retried once by stripping a registered
+//! position as a hyphen-bounded prefix or suffix and validating the remainder
+//! against the anatomy union. This covers gap endpoints that fuse an anatomy
+//! part with a row/edge scope without requiring a third name-object field —
+//! `from`/`to` still store the full compound string for legacy-key round-trip.
+
+use std::collections::HashSet;
 
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
+
+/// True if `endpoint` matches a position, a generic anatomy term, a declared
+/// anatomy part, or — failing that — is a registered position glued to one of
+/// those via a single hyphen-bounded prefix/suffix strip.
+fn endpoint_resolves(
+    endpoint: &str,
+    position_vocab: Option<&HashSet<String>>,
+    anatomy_vocab: Option<&HashSet<String>>,
+    declared_parts: &HashSet<&str>,
+) -> bool {
+    let is_anatomy =
+        |s: &str| anatomy_vocab.is_some_and(|v| v.contains(s)) || declared_parts.contains(s);
+    let is_position = |s: &str| position_vocab.is_some_and(|v| v.contains(s));
+
+    if is_position(endpoint) || is_anatomy(endpoint) {
+        return true;
+    }
+
+    let positions = match position_vocab {
+        Some(v) => v,
+        None => return false,
+    };
+    positions.iter().any(|pos| {
+        endpoint
+            .strip_prefix(pos.as_str())
+            .and_then(|rest| rest.strip_prefix('-'))
+            .is_some_and(is_anatomy)
+            || endpoint
+                .strip_suffix(pos.as_str())
+                .and_then(|rest| rest.strip_suffix('-'))
+                .is_some_and(is_anatomy)
+    })
+}
 
 pub struct Rule;
 
@@ -101,9 +143,8 @@ impl ValidationRule for Rule {
                 .unwrap_or_default();
 
             for (field, endpoint) in [("from", from.unwrap()), ("to", to.unwrap())] {
-                let valid = position_vocab.is_some_and(|v| v.contains(endpoint))
-                    || anatomy_vocab.is_some_and(|v| v.contains(endpoint))
-                    || declared_parts.contains(endpoint);
+                let valid =
+                    endpoint_resolves(endpoint, position_vocab, anatomy_vocab, &declared_parts);
 
                 if !valid {
                     out.push(Diagnostic {
@@ -159,6 +200,100 @@ mod tests {
             file: PathBuf::from("accordion.json"),
             raw: json!({"name": "accordion", "anatomy": [{"name": "handle"}]}),
         });
+        assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
+    }
+
+    #[test]
+    fn triage_04c3_registry_additions_resolve() {
+        // Regression check for the 04c.3 registry work (docs/proposals/012-
+        // space-between-decompose.md): a representative endpoint from each
+        // escalation bucket, using the real component-declared anatomy[]
+        // shape, must resolve with zero SPEC-047 diagnostics once the
+        // matching from/to fields are populated (04c.6). Catches accidental
+        // reverts of the anatomy-terms.json / positions.json additions or
+        // the position-affix split logic.
+        // (from, to, component, declared-anatomy-owner-and-parts)
+        type Case<'a> = (&'a str, &'a str, &'a str, Option<(&'a str, &'a [&'a str])>);
+        let cases: &[Case] = &[
+            // Bucket 1: generic anatomy/position vocabulary.
+            ("action", "navigation", "stack-item", None),
+            ("edge", "content", "card", None),
+            ("counter", "disclosure", "side-navigation", None),
+            // Bucket 2: component-declared multi-word parts.
+            (
+                "label",
+                "action-group-area",
+                "action-bar",
+                Some(("action-bar", &["action-group-area"])),
+            ),
+            (
+                "edge",
+                "clear-icon",
+                "tag",
+                Some(("tag", &["clear-icon", "cross-icon"])),
+            ),
+            // Bucket 3: compound anatomy+position, resolved via split.
+            ("content-area-bottom", "content", "accordion", None),
+            (
+                "column-header-row-bottom",
+                "text",
+                "table",
+                Some(("table", &["column-header-row", "row"])),
+            ),
+            ("item-top", "disclosure-icon", "menu", None),
+            ("top-text", "bottom-text", "breadcrumbs", None),
+        ];
+
+        for (from, to, component, declared) in cases {
+            let mut g = TokenGraph::from_pairs(vec![(
+                format!("{component}-{from}-to-{to}"),
+                PathBuf::from("a.tokens.json"),
+                json!({"name": {"property": "space-between", "component": component, "from": from, "to": to}, "value": "8px"}),
+            )]);
+            if let Some((owner, parts)) = declared {
+                g.components.push(crate::graph::ComponentRecord {
+                    name: (*owner).into(),
+                    file: PathBuf::from(format!("{owner}.json")),
+                    raw: json!({"name": owner, "anatomy": parts.iter().map(|p| json!({"name": p})).collect::<Vec<_>>()}),
+                });
+            }
+            let diags = diagnostics_for_rule(&g, "SPEC-047");
+            assert!(
+                diags.is_empty(),
+                "expected '{from}'-to-'{to}' on {component} to resolve, got: {diags:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn compound_position_suffix_resolves_via_declared_anatomy() {
+        // "content-area-bottom" isn't itself registered, but strips the
+        // registered position suffix "bottom" down to the declared anatomy
+        // part "content-area" — mirrors real tokens like
+        // `content-area-bottom-to-content` (accordion).
+        let mut g = TokenGraph::from_pairs(vec![(
+            "accordion-content-area-bottom-to-text".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "component": "accordion", "from": "content-area-bottom", "to": "text"}, "value": "8px"}),
+        )]);
+        g.components.push(crate::graph::ComponentRecord {
+            name: "accordion".into(),
+            file: PathBuf::from("accordion.json"),
+            raw: json!({"name": "accordion", "anatomy": [{"name": "content-area"}]}),
+        });
+        assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
+    }
+
+    #[test]
+    fn compound_position_prefix_resolves_via_generic_anatomy() {
+        // "top-text" strips the registered position prefix "top" down to the
+        // generic anatomy term "text" — mirrors real tokens like
+        // `top-text-to-bottom-text` (breadcrumbs).
+        let g = TokenGraph::from_pairs(vec![(
+            "breadcrumbs-top-text-to-text".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "from": "top-text", "to": "text"}, "value": "8px"}),
+        )]);
         assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Registers the remaining position/anatomy vocabulary needed for the `{a}-to-{b}` gap-endpoint decomposition and adds a position-affix-split resolution path to SPEC-047 validation.

- **packages/design-data/registry/positions.json**: Add edge-family positions `edge`, `start-edge`, `end-edge`, `bottom-edge`.
- **packages/design-data/registry/anatomy-terms.json**: Add generic anatomy terms `content`, `visual`, `action`, `navigation`, `disclosure`, `content-area`, `disclosure-indicator`, `disclosure-icon`, `drag-handle`, `field-button` (the last 5 promoted from component-scope since they're reused across ≥2 components, including `stack-item`/`in-field-button`, which have no component definition file).
- **packages/design-data/components/\*.json** (14 files): Add component-scoped `anatomy[]` parts for action-bar, tree-view, tag, alert-banner, number-field, slider, steplist, side-navigation, breadcrumbs, field-label, menu, status-light, table, coach-mark.
- **sdk/core/src/validate/rules/spec047.rs**: Retry unresolved endpoints by stripping a registered position affix and validating the remainder as anatomy, covering fused endpoints like `content-area-bottom`/`item-top` without requiring new atomic registry entries.
- **sdk/core/src/registry_data.rs**: Regenerated via `sdk:codegen`.
- **docs/proposals/012-space-between-decompose.md**: Updated with the 04c.3 resolution details and a data-quality note for `card-edge-to-content` (deferred to 04c.6).

## Related Issue

Closes 04c.3 (registry + component-anatomy vocabulary) of the epic 04c space-between decomposition. Also closes 04c.5 (gap qualifiers) as a verified no-op — no qualifier terms occur in the current token data.

04c.6 (the apply migration that writes `space-between` tokens using these fields) is explicitly deferred to a future PR.

## Motivation and Context

Epic 04c decomposes compound `{a}-to-{b}` `property` values in `layout-component.tokens.json` into structured `from`/`to` name-object fields. The 04c.4 triage doc classified ~135 gap base terms and flagged several escalation buckets of unresolved endpoints (missing generic vocabulary, component-specific multi-word parts, and fused anatomy+position compounds). This PR resolves all three buckets.

## How Has This Been Tested?

- `cargo fmt --check -p design-data-core`
- `cargo clippy -p design-data-core --all-targets` — no new warnings
- `moon run sdk:test` — full Rust workspace test suite, all pass (including 3 new unit tests covering the split-resolution logic and a regression test over representative endpoints from all 3 triage buckets)
- `moon run design-data:validate` — schema/registry validation passes
- `moon run sdk:codegen-check` — generated code in sync with registry JSON
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset valid

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
