### PR TITLE
feat(design-data): teach token decomposer to emit space-between endpoints (04c.7)

### DIFF
--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -111,11 +111,77 @@ export function applyField(tokens, field, registry, filename) {
   return { applied, skippedSpec025 };
 }
 
+/**
+ * Apply the space-between (gap) decomposition: unlike a single taxonomy field,
+ * `from`/`to`/`property` change together (property becomes the literal
+ * "space-between", from/to carry the two endpoints) and must be written as one
+ * unit for the legacy key to still roundtrip. `from`/`to` have no single
+ * registry (endpoints resolve against positions ∪ anatomy ∪ component-declared
+ * anatomy — see decomposer.js `endpointResolves`), so they can't go through the
+ * single-registry `applyField` path above.
+ */
+export function applySpaceBetween(tokens, registry, filename) {
+  let applied = 0;
+
+  for (const token of tokens) {
+    if (!token.name || typeof token.name !== "object") continue;
+    if (token.name.from !== undefined) continue; // already migrated
+    if (
+      typeof token.name.property !== "string" ||
+      !token.name.property.includes("-to-")
+    )
+      continue;
+
+    const legacyKey = serialize(
+      token.name,
+      registry.tokenNameMap,
+      registry.serializationOrder,
+    );
+    if (!legacyKey) continue;
+
+    const result = decompose(
+      legacyKey,
+      { deprecated: !!token.deprecated, component: token.name?.component },
+      registry,
+      filename,
+    );
+
+    if (
+      result.confidence !== "HIGH" ||
+      !result.roundtrips ||
+      result.nameObject.property !== "space-between" ||
+      result.nameObject.from === undefined ||
+      result.nameObject.to === undefined
+    )
+      continue;
+
+    const patched = {
+      ...token.name,
+      from: result.nameObject.from,
+      to: result.nameObject.to,
+      property: result.nameObject.property,
+    };
+    if (
+      serialize(patched, registry.tokenNameMap, registry.serializationOrder) !==
+      legacyKey
+    )
+      continue;
+
+    token.name.from = result.nameObject.from;
+    token.name.to = result.nameObject.to;
+    token.name.property = result.nameObject.property;
+    applied++;
+  }
+
+  return { applied, skippedSpec025: 0 };
+}
+
 async function main() {
   const { field, write } = parseArgs();
   const registry = loadRegistries();
+  const isSpaceBetween = field === "space-between";
 
-  if (!registry.byField[field]) {
+  if (!isSpaceBetween && !registry.byField[field]) {
     console.error(
       `Unknown field: "${field}". Known fields: ${Object.keys(registry.byField).join(", ")}`,
     );
@@ -131,19 +197,20 @@ async function main() {
     const filePath = resolve(CASCADE_DIR, filename);
     const tokens = JSON.parse(readFileSync(filePath, "utf-8"));
 
-    // Count pre-existing field values
+    // Count pre-existing field values. space-between is a virtual field name
+    // (property literal "space-between" + paired from/to); use "from" as the
+    // already-migrated marker since space-between itself is never a key on name.
+    const presenceField = isSpaceBetween ? "from" : field;
     const hadField = tokens.filter(
-      (t) => typeof t.name === "object" && t.name?.[field] !== undefined,
+      (t) =>
+        typeof t.name === "object" && t.name?.[presenceField] !== undefined,
     ).length;
     totalTokens += tokens.filter((t) => typeof t.name === "object").length;
     alreadyHas += hadField;
 
-    const { applied, skippedSpec025 } = applyField(
-      tokens,
-      field,
-      registry,
-      filename,
-    );
+    const { applied, skippedSpec025 } = isSpaceBetween
+      ? applySpaceBetween(tokens, registry, filename)
+      : applyField(tokens, field, registry, filename);
     totalApplied += applied;
     totalSkippedSpec025 += skippedSpec025;
 

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -214,56 +214,73 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     }
 
     if (connectorIdx > componentEndIdx) {
-      const fromSegs = segments.slice(componentEndIdx, connectorIdx);
-      const fromClean = fromSegs.every((_, k) => !matched[componentEndIdx + k]);
+      const beforeConnector = segments.slice(componentEndIdx, connectorIdx);
 
-      if (fromClean) {
-        const positionVocab = registry.byField.position;
-        const anatomyVocab = registry.byField.anatomy;
-        const declaredParts =
-          registry.componentAnatomy?.get(nameObject.component) || new Set();
+      const positionVocab = registry.byField.position;
+      const anatomyVocab = registry.byField.anatomy;
+      const declaredParts =
+        registry.componentAnatomy?.get(nameObject.component) || new Set();
 
-        const fromCandidate = fromSegs.join("-");
+      // Shrink the "from" window from the left: a leading variant/structure/
+      // etc. segment may precede the gap connective (see naming.rs's
+      // `{variant?}-{component?}-{structure?}-...-{property}` shape), so try
+      // the longest unmatched *suffix* of beforeConnector first.
+      let fromStart = -1;
+      let fromCandidate = null;
+      for (let k = beforeConnector.length; k >= 1; k--) {
+        const startOffset = beforeConnector.length - k;
+        const absoluteStart = componentEndIdx + startOffset;
+        const clean = beforeConnector
+          .slice(startOffset)
+          .every((_, j) => !matched[absoluteStart + j]);
+        if (!clean) continue;
+        const candidate = beforeConnector.slice(startOffset).join("-");
         if (
           endpointResolves(
-            fromCandidate,
+            candidate,
             positionVocab,
             anatomyVocab,
             declaredParts,
           )
         ) {
-          const rest = segments.slice(connectorIdx + 1);
-          let toSegs = null;
-          for (let k = rest.length; k >= 1; k--) {
-            if (matched[connectorIdx + 1 + k - 1]) continue;
-            const candidate = rest.slice(0, k).join("-");
-            if (
-              endpointResolves(
-                candidate,
-                positionVocab,
-                anatomyVocab,
-                declaredParts,
-              )
-            ) {
-              toSegs = rest.slice(0, k);
-              break;
-            }
-          }
+          fromStart = absoluteStart;
+          fromCandidate = candidate;
+          break;
+        }
+      }
 
-          if (toSegs) {
-            nameObject.property = "space-between";
-            nameObject.from = fromCandidate;
-            nameObject.to = toSegs.join("-");
-            for (let i = componentEndIdx; i < connectorIdx; i++) {
-              matched[i] = true;
-              matchDetails[i] = "from";
-            }
-            matched[connectorIdx] = true;
-            matchDetails[connectorIdx] = "spacing-between-connector";
-            for (let i = 0; i < toSegs.length; i++) {
-              matched[connectorIdx + 1 + i] = true;
-              matchDetails[connectorIdx + 1 + i] = "to";
-            }
+      if (fromCandidate) {
+        const rest = segments.slice(connectorIdx + 1);
+        let toSegs = null;
+        for (let k = rest.length; k >= 1; k--) {
+          if (matched[connectorIdx + 1 + k - 1]) continue;
+          const candidate = rest.slice(0, k).join("-");
+          if (
+            endpointResolves(
+              candidate,
+              positionVocab,
+              anatomyVocab,
+              declaredParts,
+            )
+          ) {
+            toSegs = rest.slice(0, k);
+            break;
+          }
+        }
+
+        if (toSegs) {
+          nameObject.property = "space-between";
+          nameObject.from = fromCandidate;
+          nameObject.to = toSegs.join("-");
+          for (let i = fromStart; i < connectorIdx; i++) {
+            matched[i] = true;
+            matchDetails[i] = "from";
+          }
+          matched[connectorIdx] = true;
+          matchDetails[connectorIdx] = "spacing-between-connector";
+          for (let i = 0; i < toSegs.length; i++) {
+            matched[connectorIdx + 1 + i] = true;
+            matchDetails[connectorIdx + 1 + i] = "to";
           }
         }
       }

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -93,6 +93,51 @@ const EXTRA_TERMS = [
 const NUMERIC_SCALE_PATTERN = /^\d+$/;
 
 /**
+ * True if `endpoint` is a valid space-between gap endpoint: a registered
+ * position, a generic anatomy term, a component-declared anatomy part, or one
+ * of those glued to a registered position via a single hyphen-bounded
+ * prefix/suffix (e.g. "content-area-bottom" = anatomy "content-area" +
+ * position "bottom"). Direct port of SPEC-047's `endpoint_resolves`
+ * (sdk/core/src/validate/rules/spec047.rs) — keep the two in sync.
+ *
+ * @param {string} endpoint
+ * @param {Set<string>|undefined} positionVocab
+ * @param {Set<string>|undefined} anatomyVocab
+ * @param {Set<string>} declaredParts - component-declared anatomy part names
+ * @returns {boolean}
+ */
+function endpointResolves(
+  endpoint,
+  positionVocab,
+  anatomyVocab,
+  declaredParts,
+) {
+  const isAnatomy = (s) =>
+    Boolean(anatomyVocab?.has(s)) || declaredParts.has(s);
+  const isPosition = (s) => Boolean(positionVocab?.has(s));
+
+  if (isPosition(endpoint) || isAnatomy(endpoint)) return true;
+  if (!positionVocab) return false;
+
+  for (const pos of positionVocab) {
+    if (
+      endpoint.startsWith(`${pos}-`) &&
+      isAnatomy(endpoint.slice(pos.length + 1))
+    ) {
+      return true;
+    }
+    const suffix = `-${pos}`;
+    if (
+      endpoint.endsWith(suffix) &&
+      isAnatomy(endpoint.slice(0, -suffix.length))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Decompose a token name into a 13-field name object.
  *
  * @param {string} tokenName - kebab-case token name
@@ -143,6 +188,84 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
       for (let i = idx; i < idx + compSegs.length; i++) {
         matched[i] = true;
         matchDetails[i] = "property";
+      }
+    }
+  }
+
+  // Phase 2.5: Detect space-between (-to-) gap endpoints.
+  //
+  // Mirrors sdk/core/src/naming.rs's space-between branch and validates each
+  // endpoint the same way SPEC-047 does (spec047.rs `endpoint_resolves`): a
+  // position, a generic anatomy term, a component-declared anatomy part, or one
+  // of those glued to a registered position via a hyphen-bounded prefix/suffix.
+  // Endpoints are stored as their full compound string — not split further.
+  {
+    let componentEndIdx = 0;
+    for (let i = 0; i < segments.length; i++) {
+      if (matchDetails[i] === "component") componentEndIdx = i + 1;
+    }
+
+    let connectorIdx = -1;
+    for (let i = componentEndIdx; i < segments.length; i++) {
+      if (segments[i] === "to" && !matched[i]) {
+        connectorIdx = i;
+        break;
+      }
+    }
+
+    if (connectorIdx > componentEndIdx) {
+      const fromSegs = segments.slice(componentEndIdx, connectorIdx);
+      const fromClean = fromSegs.every((_, k) => !matched[componentEndIdx + k]);
+
+      if (fromClean) {
+        const positionVocab = registry.byField.position;
+        const anatomyVocab = registry.byField.anatomy;
+        const declaredParts =
+          registry.componentAnatomy?.get(nameObject.component) || new Set();
+
+        const fromCandidate = fromSegs.join("-");
+        if (
+          endpointResolves(
+            fromCandidate,
+            positionVocab,
+            anatomyVocab,
+            declaredParts,
+          )
+        ) {
+          const rest = segments.slice(connectorIdx + 1);
+          let toSegs = null;
+          for (let k = rest.length; k >= 1; k--) {
+            if (matched[connectorIdx + 1 + k - 1]) continue;
+            const candidate = rest.slice(0, k).join("-");
+            if (
+              endpointResolves(
+                candidate,
+                positionVocab,
+                anatomyVocab,
+                declaredParts,
+              )
+            ) {
+              toSegs = rest.slice(0, k);
+              break;
+            }
+          }
+
+          if (toSegs) {
+            nameObject.property = "space-between";
+            nameObject.from = fromCandidate;
+            nameObject.to = toSegs.join("-");
+            for (let i = componentEndIdx; i < connectorIdx; i++) {
+              matched[i] = true;
+              matchDetails[i] = "from";
+            }
+            matched[connectorIdx] = true;
+            matchDetails[connectorIdx] = "spacing-between-connector";
+            for (let i = 0; i < toSegs.length; i++) {
+              matched[connectorIdx + 1 + i] = true;
+              matchDetails[connectorIdx + 1 + i] = "to";
+            }
+          }
+        }
       }
     }
   }
@@ -444,6 +567,33 @@ export function serialize(
     if (colorRole) parts.push(tokenNameMap[colorRole] || colorRole);
     if (nameObject.state)
       parts.push(tokenNameMap[nameObject.state] || nameObject.state);
+    return parts.join("-");
+  }
+
+  // Space-between (gap) domain: property literal term "space-between", real
+  // endpoints live in paired `from`/`to` fields (both excludeFromLegacyKey, so
+  // they're skipped below rather than serialized literally). Reconstruct the
+  // legacy connective form `{from}-to-{to}` in property's slot. Mirrors
+  // sdk/core/src/naming.rs's `property == "space-between"` branch — keep in sync.
+  if (
+    nameObject.property === "space-between" &&
+    nameObject.from &&
+    nameObject.to
+  ) {
+    const parts = [];
+    for (const field of serializationOrder) {
+      if (field === "from" || field === "to") continue;
+      if (field === "property") {
+        const fromExpanded = tokenNameMap[nameObject.from] || nameObject.from;
+        const toExpanded = tokenNameMap[nameObject.to] || nameObject.to;
+        parts.push(`${fromExpanded}-to-${toExpanded}`);
+        continue;
+      }
+      if (nameObject[field]) {
+        parts.push(tokenNameMap[nameObject[field]] || nameObject[field]);
+      }
+    }
+    if (nameObject.scaleIndex) parts.push(nameObject.scaleIndex);
     return parts.join("-");
   }
 

--- a/tools/token-mapping-analyzer/src/registry-index.js
+++ b/tools/token-mapping-analyzer/src/registry-index.js
@@ -8,28 +8,56 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { loadFieldCatalog } from "./field-catalog.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../..");
+const COMPONENTS_DIR = resolve(REPO_ROOT, "packages/design-data/components");
+
+/**
+ * Load each component's declared anatomy parts (component.json `anatomy[].name`).
+ * Used by the space-between endpoint resolver (mirrors SPEC-047's `declared_parts`,
+ * sdk/core/src/validate/rules/spec047.rs) — a component-declared anatomy part is a
+ * valid gap endpoint even when it isn't in the generic anatomy-terms registry.
+ *
+ * @returns {Map<string, Set<string>>} component name -> set of declared part names
+ */
+function loadComponentAnatomy(componentsDir = COMPONENTS_DIR) {
+  const componentAnatomy = new Map();
+  for (const filename of readdirSync(componentsDir)) {
+    if (!filename.endsWith(".json")) continue;
+    const data = JSON.parse(
+      readFileSync(resolve(componentsDir, filename), "utf-8"),
+    );
+    if (!data.name || !Array.isArray(data.anatomy)) continue;
+    componentAnatomy.set(
+      data.name,
+      new Set(data.anatomy.map((part) => part.name).filter(Boolean)),
+    );
+  }
+  return componentAnatomy;
+}
 
 /**
  * Load all registries into a unified index.
  * Registry files are resolved from the field catalog declarations rather than
  * a hardcoded mapping.
  *
- * Returns { byField, terms, tokenNameMap, serializationOrder, allFields } where:
+ * Returns { byField, terms, tokenNameMap, serializationOrder, allFields, componentAnatomy } where:
  * - byField[fieldName] = Set of known ids
  * - terms = sorted list of { segments: string[], field: string, id: string }
  *   for greedy longest-match parsing
  * - tokenNameMap = id -> tokenName for serialization
  * - serializationOrder = field names ordered by serialization.position
  * - allFields = Map of all field declarations from the catalog
+ * - componentAnatomy = Map of component name -> Set of declared anatomy part names
  */
 export function loadRegistries() {
   const { registryFiles, serializationOrder, allFields } = loadFieldCatalog();
+  const componentAnatomy = loadComponentAnatomy();
 
   const byField = {};
   const allTerms = [];
@@ -71,6 +99,7 @@ export function loadRegistries() {
     tokenNameMap,
     serializationOrder,
     allFields,
+    componentAnatomy,
   };
 }
 

--- a/tools/token-mapping-analyzer/test/apply.test.js
+++ b/tools/token-mapping-analyzer/test/apply.test.js
@@ -14,6 +14,7 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { loadRegistries } from "../src/registry-index.js";
 import { serialize } from "../src/decomposer.js";
+import { applySpaceBetween } from "../src/apply.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CASCADE_DIR = resolve(__dirname, "../../../packages/design-data/tokens");
@@ -134,4 +135,86 @@ test("size decomposition preserves the legacy key — layout.tokens.json", (t) =
       `Token ${tok.uuid?.slice(0, 8)}: must have non-empty property after decomposition`,
     );
   }
+});
+
+// ── applySpaceBetween ─────────────────────────────────────────────────────
+
+test("applySpaceBetween writes from/to/property for a clean gap token and preserves the legacy key", (t) => {
+  const registry = loadRegistries();
+  const tokens = [
+    {
+      name: { component: "accordion", property: "bottom-to-handle" },
+      value: "8px",
+    },
+  ];
+  const legacyKeyBefore = serialize(
+    tokens[0].name,
+    registry.tokenNameMap,
+    registry.serializationOrder,
+  );
+
+  const { applied } = applySpaceBetween(
+    tokens,
+    registry,
+    "fixture.tokens.json",
+  );
+
+  t.is(applied, 1);
+  t.is(tokens[0].name.property, "space-between");
+  t.is(tokens[0].name.from, "bottom");
+  t.is(tokens[0].name.to, "handle");
+  t.is(
+    serialize(
+      tokens[0].name,
+      registry.tokenNameMap,
+      registry.serializationOrder,
+    ),
+    legacyKeyBefore,
+  );
+});
+
+test("applySpaceBetween skips a token whose endpoint can't fully resolve", (t) => {
+  const registry = loadRegistries();
+  const tokens = [
+    {
+      name: {
+        component: "slider",
+        property: "control-to-field-label-side-medium",
+      },
+      value: "8px",
+    },
+  ];
+
+  const { applied } = applySpaceBetween(
+    tokens,
+    registry,
+    "fixture.tokens.json",
+  );
+
+  t.is(applied, 0);
+  t.is(tokens[0].name.from, undefined);
+  t.is(tokens[0].name.property, "control-to-field-label-side-medium");
+});
+
+test("applySpaceBetween skips tokens already migrated", (t) => {
+  const registry = loadRegistries();
+  const tokens = [
+    {
+      name: {
+        component: "accordion",
+        property: "space-between",
+        from: "bottom",
+        to: "handle",
+      },
+      value: "8px",
+    },
+  ];
+
+  const { applied } = applySpaceBetween(
+    tokens,
+    registry,
+    "fixture.tokens.json",
+  );
+
+  t.is(applied, 0);
 });

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -264,6 +264,22 @@ test("flags low confidence when a space-between endpoint can't fully resolve", (
   t.false(result.confidence === "HIGH" && result.roundtrips);
 });
 
+test("decomposes space-between gap preceded by a non-component field (variant)", (t) => {
+  // naming.rs's general shape is {variant?}-{component?}-...-{property}, so a
+  // field like variant can precede the gap connective even with no component.
+  // Phase 2.5 must shrink the "from" window from the left (not just skip a
+  // leading component) or "accent" gets folded into "from" and fails to
+  // resolve, silently losing the gap split (regression: it previously fell
+  // through with confidence !== HIGH instead of splitting variant/from/to).
+  const result = decompose("accent-top-to-bottom", {}, registry, "test");
+  t.is(result.nameObject.variant, "accent");
+  t.is(result.nameObject.property, "space-between");
+  t.is(result.nameObject.from, "top");
+  t.is(result.nameObject.to, "bottom");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
 test("serialize() reconstructs the -to- connective for a space-between name", (t) => {
   const legacyKey = serialize(
     {

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -197,3 +197,85 @@ test("does not promote non-color tokens: variant/object unaffected when property
   t.is(result.nameObject.colorFamily, undefined);
   t.is(result.nameObject.colorRole, undefined);
 });
+
+// ── space-between (gap) endpoint decomposition ───────────────────────────────
+
+test("decomposes space-between gap with two position endpoints", (t) => {
+  // Mirrors the naming.rs doc example (naming.rs:237-238).
+  const result = decompose(
+    "accordion-bottom-to-handle",
+    { component: "accordion" },
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.property, "space-between");
+  t.is(result.nameObject.from, "bottom");
+  t.is(result.nameObject.to, "handle");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("decomposes space-between gap with a position + generic-anatomy endpoint", (t) => {
+  const result = decompose(
+    "accordion-top-to-content-area",
+    { component: "accordion" },
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.property, "space-between");
+  t.is(result.nameObject.from, "top");
+  t.is(result.nameObject.to, "content-area");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("decomposes space-between gap with a compound anatomy+position endpoint", (t) => {
+  // "column-header-row-bottom" = declared anatomy part "column-header-row" (table)
+  // + registered position "bottom" suffix — mirrors SPEC-047's split-and-retry rule
+  // (spec047.rs `endpoint_resolves`) and real tokens like
+  // table-column-header-row-bottom-to-text-large.
+  const result = decompose(
+    "table-column-header-row-bottom-to-text-large",
+    { component: "table" },
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.property, "space-between");
+  t.is(result.nameObject.from, "column-header-row-bottom");
+  t.is(result.nameObject.to, "text");
+  t.is(result.nameObject.size, "l");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("flags low confidence when a space-between endpoint can't fully resolve", (t) => {
+  // "field-label-side" is neither a position, a generic anatomy term, nor a
+  // slider-declared anatomy part — an escalated triage term (see
+  // docs/proposals/012-space-between-decompose.md). The resolver falls back to
+  // the largest resolvable prefix ("field-label"), leaving "side" unmatched;
+  // that mismatch must surface as non-HIGH confidence / non-roundtripping so
+  // apply.js's guards (apply.js:79-104) skip the token instead of mis-migrating it.
+  const result = decompose(
+    "slider-control-to-field-label-side-medium",
+    { component: "slider" },
+    registry,
+    "test",
+  );
+  t.false(result.confidence === "HIGH" && result.roundtrips);
+});
+
+test("serialize() reconstructs the -to- connective for a space-between name", (t) => {
+  const legacyKey = serialize(
+    {
+      component: "accordion",
+      property: "space-between",
+      from: "bottom",
+      to: "handle",
+      size: "xl",
+      state: "hover",
+    },
+    registry.tokenNameMap,
+    registry.serializationOrder,
+  );
+  t.is(legacyKey, "accordion-bottom-to-handle-extra-large-hover");
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Teaches the JS token decomposer (`tools/token-mapping-analyzer/`) to detect and
serialize the space-between (gap) `{a}-to-{b}` pattern, so it produces
`property: "space-between"` + `from`/`to` fields and roundtrips — mirroring
the Rust contract (`sdk/core/src/naming.rs`, SPEC-047) that the 04c series
already taught to the Rust side and registries.

- **tools/token-mapping-analyzer/src/registry-index.js**: loads each
  component's declared anatomy parts (`component.json` `anatomy[].name`) for
  gap-endpoint resolution.
- **tools/token-mapping-analyzer/src/decomposer.js**: ports SPEC-047's
  `endpoint_resolves` rule, detects the `-to-` gap pattern to emit
  `property:"space-between"` + `from`/`to`, and reconstructs the `-to-`
  connective in `serialize()`.
- **tools/token-mapping-analyzer/src/apply.js**: adds `applySpaceBetween` to
  write the `from`/`to`/`property` triple as one unit, reusing the existing
  HIGH-confidence + roundtrip + safety-re-serialize guards.
- **tools/token-mapping-analyzer/test/{decomposer,apply}.test.js**: new
  coverage for clean, compound, and unresolvable gap endpoints.

No token data or Rust changes in this PR — this only makes the JS tooling
capable and dry-run-correct.

## Related Issue

Unblocks `spectrum-design-data-04c.6` (apply gap endpoint decomposition
migration), a beads task tracked internally.

## Motivation and Context

`apply.js --field space-between` previously had no way to run: the JS
forward-decomposer never learned the space-between split that the Rust side
and registries (04c.1–04c.4) already support, so 04c.6 was blocked on this
work.

## How Has This Been Tested?

- `npx ava` in `tools/token-mapping-analyzer/` — 24/24 tests passing
  (this package isn't wired into moon's project graph, so `npx ava` is the
  correct direct invocation).
- Dry-run: `node tools/token-mapping-analyzer/src/apply.js --field space-between`
  confirms clean gap tokens resolve to HIGH confidence + roundtrip, while
  ambiguous/escalated endpoints correctly fall through to low confidence
  (skipped) instead of being mis-migrated.
- Confirmed zero regressions to existing single-field dry-runs
  (`--field size`, `--field density`, `--field property`).

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
