### PR TITLE
feat(design-data): defer SPEC-047 anatomy check without catalog; migrate final gap endpoints (04c.8)

### DIFF
--- a/.changeset/04c8-gap-endpoint-validate-dataset-gap.md
+++ b/.changeset/04c8-gap-endpoint-validate-dataset-gap.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Migrate the final 19 space-between gap endpoints; defer SPEC-047's declared-anatomy
+check when no component catalog is loaded (closes 04c.8).
+
+- **sdk/core/src/validate/rules/spec047.rs**: defer (don't error) on a component-scoped
+  gap endpoint when `validate-dataset` runs with no component catalog loaded, since its
+  declared-anatomy-part arm can't be evaluated; mirrors SPEC-018's empty-catalog guard.
+- **packages/design-data/tokens/layout-component.tokens.json**: decompose the last 19
+  `{a}-to-{b}` tokens (menu, tree-view, status-light, alert-banner, etc.) into structured
+  `from`/`to` fields — all 134 eligible gap tokens are now migrated.

--- a/docs/proposals/012-space-between-decompose.md
+++ b/docs/proposals/012-space-between-decompose.md
@@ -1,9 +1,9 @@
 # Proposal 012: Space-Between (Gap) Endpoint Decomposition — Triage
 
-**Status:** Triage complete (04c.4); 04c.5 closed as a no-op (no qualifiers found in gap
+**Status:** Complete. Triage (04c.4); 04c.5 closed as a no-op (no qualifiers found in gap
 tokens); 04c.3 registry/component-anatomy additions landed, including a SPEC-047 enhancement
 to resolve compound anatomy+position endpoints (bucket 3) by splitting on a registered
-position affix. 04c.6 (apply migration) remains.\
+position affix; 04c.6 applied the migration; 04c.8 resolved the final 19 tokens (see below).\
 **Affects:** 432 distinct `(component, property)` tuples / 725 `-to-` token occurrences across `packages/design-data/tokens/layout-component.tokens.json`\
 **Spec reference:** SPEC-047 (`space-between-endpoint-valid`), `fields/from.json`, `fields/to.json`
 
@@ -185,5 +185,17 @@ atomic parts on `table` instead, per the doc's original recommendation for that 
 
 * ~~**04c.3**~~ — done; see resolution above.
 * ~~**04c.5**~~ — closed as a no-op; no qualifiers found in the gap tokens.
-* **04c.6** — apply migration, including the `disclousure` → `disclosure` and `card-edge` → `edge`
-  data fixes.
+* ~~**04c.6**~~ — applied the migration, including the `disclousure` → `disclosure` and
+  `card-edge` → `edge` data fixes. 19 endpoints that resolve only via declared component
+  anatomy (e.g. menu/`item-label`, tree-view/`action-area`, status-light/`visual-75..300`)
+  tripped SPEC-047 under `moon run design-data:validate` and were reverted pending 04c.8.
+* ~~**04c.8**~~ — root cause: `validate-dataset` (a dep of `moon run design-data:validate`)
+  passes `components_path=None`, so SPEC-047's declared-anatomy-part arm can never evaluate —
+  not an over-eager migration. The 19 endpoints' anatomy parts are genuinely declared on their
+  components; the earlier `UNKNOWN` triage flag was a false negative from checking only the
+  generic registry, not per-component anatomy. Fixed by deferring (not erroring) SPEC-047's
+  declared-anatomy check when no component catalog is loaded — mirrors SPEC-018's existing
+  empty-catalog guard — rather than loading components into `validate-dataset`, which would
+  also activate SPEC-018 and risk surfacing unrelated relational drift. See
+  `sdk/core/src/validate/rules/spec047.rs` and the comment in `run_validate_dataset`
+  (`sdk/cli/src/main.rs`). All 19 tokens now migrated; 134/134 eligible tokens complete.

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -1315,7 +1315,9 @@
   {
     "name": {
       "component": "action-bar",
-      "property": "label-to-action-group-area"
+      "property": "space-between",
+      "from": "label",
+      "to": "action-group-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
@@ -1350,7 +1352,9 @@
   {
     "name": {
       "component": "action-bar",
-      "property": "top-to-item-counter"
+      "property": "space-between",
+      "from": "top",
+      "to": "item-counter"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8108a8e0-0883-4490-a23f-f96fb9cd8ca4",
@@ -1709,8 +1713,10 @@
   {
     "name": {
       "component": "alert-banner",
-      "property": "top-to-alert-icon",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "top",
+      "to": "alert-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "37px",
@@ -1724,8 +1730,10 @@
   {
     "name": {
       "component": "alert-banner",
-      "property": "top-to-alert-icon",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "top",
+      "to": "alert-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "29px",
@@ -3326,7 +3334,9 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-separator-icon"
+      "property": "space-between",
+      "from": "top",
+      "to": "separator-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2e8091e4-f60b-438c-bcbb-111eb243900d",
@@ -3594,7 +3604,9 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "truncated-menu-to-separator-icon"
+      "property": "space-between",
+      "from": "truncated-menu",
+      "to": "separator-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "963bd7ed-cfc9-4a93-a8a6-a2340ec6479f",
@@ -5045,8 +5057,10 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "pagination-text-to-bottom-edge",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "pagination-text",
+      "to": "bottom-edge"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "33px",
@@ -5060,8 +5074,10 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "pagination-text-to-bottom-edge",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "pagination-text",
+      "to": "bottom-edge"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -8311,7 +8327,9 @@
   {
     "name": {
       "component": "menu",
-      "property": "item-label-to-description"
+      "property": "space-between",
+      "from": "item-label",
+      "to": "description"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "608fd592-fff8-435e-88e2-846bd34cc235",
@@ -11107,8 +11125,10 @@
   {
     "name": {
       "component": "side-navigation",
-      "property": "trailing-accessory-area-to-edge",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "trailing-accessory-area",
+      "to": "edge"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -11122,8 +11142,10 @@
   {
     "name": {
       "component": "side-navigation",
-      "property": "trailing-accessory-area-to-edge",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "trailing-accessory-area",
+      "to": "edge"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -12985,7 +13007,9 @@
   {
     "name": {
       "component": "status-light",
-      "property": "text-to-visual-100"
+      "property": "space-between",
+      "from": "text",
+      "to": "visual-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53e1a050-67e8-4c0d-a7f5-48abae476f3e",
@@ -12997,7 +13021,9 @@
   {
     "name": {
       "component": "status-light",
-      "property": "text-to-visual-200"
+      "property": "space-between",
+      "from": "text",
+      "to": "visual-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bd7da2ac-6c3f-4f98-8dc3-7af1a9beb366",
@@ -13009,7 +13035,9 @@
   {
     "name": {
       "component": "status-light",
-      "property": "text-to-visual-300"
+      "property": "space-between",
+      "from": "text",
+      "to": "visual-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "91fa8786-6f7d-4107-9696-3f7da07f9b1a",
@@ -13021,7 +13049,9 @@
   {
     "name": {
       "component": "status-light",
-      "property": "text-to-visual-75"
+      "property": "space-between",
+      "from": "text",
+      "to": "visual-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d0a8c780-3a64-4b74-94f8-2de15e632f4f",
@@ -19905,8 +19935,10 @@
   {
     "name": {
       "component": "tree-view",
-      "property": "end-edge-to-action-area",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "end-edge",
+      "to": "action-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -19920,8 +19952,10 @@
   {
     "name": {
       "component": "tree-view",
-      "property": "end-edge-to-action-area",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "end-edge",
+      "to": "action-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -20022,8 +20056,10 @@
   {
     "name": {
       "component": "tree-view",
-      "property": "label-to-action-area",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "label",
+      "to": "action-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -20037,8 +20073,10 @@
   {
     "name": {
       "component": "tree-view",
-      "property": "label-to-action-area",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "label",
+      "to": "action-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -699,6 +699,12 @@ fn run_validate_dataset(path: &Path, opts: ValidateDatasetOpts) -> miette::Resul
     // checked structurally below via Layer 1 schema validation. This keeps
     // dataset validation additive and avoids surfacing unrelated relational
     // drift (e.g. SPEC-018 component association) that is out of scope here.
+    //
+    // One consequence: SPEC-047's declared-anatomy-part arm can't be
+    // evaluated without a component catalog, so it defers rather than
+    // flagging component-scoped gap endpoints (see spec047.rs). Only the
+    // full `validate` subcommand — which does load components — enforces
+    // that arm.
     let mut report =
         validate::validate_dataset(&dataset_root, &registry, &exceptions, None, None, None)
             .into_diagnostic()

--- a/sdk/core/src/validate/rules/spec047.rs
+++ b/sdk/core/src/validate/rules/spec047.rs
@@ -24,6 +24,15 @@
 //! against the anatomy union. This covers gap endpoints that fuse an anatomy
 //! part with a row/edge scope without requiring a third name-object field —
 //! `from`/`to` still store the full compound string for legacy-key round-trip.
+//!
+//! When no component catalog is loaded (e.g. `validate-dataset`, which
+//! deliberately passes `components_path=None` — see `run_validate_dataset` in
+//! `sdk/cli/src/main.rs`), a component-scoped endpoint that fails the
+//! registry-only checks is deferred rather than flagged: it may still resolve
+//! via a declared anatomy part this pass can't see. The component-aware
+//! `validate` command (which does load components) is what enforces those
+//! endpoints. Endpoints on tokens with no `component` are unaffected and
+//! still error unconditionally.
 
 use std::collections::HashSet;
 
@@ -147,6 +156,16 @@ impl ValidationRule for Rule {
                     endpoint_resolves(endpoint, position_vocab, anatomy_vocab, &declared_parts);
 
                 if !valid {
+                    // No component catalog loaded (e.g. `validate-dataset`, which
+                    // passes components_path=None): the declared-anatomy-part arm
+                    // above can never match, so a component-scoped endpoint may
+                    // still be valid via a part that just isn't visible here. Defer
+                    // to the component-aware `validate` pass instead of flagging a
+                    // false positive. Endpoints on tokens with no `component` can
+                    // never resolve via a declared part, so they still error below.
+                    if ctx.graph.components.is_empty() && component.is_some() {
+                        continue;
+                    }
                     out.push(Diagnostic {
                         file: t.file.clone(),
                         token: Some(t.name.clone()),
@@ -200,6 +219,21 @@ mod tests {
             file: PathBuf::from("accordion.json"),
             raw: json!({"name": "accordion", "anatomy": [{"name": "handle"}]}),
         });
+        assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
+    }
+
+    #[test]
+    fn component_endpoint_deferred_when_no_catalog_loaded() {
+        // `validate-dataset` deliberately passes components_path=None, so
+        // ctx.graph.components is empty here (no ComponentRecord pushed).
+        // "item-label" only resolves via menu's declared anatomy — with no
+        // catalog loaded that arm can't be evaluated, so the endpoint must be
+        // deferred (no diagnostic), not flagged as unknown.
+        let g = TokenGraph::from_pairs(vec![(
+            "menu-item-label-to-description".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "space-between", "component": "menu", "from": "item-label", "to": "description"}, "value": "8px"}),
+        )]);
         assert!(diagnostics_for_rule(&g, "SPEC-047").is_empty());
     }
 

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -100,6 +100,11 @@ const NUMERIC_SCALE_PATTERN = /^\d+$/;
  * position "bottom"). Direct port of SPEC-047's `endpoint_resolves`
  * (sdk/core/src/validate/rules/spec047.rs) — keep the two in sync.
  *
+ * Note: `apply.js` always has `declaredParts` populated (it loads components
+ * from the registry directly), unlike Rust's `validate-dataset`, which may run
+ * with an empty component catalog and defers rather than errors in that case.
+ * Do not port that deferral here — this function's callers never hit it.
+ *
  * @param {string} endpoint
  * @param {Set<string>|undefined} positionVocab
  * @param {Set<string>|undefined} anatomyVocab


### PR DESCRIPTION
## Description

Closes the space-between (gap) decomposition epic (04c) by resolving its final
child, 04c.8. Investigation found the 19 tokens reverted in 04c.6 resolve
validly via declared component anatomy (menu/`item-label`, tree-view/`action-area`,
status-light/`visual-75..300`, alert-banner/`alert-icon`, breadcrumbs/`separator-icon`,
side-navigation/`trailing-accessory-area`, action-bar/`action-group-area`+`item-counter`,
coach-mark/`pagination-text`) — the migration was correct, but `moon run design-data:validate`
runs `validate-dataset` (as a dep), which always passes `components_path=None`, so SPEC-047's
declared-anatomy-part resolution arm can never evaluate and rejects otherwise-valid endpoints.

- **sdk/core/src/validate/rules/spec047.rs**: defer (don't error) a component-scoped gap
  endpoint when no component catalog is loaded, mirroring SPEC-018's existing empty-catalog
  guard. Structural errors (missing `from`/`to`, `from`/`to` without `property: space-between`)
  still fire unconditionally.
- **sdk/cli/src/main.rs**: documents why `run_validate_dataset` deliberately keeps
  `components_path=None` and how that interacts with the new SPEC-047 deferral.
- **packages/design-data/tokens/layout-component.tokens.json**: the final 19 tokens migrated
  from legacy `{a}-to-{b}` property values to structured `property: "space-between"` +
  `from`/`to` fields — all 134 eligible gap tokens are now migrated.
- **docs/proposals/012-space-between-decompose.md**: marked complete; records that the
  earlier `UNKNOWN` triage flag on these 19 was a false negative (checked only the generic
  registry, not per-component anatomy), not an over-eager migration.
- **tools/token-mapping-analyzer/src/decomposer.js**: one-line note that `apply.js` always
  has components loaded, so the new Rust-side deferral doesn't need a JS port.

## Related Issue

Closes beads issue `spectrum-design-data-04c.8` (and its parent epic `spectrum-design-data-04c`).

## Motivation and Context

Loading components into `validate-dataset` instead was considered and rejected: it would
also activate SPEC-018 (`component-name-declared`), which is currently a no-op there, and
risk surfacing unrelated pre-existing relational drift with unbounded fix scope. Deferring
SPEC-047 keeps `validate-dataset` additive, matching the intent already documented for that
command.

## How Has This Been Tested?

- `cargo test --workspace` — 1209 passed (including a new regression test,
  `component_endpoint_deferred_when_no_catalog_loaded`, plus the existing
  `unknown_endpoint_errors` test confirming endpoints with no `component` still error).
- `moon run :test` — full monorepo suite (JS + Rust) green.
- `moon run design-data:validate` and the raw `design-data validate` /
  `validate-dataset` binaries — 0 SPEC-047 errors on both, only pre-existing
  unrelated SPEC-043 warnings.
- `node src/apply.js --field space-between` (dry run, before/after) — confirmed
  exactly 19 tokens were eligible and, after `--write`, 0 remain (134/134 applied).
- `moon run design-data:roundtrip-verify` — passes.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
