### PR TITLE
feat(design-data): model nested sub-anatomy via contains, add SPEC-048 (5us)

### DIFF
--- a/.changeset/5us-nested-anatomy-contains.md
+++ b/.changeset/5us-nested-anatomy-contains.md
@@ -1,0 +1,22 @@
+---
+"@adobe/design-data-spec": minor
+"@adobe/spectrum-design-data": minor
+---
+
+Add SPEC-048 to validate nested anatomy `contains` references, and populate `contains`
+for the menu, list-view, and table composite items (closes spectrum-design-data-5us).
+
+- **packages/design-data-spec/rules/rules.yaml**: add SPEC-048 `anatomy-contains-resolves`
+  (warning) — a `contains` entry SHOULD match a sibling anatomy part's `name`.
+- **packages/design-data-spec/schemas/{anatomy-part,component}.schema.json**: update the
+  `contains` field description now that it has a validation rule.
+- **packages/design-data-spec/spec/anatomy-format.md**: document the flat-vs-`contains`
+  authoring convention and the new rule.
+- **sdk/core/src/validate/rules/spec048.rs**: implement the rule; register in `mod.rs`.
+- **packages/design-data/components/menu.json**: declare `menu-item`'s child parts
+  (icon, label, description, value, switch, checkbox, thumbnail, drill-in-chevron,
+  link-out-icon) and populate `contains`.
+- **packages/design-data/components/list-view.json**: add an `anatomy` array with
+  `list-item` and its child parts.
+- **packages/design-data/components/table.json**: populate `row`'s `contains` with the
+  existing `row-checkbox` part.

--- a/packages/design-data-spec/conformance/invalid/SPEC-048/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-048/dataset.json
@@ -1,0 +1,21 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/menu.json",
+      "name": "menu",
+      "displayName": "Menu",
+      "meta": {
+        "category": "collections",
+        "documentationUrl": "https://spectrum.adobe.com/page/menu/"
+      },
+      "anatomy": [
+        {
+          "name": "menu-item",
+          "description": "A single row within the menu.",
+          "contains": ["item-checkbox"]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-048/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-048/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-048",
+      "severity": "warning",
+      "message_pattern": ".*menu-item.*item-checkbox.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/conformance/valid/SPEC-048/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-048/dataset.json
@@ -1,0 +1,23 @@
+{
+  "tokens": [],
+  "components": [
+    {
+      "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/menu.json",
+      "name": "menu",
+      "displayName": "Menu",
+      "meta": {
+        "category": "collections",
+        "documentationUrl": "https://spectrum.adobe.com/page/menu/"
+      },
+      "anatomy": [
+        {
+          "name": "menu-item",
+          "description": "A single row within the menu.",
+          "contains": ["item-icon", "item-label"]
+        },
+        { "name": "item-icon", "description": "Leading icon of a menu item." },
+        { "name": "item-label", "description": "Label text of a menu item." }
+      ]
+    }
+  ]
+}

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -544,3 +544,19 @@ rules:
     message: "Token '{token}' has space-between endpoint '{endpoint}' that is not a known position, anatomy term, or declared anatomy part on component '{component}'"
     spec_ref: spec/token-format.md#space-between-endpoints
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-048
+    name: anatomy-contains-resolves
+    severity: warning
+    layer: 2
+    category: completeness
+    assert: >
+      Each string in an anatomy part's `contains` array SHOULD match the `name` of
+      another anatomy part declared on the same component. Unresolved references are
+      advisory rather than an error: `contains` may legitimately point at sub-component
+      anatomy in layered designs (anatomy-format.md#contains), so this rule only warns
+      when a `contains` entry cannot be resolved against the same component's declared
+      parts.
+    message: "Anatomy part '{part}' on component '{component}' contains '{child}', which is not a declared anatomy part on this component"
+    spec_ref: spec/anatomy-format.md#contains
+    introduced_in: "1.0.0-draft"

--- a/packages/design-data-spec/schemas/anatomy-part.schema.json
+++ b/packages/design-data-spec/schemas/anatomy-part.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/anatomy-part.schema.json",
   "title": "Anatomy part declaration",
-  "description": "Layer 1 structural schema for a single anatomy part object within a component declaration. Semantic rules (component-anatomy-valid, anatomy-custom-part-documented, anatomy-part-name-unique, anatomy-requires-component) are Layer 2.",
+  "description": "Layer 1 structural schema for a single anatomy part object within a component declaration. Semantic rules (component-anatomy-valid, anatomy-custom-part-documented, anatomy-part-name-unique, anatomy-requires-component, anatomy-contains-resolves) are Layer 2.",
   "type": "object",
   "required": ["name"],
   "properties": {
@@ -28,7 +28,7 @@
         "pattern": "^[a-z][a-z0-9-]*$"
       },
       "uniqueItems": true,
-      "description": "Informative list of child anatomy part names nested within this part. Does not carry enforcement semantics."
+      "description": "List of child anatomy part names nested within this part. SHOULD reference a `name` declared elsewhere in the same component's anatomy array; unresolved references are permitted (they may point at sub-component anatomy in layered designs) but rule anatomy-contains-resolves fires an advisory warning."
     },
     "documentBlocks": {
       "type": "array",

--- a/packages/design-data-spec/schemas/component.schema.json
+++ b/packages/design-data-spec/schemas/component.schema.json
@@ -225,7 +225,7 @@
         "contains": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Informative: anatomy part names nested within this part."
+          "description": "Anatomy part names nested within this part. SHOULD reference a `name` declared elsewhere in this component's anatomy array (see anatomy-contains-resolves)."
         },
         "documentBlocks": {
           "type": "array",

--- a/packages/design-data-spec/spec/anatomy-format.md
+++ b/packages/design-data-spec/spec/anatomy-format.md
@@ -46,11 +46,13 @@ When `required` is `true`, the anatomy part is unconditionally rendered (e.g. a 
 
 ### `contains`
 
-**OPTIONAL.** An informative list of child anatomy part `name` values that are visually or structurally nested within this part. This field is for documentation and tooling assistance; it does not carry enforcement semantics.
+**OPTIONAL.** A list of child anatomy part `name` values that are visually or structurally nested within this part.
 
-**RECOMMENDED:** When a part logically encloses other declared anatomy parts, authors **SHOULD** use `contains` to make the nesting explicit.
+**RECOMMENDED:** When a part logically encloses other declared anatomy parts, authors **SHOULD** use `contains` to make the nesting explicit, rather than declaring the children only as flat, unrelated parts.
 
-Each string in `contains` **MUST** match the pattern `^[a-z][a-z0-9-]*$`. References to anatomy part names not declared on the same component are permitted (they may refer to sub-component anatomy in layered designs) but validators **MAY** surface a warning for unresolved references.
+Each string in `contains` **MUST** match the pattern `^[a-z][a-z0-9-]*$`. References to anatomy part names not declared on the same component are permitted (they may refer to sub-component anatomy in layered designs), but a reference that cannot be resolved against the same component's declared parts triggers an advisory warning (rule SPEC-048, `anatomy-contains-resolves`) — it is not an error.
+
+**Authoring convention — flat vs. nested:** declare a part as a flat leaf when it has no meaningful internal sub-structure of its own (e.g. `label`, `icon`). Declare a part with `contains` when it is a composite that visually groups other declared parts (e.g. a `menu-item` row containing an `icon` and a `label`, or a `list-item` row containing a `checkbox`, `thumbnail`, and `label`). Prefer the canonical vocabulary (below) for children where the semantics match, falling back to a documented custom name (SPEC-023) otherwise.
 
 ### `lifecycle`
 
@@ -135,6 +137,7 @@ The following rules in the Layer 2 rule catalog (`rules/rules.yaml`) apply to an
 | SPEC-025 | `anatomy-requires-component`      | error    | A token name object **MUST NOT** include an `anatomy` field unless a `component` field is also present.                                                   |
 | SPEC-035 | `anatomy-part-name-registry-sync` | warning  | A component anatomy part's `name` **SHOULD** appear in the canonical anatomy-terms registry (`anatomy-terms.json`).                                       |
 | SPEC-037 | `sub-entity-deprecation-cascade`  | warning  | A non-deprecated token **SHOULD NOT** reference a deprecated anatomy part via `name.anatomy`. Advisory warning prompts migration.                         |
+| SPEC-048 | `anatomy-contains-resolves`       | warning  | An anatomy part's `contains` entries **SHOULD** match the `name` of another part declared on the same component. Advisory warning for unresolved entries. |
 
 ## Full example
 

--- a/packages/design-data/components/list-view.json
+++ b/packages/design-data/components/list-view.json
@@ -158,6 +158,46 @@
       }
     }
   },
+  "anatomy": [
+    {
+      "name": "list-item",
+      "description": "A single row within the list view.",
+      "contains": [
+        "checkbox",
+        "icon",
+        "thumbnail",
+        "label",
+        "description",
+        "actions",
+        "trailing-icon"
+      ]
+    },
+    {
+      "name": "checkbox",
+      "description": "Checkbox control for a list view item in checkbox selection style."
+    },
+    { "name": "icon", "description": "Leading icon of a list view item." },
+    {
+      "name": "thumbnail",
+      "description": "Thumbnail image of a list view item."
+    },
+    {
+      "name": "label",
+      "description": "Primary label text of a list view item."
+    },
+    {
+      "name": "description",
+      "description": "Secondary descriptive text of a list view item."
+    },
+    {
+      "name": "actions",
+      "description": "Action buttons or action menu available for a list view item."
+    },
+    {
+      "name": "trailing-icon",
+      "description": "Icon indicating a list view item navigates to a new context."
+    }
+  ],
   "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     { "token": "(multi-select", "context": "Variants" },

--- a/packages/design-data/components/menu.json
+++ b/packages/design-data/components/menu.json
@@ -169,7 +169,42 @@
     },
     {
       "name": "menu-item",
-      "description": "A single row within the menu."
+      "description": "A single row within the menu.",
+      "contains": [
+        "icon",
+        "label",
+        "description",
+        "value",
+        "switch",
+        "checkbox",
+        "thumbnail",
+        "drill-in-chevron",
+        "link-out-icon"
+      ]
+    },
+    { "name": "icon", "description": "Leading icon of a menu item." },
+    { "name": "label", "description": "Primary label text of a menu item." },
+    {
+      "name": "description",
+      "description": "Secondary descriptive text of a menu item."
+    },
+    { "name": "value", "description": "Current value display of a menu item." },
+    {
+      "name": "switch",
+      "description": "Switch control for a menu item with switch selection style."
+    },
+    {
+      "name": "checkbox",
+      "description": "Checkbox control for a menu item with checkbox selection style."
+    },
+    { "name": "thumbnail", "description": "Thumbnail image of a menu item." },
+    {
+      "name": "drill-in-chevron",
+      "description": "Chevron indicating a menu item opens a sub-menu."
+    },
+    {
+      "name": "link-out-icon",
+      "description": "Icon indicating a menu item navigates to a new context."
     }
   ],
   "states": [

--- a/packages/design-data/components/table.json
+++ b/packages/design-data/components/table.json
@@ -200,7 +200,8 @@
     },
     {
       "name": "row",
-      "description": "A single data row."
+      "description": "A single data row.",
+      "contains": ["row-checkbox"]
     },
     {
       "name": "row-checkbox",

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -58,6 +58,7 @@ mod spec043;
 mod spec045;
 mod spec046;
 mod spec047;
+mod spec048;
 
 use std::collections::HashSet;
 
@@ -157,6 +158,7 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec045::Rule),
         Box::new(spec046::Rule),
         Box::new(spec047::Rule),
+        Box::new(spec048::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec048.rs
+++ b/sdk/core/src/validate/rules/spec048.rs
@@ -1,0 +1,149 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-048: anatomy-contains-resolves
+//!
+//! An anatomy part's `contains` entries SHOULD match the `name` of another anatomy
+//! part declared on the same component. Unresolved references are advisory only —
+//! `contains` may legitimately point at sub-component anatomy in layered designs
+//! (anatomy-format.md#contains) — so this fires a warning, not an error.
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-048"
+    }
+
+    fn name(&self) -> &'static str {
+        "anatomy-contains-resolves"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+
+        for comp in &ctx.graph.components {
+            let Some(anatomy) = comp.raw.get("anatomy").and_then(|v| v.as_array()) else {
+                continue;
+            };
+
+            let declared_parts: std::collections::HashSet<&str> = anatomy
+                .iter()
+                .filter_map(|p| p.get("name").and_then(|n| n.as_str()))
+                .collect();
+
+            for part in anatomy {
+                let Some(part_name) = part.get("name").and_then(|n| n.as_str()) else {
+                    continue;
+                };
+                let Some(contains) = part.get("contains").and_then(|v| v.as_array()) else {
+                    continue;
+                };
+
+                for child in contains {
+                    let Some(child_name) = child.as_str() else {
+                        continue;
+                    };
+                    if !declared_parts.contains(child_name) {
+                        out.push(Diagnostic {
+                            file: comp.file.clone(),
+                            token: None,
+                            rule_id: Some(self.id().to_string()),
+                            severity: Severity::Warning,
+                            message: format!(
+                                "Anatomy part '{part_name}' on component '{}' contains '{child_name}', which is not a declared anatomy part on this component",
+                                comp.name
+                            ),
+                            instance_path: None,
+                            schema_path: None,
+                        });
+                    }
+                }
+            }
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::{ComponentRecord, TokenGraph};
+    use crate::registry::RegistryData;
+    use crate::report::Severity;
+    use crate::validate::rule::{ValidationContext, ValidationRule};
+    use crate::validate::rules::spec048::Rule;
+
+    fn run(comp_raw: serde_json::Value) -> Vec<crate::report::Diagnostic> {
+        let mut g = TokenGraph::default();
+        let comp_name = comp_raw
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("menu")
+            .to_string();
+        g.components.push(ComponentRecord {
+            name: comp_name,
+            file: PathBuf::from("dataset.json"),
+            raw: comp_raw,
+        });
+        let exceptions = std::collections::HashSet::new();
+        let registry = RegistryData::embedded();
+        let ctx = ValidationContext {
+            graph: &g,
+            naming_exceptions: &exceptions,
+            registry: &registry,
+            manifest: None,
+        };
+        Rule.validate(&ctx)
+    }
+
+    #[test]
+    fn resolved_contains_no_warning() {
+        let diags = run(json!({
+            "name": "menu",
+            "anatomy": [
+                { "name": "menu-item", "description": "A row.", "contains": ["icon", "label"] },
+                { "name": "icon", "description": "Leading icon." },
+                { "name": "label", "description": "Item label." }
+            ]
+        }));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn unresolved_contains_warns() {
+        let diags = run(json!({
+            "name": "menu",
+            "anatomy": [
+                { "name": "menu-item", "description": "A row.", "contains": ["checkbox"] }
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-048"));
+        assert!(diags[0].message.contains("checkbox"));
+    }
+
+    #[test]
+    fn no_contains_no_warning() {
+        let diags = run(json!({
+            "name": "menu",
+            "anatomy": [{ "name": "menu-item", "description": "A row." }]
+        }));
+        assert!(diags.is_empty());
+    }
+}

--- a/sdk/core/src/validate/rules/spec048.rs
+++ b/sdk/core/src/validate/rules/spec048.rs
@@ -54,7 +54,7 @@ impl ValidationRule for Rule {
                     let Some(child_name) = child.as_str() else {
                         continue;
                     };
-                    if !declared_parts.contains(child_name) {
+                    if child_name == part_name || !declared_parts.contains(child_name) {
                         out.push(Diagnostic {
                             file: comp.file.clone(),
                             token: None,
@@ -136,6 +136,20 @@ mod tests {
         assert_eq!(diags[0].severity, Severity::Warning);
         assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-048"));
         assert!(diags[0].message.contains("checkbox"));
+    }
+
+    #[test]
+    fn self_reference_warns() {
+        let diags = run(json!({
+            "name": "menu",
+            "anatomy": [
+                { "name": "menu-item", "description": "A row.", "contains": ["menu-item"] }
+            ]
+        }));
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].rule_id.as_deref(), Some("SPEC-048"));
+        assert!(diags[0].message.contains("menu-item"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Turns the previously-unused, purely-informative anatomy `contains` field into a real,
checked relationship, and uses it to model the actual nested structure of composite
items (menu-item, list-item, table row) instead of flat leaf parts.

- **New rule SPEC-048 `anatomy-contains-resolves`** (warning): a `contains` entry
  SHOULD match a sibling anatomy part's `name`. Deliberately advisory, not an error —
  `packages/design-data-spec/spec/anatomy-format.md` already documented that
  cross-component `contains` references are permitted (sub-component anatomy in
  layered designs), so this rule only warns on unresolved same-component references.
- **`packages/design-data-spec/`**: rule definition (`rules/rules.yaml`), schema
  description updates (`schemas/anatomy-part.schema.json`,
  `schemas/component.schema.json`), a new "flat vs. `contains`" authoring convention
  section in `spec/anatomy-format.md`, and conformance fixtures under
  `conformance/{valid,invalid}/SPEC-048/`.
- **`sdk/core/src/validate/rules/spec048.rs`**: rule implementation, registered in
  `mod.rs`.
- **Component data**: `menu.json` declares `menu-item`'s 9 child parts (icon, label,
  description, value, switch, checkbox, thumbnail, drill-in-chevron, link-out-icon);
  `list-view.json` gains its first `anatomy` array (`list-item` + 7 children — this
  component had no anatomy declared before); `table.json`'s `row` now declares
  `contains: ["row-checkbox"]`, reusing an already-declared sibling part.
- `tree-view` and `accordion` were surveyed as candidates but deferred — both would
  need a whole new anatomy structure invented from scratch, which is a bigger unit of
  work than this bead's minimum (menu-item, list-item).

## Related Issue

Closes beads issue `spectrum-design-data-5us`.

## Motivation and Context

04c.3 added flat anatomy ids (`menu-item`, `item-label`) purely to satisfy SPEC-047
gap-endpoint validation — they didn't model the real nested structure s2-docs shows
(composite items own sub-parts like icon, label, checkbox, thumbnail). The `contains`
field already existed in the schema for exactly this but was unused everywhere and
carried no enforcement, so nothing kept it accurate. This makes it a real, validated
relationship and populates it for the two components the bead names.

## How Has This Been Tested?

- `cargo test --workspace`: full suite green, including 3 new unit tests in
  `spec048.rs` and the new `conformance/{valid,invalid}/SPEC-048` fixtures picked up
  automatically by the existing conformance harness.
- `moon run design-data:validate` (full pipeline, loads components): clean — zero
  SPEC-048 warnings, confirming every declared `contains` child resolves; only
  pre-existing unrelated warnings remain.
- `moon run sdk:lint` (clippy): clean.
- `moon run design-data-spec:check` and `moon run :test --affected` (incl. wasm
  build/test): clean.
- Changeset linted with
  `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
