### PR TITLE
fix(design-data): decompose icon inverse-variant and color-wheel margin tokens

### DIFF
--- a/.changeset/fix-icon-inverse-variant-decomposition.md
+++ b/.changeset/fix-icon-inverse-variant-decomposition.md
@@ -1,0 +1,20 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Fix decomposition of `icon.color-inverse`, `icon.color-inverse-background`, and
+`color-wheel.color-area-margin` name objects (closes spectrum-design-data-2mh).
+
+- **packages/design-data/tokens/icons.tokens.json**: decompose the two inverse icon
+  color tokens into `{component: "icon", property, variant: "inverse"}`.
+- **packages/design-data/tokens/layout-component.tokens.json**: decompose
+  `color-wheel.color-area-margin` into `{component: "color-wheel", property: "margin",
+  anatomy: "color-area"}`.
+- **packages/tokens/src/icons.json**: regenerated legacy output reflecting the new
+  `inverse-icon-color` / `inverse-icon-background-color` keys.
+- **sdk/core/src/naming.rs**: `NameObject` gains a `variant` field; `parse_legacy_name`
+  and `generate_legacy_name` recognize context-category variant words (`inverse`,
+  `static`, `over-background`) as a leading key segment.
+- **sdk/core/src/migrate.rs**: `build_flat`'s no-context path now attempts decomposition
+  via `naming::roundtrips` before falling back to a thin name, matching `resolve_name`'s
+  existing behavior.

--- a/.changeset/fix-icon-inverse-variant-decomposition.md
+++ b/.changeset/fix-icon-inverse-variant-decomposition.md
@@ -3,18 +3,20 @@
 ---
 
 Fix decomposition of `icon.color-inverse`, `icon.color-inverse-background`, and
-`color-wheel.color-area-margin` name objects (closes spectrum-design-data-2mh).
+`color-wheel.color-area-margin` name objects (closes spectrum-design-data-2mh). No
+behavior change for `@adobe/spectrum-tokens` consumers — the legacy flat keys are pinned
+via the new `legacyKey` escape hatch.
 
 - **packages/design-data/tokens/icons.tokens.json**: decompose the two inverse icon
-  color tokens into `{component: "icon", property, variant: "inverse"}`.
+  color tokens into `{component, property, variant: "inverse", legacyKey}`.
 - **packages/design-data/tokens/layout-component.tokens.json**: decompose
   `color-wheel.color-area-margin` into `{component: "color-wheel", property: "margin",
   anatomy: "color-area"}`.
-- **packages/tokens/src/icons.json**: regenerated legacy output reflecting the new
-  `inverse-icon-color` / `inverse-icon-background-color` keys.
 - **sdk/core/src/naming.rs**: `NameObject` gains a `variant` field; `parse_legacy_name`
   and `generate_legacy_name` recognize context-category variant words (`inverse`,
-  `static`, `over-background`) as a leading key segment.
+  `static`, `over-background`) as a leading key segment. `extract_legacy_key` honors a new
+  `name.legacyKey` override, checked before reconstruction.
 - **sdk/core/src/migrate.rs**: `build_flat`'s no-context path now attempts decomposition
-  via `naming::roundtrips` before falling back to a thin name, matching `resolve_name`'s
-  existing behavior.
+  via `naming::roundtrips` before falling back to a thin name, matching `resolve_name`.
+- **packages/design-data-spec/schemas/token.schema.json**: document the `legacyKey`
+  escape-hatch field on the name object.

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -90,6 +90,11 @@
         "contrast": {
           "type": "string",
           "description": "Mode set: contrast level (e.g. regular, high)."
+        },
+        "legacyKey": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Escape hatch: pins the exact flat key written to legacy output (packages/tokens/src), overriding reconstruction from the rest of this name object. Use when correcting or extending a token's decomposition would otherwise change its published legacy key."
         }
       },
       "additionalProperties": {

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -1286,7 +1286,8 @@
     "name": {
       "component": "icon",
       "property": "color",
-      "variant": "inverse"
+      "variant": "inverse",
+      "legacyKey": "icon-color-inverse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
@@ -1297,7 +1298,8 @@
     "name": {
       "component": "icon",
       "property": "background-color",
-      "variant": "inverse"
+      "variant": "inverse",
+      "legacyKey": "icon-color-inverse-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -1285,7 +1285,8 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-inverse"
+      "property": "color",
+      "variant": "inverse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
@@ -1295,7 +1296,8 @@
   {
     "name": {
       "component": "icon",
-      "property": "color-inverse-background"
+      "property": "background-color",
+      "variant": "inverse"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -5628,7 +5628,8 @@
   {
     "name": {
       "component": "color-wheel",
-      "property": "color-area-margin"
+      "property": "margin",
+      "anatomy": "color-area"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",

--- a/packages/tokens/src/icons.json
+++ b/packages/tokens/src/icons.json
@@ -643,19 +643,6 @@
       }
     }
   },
-  "icon-color-inverse": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "icon",
-    "value": "{gray-50}",
-    "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
-    "deprecated": true
-  },
-  "icon-color-inverse-background": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "icon",
-    "value": "{gray-50}",
-    "uuid": "ba10ab97-0c09-4d07-ab7b-050258169d52"
-  },
   "icon-color-magenta-background": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "icon",
@@ -1369,5 +1356,18 @@
         "uuid": "f4edf76c-b3f4-4455-b1d5-e222fa79b146"
       }
     }
+  },
+  "inverse-icon-background-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "icon",
+    "value": "{gray-50}",
+    "uuid": "ba10ab97-0c09-4d07-ab7b-050258169d52"
+  },
+  "inverse-icon-color": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "icon",
+    "value": "{gray-50}",
+    "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
+    "deprecated": true
   }
 }

--- a/packages/tokens/src/icons.json
+++ b/packages/tokens/src/icons.json
@@ -643,6 +643,19 @@
       }
     }
   },
+  "icon-color-inverse": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "icon",
+    "value": "{gray-50}",
+    "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
+    "deprecated": true
+  },
+  "icon-color-inverse-background": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "icon",
+    "value": "{gray-50}",
+    "uuid": "ba10ab97-0c09-4d07-ab7b-050258169d52"
+  },
   "icon-color-magenta-background": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "component": "icon",
@@ -1356,18 +1369,5 @@
         "uuid": "f4edf76c-b3f4-4455-b1d5-e222fa79b146"
       }
     }
-  },
-  "inverse-icon-background-color": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "icon",
-    "value": "{gray-50}",
-    "uuid": "ba10ab97-0c09-4d07-ab7b-050258169d52"
-  },
-  "inverse-icon-color": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "icon",
-    "value": "{gray-50}",
-    "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
-    "deprecated": true
   }
 }

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -226,25 +226,29 @@ fn resolve_name(
         // Decompose via parse_legacy_name and check roundtrip.
         if naming::roundtrips(key, component_hint) {
             let parsed = naming::parse_legacy_name(key, component_hint);
-            let mut name = Map::new();
-            if let Some(c) = &parsed.component {
-                name.insert("component".into(), Value::String(c.clone()));
-            }
-            name.insert("property".into(), Value::String(parsed.property));
-            if let Some(s) = &parsed.state {
-                name.insert("state".into(), Value::String(s.clone()));
-            }
-            return (Value::Object(name), NameKind::Decomposed);
+            return (decomposed_name_val(&parsed), NameKind::Decomposed);
         }
     }
 
-    // 4. Thin fallback — property = full legacy key (always roundtrip-safe).
+    (thin_name_val(key, token_obj), NameKind::Thin)
+}
+
+/// Build the cascade `name` value for a successfully-decomposed [`naming::NameObject`]
+/// (variant/component/property/state, in that order — mirrors the field-catalog
+/// serialization order used by `naming::extract_legacy_key`'s general path).
+fn decomposed_name_val(parsed: &naming::NameObject) -> Value {
     let mut name = Map::new();
-    name.insert("property".into(), Value::String(key.to_string()));
-    if let Some(c) = component_hint {
-        name.insert("component".into(), Value::String(c.to_string()));
+    if let Some(v) = &parsed.variant {
+        name.insert("variant".into(), Value::String(v.clone()));
     }
-    (Value::Object(name), NameKind::Thin)
+    if let Some(c) = &parsed.component {
+        name.insert("component".into(), Value::String(c.clone()));
+    }
+    name.insert("property".into(), Value::String(parsed.property.clone()));
+    if let Some(s) = &parsed.state {
+        name.insert("state".into(), Value::String(s.clone()));
+    }
+    Value::Object(name)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -721,8 +725,15 @@ fn build_flat(
         record_name_kind(kind, 1, summary);
         resolved
     } else {
-        // Thin path: property + optional component (no name resolution context).
-        thin_name_val(property, token_obj)
+        // No sidecar/exceptions context — still attempt decomposition, since
+        // parse_legacy_name/roundtrips only need the key and the token's own
+        // `component` metadata. Falls back to thin if it doesn't roundtrip.
+        let component_hint = token_obj.get("component").and_then(|v| v.as_str());
+        if naming::roundtrips(property, component_hint) {
+            decomposed_name_val(&naming::parse_legacy_name(property, component_hint))
+        } else {
+            thin_name_val(property, token_obj)
+        }
     };
     out.insert("name".into(), name_val);
 
@@ -853,7 +864,10 @@ mod tests {
         );
         assert_eq!(tokens.len(), 1);
         let t = &tokens[0];
-        assert_eq!(t["name"]["property"], "swatch-border-color");
+        // "swatch-border-color" decomposes cleanly (component prefix + property),
+        // so build_flat's no-context path now resolves it via parse_legacy_name
+        // rather than falling back to a thin property.
+        assert_eq!(t["name"]["property"], "border-color");
         assert_eq!(t["name"]["component"], "swatch");
         assert_eq!(t["$ref"], "gray-1000");
         assert!(t.get("value").is_none());

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -58,6 +58,17 @@ static STATE_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     .collect()
 });
 
+/// Context variant words (`category: "context"` in `variants.json`) that may appear
+/// as the leading segment of a legacy key, ahead of `component` — e.g.
+/// `inverse-icon-color`. These are the only variants naming-aware since they're the
+/// only ones observed to precede `component` in a flat legacy key; other variant
+/// categories (emphasis, semantic, color) don't currently appear in this position.
+static VARIANT_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    ["inverse", "static", "over-background"]
+        .into_iter()
+        .collect()
+});
+
 /// Structured identity extracted from (or mapped to) a legacy kebab-case key.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NameObject {
@@ -65,16 +76,24 @@ pub struct NameObject {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<String>,
 }
 
 /// Generate the canonical legacy name from a [`NameObject`].
 ///
 /// Rules:
-/// 1. If `component` is present, emit `{component}-{property}`.
-/// 2. If `state` is present, append `-{state}`.
+/// 1. If `variant` is present, emit `{variant}-` first (leads `component`, mirroring
+///    the field-catalog serialization order in `extract_legacy_key`).
+/// 2. If `component` is present, emit `{component}-`.
+/// 3. Always emit `{property}`.
+/// 4. If `state` is present, append `-{state}`.
 pub fn generate_legacy_name(obj: &NameObject) -> String {
     let mut parts: Vec<&str> = Vec::new();
+    if let Some(v) = &obj.variant {
+        parts.push(v);
+    }
     if let Some(c) = &obj.component {
         parts.push(c);
     }
@@ -90,15 +109,18 @@ pub fn generate_legacy_name(obj: &NameObject) -> String {
 /// `component_hint` comes from the legacy JSON body's `"component"` field when
 /// present and is trusted for stripping the prefix.
 ///
-/// After stripping the component prefix the remainder is split: if the **last**
-/// hyphen-segment is a known state word it becomes `state`; everything else
-/// becomes `property`.
+/// A known context-variant word (see [`VARIANT_WORDS`]) leading the key is stripped
+/// first, since it's ordered before `component` in the legacy key. The component
+/// prefix is then stripped from what remains. Finally the trailing segment is
+/// checked for a known state word; everything else becomes `property`.
 pub fn parse_legacy_name(key: &str, component_hint: Option<&str>) -> NameObject {
+    let (variant, rest) = strip_leading_variant(key);
+
     let remainder = match component_hint {
-        Some(c) if key.starts_with(c) && key.get(c.len()..c.len() + 1) == Some("-") => {
-            &key[c.len() + 1..]
+        Some(c) if rest.starts_with(c) && rest.get(c.len()..c.len() + 1) == Some("-") => {
+            &rest[c.len() + 1..]
         }
-        _ => key,
+        _ => rest,
     };
 
     let (property, state) = split_trailing_state(remainder);
@@ -106,8 +128,23 @@ pub fn parse_legacy_name(key: &str, component_hint: Option<&str>) -> NameObject 
     NameObject {
         property: property.to_string(),
         component: component_hint.map(str::to_string),
+        variant: variant.map(str::to_string),
         state: state.map(str::to_string),
     }
+}
+
+/// Strip a known leading context-variant segment (e.g. `"inverse-"`) from `key`.
+///
+/// Returns `(Some(variant), remainder)` when found, else `(None, key)` unchanged.
+fn strip_leading_variant(key: &str) -> (Option<&str>, &str) {
+    for &v in VARIANT_WORDS.iter() {
+        if let Some(rest) = key.strip_prefix(v) {
+            if let Some(rest) = rest.strip_prefix('-') {
+                return (Some(v), rest);
+            }
+        }
+    }
+    (None, key)
 }
 
 /// Split a remainder string into `(property, Option<state>)` by checking

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -202,6 +202,14 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
 
     let name: &Map<String, Value> = name_val.as_object()?;
 
+    // `legacyKey` escape hatch: pins the exact flat key written to legacy output,
+    // independent of the rest of the (fully decomposed) `name` object. Use this when
+    // correcting/extending a token's cascade decomposition (e.g. adding `variant`) would
+    // otherwise change the key in the published legacy package.
+    if let Some(lk) = name.get("legacyKey").and_then(|v| v.as_str()) {
+        return Some(lk.to_string());
+    }
+
     // Color-domain serialization — two sub-cases distinguished by component presence.
     //
     //   Palette ramp (no component): {variant?}-{colorFamily}-{scaleIndex?}

--- a/sdk/core/tests/prop_naming.rs
+++ b/sdk/core/tests/prop_naming.rs
@@ -206,3 +206,14 @@ proptest! {
         );
     }
 }
+
+/// `inverse-icon-color` is the motivating case for `variant` support: a context-variant
+/// word (`inverse`) leads the key, ahead of `component`.
+#[test]
+fn variant_leading_key_roundtrips() {
+    let parsed = parse_legacy_name("inverse-icon-color", Some("icon"));
+    assert_eq!(parsed.variant, Some("inverse".to_string()));
+    assert_eq!(parsed.component, Some("icon".to_string()));
+    assert_eq!(parsed.property, "color");
+    assert_eq!(generate_legacy_name(&parsed), "inverse-icon-color");
+}

--- a/sdk/core/tests/prop_naming.rs
+++ b/sdk/core/tests/prop_naming.rs
@@ -126,6 +126,7 @@ proptest! {
             property: property.clone(),
             component: component.clone(),
             state: state.clone(),
+            variant: None,
         };
         let key = generate_legacy_name(&obj);
         let parsed = parse_legacy_name(&key, component.as_deref());
@@ -156,14 +157,14 @@ proptest! {
         component in optional_component(),
         state in optional_state(),
     ) {
-        let obj = NameObject { property, component, state };
+        let obj = NameObject { property, component, state, variant: None };
         prop_assert!(!generate_legacy_name(&obj).is_empty());
     }
 
     /// `generate_legacy_name` output contains the property as a substring.
     #[test]
     fn generated_key_contains_property(property in safe_property()) {
-        let obj = NameObject { property: property.clone(), component: None, state: None };
+        let obj = NameObject { property: property.clone(), component: None, state: None, variant: None };
         let key = generate_legacy_name(&obj);
         prop_assert!(
             key.contains(&property),
@@ -174,7 +175,7 @@ proptest! {
     /// `generate_legacy_name` with no component or state equals the property.
     #[test]
     fn generate_bare_property_is_identity(property in safe_property()) {
-        let obj = NameObject { property: property.clone(), component: None, state: None };
+        let obj = NameObject { property: property.clone(), component: None, state: None, variant: None };
         prop_assert_eq!(generate_legacy_name(&obj), property);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes the 3 tokens flagged as not fitting the `color-<hue>-<role>` migration pattern
(`migrate-color-role.js`) into proper cascade `name` objects:

- `icon.color-inverse` → `{component: "icon", property: "color", variant: "inverse"}`
- `icon.color-inverse-background` → `{component: "icon", property: "background-color", variant: "inverse"}`
- `color-wheel.color-area-margin` → `{component: "color-wheel", property: "margin", anatomy: "color-area"}`

The icon tokens use the already-registered context variant `inverse`
(`registry/variants.json`, category `context`), which the naming engine did not previously
support. Extended the naming engine so `variant` is a first-class part of the legacy-key
round trip:

- `sdk/core/src/naming.rs`: `NameObject` gains a `variant` field. `parse_legacy_name` /
  `generate_legacy_name` recognize context-category variant words (`inverse`, `static`,
  `over-background`) as a leading key segment (e.g. `inverse-icon-color`).
- `sdk/core/src/migrate.rs`: `build_flat`'s no-sidecar-context path now attempts
  decomposition via `naming::roundtrips` before falling back to a thin name, matching the
  sidecar-aware `resolve_name` path's existing behavior. (This path is what
  `roundtrip-verify` exercises internally.)

**No breaking change for `@adobe/spectrum-tokens` consumers.** Decomposing with `variant`
would otherwise change the icon tokens' flat legacy keys (`icon-color-inverse` →
`inverse-icon-color`). To avoid that right now, added a `legacyKey` escape hatch on the
cascade `name` object — checked first in `extract_legacy_key`, before any reconstruction —
that pins the exact flat key independent of the rest of the (now-correct) name object.
`packages/tokens/src/icons.json` is byte-identical to `main`.

## Related Issue

Closes spectrum-design-data-2mh (internal beads issue; no linked GitHub issue).

## Motivation and Context

These 3 tokens were skipped by the color-role migration script because they don't fit the
`color-<hue>-<role>` pattern. Investigation confirmed they're not miscategorized color
tokens — they need proper name-object decomposition using existing registry concepts
(context variant, nested anatomy `contains` from #1223/SPEC-048) rather than new fields.
The `legacyKey` escape hatch defers the actual legacy-key rename to a future, deliberate
breaking-change release.

## How Has This Been Tested?

- `moon run sdk:test` — full Rust workspace test suite passes (added `variant: None` to
  existing `NameObject` literals in `prop_naming.rs`; updated one unit test assertion in
  `migrate.rs` that now correctly decomposes rather than falling back to thin).
- `moon run design-data:roundtrip-verify` — 0 diffs across the full legacy token corpus.
- `moon run design-data:validate` — passes (only pre-existing, unrelated warnings).
- `git diff main -- packages/tokens/src/icons.json` — empty; confirms no change to
  published legacy output.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset passes.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
