### PR TITLE
feat(design-data): add typography emphasis field, decompose overloaded property values

### DIFF
--- a/.changeset/pur-typography-emphasis-decomposition.md
+++ b/.changeset/pur-typography-emphasis-decomposition.md
@@ -1,0 +1,21 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Add a typography `emphasis` field and decompose overloaded typography `property`
+values into `family`/`emphasis` (closes spectrum-design-data-pur).
+
+- **packages/design-data/fields/emphasis.json**: new field for typography emphasis
+  (`strong`, `light`, `heavy`, `emphasized`, `non-emphasized`, and compounds).
+- **packages/design-data/registry/typography-emphasis.json**: new registry backing
+  the `emphasis` field.
+- **packages/design-data/fields/family.json**: `excludeFromLegacyKey` flipped to
+  `false` so `family` now participates in legacy key reconstruction.
+- **packages/design-data/registry/property-terms.json**: register atomic typography
+  properties (margin/margin-multiplier variants, `text-transform`).
+- **sdk/core/src/naming.rs**: serialize `family`/`emphasis` into the legacy key.
+- **tools/token-mapping-analyzer/src/decomposer.js**: match `family`/`emphasis`
+  registry terms (including compound runs) instead of parking them as gaps.
+- **packages/design-data/tokens/typography.tokens.json**,
+  **layout-component.tokens.json**: migrate 197 tokens to the new `family`/`emphasis`
+  fields via `tools/token-mapping-analyzer/src/apply.js`.

--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -15,7 +15,8 @@
     "component-options-editor:validate",
     "root:test",
     "s2-docs-to-document-blocks:test",
-    "design-data:validate-guidelines"
+    "design-data:validate-guidelines",
+    "token-mapping-analyzer:test"
   ],
   "rust": [
     "sdk:fmt-check",

--- a/.github/ci-targets.json
+++ b/.github/ci-targets.json
@@ -61,6 +61,7 @@
     "site:export",
     "site:generateToolsPage",
     "token-diff-generator:diff",
+    "token-mapping-analyzer:analyze",
     "token-naming-audit:lint",
     "tokens:build",
     "viewer:clean",

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -26,6 +26,7 @@ projects:
   s2-docs-mcp: "tools/s2-docs-mcp"
   component-options-editor: "tools/component-options-editor"
   token-naming-audit: "tools/token-naming-audit"
+  token-mapping-analyzer: "tools/token-mapping-analyzer"
   demo: "tools/demo"
   design-data-glue: "tools/design-data"
   design-data-skill: "tools/design-data-skill"

--- a/docs/proposals/001-typography-taxonomy.md
+++ b/docs/proposals/001-typography-taxonomy.md
@@ -1,6 +1,6 @@
 # Proposal 001: Typography Taxonomy
 
-**Status:** Draft\
+**Status:** Partially adopted (2026-07-08) — see [Decision](#decision-2026-07-08) below\
 **Affects:** 221 active tokens in `typography.json`\
 **Spec reference:** taxonomy.md line 76 — "Additional categories do and will exist for other token types (e.g. color, typography)."
 
@@ -78,3 +78,20 @@ Note: `heavy-emphasized` is a compound emphasis value (heavy + emphasized). This
 * 221 active tokens move from MEDIUM to HIGH confidence
 * Three new registry files created
 * Taxonomy spec updated with typography scope section
+
+## Decision (2026-07-08)
+
+Adopted with one change: **`script` is dropped in favor of the already-shipped `family` field**
+(`packages/design-data/fields/family.json`), whose registry (`typography-families.json`) already
+enumerates `cjk` alongside `sans-serif`/`serif`/`code`. A separate `script` field would duplicate
+that axis for no gain — `cjk` is a family value here, not an independent dimension.
+
+`emphasis` is adopted as proposed: new field `packages/design-data/fields/emphasis.json` +
+registry `packages/design-data/registry/typography-emphasis.json`, scoped to typography, holding
+the atomic modifiers (`emphasized`, `strong`, `heavy`, `light`, `non-emphasized`). Compound values
+(e.g. `heavy-strong-emphasized`) are not separately enumerated in the registry — they're built by
+hyphen-joining atomic modifiers, per the compound-state pattern.
+
+This keeps `family` and `emphasis` distinct from the CSS-axis `weight`/`style` fields, which model
+actual `font-weight`/`font-style` values (e.g. `weight: "bold"`) rather than a relative emphasis
+modifier layered on a family/component.

--- a/packages/design-data/fields/alignment.json
+++ b/packages/design-data/fields/alignment.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/alignments.json",
   "validation": "advisory",
   "serialization": {
-    "position": 25
+    "position": 26
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/fields/color-scheme.json
+++ b/packages/design-data/fields/color-scheme.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "strict",
   "serialization": {
-    "position": 13
+    "position": 15
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/colorFamily.json
+++ b/packages/design-data/fields/colorFamily.json
@@ -2,12 +2,12 @@
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
   "specVersion": "1.0.0-draft",
   "name": "colorFamily",
-  "description": "Hue family of a color token (e.g. blue, gray, celery, accent). Used on color palette and semantic color tokens. Paired with scaleIndex for ramp tokens (e.g. colorFamily=blue + scaleIndex=100 \u2192 blue-100).",
+  "description": "Hue family of a color token (e.g. blue, gray, celery, accent). Used on color palette and semantic color tokens. Paired with scaleIndex for ramp tokens (e.g. colorFamily=blue + scaleIndex=100 → blue-100).",
   "kind": "semantic",
   "registry": "packages/design-data/registry/color-families.json",
   "validation": "advisory",
   "serialization": {
-    "position": 17
+    "position": 19
   },
   "scope": "color",
   "required": false,

--- a/packages/design-data/fields/colorRole.json
+++ b/packages/design-data/fields/colorRole.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/color-roles.json",
   "validation": "advisory",
   "serialization": {
-    "position": 16
+    "position": 18
   },
   "scope": "color",
   "required": false,

--- a/packages/design-data/fields/contrast.json
+++ b/packages/design-data/fields/contrast.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "strict",
   "serialization": {
-    "position": 15
+    "position": 17
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/density.json
+++ b/packages/design-data/fields/density.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/densities.json",
   "validation": "advisory",
   "serialization": {
-    "position": 10
+    "position": 12
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/easing.json
+++ b/packages/design-data/fields/easing.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/easing-curves.json",
   "validation": "advisory",
   "serialization": {
-    "position": 22
+    "position": 23
   },
   "scope": "motion",
   "required": false,

--- a/packages/design-data/fields/emphasis.json
+++ b/packages/design-data/fields/emphasis.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "emphasis",
+  "description": "Typographic emphasis level of a typography token (e.g. emphasized, strong, heavy, light). Distinct from the CSS font-weight axis (see `weight`) — emphasis is a relative modifier layered on a family/component, and values may compound (e.g. heavy-strong-emphasized).",
+  "kind": "semantic",
+  "registry": "packages/design-data/registry/typography-emphasis.json",
+  "validation": "advisory",
+  "serialization": {
+    "position": 7
+  },
+  "scope": "typography",
+  "required": false,
+  "valueType": "string",
+  "excludeFromLegacyKey": false
+}

--- a/packages/design-data/fields/family.json
+++ b/packages/design-data/fields/family.json
@@ -7,10 +7,10 @@
   "registry": "packages/design-data/registry/typography-families.json",
   "validation": "advisory",
   "serialization": {
-    "position": 18
+    "position": 6
   },
   "scope": "typography",
   "required": false,
   "valueType": "string",
-  "excludeFromLegacyKey": true
+  "excludeFromLegacyKey": false
 }

--- a/packages/design-data/fields/from.json
+++ b/packages/design-data/fields/from.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "advisory",
   "serialization": {
-    "position": 23
+    "position": 24
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/motionRole.json
+++ b/packages/design-data/fields/motionRole.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/motion-roles.json",
   "validation": "advisory",
   "serialization": {
-    "position": 21
+    "position": 22
   },
   "scope": "motion",
   "required": false,

--- a/packages/design-data/fields/orientation.json
+++ b/packages/design-data/fields/orientation.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/orientations.json",
   "validation": "advisory",
   "serialization": {
-    "position": 7
+    "position": 9
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/position.json
+++ b/packages/design-data/fields/position.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/positions.json",
   "validation": "advisory",
   "serialization": {
-    "position": 8
+    "position": 10
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/property.json
+++ b/packages/design-data/fields/property.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/property-terms.json",
   "validation": "advisory",
   "serialization": {
-    "position": 6
+    "position": 8
   },
   "scope": null,
   "required": true,

--- a/packages/design-data/fields/scale.json
+++ b/packages/design-data/fields/scale.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "strict",
   "serialization": {
-    "position": 14
+    "position": 16
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/shape.json
+++ b/packages/design-data/fields/shape.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/shapes.json",
   "validation": "advisory",
   "serialization": {
-    "position": 11
+    "position": 13
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/size.json
+++ b/packages/design-data/fields/size.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/sizes.json",
   "validation": "advisory",
   "serialization": {
-    "position": 9
+    "position": 11
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/state.json
+++ b/packages/design-data/fields/state.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/states.json",
   "validation": "advisory",
   "serialization": {
-    "position": 12
+    "position": 14
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/style.json
+++ b/packages/design-data/fields/style.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/typography-styles.json",
   "validation": "advisory",
   "serialization": {
-    "position": 20
+    "position": 21
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/fields/to.json
+++ b/packages/design-data/fields/to.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "advisory",
   "serialization": {
-    "position": 24
+    "position": 25
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/weight.json
+++ b/packages/design-data/fields/weight.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/typography-weights.json",
   "validation": "advisory",
   "serialization": {
-    "position": 19
+    "position": 20
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -209,6 +209,26 @@
       "description": "Unitless line-height ratio (multiplier), distinct from the absolute px line-height paired with a specific font-size tier"
     },
     {
+      "id": "margin-multiplier",
+      "label": "Margin Multiplier",
+      "description": "Unitless margin ratio (multiplier), applied to both top and bottom of a typography block"
+    },
+    {
+      "id": "margin-top-multiplier",
+      "label": "Margin Top Multiplier",
+      "description": "Unitless margin ratio (multiplier) applied above a typography block"
+    },
+    {
+      "id": "margin-bottom-multiplier",
+      "label": "Margin Bottom Multiplier",
+      "description": "Unitless margin ratio (multiplier) applied below a typography block"
+    },
+    {
+      "id": "text-transform",
+      "label": "Text Transform",
+      "description": "Case transformation applied to text content (e.g. uppercase, lowercase)"
+    },
+    {
       "id": "minimum-width",
       "label": "Minimum Width",
       "description": "CSS min-width constraint (design-system abstraction)"

--- a/packages/design-data/registry/typography-emphasis.json
+++ b/packages/design-data/registry/typography-emphasis.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "typography-emphasis",
+  "description": "Typographic emphasis identifiers for typography tokens. Assigned via the `emphasis` name-object field. Distinct from the CSS font-weight axis (see `weight`): emphasis is a relative modifier layered on a family/component (e.g. `cjk-strong-font-weight`), and values may compound (e.g. `heavy-strong-emphasized`) by hyphen-joining multiple modifiers.",
+  "values": [
+    {
+      "id": "emphasized",
+      "label": "Emphasized",
+      "description": "Standard emphasis"
+    },
+    {
+      "id": "strong",
+      "label": "Strong",
+      "description": "Strong emphasis (heavier than emphasized)"
+    },
+    {
+      "id": "heavy",
+      "label": "Heavy",
+      "description": "Heaviest emphasis"
+    },
+    {
+      "id": "light",
+      "label": "Light",
+      "description": "Lighter than default emphasis"
+    },
+    {
+      "id": "non-emphasized",
+      "label": "Non-Emphasized",
+      "description": "Explicitly not emphasized (maps to isEmphasized: false)"
+    }
+  ]
+}

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -19077,8 +19077,10 @@
   },
   {
     "name": {
-      "property": "title-cjk-emphasized-font-style",
-      "component": "title"
+      "property": "font-style",
+      "component": "title",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19086,8 +19088,10 @@
   },
   {
     "name": {
-      "property": "title-cjk-emphasized-font-weight",
-      "component": "title"
+      "property": "font-weight",
+      "component": "title",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -19096,7 +19100,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-font-family"
+      "property": "font-family",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -19105,7 +19110,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-font-style"
+      "property": "font-style",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19114,7 +19120,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-font-weight"
+      "property": "font-weight",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -19123,7 +19130,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-line-height"
+      "property": "line-height",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
@@ -19194,8 +19202,10 @@
   },
   {
     "name": {
-      "property": "title-cjk-strong-emphasized-font-style",
-      "component": "title"
+      "property": "font-style",
+      "component": "title",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19203,8 +19213,10 @@
   },
   {
     "name": {
-      "property": "title-cjk-strong-emphasized-font-weight",
-      "component": "title"
+      "property": "font-weight",
+      "component": "title",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -19213,7 +19225,9 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19222,7 +19236,9 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -19257,8 +19273,10 @@
   },
   {
     "name": {
-      "property": "title-sans-serif-emphasized-font-style",
-      "component": "title"
+      "property": "font-style",
+      "component": "title",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -19266,8 +19284,10 @@
   },
   {
     "name": {
-      "property": "title-sans-serif-emphasized-font-weight",
-      "component": "title"
+      "property": "font-weight",
+      "component": "title",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -19276,7 +19296,8 @@
   {
     "name": {
       "component": "title",
-      "property": "sans-serif-font-family"
+      "property": "font-family",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
@@ -19285,7 +19306,8 @@
   {
     "name": {
       "component": "title",
-      "property": "sans-serif-font-style"
+      "property": "font-style",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19294,7 +19316,8 @@
   {
     "name": {
       "component": "title",
-      "property": "sans-serif-font-weight"
+      "property": "font-weight",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -19302,8 +19325,10 @@
   },
   {
     "name": {
-      "property": "title-sans-serif-strong-emphasized-font-style",
-      "component": "title"
+      "property": "font-style",
+      "component": "title",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -19311,8 +19336,10 @@
   },
   {
     "name": {
-      "property": "title-sans-serif-strong-emphasized-font-weight",
-      "component": "title"
+      "property": "font-weight",
+      "component": "title",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -19321,7 +19348,9 @@
   {
     "name": {
       "component": "title",
-      "property": "sans-serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19330,7 +19359,9 @@
   {
     "name": {
       "component": "title",
-      "property": "sans-serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -19338,8 +19369,10 @@
   },
   {
     "name": {
-      "property": "title-serif-emphasized-font-style",
-      "component": "title"
+      "property": "font-style",
+      "component": "title",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -19347,8 +19380,10 @@
   },
   {
     "name": {
-      "property": "title-serif-emphasized-font-weight",
-      "component": "title"
+      "property": "font-weight",
+      "component": "title",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -19357,7 +19392,8 @@
   {
     "name": {
       "component": "title",
-      "property": "serif-font-family"
+      "property": "font-family",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
@@ -19366,7 +19402,8 @@
   {
     "name": {
       "component": "title",
-      "property": "serif-font-style"
+      "property": "font-style",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19375,7 +19412,8 @@
   {
     "name": {
       "component": "title",
-      "property": "serif-font-weight"
+      "property": "font-weight",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -19383,8 +19421,10 @@
   },
   {
     "name": {
-      "property": "title-serif-strong-emphasized-font-style",
-      "component": "title"
+      "property": "font-style",
+      "component": "title",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -19392,8 +19432,10 @@
   },
   {
     "name": {
-      "property": "title-serif-strong-emphasized-font-weight",
-      "component": "title"
+      "property": "font-weight",
+      "component": "title",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -19402,7 +19444,9 @@
   {
     "name": {
       "component": "title",
-      "property": "serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19411,7 +19455,9 @@
   {
     "name": {
       "component": "title",
-      "property": "serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -10,8 +10,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-emphasized-font-style",
-      "component": "body"
+      "property": "font-style",
+      "component": "body",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -19,8 +21,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-emphasized-font-weight",
-      "component": "body"
+      "property": "font-weight",
+      "component": "body",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -29,7 +33,8 @@
   {
     "name": {
       "component": "body",
-      "property": "cjk-font-family"
+      "property": "font-family",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -38,7 +43,8 @@
   {
     "name": {
       "component": "body",
-      "property": "cjk-font-style"
+      "property": "font-style",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -47,7 +53,8 @@
   {
     "name": {
       "component": "body",
-      "property": "cjk-font-weight"
+      "property": "font-weight",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -56,7 +63,8 @@
   {
     "name": {
       "component": "body",
-      "property": "cjk-line-height"
+      "property": "line-height",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
@@ -128,8 +136,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-strong-emphasized-font-style",
-      "component": "body"
+      "property": "font-style",
+      "component": "body",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -137,8 +147,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-strong-emphasized-font-weight",
-      "component": "body"
+      "property": "font-weight",
+      "component": "body",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -147,7 +159,9 @@
   {
     "name": {
       "component": "body",
-      "property": "cjk-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -156,7 +170,9 @@
   {
     "name": {
       "component": "body",
-      "property": "cjk-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -192,8 +208,10 @@
   },
   {
     "name": {
-      "property": "body-sans-serif-emphasized-font-style",
-      "component": "body"
+      "property": "font-style",
+      "component": "body",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -201,8 +219,10 @@
   },
   {
     "name": {
-      "property": "body-sans-serif-emphasized-font-weight",
-      "component": "body"
+      "property": "font-weight",
+      "component": "body",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -211,7 +231,8 @@
   {
     "name": {
       "component": "body",
-      "property": "sans-serif-font-family"
+      "property": "font-family",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
@@ -220,7 +241,8 @@
   {
     "name": {
       "component": "body",
-      "property": "sans-serif-font-style"
+      "property": "font-style",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -229,7 +251,8 @@
   {
     "name": {
       "component": "body",
-      "property": "sans-serif-font-weight"
+      "property": "font-weight",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -237,8 +260,10 @@
   },
   {
     "name": {
-      "property": "body-sans-serif-strong-emphasized-font-style",
-      "component": "body"
+      "property": "font-style",
+      "component": "body",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -246,8 +271,10 @@
   },
   {
     "name": {
-      "property": "body-sans-serif-strong-emphasized-font-weight",
-      "component": "body"
+      "property": "font-weight",
+      "component": "body",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -256,7 +283,9 @@
   {
     "name": {
       "component": "body",
-      "property": "sans-serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -265,7 +294,9 @@
   {
     "name": {
       "component": "body",
-      "property": "sans-serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -273,8 +304,10 @@
   },
   {
     "name": {
-      "property": "body-serif-emphasized-font-style",
-      "component": "body"
+      "property": "font-style",
+      "component": "body",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -282,8 +315,10 @@
   },
   {
     "name": {
-      "property": "body-serif-emphasized-font-weight",
-      "component": "body"
+      "property": "font-weight",
+      "component": "body",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -292,7 +327,8 @@
   {
     "name": {
       "component": "body",
-      "property": "serif-font-family"
+      "property": "font-family",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
@@ -301,7 +337,8 @@
   {
     "name": {
       "component": "body",
-      "property": "serif-font-style"
+      "property": "font-style",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -310,7 +347,8 @@
   {
     "name": {
       "component": "body",
-      "property": "serif-font-weight"
+      "property": "font-weight",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -318,8 +356,10 @@
   },
   {
     "name": {
-      "property": "body-serif-strong-emphasized-font-style",
-      "component": "body"
+      "property": "font-style",
+      "component": "body",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -327,8 +367,10 @@
   },
   {
     "name": {
-      "property": "body-serif-strong-emphasized-font-weight",
-      "component": "body"
+      "property": "font-weight",
+      "component": "body",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -337,7 +379,9 @@
   {
     "name": {
       "component": "body",
-      "property": "serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -346,7 +390,9 @@
   {
     "name": {
       "component": "body",
-      "property": "serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -434,7 +480,7 @@
   },
   {
     "name": {
-      "property": "cjk-font-family",
+      "property": "font-family",
       "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
@@ -443,7 +489,8 @@
   },
   {
     "name": {
-      "property": "cjk-letter-spacing"
+      "property": "letter-spacing",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8caf3aa-1261-411f-b383-18f87334c117",
@@ -451,7 +498,7 @@
   },
   {
     "name": {
-      "property": "cjk-line-height-100",
+      "property": "line-height-100",
       "scaleIndex": 100,
       "family": "cjk"
     },
@@ -461,7 +508,7 @@
   },
   {
     "name": {
-      "property": "cjk-line-height-200",
+      "property": "line-height-200",
       "scaleIndex": 200,
       "family": "cjk"
     },
@@ -490,7 +537,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-font-family"
+      "property": "font-family",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1",
@@ -499,7 +547,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-font-style"
+      "property": "font-style",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -508,7 +557,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-font-weight"
+      "property": "font-weight",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -517,7 +567,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-line-height"
+      "property": "line-height",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
@@ -544,7 +595,9 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -553,7 +606,9 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -570,8 +625,9 @@
   },
   {
     "name": {
-      "property": "code-emphasized-font-style",
-      "component": "code"
+      "property": "font-style",
+      "component": "code",
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -579,8 +635,9 @@
   },
   {
     "name": {
-      "property": "code-emphasized-font-weight",
-      "component": "code"
+      "property": "font-weight",
+      "component": "code",
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -589,8 +646,7 @@
   {
     "name": {
       "component": "code",
-      "property": "font-family",
-      "family": "code"
+      "property": "font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
     "value": "Source Code Pro",
@@ -670,8 +726,9 @@
   },
   {
     "name": {
-      "property": "code-strong-emphasized-font-style",
-      "component": "code"
+      "property": "font-style",
+      "component": "code",
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -679,8 +736,9 @@
   },
   {
     "name": {
-      "property": "code-strong-emphasized-font-weight",
-      "component": "code"
+      "property": "font-weight",
+      "component": "code",
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -689,7 +747,8 @@
   {
     "name": {
       "component": "code",
-      "property": "strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -698,7 +757,8 @@
   {
     "name": {
       "component": "code",
-      "property": "strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -948,8 +1008,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -957,8 +1019,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -967,7 +1031,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-font-family"
+      "property": "font-family",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -976,7 +1041,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-font-style"
+      "property": "font-style",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -985,7 +1051,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-font-weight"
+      "property": "font-weight",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -993,8 +1060,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-light-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "light-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1003,8 +1072,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-light-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "light-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1014,7 +1085,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-light-font-style"
+      "property": "font-style",
+      "emphasis": "light",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1024,7 +1097,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-light-font-weight"
+      "property": "font-weight",
+      "emphasis": "light",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
@@ -1033,8 +1108,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-light-strong-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "light-strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1043,8 +1120,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-light-strong-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "light-strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1054,7 +1133,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-light-strong-font-style"
+      "property": "font-style",
+      "emphasis": "light-strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1064,7 +1145,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-light-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "light-strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1074,7 +1157,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-line-height"
+      "property": "line-height",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
@@ -1127,8 +1211,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-strong-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1136,8 +1222,10 @@
   },
   {
     "name": {
-      "property": "detail-cjk-strong-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1146,7 +1234,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1155,7 +1245,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1211,8 +1303,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1220,8 +1314,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1230,7 +1326,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-font-family"
+      "property": "font-family",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
@@ -1239,7 +1336,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-font-style"
+      "property": "font-style",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1248,7 +1346,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-font-weight"
+      "property": "font-weight",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
@@ -1256,8 +1355,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-light-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "light-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1266,8 +1367,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-light-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "light-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1277,7 +1380,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-light-font-style"
+      "property": "font-style",
+      "emphasis": "light",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1287,7 +1392,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-light-font-weight"
+      "property": "font-weight",
+      "emphasis": "light",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1296,8 +1403,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-light-strong-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "light-strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1306,8 +1415,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-light-strong-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "light-strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1317,7 +1428,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-light-strong-font-style"
+      "property": "font-style",
+      "emphasis": "light-strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1327,7 +1440,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-light-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "light-strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1336,8 +1451,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-strong-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1345,8 +1462,10 @@
   },
   {
     "name": {
-      "property": "detail-sans-serif-strong-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -1355,7 +1474,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1364,7 +1485,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -1373,7 +1496,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "sans-serif-text-transform"
+      "property": "text-transform",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/text-transform.json",
     "value": "uppercase",
@@ -1382,8 +1506,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1391,8 +1517,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
@@ -1401,7 +1529,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-font-family"
+      "property": "font-family",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
@@ -1410,7 +1539,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-font-style"
+      "property": "font-style",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1419,7 +1549,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-font-weight"
+      "property": "font-weight",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
@@ -1427,8 +1558,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-light-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "light-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1437,8 +1570,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-light-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "light-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1448,7 +1583,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-light-font-style"
+      "property": "font-style",
+      "emphasis": "light",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1458,7 +1595,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-light-font-weight"
+      "property": "font-weight",
+      "emphasis": "light",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1467,8 +1606,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-light-strong-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "light-strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1477,8 +1618,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-light-strong-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "light-strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1488,7 +1631,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-light-strong-font-style"
+      "property": "font-style",
+      "emphasis": "light-strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1498,7 +1643,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-light-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "light-strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1507,8 +1654,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-strong-emphasized-font-style",
-      "component": "detail"
+      "property": "font-style",
+      "component": "detail",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -1516,8 +1665,10 @@
   },
   {
     "name": {
-      "property": "detail-serif-strong-emphasized-font-weight",
-      "component": "detail"
+      "property": "font-weight",
+      "component": "detail",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -1526,7 +1677,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1535,7 +1688,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -1544,7 +1699,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "serif-text-transform"
+      "property": "text-transform",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/text-transform.json",
     "value": "uppercase",
@@ -2039,8 +2195,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2048,8 +2206,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2058,7 +2218,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-font-family"
+      "property": "font-family",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -2067,7 +2228,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-font-style"
+      "property": "font-style",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2083,8 +2245,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-heavy-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "heavy-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2092,8 +2256,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-heavy-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "heavy-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2102,7 +2268,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-heavy-font-style"
+      "property": "font-style",
+      "emphasis": "heavy",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2111,7 +2279,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-heavy-font-weight"
+      "property": "font-weight",
+      "emphasis": "heavy",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2119,8 +2289,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-heavy-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "heavy-strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2128,8 +2300,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-heavy-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "heavy-strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2138,7 +2312,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-heavy-strong-font-style"
+      "property": "font-style",
+      "emphasis": "heavy-strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2147,7 +2323,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-heavy-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "heavy-strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2155,8 +2333,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-light-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "light-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2165,8 +2345,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-light-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "light-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -2176,7 +2358,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-light-font-style"
+      "property": "font-style",
+      "emphasis": "light",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2186,7 +2370,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-light-font-weight"
+      "property": "font-weight",
+      "emphasis": "light",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
@@ -2195,8 +2381,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-light-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "light-strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2205,8 +2393,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-light-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "light-strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2216,7 +2406,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-light-strong-font-style"
+      "property": "font-style",
+      "emphasis": "light-strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2226,7 +2418,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-light-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "light-strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2236,7 +2430,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-line-height"
+      "property": "line-height",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
@@ -2325,8 +2520,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2334,8 +2531,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "strong-emphasized",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2344,7 +2543,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2353,7 +2554,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "cjk"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2399,8 +2602,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2417,7 +2622,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-font-family"
+      "property": "font-family",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
@@ -2426,7 +2632,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-font-style"
+      "property": "font-style",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2442,8 +2649,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-heavy-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "heavy-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2451,8 +2660,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-heavy-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "heavy-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2461,7 +2672,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-heavy-font-style"
+      "property": "font-style",
+      "emphasis": "heavy",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2470,7 +2683,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-heavy-font-weight"
+      "property": "font-weight",
+      "emphasis": "heavy",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2478,8 +2693,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-heavy-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "heavy-strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2487,8 +2704,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-heavy-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "heavy-strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2497,7 +2716,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-heavy-strong-font-style"
+      "property": "font-style",
+      "emphasis": "heavy-strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2506,7 +2727,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-heavy-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "heavy-strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2514,8 +2737,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-light-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "light-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2524,8 +2749,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-light-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "light-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
@@ -2535,7 +2762,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-light-font-style"
+      "property": "font-style",
+      "emphasis": "light",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2545,7 +2774,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-light-font-weight"
+      "property": "font-weight",
+      "emphasis": "light",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
@@ -2554,8 +2785,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-light-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "light-strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2564,8 +2797,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-light-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "light-strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -2575,7 +2810,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-light-strong-font-style"
+      "property": "font-style",
+      "emphasis": "light-strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2585,7 +2822,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-light-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "light-strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -2594,8 +2833,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2603,8 +2844,10 @@
   },
   {
     "name": {
-      "property": "heading-sans-serif-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "strong-emphasized",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2613,7 +2856,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2622,7 +2867,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "sans-serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2630,8 +2877,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2648,7 +2897,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-font-family"
+      "property": "font-family",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7f83198f-26ec-4156-9573-826dd7feb718",
@@ -2657,7 +2907,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-font-style"
+      "property": "font-style",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2673,8 +2924,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-heavy-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "heavy-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2682,8 +2935,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-heavy-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "heavy-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2692,7 +2947,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-heavy-font-style"
+      "property": "font-style",
+      "emphasis": "heavy",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2701,7 +2958,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-heavy-font-weight"
+      "property": "font-weight",
+      "emphasis": "heavy",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2709,8 +2968,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-heavy-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "heavy-strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2718,8 +2979,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-heavy-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "heavy-strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2728,7 +2991,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-heavy-strong-font-style"
+      "property": "font-style",
+      "emphasis": "heavy-strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2737,7 +3002,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-heavy-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "heavy-strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2745,8 +3012,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-light-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "light-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2755,8 +3024,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-light-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "light-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -2766,7 +3037,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-light-font-style"
+      "property": "font-style",
+      "emphasis": "light",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2776,7 +3049,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-light-font-weight"
+      "property": "font-weight",
+      "emphasis": "light",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -2785,8 +3060,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-light-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "light-strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2795,8 +3072,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-light-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "light-strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -2806,7 +3085,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-light-strong-font-style"
+      "property": "font-style",
+      "emphasis": "light-strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2816,7 +3097,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-light-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "light-strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -2825,8 +3108,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-strong-emphasized-font-style",
-      "component": "heading"
+      "property": "font-style",
+      "component": "heading",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
@@ -2834,8 +3119,10 @@
   },
   {
     "name": {
-      "property": "heading-serif-strong-emphasized-font-weight",
-      "component": "heading"
+      "property": "font-weight",
+      "component": "heading",
+      "emphasis": "strong-emphasized",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2844,7 +3131,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-strong-font-style"
+      "property": "font-style",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2853,7 +3142,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "serif-strong-font-weight"
+      "property": "font-weight",
+      "emphasis": "strong",
+      "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2959,8 +3250,9 @@
   },
   {
     "name": {
-      "property": "light-font-weight",
-      "weight": "light"
+      "property": "font-weight",
+      "weight": "light",
+      "emphasis": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "value": "light",
@@ -3400,7 +3692,7 @@
   },
   {
     "name": {
-      "property": "sans-serif-font-family",
+      "property": "font-family",
       "family": "sans-serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
@@ -3409,7 +3701,7 @@
   },
   {
     "name": {
-      "property": "serif-font-family",
+      "property": "font-family",
       "family": "serif"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -16,7 +16,8 @@
 //!
 //! ```text
 //! {variant?}-{component?}-{structure?}-{substructure?}-{anatomy?}-{object?}
-//! -{property}-{orientation?}-{position?}-{size?}-{density?}-{shape?}-{state?}
+//! -{family?}-{emphasis?}-{property}-{orientation?}-{position?}-{size?}-{density?}
+//! -{shape?}-{state?}
 //! ```
 //!
 //! Registry ids are expanded to their `tokenName` long-forms before joining
@@ -24,8 +25,10 @@
 //! `tools/token-mapping-analyzer/src/decomposer.js`.
 //!
 //! Mode-set fields (`colorScheme`, `scale`, `contrast`), the color-domain field
-//! (`colorFamily`), and `scaleIndex` are excluded from the general key. Color-palette
-//! tokens have their own path: `{variant?}-{colorFamily}-{scaleIndex?}`.
+//! (`colorFamily`, `colorRole`), and `scaleIndex` are excluded from the general key.
+//! Color-palette tokens have their own path: `{variant?}-{colorFamily}-{scaleIndex?}`.
+//! `weight`/`style` (CSS font-weight/font-style values) remain excluded pending their
+//! own decomposition pass — only `family`/`emphasis` are enabled so far.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -326,8 +329,12 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     //   Color-domain (handled by color-domain branch above): colorFamily, colorRole
     //   Integer scale (already embedded in `property`; would double-emit): scaleIndex
     //   Legacy metadata annotations (value already embedded in `property` for all current
-    //     tokens): weight, family, style, structure — if any joins Phase D decomposition,
-    //     remove its excludeFromLegacyKey flag and re-verify against the three legacy gates.
+    //     tokens): weight, style, structure — if any joins Phase D decomposition, remove
+    //     its excludeFromLegacyKey flag and re-verify against the three legacy gates.
+    //
+    // `family` and `emphasis` (typography-scoped, positions 6/7 — before `property` so
+    // e.g. cjk-strong-font-weight serializes as family:"cjk" + emphasis:"strong" +
+    // property:"font-weight") were enabled for the pur/typography decomposition pass.
 
     let registry = crate::registry::RegistryData::embedded();
     let catalog = crate::registry::FieldCatalog::embedded();
@@ -641,11 +648,32 @@ mod tests {
 
     #[test]
     fn extract_key_anatomy_before_property() {
-        // anatomy (pos 4) before property (pos 6).
+        // anatomy (pos 4) before property (pos 8).
         let name = json!({"component": "button", "anatomy": "icon", "property": "color"});
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("button-icon-color")
+        );
+    }
+
+    #[test]
+    fn extract_key_family_emphasis_before_property() {
+        // family (pos 6) and emphasis (pos 7) precede property (pos 8), matching the
+        // real typography legacy name shape: {family}-{emphasis}-{property}.
+        let name = json!({"family": "cjk", "emphasis": "strong", "property": "font-weight"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("cjk-strong-font-weight")
+        );
+    }
+
+    #[test]
+    fn extract_key_family_only_before_property() {
+        // family present without emphasis: {family}-{property}.
+        let name = json!({"family": "sans-serif", "property": "font-family"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("sans-serif-font-family")
         );
     }
 
@@ -667,23 +695,20 @@ mod tests {
 
     #[test]
     fn extract_key_legacy_annotation_fields_excluded_from_key() {
-        // structure, family, weight, style are legacy-metadata annotations whose values
-        // are already embedded in `property` for all current tokens. They carry
+        // structure, weight, style are legacy-metadata annotations whose values are
+        // already embedded in `property` for all current tokens. They carry
         // exclude_from_legacy_key: true so a catalog-walk refactor can't silently re-include them.
+        // (`family` was promoted out of this group for the pur/typography pass — see
+        // extract_key_family_emphasis_before_property.)
         let name = json!({
             "component": "body",
             "property": "bold-font-weight",
             "structure": "body",
-            "family": "adobe-clean",
             "weight": "bold",
             "style": "italic"
         });
         let key = extract_legacy_key(&name).unwrap();
         assert_eq!(key, "body-bold-font-weight");
-        assert!(
-            !key.contains("adobe-clean"),
-            "family must not appear in legacy key"
-        );
         assert!(
             !key.contains("italic"),
             "style must not appear in legacy key"

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1483,6 +1483,67 @@ const TOKEN_OBJECTS_JSON: &str = r##"{
   ]
 }
 "##;
+const TYPOGRAPHY_FAMILIES_JSON: &str = r##"{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "typography-family",
+  "description": "Type family identifiers for typography tokens. Assigned via the `family` name-object field. Represents the script or display context of the typeface, not a specific font name.",
+  "values": [
+    {
+      "id": "sans-serif",
+      "label": "Sans-Serif",
+      "description": "Sans-serif typeface family (e.g. Adobe Clean)"
+    },
+    {
+      "id": "serif",
+      "label": "Serif",
+      "description": "Serif typeface family (e.g. Adobe Clean Serif)"
+    },
+    {
+      "id": "cjk",
+      "label": "CJK",
+      "description": "CJK (Chinese, Japanese, Korean) script typeface family"
+    },
+    {
+      "id": "code",
+      "label": "Code",
+      "description": "Monospace typeface family for code and technical content"
+    }
+  ]
+}
+"##;
+const TYPOGRAPHY_EMPHASIS_JSON: &str = r##"{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "typography-emphasis",
+  "description": "Typographic emphasis identifiers for typography tokens. Assigned via the `emphasis` name-object field. Distinct from the CSS font-weight axis (see `weight`): emphasis is a relative modifier layered on a family/component (e.g. `cjk-strong-font-weight`), and values may compound (e.g. `heavy-strong-emphasized`) by hyphen-joining multiple modifiers.",
+  "values": [
+    {
+      "id": "emphasized",
+      "label": "Emphasized",
+      "description": "Standard emphasis"
+    },
+    {
+      "id": "strong",
+      "label": "Strong",
+      "description": "Strong emphasis (heavier than emphasized)"
+    },
+    {
+      "id": "heavy",
+      "label": "Heavy",
+      "description": "Heaviest emphasis"
+    },
+    {
+      "id": "light",
+      "label": "Light",
+      "description": "Lighter than default emphasis"
+    },
+    {
+      "id": "non-emphasized",
+      "label": "Non-Emphasized",
+      "description": "Explicitly not emphasized (maps to isEmphasized: false)"
+    }
+  ]
+}
+"##;
 const PROPERTY_TERMS_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "property-term",
@@ -1692,6 +1753,26 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "line-height-multiplier",
       "label": "Line Height Multiplier",
       "description": "Unitless line-height ratio (multiplier), distinct from the absolute px line-height paired with a specific font-size tier"
+    },
+    {
+      "id": "margin-multiplier",
+      "label": "Margin Multiplier",
+      "description": "Unitless margin ratio (multiplier), applied to both top and bottom of a typography block"
+    },
+    {
+      "id": "margin-top-multiplier",
+      "label": "Margin Top Multiplier",
+      "description": "Unitless margin ratio (multiplier) applied above a typography block"
+    },
+    {
+      "id": "margin-bottom-multiplier",
+      "label": "Margin Bottom Multiplier",
+      "description": "Unitless margin ratio (multiplier) applied below a typography block"
+    },
+    {
+      "id": "text-transform",
+      "label": "Text Transform",
+      "description": "Case transformation applied to text content (e.g. uppercase, lowercase)"
     },
     {
       "id": "minimum-width",
@@ -2276,34 +2357,6 @@ const COLOR_FAMILIES_JSON: &str = r##"{
   ]
 }
 "##;
-const TYPOGRAPHY_FAMILIES_JSON: &str = r##"{
-  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
-  "type": "typography-family",
-  "description": "Type family identifiers for typography tokens. Assigned via the `family` name-object field. Represents the script or display context of the typeface, not a specific font name.",
-  "values": [
-    {
-      "id": "sans-serif",
-      "label": "Sans-Serif",
-      "description": "Sans-serif typeface family (e.g. Adobe Clean)"
-    },
-    {
-      "id": "serif",
-      "label": "Serif",
-      "description": "Serif typeface family (e.g. Adobe Clean Serif)"
-    },
-    {
-      "id": "cjk",
-      "label": "CJK",
-      "description": "CJK (Chinese, Japanese, Korean) script typeface family"
-    },
-    {
-      "id": "code",
-      "label": "Code",
-      "description": "Monospace typeface family for code and technical content"
-    }
-  ]
-}
-"##;
 const TYPOGRAPHY_WEIGHTS_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "typography-weight",
@@ -2521,7 +2574,7 @@ const CATEGORIES_JSON: &str = r##"{
 }
 "##;
 
-pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "family", "weight", "style", "motionRole", "easing", "alignment"];
+pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "family", "emphasis", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "weight", "style", "motionRole", "easing", "alignment"];
 
 pub(crate) fn build_registry_map(
 ) -> std::collections::HashMap<String, std::collections::HashSet<String>> {
@@ -2532,6 +2585,8 @@ pub(crate) fn build_registry_map(
     map.insert("substructure".to_string(), parse_registry(SUBSTRUCTURES_JSON));
     map.insert("anatomy".to_string(), parse_registry(ANATOMY_TERMS_JSON));
     map.insert("object".to_string(), parse_registry(TOKEN_OBJECTS_JSON));
+    map.insert("family".to_string(), parse_registry(TYPOGRAPHY_FAMILIES_JSON));
+    map.insert("emphasis".to_string(), parse_registry(TYPOGRAPHY_EMPHASIS_JSON));
     map.insert("property".to_string(), parse_registry(PROPERTY_TERMS_JSON));
     map.insert("orientation".to_string(), parse_registry(ORIENTATIONS_JSON));
     map.insert("position".to_string(), parse_registry(POSITIONS_JSON));
@@ -2541,7 +2596,6 @@ pub(crate) fn build_registry_map(
     map.insert("state".to_string(), parse_registry(STATES_JSON));
     map.insert("colorRole".to_string(), parse_registry(COLOR_ROLES_JSON));
     map.insert("colorFamily".to_string(), parse_registry(COLOR_FAMILIES_JSON));
-    map.insert("family".to_string(), parse_registry(TYPOGRAPHY_FAMILIES_JSON));
     map.insert("weight".to_string(), parse_registry(TYPOGRAPHY_WEIGHTS_JSON));
     map.insert("style".to_string(), parse_registry(TYPOGRAPHY_STYLES_JSON));
     map.insert("motionRole".to_string(), parse_registry(MOTION_ROLES_JSON));
@@ -2560,6 +2614,8 @@ pub(crate) fn build_token_name_map(
     map.insert("substructure".to_string(), parse_token_name_map(SUBSTRUCTURES_JSON));
     map.insert("anatomy".to_string(), parse_token_name_map(ANATOMY_TERMS_JSON));
     map.insert("object".to_string(), parse_token_name_map(TOKEN_OBJECTS_JSON));
+    map.insert("family".to_string(), parse_token_name_map(TYPOGRAPHY_FAMILIES_JSON));
+    map.insert("emphasis".to_string(), parse_token_name_map(TYPOGRAPHY_EMPHASIS_JSON));
     map.insert("property".to_string(), parse_token_name_map(PROPERTY_TERMS_JSON));
     map.insert("orientation".to_string(), parse_token_name_map(ORIENTATIONS_JSON));
     map.insert("position".to_string(), parse_token_name_map(POSITIONS_JSON));
@@ -2569,7 +2625,6 @@ pub(crate) fn build_token_name_map(
     map.insert("state".to_string(), parse_token_name_map(STATES_JSON));
     map.insert("colorRole".to_string(), parse_token_name_map(COLOR_ROLES_JSON));
     map.insert("colorFamily".to_string(), parse_token_name_map(COLOR_FAMILIES_JSON));
-    map.insert("family".to_string(), parse_token_name_map(TYPOGRAPHY_FAMILIES_JSON));
     map.insert("weight".to_string(), parse_token_name_map(TYPOGRAPHY_WEIGHTS_JSON));
     map.insert("style".to_string(), parse_token_name_map(TYPOGRAPHY_STYLES_JSON));
     map.insert("motionRole".to_string(), parse_token_name_map(MOTION_ROLES_JSON));
@@ -2586,26 +2641,27 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "substructure", position: 3, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "anatomy", position: 4, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "object", position: 5, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "property", position: 6, validation: FieldValidation::Advisory, scope: None, required: true, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "orientation", position: 7, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "position", position: 8, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "size", position: 9, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "density", position: 10, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "shape", position: 11, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "state", position: 12, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "colorScheme", position: 13, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "scale", position: 14, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "contrast", position: 15, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "colorRole", position: 16, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "colorFamily", position: 17, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "family", position: 18, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "weight", position: 19, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "style", position: 20, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "motionRole", position: 21, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "easing", position: 22, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "from", position: 23, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "to", position: 24, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "alignment", position: 25, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "family", position: 6, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "emphasis", position: 7, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "property", position: 8, validation: FieldValidation::Advisory, scope: None, required: true, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "orientation", position: 9, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "position", position: 10, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "size", position: 11, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "density", position: 12, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "shape", position: 13, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "state", position: 14, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "colorScheme", position: 15, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "scale", position: 16, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "contrast", position: 17, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "colorRole", position: 18, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "colorFamily", position: 19, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "weight", position: 20, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "style", position: 21, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "motionRole", position: 22, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "easing", position: 23, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "from", position: 24, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "to", position: 25, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "alignment", position: 26, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "scaleIndex", position: 99, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
     ]
 }

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -108,6 +108,20 @@ export function applyField(tokens, field, registry, filename) {
       continue;
     }
 
+    // A decomposition pass must not invent ownership metadata as a side effect
+    // of extracting an unrelated field. A term can be registered as both an
+    // anatomy and a component alias (e.g. "heading"), so decompose() resolving
+    // it as `component` instead of `anatomy` must not fabricate a component the
+    // token never declared — reject that regardless of whether anatomy is also
+    // present in the merged result.
+    if (
+      result.nameObject.component !== undefined &&
+      token.name.component === undefined
+    ) {
+      skippedSpec025++;
+      continue;
+    }
+
     if (
       serialize(patched, registry.tokenNameMap, registry.serializationOrder) !==
       legacyKey

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -91,20 +91,30 @@ export function applyField(tokens, field, registry, filename) {
     )
       continue;
 
-    // Safety re-serialize: patched name must still produce the same legacy key
-    const patched = {
-      ...token.name,
-      [field]: result.nameObject[field],
-      property: result.nameObject.property,
-    };
+    // Safety re-serialize: patched name must still produce the same legacy key.
+    // Merge the *entire* resolved name object, not just [field]+property: when
+    // a token stacks multiple concepts in one property string (e.g. typography's
+    // "cjk-strong-font-weight" resolving to family+emphasis+property together),
+    // decompose() strips all of them from property at once, so writing back only
+    // the targeted field would silently drop the others and break the roundtrip.
+    const patched = { ...token.name, ...result.nameObject };
+
+    // SPEC-025: anatomy requires component. decompose() can resolve `anatomy`
+    // as a side effect of extracting an unrelated field (e.g. family/emphasis
+    // stacked with an anatomy term in the same property string), so this guard
+    // must apply to the merged result regardless of which field was targeted.
+    if (patched.anatomy && !patched.component) {
+      skippedSpec025++;
+      continue;
+    }
+
     if (
       serialize(patched, registry.tokenNameMap, registry.serializationOrder) !==
       legacyKey
     )
       continue;
 
-    token.name[field] = result.nameObject[field];
-    token.name.property = result.nameObject.property;
+    Object.assign(token.name, result.nameObject);
     applied++;
   }
 

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -57,11 +57,6 @@ const COMPOUND_PROPERTIES = [
  * These are classified as gap categories for the report rather than matched to fields.
  */
 const KNOWN_GAP_TERMS = {
-  // Typography script/family — need a new field or vocabulary expansion
-  "typography-script": ["cjk"],
-  "typography-family": ["sans", "serif"],
-  // Typography weight/emphasis — overlap with states/variants
-  "typography-weight": ["emphasized", "strong", "heavy", "light"],
   // Variant qualifiers — subtle, subdued, and static are now in the variant registry.
   // Only "non" remains unregistered (used as a negation prefix, not a standalone variant).
   "variant-qualifier": ["non"],
@@ -288,6 +283,54 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
             matchDetails[connectorIdx + 1 + i] = "to";
           }
         }
+      }
+    }
+  }
+
+  // Phase 2.6: Compound emphasis — hyphen-join a run of adjacent unmatched
+  // segments that each independently match an `emphasis` registry term (e.g.
+  // "heavy"+"strong" -> "heavy-strong"), mirroring the compound-state pattern
+  // (Proposal 001 / 005). Without this, only the first term in the run would
+  // be captured and any adjacent ones lost as unmatched segments. Only the
+  // leftmost run is combined — real typography tokens carry at most one.
+  {
+    const emphasisTerms = [...registry.terms]
+      .filter((t) => t.field === "emphasis")
+      .sort((a, b) => b.segments.length - a.segments.length);
+
+    const matchEmphasisAt = (idx) => {
+      for (const term of emphasisTerms) {
+        if (matched[idx] || term.segments.length > segments.length - idx)
+          continue;
+        let ok = true;
+        for (let j = 0; j < term.segments.length; j++) {
+          if (matched[idx + j] || segments[idx + j] !== term.segments[j]) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) return term;
+      }
+      return null;
+    };
+
+    for (let i = 0; i < segments.length && !nameObject.emphasis; i++) {
+      const first = matchEmphasisAt(i);
+      if (!first) continue;
+      const ids = [first.id];
+      let cursor = i + first.segments.length;
+      for (
+        let next = matchEmphasisAt(cursor);
+        next;
+        next = matchEmphasisAt(cursor)
+      ) {
+        ids.push(next.id);
+        cursor += next.segments.length;
+      }
+      nameObject.emphasis = ids.join("-");
+      for (let k = i; k < cursor; k++) {
+        matched[k] = true;
+        matchDetails[k] = "emphasis";
       }
     }
   }
@@ -590,6 +633,19 @@ export function serialize(
     if (nameObject.state)
       parts.push(tokenNameMap[nameObject.state] || nameObject.state);
     return parts.join("-");
+  }
+
+  // Thin-format detection: `property` already begins `{component}-`, meaning
+  // the full legacy key is stored verbatim in `property` and `component` is
+  // duplicated metadata annotation only. Emitting component then property here
+  // would double the prefix (e.g. "heading-heading-cjk-font-style"). Mirrors
+  // sdk/core/src/naming.rs's `is_thin` branch — keep in sync.
+  if (
+    component &&
+    nameObject.property &&
+    nameObject.property.startsWith(`${component}-`)
+  ) {
+    return nameObject.property;
   }
 
   // Space-between (gap) domain: property literal term "space-between", real

--- a/tools/token-mapping-analyzer/test/apply.test.js
+++ b/tools/token-mapping-analyzer/test/apply.test.js
@@ -14,7 +14,7 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { loadRegistries } from "../src/registry-index.js";
 import { serialize } from "../src/decomposer.js";
-import { applySpaceBetween } from "../src/apply.js";
+import { applyField, applySpaceBetween } from "../src/apply.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CASCADE_DIR = resolve(__dirname, "../../../packages/design-data/tokens");
@@ -217,4 +217,67 @@ test("applySpaceBetween skips tokens already migrated", (t) => {
   );
 
   t.is(applied, 0);
+});
+
+// A property string that stacks two concepts (family + emphasis) must have both
+// extracted together in one applyField call, even though only "family" was
+// requested: decompose() strips both from `property` at once, so writing back
+// only the targeted field (and the fully-stripped property) would silently
+// drop the other and break the roundtrip. Regression test for that bug.
+test("applyField extracts co-occurring fields together to preserve the roundtrip", (t) => {
+  const registry = loadRegistries();
+  const tokens = [
+    {
+      name: { property: "cjk-strong-font-weight" },
+      value: "700",
+    },
+  ];
+
+  const { applied } = applyField(
+    tokens,
+    "family",
+    registry,
+    "fixture.tokens.json",
+  );
+
+  t.is(applied, 1);
+  t.is(tokens[0].name.family, "cjk");
+  t.is(tokens[0].name.emphasis, "strong");
+  t.is(tokens[0].name.property, "font-weight");
+  t.is(
+    serialize(
+      tokens[0].name,
+      registry.tokenNameMap,
+      registry.serializationOrder,
+    ),
+    "cjk-strong-font-weight",
+  );
+});
+
+// decompose() can resolve `anatomy` as a side effect of extracting an unrelated
+// field (e.g. "heading-serif-emphasized-font-weight" -> anatomy:"heading" +
+// family:"serif" + emphasis:"emphasized"). Without a component field, applying
+// that merge violates SPEC-025 (anatomy requires component) even though the
+// *targeted* field was "family", not "anatomy". Regression test for that bug.
+test("applyField skips a merge that would introduce a SPEC-025 violation (anatomy without component)", (t) => {
+  const registry = loadRegistries();
+  const tokens = [
+    {
+      name: { property: "heading-serif-emphasized-font-weight" },
+      value: "700",
+    },
+  ];
+
+  const { applied, skippedSpec025 } = applyField(
+    tokens,
+    "family",
+    registry,
+    "fixture.tokens.json",
+  );
+
+  t.is(applied, 0);
+  t.is(skippedSpec025, 1);
+  t.is(tokens[0].name.family, undefined);
+  t.is(tokens[0].name.anatomy, undefined);
+  t.is(tokens[0].name.property, "heading-serif-emphasized-font-weight");
 });

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -82,18 +82,54 @@ test("detects spacing-between pattern", (t) => {
   t.truthy(spacingGap);
 });
 
-test("classifies typography weight terms as gaps", (t) => {
+test("matches typography family and emphasis as real fields, not gaps", (t) => {
   const result = decompose(
     "body-cjk-emphasized-font-weight",
     { component: "body" },
     registry,
     "test",
   );
-  // "emphasized" is unregistered → typography-weight gap
-  const weightGap = result.gaps.find((g) => g.type === "typography-weight");
-  t.truthy(weightGap);
-  // "cjk" is registered in the family registry → matched as family, not a gap
   t.is(result.nameObject.family, "cjk");
+  t.is(result.nameObject.emphasis, "emphasized");
+  t.is(result.nameObject.property, "font-weight");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+  t.deepEqual(result.gaps, []);
+});
+
+test("compounds adjacent emphasis terms into one hyphen-joined value", (t) => {
+  const result = decompose(
+    "cjk-light-strong-font-weight",
+    {},
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.family, "cjk");
+  t.is(result.nameObject.emphasis, "light-strong");
+  t.is(result.nameObject.property, "font-weight");
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("compounds emphasis terms alongside anatomy and family", (t) => {
+  const result = decompose(
+    "body-cjk-strong-emphasized-font-weight",
+    { component: "body" },
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.family, "cjk");
+  t.is(result.nameObject.emphasis, "strong-emphasized");
+  t.is(result.nameObject.property, "font-weight");
+  t.true(result.roundtrips);
+});
+
+test("matches a lone family term with no emphasis", (t) => {
+  const result = decompose("sans-serif-font-family", {}, registry, "test");
+  t.is(result.nameObject.family, "sans-serif");
+  t.is(result.nameObject.emphasis, undefined);
+  t.is(result.nameObject.property, "font-family");
+  t.true(result.roundtrips);
 });
 
 test("matches key-focus as keyboard-focus state", (t) => {


### PR DESCRIPTION
## Description

Adds a new `emphasis` field for typography-scoped tokens and decomposes
overloaded typography `property` values into `family`/`emphasis`, per
Proposal 001's typography taxonomy decision.

- **`packages/design-data/fields/emphasis.json`**: new field definition.
- **`packages/design-data/registry/typography-emphasis.json`**,
  **`registry/property-terms.json`**: registry entries backing the new field
  and decomposed property terms.
- **`packages/design-data/tokens/typography.tokens.json`**,
  **`tokens/layout-component.tokens.json`**: typography tokens updated to use
  `family`/`emphasis` instead of overloaded `property` values.
- **`sdk/core/src/naming.rs`**: naming/serialization support for the new field.
- **`docs/proposals/001-typography-taxonomy.md`**: taxonomy decision doc.

## Related Issue

<!-- link the relevant issue/bead here -->

## Motivation and Context

Typography `property` values were overloaded to encode both the CSS property
and emphasis/family distinctions in one string. This adds a dedicated
`emphasis` field so that information is explicit and validated, rather than
packed into `property`.

## How Has This Been Tested?

- `cargo test --workspace`: full suite green.
- `moon run sdk:codegen-check`: registry_data.rs matches sources.
- `moon run design-data:validate`: clean (only pre-existing unrelated warnings).
- Changesets linted with
  `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
