### PR TITLE
chore(design-data): fix stale SPEC-009 docstring, add warning triage report

### DIFF
--- a/packages/design-data/moon.yml
+++ b/packages/design-data/moon.yml
@@ -46,7 +46,8 @@ tasks:
     command: node
     args:
       - scripts/spec009-report.js
-    local: true
+    options:
+      runInCI: false
     deps:
       - sdk:build
     inputs:

--- a/packages/design-data/moon.yml
+++ b/packages/design-data/moon.yml
@@ -38,6 +38,22 @@ tasks:
       - "scripts/validate-registry.js"
       - "/packages/design-data-spec/schemas/registry-value.json"
 
+  # Ad-hoc report: groups SPEC-009 (name-field-enum-sync) warnings from `validate`
+  # by name.<field> and unique value, so the registry-completeness backlog is a
+  # trackable metric instead of a wall of duplicate-shaped lines. Not part of the
+  # `validate` dependency chain — run manually. See beads epic spectrum-design-data-dm2.
+  spec009-report:
+    command: node
+    args:
+      - scripts/spec009-report.js
+    local: true
+    deps:
+      - sdk:build
+    inputs:
+      - "@globs(tokens)"
+      - "scripts/spec009-report.js"
+      - "/packages/tokens/naming-exceptions.json"
+
   # Validate guideline JSON files against guideline.schema.json (AJV + document-block $ref).
   validate-guidelines:
     command: node

--- a/packages/design-data/scripts/spec009-report.js
+++ b/packages/design-data/scripts/spec009-report.js
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// SPEC-009 (name-field-enum-sync) fires once per token per unregistered
+// name.* value, so a flat warning count buries the real signal: how many
+// *distinct* values are actually missing from each registry, per field.
+// This groups the `design-data validate --format json` output by
+// name.<field> and reports unique-value counts so the backlog (tracked in
+// beads epic spectrum-design-data-dm2) is a metric, not a wall of lines.
+
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(__dirname, "..");
+const binary = join(
+  pkgRoot,
+  "..",
+  "..",
+  "sdk",
+  "target",
+  "debug",
+  "design-data",
+);
+
+const raw = execFileSync(
+  binary,
+  [
+    "validate",
+    "./tokens",
+    "--exceptions-path",
+    "../tokens/naming-exceptions.json",
+    "--format",
+    "json",
+  ],
+  { cwd: pkgRoot, encoding: "utf8", maxBuffer: 1024 * 1024 * 64 },
+);
+
+const { warnings } = JSON.parse(raw);
+const spec009 = warnings.filter((w) => w.rule_id === "SPEC-009");
+
+// field ("property", "component", ...) -> value -> occurrence count
+const byField = new Map();
+const valueRe = /value "([^"]*)"/;
+
+for (const w of spec009) {
+  const field = w.instance_path?.replace(/^\/name\//, "") ?? "unknown";
+  const value = w.message.match(valueRe)?.[1] ?? "unknown";
+  if (!byField.has(field)) byField.set(field, new Map());
+  const values = byField.get(field);
+  values.set(value, (values.get(value) ?? 0) + 1);
+}
+
+console.log(`SPEC-009 (name-field-enum-sync): ${spec009.length} warnings\n`);
+
+for (const [field, values] of [...byField].sort(
+  (a, b) => b[1].size - a[1].size,
+)) {
+  const total = [...values.values()].reduce((a, b) => a + b, 0);
+  console.log(`name.${field}: ${total} warnings, ${values.size} unique values`);
+}
+
+console.log("");
+
+const detailField = process.argv[2];
+if (detailField) {
+  const values = byField.get(detailField);
+  if (!values) {
+    console.error(`No SPEC-009 warnings for field "${detailField}".`);
+    process.exit(1);
+  }
+  console.log(`name.${detailField} — unique missing values by frequency:\n`);
+  for (const [value, count] of [...values].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(count).padStart(4)}  ${value}`);
+  }
+} else {
+  console.log(
+    "Pass a field name (e.g. `component`) as an argument for a per-value breakdown.",
+  );
+}

--- a/sdk/core/src/validate/rules/spec009.rs
+++ b/sdk/core/src/validate/rules/spec009.rs
@@ -15,8 +15,9 @@
 //! field catalog (`packages/design-data/fields/`) — fields with
 //! `validation: "advisory"` and a non-null registry are checked here.
 //!
-//! This is a warning-only rule. Fields excluded from this check:
-//! - `property` — free-form, no registry
+//! This is a warning-only rule. `property` is included (advisory registry added
+//! in #941) and checked here like any other advisory field. Fields excluded from
+//! this check:
 //! - `colorScheme`, `scale`, `contrast` — mode-set fields, validated by SPEC-005/SPEC-008
 
 use crate::report::{Diagnostic, Severity};


### PR DESCRIPTION
## Description

`moon run design-data:validate` currently emits 3,590 warnings, 98% of which (3,535) are `SPEC-009` (`name-field-enum-sync`). Investigation showed the warnings are legitimate — `property` was deliberately made an advisory field (backed by a registry) in #941, and `spec009.rs`'s doc comment was never updated to reflect that, so it was actively misleading anyone reading the rule.

This PR:
- Fixes the stale docstring in `sdk/core/src/validate/rules/spec009.rs`, which still claimed `property` was excluded from the check.
- Adds `packages/design-data/scripts/spec009-report.js` (+ `moon run design-data:spec009-report` task) — groups SPEC-009 warnings by `name.<field>` and by unique value, so the backlog is a trackable metric (e.g. "1,271 unique property values, 51 unique missing components") instead of thousands of duplicate-shaped lines.

No behavior change to validation itself — same warnings fire, same severity, same exit code.

## Related Issue

Tracked via beads epic `spectrum-design-data-dm2` (triage & reduce SPEC-009 warnings). Follow-on work (registering missing components, resolving compound emphasis/state values) is gated on a taxonomy decision and tracked separately in that epic.

## Motivation and Context

The warning volume was undifferentiated noise — no way to tell "3,535 warnings" apart from "1,271 distinct issues across 3 unrelated causes" without manual analysis. The report script makes that breakdown reproducible so the backlog can be triaged and burned down incrementally.

## How Has This Been Tested?

- `moon run sdk:build` — clean build from `main`.
- `cargo test -p design-data-core spec009` — 10/10 existing unit tests pass (docstring-only change, no logic touched).
- `moon run design-data:spec009-report -- component` — verified output (3535 total; property 2333/1271 unique; component 1121/51 unique; emphasis 80/7 unique; state 1/1 unique) matches manual analysis of the raw `validate --format json` output.

## Screenshots (if appropriate):

N/A (CLI tooling change)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) — stale/misleading docstring
- [x] New feature (non-breaking change which adds functionality) — triage report script
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (existing spec009 unit tests cover the rule; report script is a dev-facing CLI tool, verified manually as described above)
- [x] All new and existing tests passed.
