### PR TITLE
fix(design-data): sync component registry, decompose drop-shadow emphasized (SPEC-009)

### DIFF
--- a/.changeset/spec009-component-registry-sync.md
+++ b/.changeset/spec009-component-registry-sync.md
@@ -5,11 +5,12 @@
 Sync `components.json` with existing component definitions and decompose a misclassified
 drop-shadow state (part of SPEC-009 triage epic, closes spectrum-design-data-dm2.3).
 
-- **packages/design-data/registry/components.json**: add 32 missing component ids — 21 with
-  existing `components/*.json` definitions (`heading`, `card`, `tree-view`, `body`, …), 8 real
-  standalone components with no file yet (`date-field`, `floating-action-button`, …), and 3
-  card variants (`collection-card`, `user-card`, `card-horizontal`).
+- **packages/design-data/registry/components.json**: add 32 missing component ids — 20 with
+  existing `components/*.json` definitions (`heading`, `tree-view`, `body`, …) and 12 without a
+  dedicated file yet (`date-field`, `floating-action-button`, `card`, the card variants
+  `collection-card`/`user-card`/`card-horizontal`, …).
 - **packages/design-data/tokens/color-aliases.tokens.json**: decompose the drop-shadow
   `emphasized` token from `{property: "drop-shadow", state: "emphasized"}` to
   `{property: "drop-shadow", variant: "emphasized"}` — emphasis isn't an interactive state.
+  A `legacyKey` pins the published flat name so `@adobe/spectrum-tokens` consumers see no change.
 - **packages/design-data/registry/variants.json**: add `emphasized` (category `emphasis`).

--- a/.changeset/spec009-component-registry-sync.md
+++ b/.changeset/spec009-component-registry-sync.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Sync `components.json` with existing component definitions and decompose a misclassified
+drop-shadow state (part of SPEC-009 triage epic, closes spectrum-design-data-dm2.3).
+
+- **packages/design-data/registry/components.json**: add 32 missing component ids — 21 with
+  existing `components/*.json` definitions (`heading`, `card`, `tree-view`, `body`, …), 8 real
+  standalone components with no file yet (`date-field`, `floating-action-button`, …), and 3
+  card variants (`collection-card`, `user-card`, `card-horizontal`).
+- **packages/design-data/tokens/color-aliases.tokens.json**: decompose the drop-shadow
+  `emphasized` token from `{property: "drop-shadow", state: "emphasized"}` to
+  `{property: "drop-shadow", variant: "emphasized"}` — emphasis isn't an interactive state.
+- **packages/design-data/registry/variants.json**: add `emphasized` (category `emphasis`).

--- a/packages/design-data/registry/components.json
+++ b/packages/design-data/registry/components.json
@@ -49,6 +49,11 @@
       "documentationUrl": "https://spectrum.adobe.com/page/badge/"
     },
     {
+      "id": "body",
+      "label": "Body",
+      "documentationUrl": "https://spectrum.adobe.com/page/body/"
+    },
+    {
       "id": "breadcrumbs",
       "label": "Breadcrumbs",
       "documentationUrl": "https://spectrum.adobe.com/page/breadcrumbs/"
@@ -69,6 +74,16 @@
       "documentationUrl": "https://spectrum.adobe.com/page/calendar/"
     },
     {
+      "id": "card",
+      "label": "Card",
+      "documentationUrl": "https://spectrum.adobe.com/page/card/"
+    },
+    {
+      "id": "card-horizontal",
+      "label": "Card Horizontal",
+      "documentationUrl": "https://spectrum.adobe.com/page/card-horizontal/"
+    },
+    {
       "id": "checkbox",
       "label": "Checkbox",
       "documentationUrl": "https://spectrum.adobe.com/page/checkbox/"
@@ -82,6 +97,26 @@
       "id": "close-button",
       "label": "Close Button",
       "documentationUrl": "https://spectrum.adobe.com/page/close-button/"
+    },
+    {
+      "id": "coach-indicator",
+      "label": "Coach Indicator",
+      "documentationUrl": "https://spectrum.adobe.com/page/coach-indicator/"
+    },
+    {
+      "id": "coach-mark",
+      "label": "Coach Mark",
+      "documentationUrl": "https://spectrum.adobe.com/page/coach-mark/"
+    },
+    {
+      "id": "code",
+      "label": "Code",
+      "documentationUrl": "https://spectrum.adobe.com/page/code/"
+    },
+    {
+      "id": "collection-card",
+      "label": "Collection Card",
+      "documentationUrl": "https://spectrum.adobe.com/page/collection-card/"
     },
     {
       "id": "color-area",
@@ -119,14 +154,29 @@
       "documentationUrl": "https://spectrum.adobe.com/page/contextual-help/"
     },
     {
+      "id": "date-field",
+      "label": "Date Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/date-field/"
+    },
+    {
       "id": "date-picker",
       "label": "Date Picker",
       "documentationUrl": "https://spectrum.adobe.com/page/date-picker/"
     },
     {
+      "id": "detail",
+      "label": "Detail",
+      "documentationUrl": "https://spectrum.adobe.com/page/detail/"
+    },
+    {
       "id": "divider",
       "label": "Divider",
       "documentationUrl": "https://spectrum.adobe.com/page/divider/"
+    },
+    {
+      "id": "double-calendar",
+      "label": "Double Calendar",
+      "documentationUrl": "https://spectrum.adobe.com/page/double-calendar/"
     },
     {
       "id": "drop-zone",
@@ -139,6 +189,21 @@
       "documentationUrl": "https://spectrum.adobe.com/page/field-label/"
     },
     {
+      "id": "floating-action-button",
+      "label": "Floating Action Button",
+      "documentationUrl": "https://spectrum.adobe.com/page/floating-action-button/"
+    },
+    {
+      "id": "form-item",
+      "label": "Form Item",
+      "documentationUrl": "https://spectrum.adobe.com/page/form-item/"
+    },
+    {
+      "id": "heading",
+      "label": "Heading",
+      "documentationUrl": "https://spectrum.adobe.com/page/heading/"
+    },
+    {
       "id": "help-text",
       "label": "Help Text",
       "documentationUrl": "https://spectrum.adobe.com/page/help-text/"
@@ -149,6 +214,11 @@
       "documentationUrl": "https://spectrum.adobe.com/page/illustrated-message/"
     },
     {
+      "id": "in-field-progress-circle",
+      "label": "In-Field Progress Circle",
+      "documentationUrl": "https://spectrum.adobe.com/page/in-field-progress-circle/"
+    },
+    {
       "id": "in-line-alert",
       "label": "In-Line Alert",
       "documentationUrl": "https://spectrum.adobe.com/page/in-line-alert/"
@@ -157,6 +227,11 @@
       "id": "link",
       "label": "Link",
       "documentationUrl": "https://spectrum.adobe.com/page/link/"
+    },
+    {
+      "id": "list-view",
+      "label": "List View",
+      "documentationUrl": "https://spectrum.adobe.com/page/list-view/"
     },
     {
       "id": "menu",
@@ -172,6 +247,11 @@
       "id": "number-field",
       "label": "Number Field",
       "documentationUrl": "https://spectrum.adobe.com/page/number-field/"
+    },
+    {
+      "id": "opacity-checkerboard",
+      "label": "Opacity Checkerboard",
+      "documentationUrl": "https://spectrum.adobe.com/page/opacity-checkerboard/"
     },
     {
       "id": "picker",
@@ -214,9 +294,29 @@
       "documentationUrl": "https://spectrum.adobe.com/page/search-field/"
     },
     {
+      "id": "segmented-control",
+      "label": "Segmented Control",
+      "documentationUrl": "https://spectrum.adobe.com/page/segmented-control/"
+    },
+    {
+      "id": "segmented-text-field",
+      "label": "Segmented Text Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/segmented-text-field/"
+    },
+    {
       "id": "select-box",
       "label": "Select Box",
       "documentationUrl": "https://spectrum.adobe.com/page/select-box/"
+    },
+    {
+      "id": "side-navigation",
+      "label": "Side Navigation",
+      "documentationUrl": "https://spectrum.adobe.com/page/side-navigation/"
+    },
+    {
+      "id": "single-calendar",
+      "label": "Single Calendar",
+      "documentationUrl": "https://spectrum.adobe.com/page/single-calendar/"
     },
     {
       "id": "slider",
@@ -224,14 +324,34 @@
       "documentationUrl": "https://spectrum.adobe.com/page/slider/"
     },
     {
+      "id": "standard-dialog",
+      "label": "Standard Dialog",
+      "documentationUrl": "https://spectrum.adobe.com/page/standard-dialog/"
+    },
+    {
+      "id": "standard-panel",
+      "label": "Standard Panel",
+      "documentationUrl": "https://spectrum.adobe.com/page/standard-panel/"
+    },
+    {
       "id": "status-light",
       "label": "Status Light",
       "documentationUrl": "https://spectrum.adobe.com/page/status-light/"
     },
     {
+      "id": "steplist",
+      "label": "Steplist",
+      "documentationUrl": "https://spectrum.adobe.com/page/steplist/"
+    },
+    {
       "id": "swatch",
       "label": "Swatch",
       "documentationUrl": "https://spectrum.adobe.com/page/swatch/"
+    },
+    {
+      "id": "swatch-group",
+      "label": "Swatch Group",
+      "documentationUrl": "https://spectrum.adobe.com/page/swatch-group/"
     },
     {
       "id": "switch",
@@ -254,9 +374,19 @@
       "documentationUrl": "https://spectrum.adobe.com/page/tag/"
     },
     {
+      "id": "tag-field",
+      "label": "Tag Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/tag-field/"
+    },
+    {
       "id": "tag-group",
       "label": "Tag Group",
       "documentationUrl": "https://spectrum.adobe.com/page/tag-group/"
+    },
+    {
+      "id": "takeover-dialog",
+      "label": "Takeover Dialog",
+      "documentationUrl": "https://spectrum.adobe.com/page/takeover-dialog/"
     },
     {
       "id": "text-area",
@@ -267,6 +397,21 @@
       "id": "text-field",
       "label": "Text Field",
       "documentationUrl": "https://spectrum.adobe.com/page/text-field/"
+    },
+    {
+      "id": "thumbnail",
+      "label": "Thumbnail",
+      "documentationUrl": "https://spectrum.adobe.com/page/thumbnail/"
+    },
+    {
+      "id": "time-field",
+      "label": "Time Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/time-field/"
+    },
+    {
+      "id": "title",
+      "label": "Title",
+      "documentationUrl": "https://spectrum.adobe.com/page/title/"
     },
     {
       "id": "toast",
@@ -282,6 +427,21 @@
       "id": "tray",
       "label": "Tray",
       "documentationUrl": "https://spectrum.adobe.com/page/tray/"
+    },
+    {
+      "id": "tree-view",
+      "label": "Tree View",
+      "documentationUrl": "https://spectrum.adobe.com/page/tree-view/"
+    },
+    {
+      "id": "triple-calendar",
+      "label": "Triple Calendar",
+      "documentationUrl": "https://spectrum.adobe.com/page/triple-calendar/"
+    },
+    {
+      "id": "user-card",
+      "label": "User Card",
+      "documentationUrl": "https://spectrum.adobe.com/page/user-card/"
     }
   ]
 }

--- a/packages/design-data/registry/variants.json
+++ b/packages/design-data/registry/variants.json
@@ -208,6 +208,13 @@
       "usedIn": ["tokens"]
     },
     {
+      "id": "emphasized",
+      "label": "Emphasized",
+      "description": "Elevated emphasis variant for prominent surfaces (e.g. drop shadows)",
+      "category": "emphasis",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "static",
       "label": "Static",
       "description": "Context variant indicating the token does not change with theme",

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1378,7 +1378,8 @@
   {
     "name": {
       "property": "drop-shadow",
-      "variant": "emphasized"
+      "variant": "emphasized",
+      "legacyKey": "drop-shadow-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1378,7 +1378,7 @@
   {
     "name": {
       "property": "drop-shadow",
-      "state": "emphasized"
+      "variant": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -212,6 +212,13 @@ const VARIANTS_JSON: &str = r##"{
       "usedIn": ["tokens"]
     },
     {
+      "id": "emphasized",
+      "label": "Emphasized",
+      "description": "Elevated emphasis variant for prominent surfaces (e.g. drop shadows)",
+      "category": "emphasis",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "static",
       "label": "Static",
       "description": "Context variant indicating the token does not change with theme",
@@ -336,6 +343,11 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/badge/"
     },
     {
+      "id": "body",
+      "label": "Body",
+      "documentationUrl": "https://spectrum.adobe.com/page/body/"
+    },
+    {
       "id": "breadcrumbs",
       "label": "Breadcrumbs",
       "documentationUrl": "https://spectrum.adobe.com/page/breadcrumbs/"
@@ -356,6 +368,16 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/calendar/"
     },
     {
+      "id": "card",
+      "label": "Card",
+      "documentationUrl": "https://spectrum.adobe.com/page/card/"
+    },
+    {
+      "id": "card-horizontal",
+      "label": "Card Horizontal",
+      "documentationUrl": "https://spectrum.adobe.com/page/card-horizontal/"
+    },
+    {
       "id": "checkbox",
       "label": "Checkbox",
       "documentationUrl": "https://spectrum.adobe.com/page/checkbox/"
@@ -369,6 +391,26 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "close-button",
       "label": "Close Button",
       "documentationUrl": "https://spectrum.adobe.com/page/close-button/"
+    },
+    {
+      "id": "coach-indicator",
+      "label": "Coach Indicator",
+      "documentationUrl": "https://spectrum.adobe.com/page/coach-indicator/"
+    },
+    {
+      "id": "coach-mark",
+      "label": "Coach Mark",
+      "documentationUrl": "https://spectrum.adobe.com/page/coach-mark/"
+    },
+    {
+      "id": "code",
+      "label": "Code",
+      "documentationUrl": "https://spectrum.adobe.com/page/code/"
+    },
+    {
+      "id": "collection-card",
+      "label": "Collection Card",
+      "documentationUrl": "https://spectrum.adobe.com/page/collection-card/"
     },
     {
       "id": "color-area",
@@ -406,14 +448,29 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/contextual-help/"
     },
     {
+      "id": "date-field",
+      "label": "Date Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/date-field/"
+    },
+    {
       "id": "date-picker",
       "label": "Date Picker",
       "documentationUrl": "https://spectrum.adobe.com/page/date-picker/"
     },
     {
+      "id": "detail",
+      "label": "Detail",
+      "documentationUrl": "https://spectrum.adobe.com/page/detail/"
+    },
+    {
       "id": "divider",
       "label": "Divider",
       "documentationUrl": "https://spectrum.adobe.com/page/divider/"
+    },
+    {
+      "id": "double-calendar",
+      "label": "Double Calendar",
+      "documentationUrl": "https://spectrum.adobe.com/page/double-calendar/"
     },
     {
       "id": "drop-zone",
@@ -426,6 +483,21 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/field-label/"
     },
     {
+      "id": "floating-action-button",
+      "label": "Floating Action Button",
+      "documentationUrl": "https://spectrum.adobe.com/page/floating-action-button/"
+    },
+    {
+      "id": "form-item",
+      "label": "Form Item",
+      "documentationUrl": "https://spectrum.adobe.com/page/form-item/"
+    },
+    {
+      "id": "heading",
+      "label": "Heading",
+      "documentationUrl": "https://spectrum.adobe.com/page/heading/"
+    },
+    {
       "id": "help-text",
       "label": "Help Text",
       "documentationUrl": "https://spectrum.adobe.com/page/help-text/"
@@ -436,6 +508,11 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/illustrated-message/"
     },
     {
+      "id": "in-field-progress-circle",
+      "label": "In-Field Progress Circle",
+      "documentationUrl": "https://spectrum.adobe.com/page/in-field-progress-circle/"
+    },
+    {
       "id": "in-line-alert",
       "label": "In-Line Alert",
       "documentationUrl": "https://spectrum.adobe.com/page/in-line-alert/"
@@ -444,6 +521,11 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "link",
       "label": "Link",
       "documentationUrl": "https://spectrum.adobe.com/page/link/"
+    },
+    {
+      "id": "list-view",
+      "label": "List View",
+      "documentationUrl": "https://spectrum.adobe.com/page/list-view/"
     },
     {
       "id": "menu",
@@ -459,6 +541,11 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "number-field",
       "label": "Number Field",
       "documentationUrl": "https://spectrum.adobe.com/page/number-field/"
+    },
+    {
+      "id": "opacity-checkerboard",
+      "label": "Opacity Checkerboard",
+      "documentationUrl": "https://spectrum.adobe.com/page/opacity-checkerboard/"
     },
     {
       "id": "picker",
@@ -501,9 +588,29 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/search-field/"
     },
     {
+      "id": "segmented-control",
+      "label": "Segmented Control",
+      "documentationUrl": "https://spectrum.adobe.com/page/segmented-control/"
+    },
+    {
+      "id": "segmented-text-field",
+      "label": "Segmented Text Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/segmented-text-field/"
+    },
+    {
       "id": "select-box",
       "label": "Select Box",
       "documentationUrl": "https://spectrum.adobe.com/page/select-box/"
+    },
+    {
+      "id": "side-navigation",
+      "label": "Side Navigation",
+      "documentationUrl": "https://spectrum.adobe.com/page/side-navigation/"
+    },
+    {
+      "id": "single-calendar",
+      "label": "Single Calendar",
+      "documentationUrl": "https://spectrum.adobe.com/page/single-calendar/"
     },
     {
       "id": "slider",
@@ -511,14 +618,34 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/slider/"
     },
     {
+      "id": "standard-dialog",
+      "label": "Standard Dialog",
+      "documentationUrl": "https://spectrum.adobe.com/page/standard-dialog/"
+    },
+    {
+      "id": "standard-panel",
+      "label": "Standard Panel",
+      "documentationUrl": "https://spectrum.adobe.com/page/standard-panel/"
+    },
+    {
       "id": "status-light",
       "label": "Status Light",
       "documentationUrl": "https://spectrum.adobe.com/page/status-light/"
     },
     {
+      "id": "steplist",
+      "label": "Steplist",
+      "documentationUrl": "https://spectrum.adobe.com/page/steplist/"
+    },
+    {
       "id": "swatch",
       "label": "Swatch",
       "documentationUrl": "https://spectrum.adobe.com/page/swatch/"
+    },
+    {
+      "id": "swatch-group",
+      "label": "Swatch Group",
+      "documentationUrl": "https://spectrum.adobe.com/page/swatch-group/"
     },
     {
       "id": "switch",
@@ -541,9 +668,19 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/tag/"
     },
     {
+      "id": "tag-field",
+      "label": "Tag Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/tag-field/"
+    },
+    {
       "id": "tag-group",
       "label": "Tag Group",
       "documentationUrl": "https://spectrum.adobe.com/page/tag-group/"
+    },
+    {
+      "id": "takeover-dialog",
+      "label": "Takeover Dialog",
+      "documentationUrl": "https://spectrum.adobe.com/page/takeover-dialog/"
     },
     {
       "id": "text-area",
@@ -554,6 +691,21 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "text-field",
       "label": "Text Field",
       "documentationUrl": "https://spectrum.adobe.com/page/text-field/"
+    },
+    {
+      "id": "thumbnail",
+      "label": "Thumbnail",
+      "documentationUrl": "https://spectrum.adobe.com/page/thumbnail/"
+    },
+    {
+      "id": "time-field",
+      "label": "Time Field",
+      "documentationUrl": "https://spectrum.adobe.com/page/time-field/"
+    },
+    {
+      "id": "title",
+      "label": "Title",
+      "documentationUrl": "https://spectrum.adobe.com/page/title/"
     },
     {
       "id": "toast",
@@ -569,6 +721,21 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "tray",
       "label": "Tray",
       "documentationUrl": "https://spectrum.adobe.com/page/tray/"
+    },
+    {
+      "id": "tree-view",
+      "label": "Tree View",
+      "documentationUrl": "https://spectrum.adobe.com/page/tree-view/"
+    },
+    {
+      "id": "triple-calendar",
+      "label": "Triple Calendar",
+      "documentationUrl": "https://spectrum.adobe.com/page/triple-calendar/"
+    },
+    {
+      "id": "user-card",
+      "label": "User Card",
+      "documentationUrl": "https://spectrum.adobe.com/page/user-card/"
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Syncs `registry/components.json` with component data that already exists in the
repo, and reclassifies a misplaced token field.

- **packages/design-data/registry/components.json**: registers 32 missing
  component ids — 20 that already have full definitions under
  `packages/design-data/components/*.json` (`heading`, `tree-view`, `body`,
  `code`, …) and 12 without a dedicated file yet (`date-field`,
  `floating-action-button`, the calendar variants, `card` and its variants
  `collection-card`/`user-card`/`card-horizontal`, …).
- **packages/design-data/tokens/color-aliases.tokens.json**: the drop-shadow
  `emphasized` token was keyed as `{property: "drop-shadow", state:
  "emphasized"}`. Emphasis isn't an interactive state, so it's decomposed to
  `{property: "drop-shadow", variant: "emphasized"}` instead — this also avoids
  folding it into a compound `property` string, which is the exact pattern the
  wider `property` SPEC-009 backlog is trying to move away from. A `legacyKey`
  pins the published flat name (`drop-shadow-emphasized`) so
  `@adobe/spectrum-tokens` consumers see no change.
- **packages/design-data/registry/variants.json**: adds `emphasized`
  (category `emphasis`, alongside `subtle`/`subdued`).

## Related Issue

Part of the SPEC-009 (`name-field-enum-sync`) triage epic. Closes
spectrum-design-data-dm2.2, spectrum-design-data-dm2.3, spectrum-design-data-dm2.5
(beads).

## Motivation and Context

`moon run design-data:validate` emits ~3,660 SPEC-009 warnings — advisory, not
CI-blocking, but a real backlog. Investigation showed the `component` and
`state` populations were mostly registry drift (81 component definition files
existed but only 56 were registered) rather than bad data. This change closes
that drift for the unambiguous cases and fixes the one `state` warning.

Remaining `component` warnings (anatomy sub-parts, icons) are routed to
follow-up beads (`spectrum-design-data-uep`, `-p89`, `-aui`) since icons need a
new Rust name-field before they can be re-keyed.

## How Has This Been Tested?

- `moon run sdk:codegen` / `sdk:codegen-check` — registry embed regenerated and
  confirmed in sync.
- `moon run sdk:build` — SDK binary rebuilds clean.
- `moon run sdk:test` — full Rust workspace test suite passes (all crates, 0
  failures).
- `moon run design-data:validate-registry` — AJV schema + semantic checks pass.
- `moon run design-data-spec:check` — spec layout check passes.
- `node packages/design-data/scripts/spec009-report.js` — confirms the
  warning burn-down: 3,660 → 3,047 total; `component` 51 → 19 unique values;
  `state` 1 → 0.
- Changeset linted: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
