### PR TITLE
fix(design-data): route anatomy sub-parts to real parent component (SPEC-009)

### DIFF
--- a/.changeset/spec009-anatomy-subparts-tab-menu-stepper.md
+++ b/.changeset/spec009-anatomy-subparts-tab-menu-stepper.md
@@ -1,0 +1,24 @@
+---
+"@adobe/spectrum-design-data": minor
+"@adobe/spectrum-tokens": minor
+"@adobe/design-data-tui": minor
+---
+
+Route tab-item, menu-item, and in-field-stepper anatomy sub-parts to their real parent
+component, clearing 123 SPEC-009 warnings (part of spectrum-design-data-uep; remaining
+71 tokens tracked separately pending a taxonomy ruling).
+
+- **packages/design-data/registry/anatomy-terms.json**: add `in-field-stepper`; mark
+  `tab-item`/`menu-item` `usedIn: ["tokens"]`.
+- **packages/design-data/tokens/{layout,color}-component.tokens.json**: 123 tokens gain
+  `component` (real parent: `tabs`, `menu`, `number-field`) + `anatomy` (sub-part) + a
+  pinned `legacyKey` so the published key is unchanged.
+- **packages/tokens/src/{layout,color}-component.json**: regenerated; only the flat
+  `component` attribute value changed (67 tokens), no key renames.
+- **packages/tokens/naming-exceptions.json** / **validation-snapshot.json**: track the
+  49 tokens whose pinned legacy key no longer roundtrips through canonical name
+  generation (category `anatomy-decomposition`).
+- **packages/tokens/test/checkComponentProps.js**: recognize anatomy sub-part prefixes
+  (via the anatomy registry) as valid even when they don't match `component`.
+- **sdk/core/src/migrate.rs**: `thin_name_val` now pins `legacyKey` when a corrected
+  `component` no longer reproduces the original key, fixing legacy→cascade roundtrip.

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -319,7 +319,7 @@
       "id": "menu-item",
       "label": "Menu Item",
       "description": "Individual selectable item within a menu",
-      "usedIn": ["s2-docs"]
+      "usedIn": ["tokens", "s2-docs"]
     },
     {
       "id": "section-header",
@@ -637,7 +637,7 @@
       "id": "tab-item",
       "label": "Tab Item",
       "description": "Individual tab button within a tabs component",
-      "usedIn": ["s2-docs"]
+      "usedIn": ["tokens", "s2-docs"]
     },
     {
       "id": "breadcrumb-item",
@@ -799,6 +799,12 @@
       "id": "field-button",
       "label": "Field button",
       "description": "A trigger button embedded within a text field or picker",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "in-field-stepper",
+      "label": "In-field stepper",
+      "description": "A stepper control embedded within a field element (e.g. number-field)",
       "usedIn": ["tokens"]
     }
   ]

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -359,7 +359,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-default",
       "property": "background-color",
       "state": "default",
       "colorScheme": "light"
@@ -372,7 +374,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-default",
       "property": "background-color",
       "state": "default",
       "colorScheme": "dark"
@@ -385,7 +389,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-default",
       "property": "background-color",
       "state": "default",
       "colorScheme": "wireframe"
@@ -398,7 +404,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-disabled",
       "property": "background-color",
       "state": "disabled",
       "colorScheme": "light"
@@ -411,7 +419,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-disabled",
       "property": "background-color",
       "state": "disabled",
       "colorScheme": "dark"
@@ -424,7 +434,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-disabled",
       "property": "background-color",
       "state": "disabled",
       "colorScheme": "wireframe"
@@ -437,7 +449,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-down",
       "property": "background-color",
       "state": "down",
       "colorScheme": "light"
@@ -450,7 +464,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-down",
       "property": "background-color",
       "state": "down",
       "colorScheme": "dark"
@@ -463,7 +479,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-down",
       "property": "background-color",
       "state": "down",
       "colorScheme": "wireframe"
@@ -476,7 +494,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-hover",
       "property": "background-color",
       "state": "hover",
       "colorScheme": "light"
@@ -489,7 +509,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-hover",
       "property": "background-color",
       "state": "hover",
       "colorScheme": "dark"
@@ -502,7 +524,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-hover",
       "property": "background-color",
       "state": "hover",
       "colorScheme": "wireframe"
@@ -515,7 +539,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-keyboard-focus",
       "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "light"
@@ -528,7 +554,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-keyboard-focus",
       "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "dark"
@@ -541,7 +569,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-color-keyboard-focus",
       "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "wireframe"

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -7882,7 +7882,9 @@
   },
   {
     "name": {
-      "component": "in-field-stepper",
+      "component": "number-field",
+      "anatomy": "in-field-stepper",
+      "legacyKey": "in-field-stepper-to-end-extra-large",
       "property": "to-end-extra-large",
       "scale": "desktop"
     },
@@ -7897,7 +7899,9 @@
   },
   {
     "name": {
-      "component": "in-field-stepper",
+      "component": "number-field",
+      "anatomy": "in-field-stepper",
+      "legacyKey": "in-field-stepper-to-end-extra-large",
       "property": "to-end-extra-large",
       "scale": "mobile"
     },
@@ -7912,7 +7916,9 @@
   },
   {
     "name": {
-      "component": "in-field-stepper",
+      "component": "number-field",
+      "anatomy": "in-field-stepper",
+      "legacyKey": "in-field-stepper-to-end-large",
       "property": "to-end-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -7924,7 +7930,9 @@
   },
   {
     "name": {
-      "component": "in-field-stepper",
+      "component": "number-field",
+      "anatomy": "in-field-stepper",
+      "legacyKey": "in-field-stepper-to-end-medium",
       "property": "to-end-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -7936,7 +7944,9 @@
   },
   {
     "name": {
-      "component": "in-field-stepper",
+      "component": "number-field",
+      "anatomy": "in-field-stepper",
+      "legacyKey": "in-field-stepper-to-end-small",
       "property": "to-end-small",
       "scale": "desktop"
     },
@@ -7951,7 +7961,9 @@
   },
   {
     "name": {
-      "component": "in-field-stepper",
+      "component": "number-field",
+      "anatomy": "in-field-stepper",
+      "legacyKey": "in-field-stepper-to-end-small",
       "property": "to-end-small",
       "scale": "mobile"
     },
@@ -8205,7 +8217,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-background-opacity",
       "property": "opacity",
       "object": "background"
     },
@@ -8339,7 +8353,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-label-to-description-extra-large",
       "property": "label-to-description-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -8351,7 +8367,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-label-to-description-large",
       "property": "label-to-description-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -8363,7 +8381,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-label-to-description-medium",
       "property": "label-to-description-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -8375,7 +8395,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-label-to-description-small",
       "property": "label-to-description-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -8636,7 +8658,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-extra-large",
       "property": "top-to-thumbnail-extra-large",
       "scale": "desktop"
     },
@@ -8651,7 +8675,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-extra-large",
       "property": "top-to-thumbnail-extra-large",
       "scale": "mobile"
     },
@@ -8666,7 +8692,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-large",
       "property": "top-to-thumbnail-large",
       "scale": "desktop"
     },
@@ -8681,7 +8709,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-large",
       "property": "top-to-thumbnail-large",
       "scale": "mobile"
     },
@@ -8696,7 +8726,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-medium",
       "property": "top-to-thumbnail-medium",
       "scale": "desktop"
     },
@@ -8711,7 +8743,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-medium",
       "property": "top-to-thumbnail-medium",
       "scale": "mobile"
     },
@@ -8726,7 +8760,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-small",
       "property": "top-to-thumbnail-small",
       "scale": "desktop"
     },
@@ -8741,7 +8777,9 @@
   },
   {
     "name": {
-      "component": "menu-item",
+      "component": "menu",
+      "anatomy": "menu-item",
+      "legacyKey": "menu-item-top-to-thumbnail-small",
       "property": "top-to-thumbnail-small",
       "scale": "mobile"
     },
@@ -14027,7 +14065,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-extra-large",
       "property": "bottom-to-text-compact-extra-large",
       "scale": "desktop"
     },
@@ -14042,7 +14082,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-extra-large",
       "property": "bottom-to-text-compact-extra-large",
       "scale": "mobile"
     },
@@ -14057,7 +14099,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-large",
       "property": "bottom-to-text-compact-large",
       "scale": "desktop"
     },
@@ -14072,7 +14116,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-large",
       "property": "bottom-to-text-compact-large",
       "scale": "mobile"
     },
@@ -14087,7 +14133,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-medium",
       "property": "bottom-to-text-compact-medium",
       "scale": "desktop"
     },
@@ -14102,7 +14150,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-medium",
       "property": "bottom-to-text-compact-medium",
       "scale": "mobile"
     },
@@ -14117,7 +14167,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-small",
       "property": "bottom-to-text-compact-small",
       "scale": "desktop"
     },
@@ -14132,7 +14184,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-compact-small",
       "property": "bottom-to-text-compact-small",
       "scale": "mobile"
     },
@@ -14147,7 +14201,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-extra-large",
       "property": "bottom-to-text-extra-large",
       "scale": "desktop"
     },
@@ -14162,7 +14218,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-extra-large",
       "property": "bottom-to-text-extra-large",
       "scale": "mobile"
     },
@@ -14177,7 +14235,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-large",
       "property": "bottom-to-text-large",
       "scale": "desktop"
     },
@@ -14192,7 +14252,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-large",
       "property": "bottom-to-text-large",
       "scale": "mobile"
     },
@@ -14207,7 +14269,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-medium",
       "property": "bottom-to-text-medium",
       "scale": "desktop"
     },
@@ -14222,7 +14286,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-medium",
       "property": "bottom-to-text-medium",
       "scale": "mobile"
     },
@@ -14237,7 +14303,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-small",
       "property": "bottom-to-text-small",
       "scale": "desktop"
     },
@@ -14252,7 +14320,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-bottom-to-text-small",
       "property": "bottom-to-text-small",
       "scale": "mobile"
     },
@@ -14267,7 +14337,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-compact-height-extra-large",
       "property": "compact-height-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -14276,7 +14348,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-compact-height-large",
       "property": "compact-height-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -14285,7 +14359,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-compact-height-medium",
       "property": "compact-height-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -14294,7 +14370,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-compact-height-small",
       "property": "compact-height-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -14304,7 +14382,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-extra-large",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-extra-large",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14319,7 +14399,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-extra-large",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-extra-large",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14334,7 +14416,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-large",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-large",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14349,7 +14433,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-large",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-large",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14364,7 +14450,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-medium",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-medium",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14379,7 +14467,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-medium",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-medium",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14394,7 +14484,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-small",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-small",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14409,7 +14501,9 @@
   {
     "name": {
       "property": "tab-item-focus-indicator-gap-small",
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-focus-indicator-gap-small",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14423,7 +14517,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-height-extra-large",
       "property": "height",
       "size": "xl"
     },
@@ -14433,7 +14529,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-height-large",
       "property": "height",
       "size": "l"
     },
@@ -14443,7 +14541,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-height-medium",
       "property": "height",
       "size": "m"
     },
@@ -14453,7 +14553,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-height-small",
       "property": "height",
       "size": "s"
     },
@@ -14463,7 +14565,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-extra-large",
       "property": "start-to-edge-extra-large",
       "scale": "desktop"
     },
@@ -14478,7 +14582,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-extra-large",
       "property": "start-to-edge-extra-large",
       "scale": "mobile"
     },
@@ -14493,7 +14599,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-large",
       "property": "start-to-edge-large",
       "scale": "desktop"
     },
@@ -14508,7 +14616,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-large",
       "property": "start-to-edge-large",
       "scale": "mobile"
     },
@@ -14523,7 +14633,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-medium",
       "property": "start-to-edge-medium",
       "scale": "desktop"
     },
@@ -14538,7 +14650,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-medium",
       "property": "start-to-edge-medium",
       "scale": "mobile"
     },
@@ -14553,7 +14667,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-quiet",
       "property": "start-to-edge-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -14564,7 +14680,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-small",
       "property": "start-to-edge-small",
       "scale": "desktop"
     },
@@ -14579,7 +14697,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-start-to-edge-small",
       "property": "start-to-edge-small",
       "scale": "mobile"
     },
@@ -14594,7 +14714,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-extra-large",
       "property": "to-tab-item-horizontal-extra-large",
       "scale": "desktop"
     },
@@ -14609,7 +14731,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-extra-large",
       "property": "to-tab-item-horizontal-extra-large",
       "scale": "mobile"
     },
@@ -14624,7 +14748,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-large",
       "property": "to-tab-item-horizontal-large",
       "scale": "desktop"
     },
@@ -14639,7 +14765,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-large",
       "property": "to-tab-item-horizontal-large",
       "scale": "mobile"
     },
@@ -14654,7 +14782,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-medium",
       "property": "to-tab-item-horizontal-medium",
       "scale": "desktop"
     },
@@ -14669,7 +14799,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-medium",
       "property": "to-tab-item-horizontal-medium",
       "scale": "mobile"
     },
@@ -14684,7 +14816,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-small",
       "property": "to-tab-item-horizontal-small",
       "scale": "desktop"
     },
@@ -14699,7 +14833,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-horizontal-small",
       "property": "to-tab-item-horizontal-small",
       "scale": "mobile"
     },
@@ -14714,7 +14850,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-extra-large",
       "property": "to-tab-item-vertical-extra-large",
       "scale": "desktop"
     },
@@ -14729,7 +14867,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-extra-large",
       "property": "to-tab-item-vertical-extra-large",
       "scale": "mobile"
     },
@@ -14744,7 +14884,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-large",
       "property": "to-tab-item-vertical-large",
       "scale": "desktop"
     },
@@ -14759,7 +14901,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-large",
       "property": "to-tab-item-vertical-large",
       "scale": "mobile"
     },
@@ -14774,7 +14918,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-medium",
       "property": "to-tab-item-vertical-medium",
       "scale": "desktop"
     },
@@ -14789,7 +14935,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-medium",
       "property": "to-tab-item-vertical-medium",
       "scale": "mobile"
     },
@@ -14804,7 +14952,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-small",
       "property": "to-tab-item-vertical-small",
       "scale": "desktop"
     },
@@ -14819,7 +14969,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-to-tab-item-vertical-small",
       "property": "to-tab-item-vertical-small",
       "scale": "mobile"
     },
@@ -14834,7 +14986,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-extra-large",
       "property": "top-to-text-compact-extra-large",
       "scale": "desktop"
     },
@@ -14849,7 +15003,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-extra-large",
       "property": "top-to-text-compact-extra-large",
       "scale": "mobile"
     },
@@ -14864,7 +15020,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-large",
       "property": "top-to-text-compact-large",
       "scale": "desktop"
     },
@@ -14879,7 +15037,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-large",
       "property": "top-to-text-compact-large",
       "scale": "mobile"
     },
@@ -14894,7 +15054,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-medium",
       "property": "top-to-text-compact-medium",
       "scale": "desktop"
     },
@@ -14909,7 +15071,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-medium",
       "property": "top-to-text-compact-medium",
       "scale": "mobile"
     },
@@ -14924,7 +15088,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-small",
       "property": "top-to-text-compact-small",
       "scale": "desktop"
     },
@@ -14939,7 +15105,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-compact-small",
       "property": "top-to-text-compact-small",
       "scale": "mobile"
     },
@@ -14954,7 +15122,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-extra-large",
       "property": "top-to-text-extra-large",
       "scale": "desktop"
     },
@@ -14969,7 +15139,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-extra-large",
       "property": "top-to-text-extra-large",
       "scale": "mobile"
     },
@@ -14984,7 +15156,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-large",
       "property": "top-to-text-large",
       "scale": "desktop"
     },
@@ -14999,7 +15173,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-large",
       "property": "top-to-text-large",
       "scale": "mobile"
     },
@@ -15014,7 +15190,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-medium",
       "property": "top-to-text-medium",
       "scale": "desktop"
     },
@@ -15029,7 +15207,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-medium",
       "property": "top-to-text-medium",
       "scale": "mobile"
     },
@@ -15044,7 +15224,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-small",
       "property": "top-to-text-small",
       "scale": "desktop"
     },
@@ -15059,7 +15241,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-text-small",
       "property": "top-to-text-small",
       "scale": "mobile"
     },
@@ -15074,7 +15258,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-extra-large",
       "property": "top-to-workflow-icon-compact-extra-large",
       "scale": "desktop"
     },
@@ -15089,7 +15275,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-extra-large",
       "property": "top-to-workflow-icon-compact-extra-large",
       "scale": "mobile"
     },
@@ -15104,7 +15292,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-large",
       "property": "top-to-workflow-icon-compact-large",
       "scale": "desktop"
     },
@@ -15119,7 +15309,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-large",
       "property": "top-to-workflow-icon-compact-large",
       "scale": "mobile"
     },
@@ -15134,7 +15326,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-medium",
       "property": "top-to-workflow-icon-compact-medium",
       "scale": "desktop"
     },
@@ -15149,7 +15343,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-medium",
       "property": "top-to-workflow-icon-compact-medium",
       "scale": "mobile"
     },
@@ -15164,7 +15360,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-small",
       "property": "top-to-workflow-icon-compact-small",
       "scale": "desktop"
     },
@@ -15179,7 +15377,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-compact-small",
       "property": "top-to-workflow-icon-compact-small",
       "scale": "mobile"
     },
@@ -15194,7 +15394,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-extra-large",
       "property": "top-to-workflow-icon-extra-large",
       "scale": "desktop"
     },
@@ -15209,7 +15411,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-extra-large",
       "property": "top-to-workflow-icon-extra-large",
       "scale": "mobile"
     },
@@ -15224,7 +15428,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-large",
       "property": "top-to-workflow-icon-large",
       "scale": "desktop"
     },
@@ -15239,7 +15445,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-large",
       "property": "top-to-workflow-icon-large",
       "scale": "mobile"
     },
@@ -15254,7 +15462,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-medium",
       "property": "top-to-workflow-icon-medium",
       "scale": "desktop"
     },
@@ -15269,7 +15479,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-medium",
       "property": "top-to-workflow-icon-medium",
       "scale": "mobile"
     },
@@ -15284,7 +15496,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-small",
       "property": "top-to-workflow-icon-small",
       "scale": "desktop"
     },
@@ -15299,7 +15513,9 @@
   },
   {
     "name": {
-      "component": "tab-item",
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "legacyKey": "tab-item-top-to-workflow-icon-small",
       "property": "top-to-workflow-icon-small",
       "scale": "mobile"
     },

--- a/packages/tokens/naming-exceptions.json
+++ b/packages/tokens/naming-exceptions.json
@@ -1165,6 +1165,300 @@
       "file": "typography.json",
       "category": "state-position",
       "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "in-field-stepper-to-end-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "in-field-stepper-to-end-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "in-field-stepper-to-end-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "in-field-stepper-to-end-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-compact-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-compact-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-compact-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-compact-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-bottom-to-text-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-compact-height-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-compact-height-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-compact-height-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-compact-height-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-height-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-height-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-height-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-height-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-start-to-edge-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-start-to-edge-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-start-to-edge-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-start-to-edge-quiet",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-start-to-edge-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-horizontal-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-horizontal-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-horizontal-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-horizontal-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-vertical-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-vertical-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-vertical-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-to-tab-item-vertical-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-compact-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-compact-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-compact-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-compact-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-text-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-compact-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-compact-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-compact-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-compact-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-extra-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-large",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-medium",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "tab-item-top-to-workflow-icon-small",
+      "file": "layout-component.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
     }
   ]
 }

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -381,6 +381,34 @@
     },
     {
       "file": "./src/layout-component.json",
+      "token": "in-field-stepper-to-end-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'in-field-stepper-to-end-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "in-field-stepper-to-end-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'in-field-stepper-to-end-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "in-field-stepper-to-end-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'in-field-stepper-to-end-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "in-field-stepper-to-end-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'in-field-stepper-to-end-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
       "token": "menu-item-edge-to-content-not-selected-extra-large",
       "rule_id": "SPEC-007",
       "severity": "info",
@@ -598,6 +626,90 @@
     },
     {
       "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-compact-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-compact-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-compact-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-compact-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-compact-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-compact-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-compact-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-compact-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-bottom-to-text-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-bottom-to-text-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-compact-height-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-compact-height-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-compact-height-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-compact-height-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-compact-height-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-compact-height-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-compact-height-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-compact-height-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
       "token": "tab-item-focus-indicator-gap-extra-large",
       "rule_id": "SPEC-007",
       "severity": "info",
@@ -623,6 +735,237 @@
       "rule_id": "SPEC-007",
       "severity": "info",
       "message": "Known naming exception: 'tab-item-focus-indicator-gap-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-height-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-height-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-height-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-height-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-height-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-height-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-height-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-height-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-start-to-edge-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-start-to-edge-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-start-to-edge-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-start-to-edge-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-start-to-edge-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-start-to-edge-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-start-to-edge-quiet",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-start-to-edge-quiet' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-start-to-edge-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-start-to-edge-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-horizontal-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-horizontal-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-horizontal-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-horizontal-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-horizontal-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-horizontal-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-horizontal-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-horizontal-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-vertical-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-vertical-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-vertical-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-vertical-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-vertical-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-vertical-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-to-tab-item-vertical-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-to-tab-item-vertical-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-compact-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-compact-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-compact-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-compact-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-compact-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-compact-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-compact-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-compact-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-text-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-text-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-compact-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-compact-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-compact-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-compact-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-compact-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-compact-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-compact-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-compact-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout-component.json",
+      "token": "tab-item-top-to-workflow-icon-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-item-top-to-workflow-icon-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
     },
     {
       "file": "./src/layout-component.json",

--- a/packages/tokens/src/color-component.json
+++ b/packages/tokens/src/color-component.json
@@ -236,7 +236,7 @@
   },
   "menu-item-background-color-default": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "0c358fa2-087d-402a-bf64-9edefa6545cd",
     "sets": {
       "light": {
@@ -258,7 +258,7 @@
   },
   "menu-item-background-color-disabled": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "54607292-7896-4ca9-8c86-9c053c95c7d3",
     "sets": {
       "light": {
@@ -280,7 +280,7 @@
   },
   "menu-item-background-color-down": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "bc7380b4-c387-4b2b-b3ba-8361ae0d11fd",
     "sets": {
       "light": {
@@ -302,7 +302,7 @@
   },
   "menu-item-background-color-hover": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "cf29fd2d-b99b-45e0-9326-fedc1aa7fd13",
     "sets": {
       "light": {
@@ -324,7 +324,7 @@
   },
   "menu-item-background-color-keyboard-focus": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "47a9204b-22f4-4685-9756-dcb2a0bbde61",
     "sets": {
       "light": {

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -5340,7 +5340,7 @@
   },
   "in-field-stepper-to-end-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "in-field-stepper",
+    "component": "number-field",
     "uuid": "e405ccc1-4c8d-4d2e-8bb0-7013733e82c4",
     "deprecated": true,
     "deprecated_comment": "Use semantic token accessory-gap-extra-large instead. Refactoring required",
@@ -5360,7 +5360,7 @@
   },
   "in-field-stepper-to-end-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "in-field-stepper",
+    "component": "number-field",
     "value": "4px",
     "uuid": "cb3e458d-7dcd-484d-9028-220d08c9f129",
     "deprecated": true,
@@ -5369,7 +5369,7 @@
   },
   "in-field-stepper-to-end-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "in-field-stepper",
+    "component": "number-field",
     "value": "3px",
     "uuid": "fe42bdd0-de02-4814-b498-038b26a3c0e7",
     "deprecated": true,
@@ -5378,7 +5378,7 @@
   },
   "in-field-stepper-to-end-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "in-field-stepper",
+    "component": "number-field",
     "uuid": "bceb3359-ccf7-4f05-9cf5-1fba6b7b9efb",
     "deprecated": true,
     "deprecated_comment": "Use semantic token accessory-gap-small instead. Refactoring required",
@@ -5560,7 +5560,7 @@
   },
   "menu-item-background-opacity": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
-    "component": "menu-item",
+    "component": "menu",
     "value": "0",
     "uuid": "6f464689-0b87-4f38-b9a4-e5015acdd0d7"
   },
@@ -5649,7 +5649,7 @@
   },
   "menu-item-label-to-description-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "menu-item",
+    "component": "menu",
     "value": "2px",
     "uuid": "5543ede1-4e55-44f5-920f-288ee96e06ca",
     "deprecated": true,
@@ -5658,7 +5658,7 @@
   },
   "menu-item-label-to-description-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "menu-item",
+    "component": "menu",
     "value": "2px",
     "uuid": "4ce8b4db-72f8-411b-baad-8b66c0496182",
     "deprecated": true,
@@ -5667,7 +5667,7 @@
   },
   "menu-item-label-to-description-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "menu-item",
+    "component": "menu",
     "value": "1px",
     "uuid": "608fd592-fff8-435e-88e2-846bd34cc235",
     "deprecated": true,
@@ -5676,7 +5676,7 @@
   },
   "menu-item-label-to-description-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "menu-item",
+    "component": "menu",
     "value": "1px",
     "uuid": "66d57402-d7db-45df-8872-fd362014bcbe",
     "deprecated": true,
@@ -5851,7 +5851,7 @@
   },
   "menu-item-top-to-thumbnail-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "ea52bf43-3e3b-4559-aec3-4f0a02734a95",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Unify with all top component paddings",
@@ -5871,7 +5871,7 @@
   },
   "menu-item-top-to-thumbnail-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "1df536f1-c853-4955-9533-8c9371fc05cc",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Unify with all top component paddings",
@@ -5891,7 +5891,7 @@
   },
   "menu-item-top-to-thumbnail-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "57fe1e26-77a9-4d8a-ab54-a6f16dc9c5fc",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Unify with all top component paddings",
@@ -5911,7 +5911,7 @@
   },
   "menu-item-top-to-thumbnail-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "menu-item",
+    "component": "menu",
     "uuid": "f81ebf2a-300e-4bc8-89e0-baec8fc07ee4",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Unify with all top component paddings",
@@ -9459,7 +9459,7 @@
   },
   "tab-item-bottom-to-text-compact-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "adc6e66b-3fc9-4fd7-84ec-ef4494c62774",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -9479,7 +9479,7 @@
   },
   "tab-item-bottom-to-text-compact-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "c3498128-c005-4ee4-915e-eb287caa1041",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -9499,7 +9499,7 @@
   },
   "tab-item-bottom-to-text-compact-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "d4758ee5-0e66-4812-90f3-618775a200e2",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -9519,7 +9519,7 @@
   },
   "tab-item-bottom-to-text-compact-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "4a7ca31f-9087-4865-9a19-669fec8b1e6d",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -9539,7 +9539,7 @@
   },
   "tab-item-bottom-to-text-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "60b185b4-b257-47e6-9340-7e1a074a40ea",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -9559,7 +9559,7 @@
   },
   "tab-item-bottom-to-text-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "662d4ef9-344e-450f-bd48-0298f111d88a",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -9579,7 +9579,7 @@
   },
   "tab-item-bottom-to-text-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "1cb59572-fa95-4bc4-b3b1-bad21a5bc28d",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -9599,7 +9599,7 @@
   },
   "tab-item-bottom-to-text-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "cfdfec23-be3a-4327-9067-60ecf3e9bed6",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -9619,31 +9619,31 @@
   },
   "tab-item-compact-height-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-300}",
     "uuid": "49130d66-edfb-48bd-8648-96c47f40a884"
   },
   "tab-item-compact-height-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-200}",
     "uuid": "6d781a0e-e03d-4750-ae4f-67a29d731702"
   },
   "tab-item-compact-height-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-100}",
     "uuid": "e8c7c826-548d-4037-b064-3cf699675d35"
   },
   "tab-item-compact-height-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-75}",
     "uuid": "25f7d9a5-9464-4447-97d9-97839b371f96"
   },
   "tab-item-focus-indicator-gap-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "efaf1230-6cee-4541-89de-e4ae0879cbdc",
     "deprecated": true,
     "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
@@ -9663,7 +9663,7 @@
   },
   "tab-item-focus-indicator-gap-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "c3865c45-3de0-4ab2-bb81-720c5bff2b41",
     "deprecated": true,
     "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
@@ -9683,7 +9683,7 @@
   },
   "tab-item-focus-indicator-gap-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "b84c88e4-e5f2-489b-9564-185e3bd4beda",
     "deprecated": true,
     "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
@@ -9703,7 +9703,7 @@
   },
   "tab-item-focus-indicator-gap-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "352d0f7d-f92e-4ac0-8170-9583107459bb",
     "deprecated": true,
     "deprecated_comment": "Use semantic token focus-ring-gap instead. Requires refactor;",
@@ -9723,31 +9723,31 @@
   },
   "tab-item-height-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-500}",
     "uuid": "42ed814c-5044-4c70-b82f-b49f8226241e"
   },
   "tab-item-height-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-400}",
     "uuid": "8abd0b0e-fd6d-4064-9d0e-1ab998fcb0ce"
   },
   "tab-item-height-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-300}",
     "uuid": "5d2288f4-f383-47fa-baca-0168cb46750a"
   },
   "tab-item-height-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "{component-height-200}",
     "uuid": "7b31cf38-5bac-4f79-a4f1-172a4ea66e10"
   },
   "tab-item-start-to-edge-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "b3d0f59e-2e13-4e51-9252-a91a1556de92",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Not present in design; obscure and difficult to find in implementations",
@@ -9767,7 +9767,7 @@
   },
   "tab-item-start-to-edge-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "d4258a99-f47a-495c-9f24-b63f19c55c71",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Not present in design; obscure and difficult to find in implementations",
@@ -9787,7 +9787,7 @@
   },
   "tab-item-start-to-edge-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "b3abe910-99fc-4f8b-83af-057fd478c2ee",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Not present in design; obscure and difficult to find in implementations",
@@ -9807,7 +9807,7 @@
   },
   "tab-item-start-to-edge-quiet": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
-    "component": "tab-item",
+    "component": "tabs",
     "value": "0px",
     "uuid": "f869f703-a850-4c6c-b518-ec8a1b355046",
     "deprecated": true,
@@ -9815,7 +9815,7 @@
   },
   "tab-item-start-to-edge-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "52087c63-410d-455b-8e3b-51ab1bd831c3",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Not present in design; obscure and difficult to find in implementations",
@@ -9835,7 +9835,7 @@
   },
   "tab-item-to-tab-item-horizontal-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "f1708d11-7b46-45fd-8d39-5c31a65b7e0c",
     "deprecated": true,
     "deprecated_comment": "Use semantic token tab-gap-horizontal-extra-large instead.",
@@ -9855,7 +9855,7 @@
   },
   "tab-item-to-tab-item-horizontal-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "3b8da429-2985-480a-b85b-319f0c458bd1",
     "deprecated": true,
     "deprecated_comment": "Use semantic token tab-gap-horizontal-large instead.",
@@ -9875,7 +9875,7 @@
   },
   "tab-item-to-tab-item-horizontal-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "ebae14c7-73ca-4f71-9caa-82fde4816b90",
     "deprecated": true,
     "deprecated_comment": "Use semantic token tab-gap-horizontal-medium instead. Requires acknowledgement of internal button structure",
@@ -9895,7 +9895,7 @@
   },
   "tab-item-to-tab-item-horizontal-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "038f3637-a968-4ccb-bf7e-6dde89677a8b",
     "deprecated": true,
     "deprecated_comment": "Use semantic token tab-gap-horizontal-small instead.",
@@ -9915,7 +9915,7 @@
   },
   "tab-item-to-tab-item-vertical-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "5ce7dfa6-aa85-4be6-bd22-10ae28c79f71",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-gap-regular instead.",
@@ -9935,7 +9935,7 @@
   },
   "tab-item-to-tab-item-vertical-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "b0613cb8-b17d-4c5c-bab9-02153144c284",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-gap-regular instead.",
@@ -9955,7 +9955,7 @@
   },
   "tab-item-to-tab-item-vertical-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "1579ace5-820f-4b4b-81ed-3b1b8dfc3ae8",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-gap-regular instead.",
@@ -9975,7 +9975,7 @@
   },
   "tab-item-to-tab-item-vertical-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "877ed7ee-8207-4eb3-8412-de9089cd8eae",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-gap-regular instead.",
@@ -9995,7 +9995,7 @@
   },
   "tab-item-top-to-text-compact-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "e5a80358-315d-47b0-ad24-c74d9ad8ac98",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10015,7 +10015,7 @@
   },
   "tab-item-top-to-text-compact-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "4506ad0b-71e6-4627-b8e8-d6ff00b14e58",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10035,7 +10035,7 @@
   },
   "tab-item-top-to-text-compact-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "b88d643b-05db-464a-8b71-cd6b682e17e8",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10055,7 +10055,7 @@
   },
   "tab-item-top-to-text-compact-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "1f2a4336-4d5b-4b39-a163-0a78a39c848c",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10075,7 +10075,7 @@
   },
   "tab-item-top-to-text-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "9a697594-5717-49da-a138-f3c03306082a",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
@@ -10095,7 +10095,7 @@
   },
   "tab-item-top-to-text-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "1ad119cf-c6ec-458f-b6d6-16c8432b9c28",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
@@ -10115,7 +10115,7 @@
   },
   "tab-item-top-to-text-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "b66ff2e3-edd1-4e73-9446-85f596b6252e",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure",
@@ -10135,7 +10135,7 @@
   },
   "tab-item-top-to-text-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "1a709fec-7699-4373-83ba-8e8cb6963c5b",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
@@ -10155,7 +10155,7 @@
   },
   "tab-item-top-to-workflow-icon-compact-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "863df6bc-a4c3-46f7-80c4-43b3437b37a8",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10175,7 +10175,7 @@
   },
   "tab-item-top-to-workflow-icon-compact-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "d7b9e286-1b4e-47ef-a0fa-549f26e89848",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10195,7 +10195,7 @@
   },
   "tab-item-top-to-workflow-icon-compact-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "ae256abb-27d9-4771-9617-e24c722279ab",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10215,7 +10215,7 @@
   },
   "tab-item-top-to-workflow-icon-compact-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "04cfef16-7bba-4d8f-9270-6334a2473cff",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Requires acknowledgement of internal button structure - Density does not affect this value; onlly the tab item vertical padding",
@@ -10235,7 +10235,7 @@
   },
   "tab-item-top-to-workflow-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "f94bad20-f7c9-4998-822c-b8d20158c4bb",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -10255,7 +10255,7 @@
   },
   "tab-item-top-to-workflow-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "8f813787-f636-49e9-94bf-464b291df600",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -10275,7 +10275,7 @@
   },
   "tab-item-top-to-workflow-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "5c4ae90f-f4b7-4f50-9e86-b8711c101c9e",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",
@@ -10295,7 +10295,7 @@
   },
   "tab-item-top-to-workflow-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
-    "component": "tab-item",
+    "component": "tabs",
     "uuid": "906995a7-4f9b-4b37-a90f-7f7712aa6f70",
     "deprecated": true,
     "deprecated_comment": "Use semantic token list-item-padding-vertical-spacious instead. Requires refactor: this token + base-padding-vertical will get desired value",

--- a/packages/tokens/test/checkComponentProps.js
+++ b/packages/tokens/test/checkComponentProps.js
@@ -16,13 +16,23 @@ import { getFileTokens } from "../index.js";
 
 // Anatomy sub-part tokens (e.g. tab-item-*) keep their legacy key (the
 // sub-part name) but carry their real parent component (e.g. "tabs"), so the
-// key no longer starts with the component value. Recognize the sub-part
-// prefix via the anatomy registry rather than failing.
-const anatomyIds = JSON.parse(
-  readFileSync(
-    new URL("../../design-data/registry/anatomy-terms.json", import.meta.url),
+// key no longer starts with the component value. The cascade source of
+// truth (packages/design-data/tokens/*.tokens.json) declares this explicitly
+// via a pinned `legacyKey` alongside `anatomy`; read that exact set instead
+// of loosely matching any anatomy-registry id prefix, since many ids (icon,
+// label, field, item, ...) also legitimately prefix unrelated component keys.
+const cascadeDecomposedKeys = new Set(
+  ["color-component.tokens.json", "layout-component.tokens.json"].flatMap(
+    (file) =>
+      JSON.parse(
+        readFileSync(
+          new URL(`../../design-data/tokens/${file}`, import.meta.url),
+        ),
+      )
+        .filter((t) => t.name?.anatomy && t.name?.legacyKey)
+        .map((t) => t.name.legacyKey),
   ),
-).values.map((v) => v.id);
+);
 
 test("ensure all component tokens are have component data", async (t) => {
   const tokenData = {
@@ -31,12 +41,9 @@ test("ensure all component tokens are have component data", async (t) => {
     ...(await getFileTokens("icons.json")),
   };
   const result = Object.keys(tokenData).filter((tokenName) => {
+    if (cascadeDecomposedKeys.has(tokenName)) return false;
     const { component } = tokenData[tokenName];
-    if (!component) return true;
-    if (tokenName.indexOf(component) === 0) return false;
-    return !anatomyIds.some(
-      (id) => tokenName === id || tokenName.startsWith(`${id}-`),
-    );
+    return !component || tokenName.indexOf(component) != 0;
   });
   t.deepEqual(result, []);
 });

--- a/packages/tokens/test/checkComponentProps.js
+++ b/packages/tokens/test/checkComponentProps.js
@@ -10,8 +10,19 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { readFileSync } from "node:fs";
 import test from "ava";
 import { getFileTokens } from "../index.js";
+
+// Anatomy sub-part tokens (e.g. tab-item-*) keep their legacy key (the
+// sub-part name) but carry their real parent component (e.g. "tabs"), so the
+// key no longer starts with the component value. Recognize the sub-part
+// prefix via the anatomy registry rather than failing.
+const anatomyIds = JSON.parse(
+  readFileSync(
+    new URL("../../design-data/registry/anatomy-terms.json", import.meta.url),
+  ),
+).values.map((v) => v.id);
 
 test("ensure all component tokens are have component data", async (t) => {
   const tokenData = {
@@ -20,9 +31,11 @@ test("ensure all component tokens are have component data", async (t) => {
     ...(await getFileTokens("icons.json")),
   };
   const result = Object.keys(tokenData).filter((tokenName) => {
-    return (
-      !Object.hasOwn(tokenData[tokenName], "component") ||
-      tokenName.indexOf(tokenData[tokenName].component) != 0
+    const { component } = tokenData[tokenName];
+    if (!component) return true;
+    if (tokenName.indexOf(component) === 0) return false;
+    return !anatomyIds.some(
+      (id) => tokenName === id || tokenName.startsWith(`${id}-`),
     );
   });
   t.deepEqual(result, []);

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -497,6 +497,16 @@ fn thin_name_val(property: &str, source: &Map<String, Value>) -> Value {
     if let Some(c) = source.get("component").and_then(|v| v.as_str()) {
         name.insert("component".into(), Value::String(c.to_string()));
     }
+    // Including `component` alongside the full-key `property` normally still
+    // reproduces the original key (the common case: the flat `component`
+    // value is a prefix of `property`'s legacy key). But if the flat
+    // `component` was corrected independently of the key (e.g. an anatomy
+    // sub-part token whose `component` now names its real parent rather than
+    // the sub-part itself), the naive reconstruction yields a different key.
+    // Pin the original key explicitly rather than silently derive a new one.
+    if naming::extract_legacy_key(&Value::Object(name.clone())).as_deref() != Some(property) {
+        name.insert("legacyKey".into(), Value::String(property.to_string()));
+    }
     Value::Object(name)
 }
 

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -1302,4 +1302,27 @@ mod tests {
         let (_name, kind) = resolve_name("swatch-disabled-icon-border-color", &tok, &ctx);
         assert_eq!(kind, NameKind::Thin);
     }
+
+    #[test]
+    fn thin_name_val_omits_legacy_key_when_component_prefixes_property() {
+        // Common case: `component` is a literal prefix of the full legacy key, so
+        // reconstruction from {component, property} reproduces it exactly.
+        let source = obj(json!({"component": "swatch", "uuid": "0000"}));
+        let name = thin_name_val("swatch-disabled-icon-border-color", &source);
+        assert_eq!(name["property"], "swatch-disabled-icon-border-color");
+        assert_eq!(name["component"], "swatch");
+        assert!(name.get("legacyKey").is_none());
+    }
+
+    #[test]
+    fn thin_name_val_pins_legacy_key_when_component_does_not_prefix_property() {
+        // Anatomy sub-part case: `component` names the real parent (not the
+        // sub-part that literally prefixes the key), so reconstruction from
+        // {component, property} would yield a different key than the original.
+        let source = obj(json!({"component": "tabs", "uuid": "0000"}));
+        let name = thin_name_val("tab-item-height-medium", &source);
+        assert_eq!(name["property"], "tab-item-height-medium");
+        assert_eq!(name["component"], "tabs");
+        assert_eq!(name["legacyKey"], "tab-item-height-medium");
+    }
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1132,7 +1132,7 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "menu-item",
       "label": "Menu Item",
       "description": "Individual selectable item within a menu",
-      "usedIn": ["s2-docs"]
+      "usedIn": ["tokens", "s2-docs"]
     },
     {
       "id": "section-header",
@@ -1450,7 +1450,7 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "tab-item",
       "label": "Tab Item",
       "description": "Individual tab button within a tabs component",
-      "usedIn": ["s2-docs"]
+      "usedIn": ["tokens", "s2-docs"]
     },
     {
       "id": "breadcrumb-item",
@@ -1612,6 +1612,12 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "field-button",
       "label": "Field button",
       "description": "A trigger button embedded within a text field or picker",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "in-field-stepper",
+      "label": "In-field stepper",
+      "description": "A stepper control embedded within a field element (e.g. number-field)",
       "usedIn": ["tokens"]
     }
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Routes three anatomy sub-part `name.component` values — `tab-item`, `menu-item`,
`in-field-stepper` — to their real parent component (`tabs`, `menu`, `number-field`)
plus an `anatomy` field for the sub-part, clearing 123 of 194 SPEC-009
(`name-field-enum-sync`) warnings scoped in this task. Each rekeyed token pins a
`legacyKey` so the published legacy token key is byte-identical.

The remaining 4 values (`stack-item`, `in-field-button`, `field`, `bar-panel` = 71
warnings) have no single unambiguous parent component, so they're split out to a new
taxonomy-ruling bead (`spectrum-design-data-46d`) rather than forced into this fix.

Also includes two supporting fixes discovered while verifying this change end-to-end:

- `sdk/core/src/migrate.rs`: `thin_name_val` now pins `legacyKey` whenever a corrected
  `component` value no longer reproduces the original legacy key — without this, the
  legacy→cascade migration tool (and CI's `roundtrip-verify`) reconstructed a different
  key than the one actually published.
- `packages/tokens/naming-exceptions.json` / `validation-snapshot.json`: track the 49
  tokens whose pinned legacy key no longer roundtrips through canonical name generation
  (SPEC-007), same pattern as existing `compound-state`/`state-position` exceptions.
- `packages/tokens/test/checkComponentProps.js`: the existing invariant (`component`
  must literally prefix the token's key) predates anatomy sub-parts; now recognizes
  anatomy-registry sub-part prefixes as valid too.

## Related Issue

Closes spectrum-design-data-uep (partial — see follow-up spectrum-design-data-46d for
the remaining 71 warnings).

## Motivation and Context

Part of the `spectrum-design-data-dm2` epic burning down 3,535 SPEC-009 warnings.
`tab-item`, `menu-item`, and `in-field-stepper` are anatomy sub-parts, not standalone
components — SPEC-009 was flagging them because they weren't in `components.json` and
weren't yet in the anatomy registry either.

## How Has This Been Tested?

- `moon run sdk:codegen-check` — registry codegen in sync
- `moon run sdk:test` — full Rust test suite
- `moon run design-data:validate` (full validate, not just validate-dataset)
- `moon run design-data:roundtrip-verify` — legacy output unaffected
- `design-data migrate legacy-verify` — cascade matches published legacy tokens exactly
- `node packages/design-data/scripts/spec009-report.js component` — confirms exactly
  123 warnings cleared (tab-item, menu-item, in-field-stepper gone; stack-item 32,
  in-field-button 25, field 8, bar-panel 6 remain as expected)
- `pnpm --filter @adobe/spectrum-tokens test` (via `npx ava`) — full package suite
- `moon run :test` — full workspace test suite (28/28 tasks)
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset lints
  clean

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
