### PR TITLE
feat(design-data): finish SPEC-009 epic — icon field + anatomy sub-part components

### DIFF
--- a/.changeset/spec009-anatomy-subparts-register-components.md
+++ b/.changeset/spec009-anatomy-subparts-register-components.md
@@ -1,0 +1,11 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Register 4 cross-cutting anatomy sub-parts as first-class components (part of
+spectrum-design-data-46d), clearing the remaining 71 SPEC-009 warnings. No token data
+changes — these values are reused across multiple unrelated components with no single
+accurate parent, so each is registered directly rather than routed via `anatomy`.
+
+- **packages/design-data/registry/components.json**: add `bar-panel` (6 tokens),
+  `field` (8), `in-field-button` (25), `stack-item` (32).

--- a/.changeset/spec009-icon-name-field.md
+++ b/.changeset/spec009-icon-name-field.md
@@ -1,0 +1,16 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Add a first-class `icon` name field (part of spectrum-design-data-p89), the Rust
+prerequisite for re-keying icon tokens off `component` to clear ~315 SPEC-009 warnings.
+No token data changes yet — `icon` is not used by any token in this change.
+
+- **packages/design-data/fields/icon.json**: new field, registry-backed, advisory.
+- **packages/design-data/registry/icon-terms.json**: 12 icon ids (`icon`, `ui`,
+  `checkmark`, `chevron`, `dash`, `arrow`, `cross`, `add`, `link-out`, `drag-handle`,
+  `asterisk`, `gripper`), with `tokenName` long-form expansions for legacy keys.
+- **sdk/core/src/naming.rs**: `extract_legacy_key` treats `icon` as an alternate,
+  mutually-exclusive owner to `component` — both in the color-domain branch
+  (`{icon}-{property}-{colorFamily?}-{colorRole?}-{state?}`) and a new non-color branch
+  (`{icon-tokenName}-{property}-{state?}`) for layout/dimension icon tokens.

--- a/.changeset/spec009-icon-token-rekey.md
+++ b/.changeset/spec009-icon-token-rekey.md
@@ -1,0 +1,21 @@
+---
+"@adobe/spectrum-design-data": minor
+"@adobe/spectrum-tokens": minor
+---
+
+Re-key icon tokens off the new `icon` name field (part of spectrum-design-data-aui),
+clearing ~315 SPEC-009 warnings. Published legacy keys are unchanged.
+
+- **packages/design-data/registry/icon-terms.json**: new registry, 12 icon ids (`icon`,
+  `ui`, `checkmark`, `chevron`, `dash`, `arrow`, `cross`, `add`, `link-out`,
+  `drag-handle`, `asterisk`, `gripper`), with `tokenName` long-form expansions.
+- **packages/design-data/tokens/icons.tokens.json**: 191 tokens re-keyed
+  `component:'icon'` → `icon:'icon'`.
+- **packages/design-data/tokens/layout-component.tokens.json**: 124 tokens re-keyed
+  `component:'X-icon'` → `icon:'X'` across 11 distinct values.
+- **sdk/core/src/naming.rs**: `extract_legacy_key` gains an icon (non-color) branch and
+  a thin-format guard so re-keyed tokens still resolve to their original legacy key.
+- **sdk/core/src/legacy.rs**: legacy-metadata hoisting (`resolve_owner_component`) now
+  falls back to the icon field so published `component` metadata is unaffected.
+- **packages/tokens/src/icons.json**, **layout-component.json**: regenerated, byte-identical
+  to their pre-change state.

--- a/packages/design-data/fields/icon.json
+++ b/packages/design-data/fields/icon.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "icon",
+  "description": "Icon identity for icon-family tokens (e.g. checkmark, chevron, ui). Mutually exclusive with `component`. Legacy-key placement (leading, like `component`) is handled by an explicit owner-prefix branch in `extract_legacy_key` rather than the generic position-walk, so this position value only needs to be unique — it does not control key order.",
+  "kind": "semantic",
+  "registry": "packages/design-data/registry/icon-terms.json",
+  "validation": "advisory",
+  "serialization": {
+    "position": 100
+  },
+  "scope": null,
+  "required": false,
+  "valueType": "string"
+}

--- a/packages/design-data/registry/components.json
+++ b/packages/design-data/registry/components.json
@@ -49,6 +49,11 @@
       "documentationUrl": "https://spectrum.adobe.com/page/badge/"
     },
     {
+      "id": "bar-panel",
+      "label": "Bar Panel",
+      "description": "A cross-cutting anatomy sub-part shared by multiple components (e.g. color area, color wheel) rather than a standalone top-level component."
+    },
+    {
       "id": "body",
       "label": "Body",
       "documentationUrl": "https://spectrum.adobe.com/page/body/"
@@ -184,6 +189,11 @@
       "documentationUrl": "https://spectrum.adobe.com/page/drop-zone/"
     },
     {
+      "id": "field",
+      "label": "Field",
+      "description": "A cross-cutting anatomy sub-part shared by multiple form-adjacent components rather than a standalone top-level component."
+    },
+    {
       "id": "field-label",
       "label": "Field Label",
       "documentationUrl": "https://spectrum.adobe.com/page/field-label/"
@@ -212,6 +222,11 @@
       "id": "illustrated-message",
       "label": "Illustrated Message",
       "documentationUrl": "https://spectrum.adobe.com/page/illustrated-message/"
+    },
+    {
+      "id": "in-field-button",
+      "label": "In-Field Button",
+      "description": "A cross-cutting anatomy sub-part shared by multiple field-adjacent components rather than a standalone top-level component."
     },
     {
       "id": "in-field-progress-circle",
@@ -322,6 +337,11 @@
       "id": "slider",
       "label": "Slider",
       "documentationUrl": "https://spectrum.adobe.com/page/slider/"
+    },
+    {
+      "id": "stack-item",
+      "label": "Stack Item",
+      "description": "A cross-cutting anatomy sub-part shared by multiple stacking-layout components rather than a standalone top-level component."
     },
     {
       "id": "standard-dialog",

--- a/packages/design-data/registry/icon-terms.json
+++ b/packages/design-data/registry/icon-terms.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "icon",
+  "description": "Icon identities used as the `icon` name-field value on icon-family tokens. `tokenName` gives the long form used in legacy keys (e.g. \"checkmark\" -> \"checkmark-icon\"); ids without a `tokenName` already match the legacy form.",
+  "values": [
+    {
+      "id": "icon",
+      "label": "Icon",
+      "description": "Generic icon token, not tied to a specific glyph",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "ui",
+      "label": "UI Icon",
+      "description": "Generic UI icon glyph",
+      "tokenName": "ui-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "checkmark",
+      "label": "Checkmark Icon",
+      "description": "Checkmark glyph",
+      "tokenName": "checkmark-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "chevron",
+      "label": "Chevron Icon",
+      "description": "Chevron glyph",
+      "tokenName": "chevron-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "dash",
+      "label": "Dash Icon",
+      "description": "Dash glyph",
+      "tokenName": "dash-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "arrow",
+      "label": "Arrow Icon",
+      "description": "Arrow glyph",
+      "tokenName": "arrow-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "cross",
+      "label": "Cross Icon",
+      "description": "Cross (close) glyph",
+      "tokenName": "cross-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "add",
+      "label": "Add Icon",
+      "description": "Add (plus) glyph",
+      "tokenName": "add-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "link-out",
+      "label": "Link Out Icon",
+      "description": "External-link glyph",
+      "tokenName": "link-out-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "drag-handle",
+      "label": "Drag Handle Icon",
+      "description": "Drag handle glyph",
+      "tokenName": "drag-handle-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "asterisk",
+      "label": "Asterisk Icon",
+      "description": "Asterisk glyph",
+      "tokenName": "asterisk-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "gripper",
+      "label": "Gripper Icon",
+      "description": "Gripper glyph",
+      "tokenName": "gripper-icon",
+      "usedIn": ["tokens"]
+    }
+  ]
+}

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -15,7 +15,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -29,7 +29,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -43,7 +43,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -58,7 +58,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -73,7 +73,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -88,7 +88,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -103,7 +103,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -118,7 +118,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -133,7 +133,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -148,7 +148,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -163,7 +163,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -178,7 +178,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -192,7 +192,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -206,7 +206,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -220,7 +220,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -235,7 +235,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -250,7 +250,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -265,7 +265,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -280,7 +280,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -295,7 +295,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -310,7 +310,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -325,7 +325,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -340,7 +340,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -355,7 +355,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -369,7 +369,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -383,7 +383,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -397,7 +397,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -412,7 +412,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -427,7 +427,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -442,7 +442,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -457,7 +457,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -472,7 +472,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -487,7 +487,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -502,7 +502,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -517,7 +517,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -532,7 +532,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -546,7 +546,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -560,7 +560,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -574,7 +574,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -589,7 +589,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -604,7 +604,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -619,7 +619,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -634,7 +634,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -649,7 +649,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -664,7 +664,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -679,7 +679,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -694,7 +694,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -709,7 +709,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -723,7 +723,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -737,7 +737,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -751,7 +751,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorRole": "primary",
@@ -763,7 +763,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorRole": "primary",
@@ -775,7 +775,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorRole": "primary",
@@ -787,7 +787,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -801,7 +801,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -815,7 +815,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -829,7 +829,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorRole": "primary",
@@ -841,7 +841,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorRole": "primary",
@@ -853,7 +853,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorRole": "primary",
@@ -866,7 +866,7 @@
   {
     "name": {
       "property": "icon-color-disabled-primary",
-      "component": "icon"
+      "icon": "icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -875,7 +875,7 @@
   {
     "name": {
       "property": "icon-color-emphasized-background",
-      "component": "icon"
+      "icon": "icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -883,7 +883,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorRole": "background",
       "colorFamily": "fuchsia"
@@ -894,7 +894,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -909,7 +909,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -924,7 +924,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -939,7 +939,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -954,7 +954,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -969,7 +969,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -984,7 +984,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -999,7 +999,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -1014,7 +1014,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -1029,7 +1029,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -1043,7 +1043,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -1057,7 +1057,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -1071,7 +1071,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorRole": "primary",
@@ -1083,7 +1083,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorRole": "primary",
@@ -1095,7 +1095,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorRole": "primary",
@@ -1107,7 +1107,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -1121,7 +1121,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -1135,7 +1135,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -1149,7 +1149,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -1164,7 +1164,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -1179,7 +1179,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -1194,7 +1194,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -1209,7 +1209,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -1224,7 +1224,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -1239,7 +1239,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -1254,7 +1254,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -1269,7 +1269,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -1284,7 +1284,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "variant": "inverse",
       "legacyKey": "icon-color-inverse"
@@ -1296,7 +1296,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "background-color",
       "variant": "inverse",
       "legacyKey": "icon-color-inverse-background"
@@ -1307,7 +1307,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorRole": "background",
       "colorFamily": "magenta"
@@ -1318,7 +1318,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -1333,7 +1333,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -1348,7 +1348,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -1363,7 +1363,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -1378,7 +1378,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -1393,7 +1393,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -1408,7 +1408,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -1423,7 +1423,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -1438,7 +1438,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -1453,7 +1453,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -1467,7 +1467,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -1481,7 +1481,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -1495,7 +1495,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -1510,7 +1510,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -1525,7 +1525,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -1540,7 +1540,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -1555,7 +1555,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -1570,7 +1570,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -1585,7 +1585,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -1600,7 +1600,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -1615,7 +1615,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -1630,7 +1630,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorRole": "background",
       "colorFamily": "pink"
@@ -1641,7 +1641,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -1656,7 +1656,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -1671,7 +1671,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -1686,7 +1686,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -1701,7 +1701,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -1716,7 +1716,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -1731,7 +1731,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -1746,7 +1746,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -1761,7 +1761,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -1776,7 +1776,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorRole": "primary"
@@ -1787,7 +1787,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorRole": "primary"
@@ -1798,7 +1798,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorRole": "primary"
@@ -1809,7 +1809,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorRole": "background",
       "colorFamily": "purple"
@@ -1820,7 +1820,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -1835,7 +1835,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -1850,7 +1850,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -1865,7 +1865,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -1880,7 +1880,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -1895,7 +1895,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -1910,7 +1910,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -1925,7 +1925,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -1940,7 +1940,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -1955,7 +1955,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -1969,7 +1969,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -1983,7 +1983,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -1997,7 +1997,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -2012,7 +2012,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -2027,7 +2027,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -2042,7 +2042,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -2057,7 +2057,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -2072,7 +2072,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -2087,7 +2087,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -2102,7 +2102,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -2117,7 +2117,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -2132,7 +2132,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -2146,7 +2146,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -2160,7 +2160,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -2174,7 +2174,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorRole": "primary",
@@ -2186,7 +2186,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorRole": "primary",
@@ -2198,7 +2198,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorRole": "primary",
@@ -2210,7 +2210,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -2224,7 +2224,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -2238,7 +2238,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -2252,7 +2252,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -2267,7 +2267,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -2282,7 +2282,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -2297,7 +2297,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -2312,7 +2312,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -2327,7 +2327,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -2342,7 +2342,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -2357,7 +2357,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -2372,7 +2372,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -2387,7 +2387,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -2401,7 +2401,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -2415,7 +2415,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -2429,7 +2429,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -2444,7 +2444,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -2459,7 +2459,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -2474,7 +2474,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -2489,7 +2489,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -2504,7 +2504,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -2519,7 +2519,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -2534,7 +2534,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -2549,7 +2549,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",
@@ -2564,7 +2564,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "light",
       "colorRole": "background",
@@ -2578,7 +2578,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "dark",
       "colorRole": "background",
@@ -2592,7 +2592,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "colorScheme": "wireframe",
       "colorRole": "background",
@@ -2606,7 +2606,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "light",
@@ -2621,7 +2621,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "dark",
@@ -2636,7 +2636,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "default",
       "colorScheme": "wireframe",
@@ -2651,7 +2651,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "light",
@@ -2666,7 +2666,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "dark",
@@ -2681,7 +2681,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "down",
       "colorScheme": "wireframe",
@@ -2696,7 +2696,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "light",
@@ -2711,7 +2711,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "dark",
@@ -2726,7 +2726,7 @@
   },
   {
     "name": {
-      "component": "icon",
+      "icon": "icon",
       "property": "color",
       "state": "hover",
       "colorScheme": "wireframe",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -1479,7 +1479,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -1492,7 +1492,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -1505,7 +1505,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -1518,7 +1518,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -1531,7 +1531,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -1544,7 +1544,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -1557,7 +1557,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-50",
       "scale": "desktop"
     },
@@ -1570,7 +1570,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-50",
       "scale": "mobile"
     },
@@ -1583,7 +1583,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -1596,7 +1596,7 @@
   },
   {
     "name": {
-      "component": "add-icon",
+      "icon": "add",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -1940,7 +1940,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -1953,7 +1953,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -1966,7 +1966,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -1979,7 +1979,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -1992,7 +1992,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -2005,7 +2005,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -2018,7 +2018,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-400",
       "scale": "desktop"
     },
@@ -2031,7 +2031,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-400",
       "scale": "mobile"
     },
@@ -2044,7 +2044,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-500",
       "scale": "desktop"
     },
@@ -2057,7 +2057,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-500",
       "scale": "mobile"
     },
@@ -2070,7 +2070,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-600",
       "scale": "desktop"
     },
@@ -2083,7 +2083,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-600",
       "scale": "mobile"
     },
@@ -2096,7 +2096,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -2109,7 +2109,7 @@
   },
   {
     "name": {
-      "component": "arrow-icon",
+      "icon": "arrow",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -2122,7 +2122,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -2135,7 +2135,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -2148,7 +2148,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -2161,7 +2161,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -2174,7 +2174,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -2187,7 +2187,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -2200,7 +2200,7 @@
   },
   {
     "name": {
-      "component": "asterisk-icon",
+      "icon": "asterisk",
       "property": "size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -4358,7 +4358,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -4371,7 +4371,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -4384,7 +4384,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -4397,7 +4397,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -4410,7 +4410,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -4423,7 +4423,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -4436,7 +4436,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-400",
       "scale": "desktop"
     },
@@ -4449,7 +4449,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-400",
       "scale": "mobile"
     },
@@ -4462,7 +4462,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-50",
       "scale": "desktop"
     },
@@ -4475,7 +4475,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-50",
       "scale": "mobile"
     },
@@ -4488,7 +4488,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-500",
       "scale": "desktop"
     },
@@ -4501,7 +4501,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-500",
       "scale": "mobile"
     },
@@ -4514,7 +4514,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-600",
       "scale": "desktop"
     },
@@ -4527,7 +4527,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-600",
       "scale": "mobile"
     },
@@ -4540,7 +4540,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -4553,7 +4553,7 @@
   },
   {
     "name": {
-      "component": "checkmark-icon",
+      "icon": "checkmark",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -4566,7 +4566,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -4579,7 +4579,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -4592,7 +4592,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -4605,7 +4605,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -4618,7 +4618,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -4631,7 +4631,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -4644,7 +4644,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-400",
       "scale": "desktop"
     },
@@ -4657,7 +4657,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-400",
       "scale": "mobile"
     },
@@ -4670,7 +4670,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-50",
       "scale": "desktop"
     },
@@ -4683,7 +4683,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-50",
       "scale": "mobile"
     },
@@ -4696,7 +4696,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-500",
       "scale": "desktop"
     },
@@ -4709,7 +4709,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-500",
       "scale": "mobile"
     },
@@ -4722,7 +4722,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-600",
       "scale": "desktop"
     },
@@ -4735,7 +4735,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-600",
       "scale": "mobile"
     },
@@ -4748,7 +4748,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -4761,7 +4761,7 @@
   },
   {
     "name": {
-      "component": "chevron-icon",
+      "icon": "chevron",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -5860,7 +5860,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -5873,7 +5873,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -5886,7 +5886,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -5899,7 +5899,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -5912,7 +5912,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -5925,7 +5925,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -5938,7 +5938,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-400",
       "scale": "desktop"
     },
@@ -5951,7 +5951,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-400",
       "scale": "mobile"
     },
@@ -5964,7 +5964,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-500",
       "scale": "desktop"
     },
@@ -5977,7 +5977,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-500",
       "scale": "mobile"
     },
@@ -5990,7 +5990,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-600",
       "scale": "desktop"
     },
@@ -6003,7 +6003,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-600",
       "scale": "mobile"
     },
@@ -6016,7 +6016,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -6029,7 +6029,7 @@
   },
   {
     "name": {
-      "component": "cross-icon",
+      "icon": "cross",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -6042,7 +6042,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -6055,7 +6055,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -6068,7 +6068,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -6081,7 +6081,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -6094,7 +6094,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -6107,7 +6107,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -6120,7 +6120,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-400",
       "scale": "desktop"
     },
@@ -6133,7 +6133,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-400",
       "scale": "mobile"
     },
@@ -6146,7 +6146,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-50",
       "scale": "desktop"
     },
@@ -6159,7 +6159,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-50",
       "scale": "mobile"
     },
@@ -6172,7 +6172,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-500",
       "scale": "desktop"
     },
@@ -6185,7 +6185,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-500",
       "scale": "mobile"
     },
@@ -6198,7 +6198,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-600",
       "scale": "desktop"
     },
@@ -6211,7 +6211,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-600",
       "scale": "mobile"
     },
@@ -6224,7 +6224,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -6237,7 +6237,7 @@
   },
   {
     "name": {
-      "component": "dash-icon",
+      "icon": "dash",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -6374,7 +6374,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -6387,7 +6387,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -6400,7 +6400,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -6413,7 +6413,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -6426,7 +6426,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -6439,7 +6439,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -6452,7 +6452,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -6465,7 +6465,7 @@
   },
   {
     "name": {
-      "component": "drag-handle-icon",
+      "icon": "drag-handle",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -7101,7 +7101,7 @@
   },
   {
     "name": {
-      "component": "gripper-icon",
+      "icon": "gripper",
       "property": "size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -7987,7 +7987,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-100",
       "scale": "desktop"
     },
@@ -8000,7 +8000,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-100",
       "scale": "mobile"
     },
@@ -8013,7 +8013,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-200",
       "scale": "desktop"
     },
@@ -8026,7 +8026,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-200",
       "scale": "mobile"
     },
@@ -8039,7 +8039,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-300",
       "scale": "desktop"
     },
@@ -8052,7 +8052,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-300",
       "scale": "mobile"
     },
@@ -8065,7 +8065,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-400",
       "scale": "desktop"
     },
@@ -8078,7 +8078,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-400",
       "scale": "mobile"
     },
@@ -8091,7 +8091,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-75",
       "scale": "desktop"
     },
@@ -8104,7 +8104,7 @@
   },
   {
     "name": {
-      "component": "link-out-icon",
+      "icon": "link-out",
       "property": "size-75",
       "scale": "mobile"
     },
@@ -20620,7 +20620,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "2x-large",
       "scale": "desktop"
     },
@@ -20632,7 +20632,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "2x-large",
       "scale": "mobile"
     },
@@ -20644,7 +20644,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "extra-large",
       "scale": "desktop"
     },
@@ -20656,7 +20656,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "extra-large",
       "scale": "mobile"
     },
@@ -20668,7 +20668,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "extra-small",
       "scale": "desktop"
     },
@@ -20680,7 +20680,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "extra-small",
       "scale": "mobile"
     },
@@ -20692,7 +20692,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "large",
       "scale": "desktop"
     },
@@ -20704,7 +20704,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "large",
       "scale": "mobile"
     },
@@ -20716,7 +20716,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "medium",
       "scale": "desktop"
     },
@@ -20728,7 +20728,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "medium",
       "scale": "mobile"
     },
@@ -20740,7 +20740,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "small",
       "scale": "desktop"
     },
@@ -20752,7 +20752,7 @@
   },
   {
     "name": {
-      "component": "ui-icon",
+      "icon": "ui",
       "property": "small",
       "scale": "mobile"
     },

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -670,15 +670,21 @@ fn build_set_entry(
     let mut outer = Map::new();
     outer.insert("$schema".into(), Value::String(set_schema.to_string()));
 
-    // Hoist component from name object if consistent across all tokens.
-    let component = consistent_str_field(tokens, |tok| {
+    // Hoist component from name object if consistent across all tokens. Icon-family
+    // tokens carry `icon` instead of `component` — resolve_owner_component() falls
+    // back to the icon's expanded tokenName so legacy output is unaffected.
+    let owner_of = |tok: &&Map<String, Value>| {
         tok.get("name")
             .and_then(|v| v.as_object())
-            .and_then(|n| n.get("component"))
-            .and_then(|v| v.as_str())
+            .and_then(crate::naming::resolve_owner_component)
+    };
+    let component = tokens.first().and_then(owner_of).filter(|first| {
+        tokens
+            .iter()
+            .all(|t| owner_of(t).as_deref() == Some(first.as_str()))
     });
     if let Some(c) = component {
-        outer.insert("component".into(), Value::String(c.to_string()));
+        outer.insert("component".into(), Value::String(c));
     }
 
     // Recover the outer set-level UUID from the cascade tokens (stored as set_uuid).
@@ -755,14 +761,15 @@ fn build_flat_entry(tok: &Map<String, Value>, uuid_to_name: &HashMap<String, Str
         entry.insert("$schema".into(), Value::String(schema.to_string()));
     }
 
-    // Component lives at the outer level in legacy format.
+    // Component lives at the outer level in legacy format. Icon-family tokens
+    // carry `icon` instead of `component`; resolve_owner_component() falls back
+    // to the icon's expanded tokenName so legacy output is unaffected.
     if let Some(c) = tok
         .get("name")
         .and_then(|v| v.as_object())
-        .and_then(|n| n.get("component"))
-        .and_then(|v| v.as_str())
+        .and_then(crate::naming::resolve_owner_component)
     {
-        entry.insert("component".into(), Value::String(c.to_string()));
+        entry.insert("component".into(), Value::String(c));
     }
 
     insert_value_or_ref(&mut entry, tok, uuid_to_name);

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -185,6 +185,12 @@ fn split_trailing_state(s: &str) -> (&str, Option<&str>) {
 /// `icon` instead of `component`; this expands the short registry id through
 /// `tokenName` (e.g. `"add"` → `"add-icon"`) so published legacy output is
 /// unaffected by the field rename. Returns `None` when neither field is present.
+///
+/// This duplicates the "prefer `component`, else expand `icon` via `tokenName`"
+/// logic in the owner computation inside [`extract_legacy_key`]'s color-domain
+/// branch — the two aren't wired together because one produces key *segments*
+/// and the other an outer metadata *field*. Keep them in sync if either's
+/// fallback behavior changes.
 pub fn resolve_owner_component(name: &Map<String, Value>) -> Option<String> {
     if let Some(c) = name.get("component").and_then(|v| v.as_str()) {
         return Some(c.to_string());
@@ -245,7 +251,7 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     //   where state@12 < colorFamily@17 would produce the wrong segment order.
     //   `icon` is expanded through its registry `tokenName` (e.g. "checkmark" →
     //   "checkmark-icon") the same way the general position-walk path expands ids.
-    //   e.g. {component:"icon", property:"color", colorFamily:"blue", colorRole:"primary",
+    //   e.g. {icon:"icon", property:"color", colorFamily:"blue", colorRole:"primary",
     //         state:"default"} → "icon-color-blue-primary-default"
     let color_family = name.get("colorFamily").and_then(|v| v.as_str());
     let color_role = name.get("colorRole").and_then(|v| v.as_str());

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -178,6 +178,27 @@ fn split_trailing_state(s: &str) -> (&str, Option<&str>) {
     (s, None)
 }
 
+/// Resolve the legacy `component` metadata value for a name object.
+///
+/// Legacy output hoists `name.component` to an outer `component` field (see
+/// `legacy::build_flat_entry` / `legacy::convert_set`). Icon-family tokens carry
+/// `icon` instead of `component`; this expands the short registry id through
+/// `tokenName` (e.g. `"add"` → `"add-icon"`) so published legacy output is
+/// unaffected by the field rename. Returns `None` when neither field is present.
+pub fn resolve_owner_component(name: &Map<String, Value>) -> Option<String> {
+    if let Some(c) = name.get("component").and_then(|v| v.as_str()) {
+        return Some(c.to_string());
+    }
+    let icon = name.get("icon").and_then(|v| v.as_str())?;
+    let registry = crate::registry::RegistryData::embedded();
+    Some(
+        registry
+            .token_name("icon", icon)
+            .unwrap_or(icon)
+            .to_string(),
+    )
+}
+
 /// Extract the canonical legacy kebab-case key from a cascade `name` value.
 ///
 /// Handles two name forms:
@@ -210,25 +231,40 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         return Some(lk.to_string());
     }
 
-    // Color-domain serialization — two sub-cases distinguished by component presence.
+    // Color-domain serialization — two sub-cases distinguished by owner presence.
+    // `owner` is `component`, or `icon` for icon-family tokens (the two are
+    // mutually exclusive — a name object never carries both).
     //
-    //   Palette ramp (no component): {variant?}-{colorFamily}-{scaleIndex?}
+    //   Palette ramp (no owner): {variant?}-{colorFamily}-{scaleIndex?}
     //   `property` ("color") is implicit and omitted from the key.
     //   e.g. {colorFamily:"blue", scaleIndex:100} → "blue-100"
     //
-    //   Component color (component + colorFamily and/or colorRole):
-    //   {component}-{property}-{colorFamily?}-{colorRole?}-{state?}
+    //   Owner color (owner + colorFamily and/or colorRole):
+    //   {owner}-{property}-{colorFamily?}-{colorRole?}-{state?}
     //   `property` is always "color". Explicit ordering avoids the position-walk trap
     //   where state@12 < colorFamily@17 would produce the wrong segment order.
+    //   `icon` is expanded through its registry `tokenName` (e.g. "checkmark" →
+    //   "checkmark-icon") the same way the general position-walk path expands ids.
     //   e.g. {component:"icon", property:"color", colorFamily:"blue", colorRole:"primary",
     //         state:"default"} → "icon-color-blue-primary-default"
     let color_family = name.get("colorFamily").and_then(|v| v.as_str());
     let color_role = name.get("colorRole").and_then(|v| v.as_str());
     let component = name.get("component").and_then(|v| v.as_str());
+    let icon = name.get("icon").and_then(|v| v.as_str());
+    let owner = component.or(icon).map(|v| {
+        if component.is_some() {
+            v.to_string()
+        } else {
+            crate::registry::RegistryData::embedded()
+                .token_name("icon", v)
+                .unwrap_or(v)
+                .to_string()
+        }
+    });
 
     if let Some(cf) = color_family {
-        if component.is_none() {
-            // Palette ramp: no component, property implicit.
+        if owner.is_none() {
+            // Palette ramp: no owner, property implicit.
             let mut parts: Vec<String> = Vec::new();
             if let Some(v) = name.get("variant").and_then(|v| v.as_str()) {
                 parts.push(v.to_string());
@@ -241,11 +277,11 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         }
     }
 
-    // Component color: component present AND at least one of colorFamily/colorRole.
-    if component.is_some() && (color_family.is_some() || color_role.is_some()) {
+    // Owner color: owner present AND at least one of colorFamily/colorRole.
+    if owner.is_some() && (color_family.is_some() || color_role.is_some()) {
         let property = name.get("property").and_then(|v| v.as_str())?;
         let mut parts: Vec<String> = Vec::new();
-        parts.push(component.unwrap().to_string());
+        parts.push(owner.unwrap());
         parts.push(property.to_string());
         if let Some(cf) = color_family {
             parts.push(cf.to_string());
@@ -260,6 +296,34 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     }
 
     let property = name.get("property").and_then(|v| v.as_str())?;
+
+    // Icon (non-color) domain: an icon-family token without colorFamily/colorRole
+    // (the owner-color branch above didn't apply). Unlike `component`, whose legacy
+    // values already match the registry id, `icon` registry ids are the short form
+    // (e.g. "add") and expand through `tokenName` to the long form used in legacy
+    // keys ("add-icon"). Explicit branch — like the color and space-between cases
+    // above — since `icon`'s position (100) sits after `property` in the catalog,
+    // so the generic position-walk below can't express the required leading order.
+    // e.g. {icon:"add", property:"size-100"} → "add-icon-size-100"
+    //
+    // Thin-format check mirrors the `component` case just below: some tokens store
+    // the full legacy key in `property` already (e.g. property:"icon-color-disabled-
+    // primary", icon:"icon"), with `icon` duplicated as a metadata annotation only.
+    // Prepending the owner there would double the prefix.
+    if let Some(ic) = icon {
+        let registry = crate::registry::RegistryData::embedded();
+        let ic_expanded = registry.token_name("icon", ic).unwrap_or(ic);
+        let is_thin =
+            property.starts_with(ic_expanded) && property[ic_expanded.len()..].starts_with('-');
+        if is_thin {
+            return Some(property.to_string());
+        }
+        let mut parts: Vec<String> = vec![ic_expanded.to_string(), property.to_string()];
+        if let Some(st) = name.get("state").and_then(|v| v.as_str()) {
+            parts.push(st.to_string());
+        }
+        return Some(parts.join("-"));
+    }
 
     // Thin-format detection: `property` already begins with `{component}-`.
     // In the thin cascade format the full legacy key is stored in `property`; component is
@@ -742,5 +806,69 @@ mod tests {
         // Palette ramp (no component) still uses the short form.
         let name = json!({"property": "color", "colorFamily": "blue", "scaleIndex": 700});
         assert_eq!(extract_legacy_key(&name).as_deref(), Some("blue-700"));
+    }
+
+    // ── Icon field (SPEC-009 icon-terms) ──────────────────────────────────────
+
+    #[test]
+    fn extract_key_icon_color_domain_uses_icon_as_owner() {
+        // `icon` stands in for `component` in the owner-color branch; the bare
+        // "icon" id has no tokenName expansion (already the legacy form).
+        let name = json!({
+            "icon": "icon",
+            "property": "color",
+            "colorScheme": "dark",
+            "colorRole": "background",
+            "colorFamily": "blue"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("icon-color-blue-background")
+        );
+    }
+
+    #[test]
+    fn extract_key_icon_non_color_expands_token_name() {
+        // General (non-color) icon domain: short registry id "add" expands to
+        // "add-icon" and leads `property`, mirroring {icon:"add-icon", property:"size-100"}.
+        let name = json!({"icon": "add", "property": "size-100"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("add-icon-size-100")
+        );
+    }
+
+    #[test]
+    fn extract_key_icon_non_color_with_state() {
+        let name = json!({"icon": "checkmark", "property": "size", "state": "hover"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("checkmark-icon-size-hover")
+        );
+    }
+
+    #[test]
+    fn extract_key_icon_unregistered_id_falls_back_to_raw_value() {
+        // No tokenName expansion available (id not in the registry) — the raw
+        // value is used verbatim rather than failing the roundtrip.
+        let name = json!({"icon": "unregistered-widget", "property": "size-100"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("unregistered-widget-size-100")
+        );
+    }
+
+    #[test]
+    fn extract_key_icon_thin_format_not_double_prefixed() {
+        // Thin cascade format: `property` already holds the full legacy key
+        // ("icon-color-disabled-primary"); `icon:"icon"` (which expands to itself,
+        // no tokenName mapping) is a metadata duplicate only. Regression test for
+        // a bug where the icon branch unconditionally prepended the owner,
+        // producing "icon-icon-color-disabled-primary".
+        let name = json!({"icon": "icon", "property": "icon-color-disabled-primary"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("icon-color-disabled-primary")
+        );
     }
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -343,6 +343,11 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/badge/"
     },
     {
+      "id": "bar-panel",
+      "label": "Bar Panel",
+      "description": "A cross-cutting anatomy sub-part shared by multiple components (e.g. color area, color wheel) rather than a standalone top-level component."
+    },
+    {
       "id": "body",
       "label": "Body",
       "documentationUrl": "https://spectrum.adobe.com/page/body/"
@@ -478,6 +483,11 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/drop-zone/"
     },
     {
+      "id": "field",
+      "label": "Field",
+      "description": "A cross-cutting anatomy sub-part shared by multiple form-adjacent components rather than a standalone top-level component."
+    },
+    {
       "id": "field-label",
       "label": "Field Label",
       "documentationUrl": "https://spectrum.adobe.com/page/field-label/"
@@ -506,6 +516,11 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "illustrated-message",
       "label": "Illustrated Message",
       "documentationUrl": "https://spectrum.adobe.com/page/illustrated-message/"
+    },
+    {
+      "id": "in-field-button",
+      "label": "In-Field Button",
+      "description": "A cross-cutting anatomy sub-part shared by multiple field-adjacent components rather than a standalone top-level component."
     },
     {
       "id": "in-field-progress-circle",
@@ -616,6 +631,11 @@ const COMPONENTS_JSON: &str = r##"{
       "id": "slider",
       "label": "Slider",
       "documentationUrl": "https://spectrum.adobe.com/page/slider/"
+    },
+    {
+      "id": "stack-item",
+      "label": "Stack Item",
+      "description": "A cross-cutting anatomy sub-part shared by multiple stacking-layout components rather than a standalone top-level component."
     },
     {
       "id": "standard-dialog",
@@ -2637,6 +2657,97 @@ const ALIGNMENTS_JSON: &str = r##"{
   ]
 }
 "##;
+const ICON_TERMS_JSON: &str = r##"{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "icon",
+  "description": "Icon identities used as the `icon` name-field value on icon-family tokens. `tokenName` gives the long form used in legacy keys (e.g. \"checkmark\" -> \"checkmark-icon\"); ids without a `tokenName` already match the legacy form.",
+  "values": [
+    {
+      "id": "icon",
+      "label": "Icon",
+      "description": "Generic icon token, not tied to a specific glyph",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "ui",
+      "label": "UI Icon",
+      "description": "Generic UI icon glyph",
+      "tokenName": "ui-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "checkmark",
+      "label": "Checkmark Icon",
+      "description": "Checkmark glyph",
+      "tokenName": "checkmark-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "chevron",
+      "label": "Chevron Icon",
+      "description": "Chevron glyph",
+      "tokenName": "chevron-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "dash",
+      "label": "Dash Icon",
+      "description": "Dash glyph",
+      "tokenName": "dash-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "arrow",
+      "label": "Arrow Icon",
+      "description": "Arrow glyph",
+      "tokenName": "arrow-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "cross",
+      "label": "Cross Icon",
+      "description": "Cross (close) glyph",
+      "tokenName": "cross-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "add",
+      "label": "Add Icon",
+      "description": "Add (plus) glyph",
+      "tokenName": "add-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "link-out",
+      "label": "Link Out Icon",
+      "description": "External-link glyph",
+      "tokenName": "link-out-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "drag-handle",
+      "label": "Drag Handle Icon",
+      "description": "Drag handle glyph",
+      "tokenName": "drag-handle-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "asterisk",
+      "label": "Asterisk Icon",
+      "description": "Asterisk glyph",
+      "tokenName": "asterisk-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "gripper",
+      "label": "Gripper Icon",
+      "description": "Gripper glyph",
+      "tokenName": "gripper-icon",
+      "usedIn": ["tokens"]
+    }
+  ]
+}
+"##;
 const CATEGORIES_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "category",
@@ -2694,7 +2805,7 @@ const CATEGORIES_JSON: &str = r##"{
 }
 "##;
 
-pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "family", "weight", "style", "motionRole", "easing", "alignment"];
+pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "family", "weight", "style", "motionRole", "easing", "alignment", "icon"];
 
 pub(crate) fn build_registry_map(
 ) -> std::collections::HashMap<String, std::collections::HashSet<String>> {
@@ -2720,6 +2831,7 @@ pub(crate) fn build_registry_map(
     map.insert("motionRole".to_string(), parse_registry(MOTION_ROLES_JSON));
     map.insert("easing".to_string(), parse_registry(EASING_CURVES_JSON));
     map.insert("alignment".to_string(), parse_registry(ALIGNMENTS_JSON));
+    map.insert("icon".to_string(), parse_registry(ICON_TERMS_JSON));
     map.insert("categories".to_string(), parse_registry(CATEGORIES_JSON));
     map
 }
@@ -2748,6 +2860,7 @@ pub(crate) fn build_token_name_map(
     map.insert("motionRole".to_string(), parse_token_name_map(MOTION_ROLES_JSON));
     map.insert("easing".to_string(), parse_token_name_map(EASING_CURVES_JSON));
     map.insert("alignment".to_string(), parse_token_name_map(ALIGNMENTS_JSON));
+    map.insert("icon".to_string(), parse_token_name_map(ICON_TERMS_JSON));
     map
 }
 
@@ -2780,5 +2893,6 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "to", position: 24, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "alignment", position: 25, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "scaleIndex", position: 99, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "icon", position: 100, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Finishes the SPEC-009 name-field-enum-sync warning triage epic (`spectrum-design-data-dm2`):

1. Adds a first-class `icon` name field to `naming.rs` so icon-family tokens can be
   re-keyed off `component` without changing published legacy keys.
2. Re-keys 315 icon tokens (`icons.tokens.json`, `layout-component.tokens.json`) onto
   the new `icon` field.
3. Registers the 4 remaining cross-cutting anatomy sub-parts (`bar-panel`, `field`,
   `in-field-button`, `stack-item`) as first-class components in `components.json`,
   per a taxonomy ruling recorded on bead `spectrum-design-data-46d` — they're reused
   across multiple unrelated components with no single accurate parent, so each is
   registered directly rather than routed via `anatomy`.

Along the way, found and fixed a real regression: `legacy.rs`'s independent
component-metadata hoisting didn't know about the new `icon` field, silently dropping
`"component"` from published legacy output for re-keyed tokens. Fixed via a shared
`resolve_owner_component` helper used by both hoisting call sites.

## Related Issue

Closes the `spectrum-design-data-dm2` epic (beads tracker) — 9/9 children complete,
SPEC-009 addressable warning count reduced to 0.

## Motivation and Context

SPEC-009 fires when `name.component` isn't in the components registry. ~386
addressable warnings remained, split into icon tokens (~315, needed a dedicated
`icon` name axis rather than overloading `component`) and 4 cross-cutting anatomy
sub-parts (71, no single real parent component).

## How Has This Been Tested?

- `moon run sdk:test` — full workspace suite green, including new regression tests
  for the icon field (color-domain owner branch, non-color branch, thin-format
  double-prefix guard, unregistered-id fallback).
- `moon run sdk:lint` — clean.
- `moon run design-data:validate --force` — 0 errors, 0 SPEC-009 `name.component`
  warnings remaining, 0 new SPEC-023/024/025 regressions.
- Legacy output (`packages/tokens/src/icons.json`, `layout-component.json`)
  regenerated directly from the built binary and diffed against `main` — byte-identical,
  confirming the re-key and the metadata-hoisting fix don't change published keys.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — all 3 new
  changesets valid.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
