### PR TITLE
fix(token-mapping-analyzer): source structured token tree, not legacy flat keys

### DIFF
--- a/tools/token-mapping-analyzer/src/index.js
+++ b/tools/token-mapping-analyzer/src/index.js
@@ -60,7 +60,12 @@ async function main() {
           registry.tokenNameMap,
           registry.serializationOrder,
         ) || token.name.legacyKey;
-      if (!legacyKey) continue;
+      if (!legacyKey) {
+        console.warn(
+          `  WARNING: could not reconstruct legacy key for token in ${filename} (name: ${JSON.stringify(token.name)}) — dropped from report`,
+        );
+        continue;
+      }
 
       const result = decompose(
         legacyKey,

--- a/tools/token-mapping-analyzer/src/index.js
+++ b/tools/token-mapping-analyzer/src/index.js
@@ -8,27 +8,25 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, readdirSync, writeFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { loadRegistries } from "./registry-index.js";
-import { decompose } from "./decomposer.js";
+import { decompose, serialize } from "./decomposer.js";
 import { generateReport } from "./report.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const TOKENS_DIR = resolve(__dirname, "../../../packages/tokens/src");
+// Structured cascade tree (inline name objects) — the source of truth for
+// decomposition state. The legacy flat-key tree (packages/tokens/src) is
+// stale here: apply.js already extracts fields into this tree, so analyzing
+// the legacy tree would re-report fields as "residual" that are already
+// migrated. See spectrum-design-data-dsi.
+const TOKENS_DIR = resolve(__dirname, "../../../packages/design-data/tokens");
 const OUTPUT_DIR = resolve(__dirname, "../output");
 
-const TOKEN_FILES = [
-  "color-palette.json",
-  "semantic-color-palette.json",
-  "color-aliases.json",
-  "color-component.json",
-  "icons.json",
-  "layout.json",
-  "layout-component.json",
-  "typography.json",
-];
+const TOKEN_FILES = readdirSync(TOKENS_DIR)
+  .filter((f) => f.endsWith(".tokens.json"))
+  .sort();
 
 async function main() {
   console.log("Loading registries...");
@@ -44,12 +42,36 @@ async function main() {
 
   for (const filename of TOKEN_FILES) {
     const filePath = resolve(TOKENS_DIR, filename);
-    const data = JSON.parse(readFileSync(filePath, "utf-8"));
-    const tokenCount = Object.keys(data).length;
-    console.log(`\n  ${filename}: ${tokenCount} tokens`);
+    const tokens = JSON.parse(readFileSync(filePath, "utf-8"));
+    // String-name tokens (the escape hatch, proposal 011) have no fields to
+    // decompose and are already tracked by token-naming-audit's
+    // scan-string-names.js — skip them here.
+    const namedTokens = tokens.filter((t) => typeof t.name === "object");
+    console.log(`\n  ${filename}: ${namedTokens.length} tokens`);
 
-    for (const [tokenName, tokenData] of Object.entries(data)) {
-      const result = decompose(tokenName, tokenData, registry, filename);
+    for (const token of namedTokens) {
+      // Reconstruct the legacy key from the inline name object (mirrors
+      // apply.js). Most tokens roundtrip through serialize(); a small set of
+      // pinned exceptions (broken by prior decomposition passes) carry an
+      // explicit name.legacyKey instead — fall back to that.
+      const legacyKey =
+        serialize(
+          token.name,
+          registry.tokenNameMap,
+          registry.serializationOrder,
+        ) || token.name.legacyKey;
+      if (!legacyKey) continue;
+
+      const result = decompose(
+        legacyKey,
+        {
+          deprecated: !!token.deprecated,
+          private: !!token.private,
+          component: token.name.component,
+        },
+        registry,
+        filename,
+      );
       allResults.push(result);
     }
 


### PR DESCRIPTION
## Description

`tools/token-mapping-analyzer/src/index.js` analyzed the legacy flat-key tree
(`packages/tokens/src`) to produce the residual-property decomposition report consumed by
`generate-exceptions.js`. `apply.js` has since migrated resolved fields into the structured
cascade tree (`packages/design-data/tokens`), which the legacy tree can't reflect — so the
analysis over-reported already-migrated fields as unresolved residual.

This repoints `index.js` at the structured tree and reconstructs each legacy key via
`serialize()`/`name.legacyKey`, mirroring the same roundtrip pattern `apply.js` already uses.
Output shape of `output/all-decompositions.json` is unchanged, so `generate-exceptions.js` needs
no changes.

## Related Issue

Unblocks `spectrum-design-data-dsi` (Phase D: triage uncategorized residual property values,
tracked in this repo's beads issue database).

## Motivation and Context

Needed an accurate, current-tree-sourced residual inventory before triaging what's left to
decompose/register/route to a human decision. Confirmed via cross-check against two independent
current-tree tools (`token-naming-audit`, `design-data:spec009-report`) — magnitudes now agree.

## How Has This Been Tested?

- `moon run token-mapping-analyzer:analyze` runs clean end-to-end against the structured tree.
- Spot-checked a known already-migrated token and a known ordering-residual token
  (`accordion-bottom-to-text-compact-large`) to confirm the sourcing fix behaves correctly.
- `moon run token-mapping-analyzer:test` — all 30 existing AVA tests pass unchanged.
- Cross-referenced the resulting residual tally against `token-naming-audit` and
  `design-data:spec009-report`; all three agree in order of magnitude.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes. (No new tests: `index.js` is an unrefactored CLI
      entry point with no exported internals to unit test; existing decomposer/apply tests and
      an end-to-end run + spot-check cover the change.)
- [x] All new and existing tests passed.
