### PR TITLE
fix(ci): stale diff comments + feat(design-data): drop-shadow decomposition (dsi.1)

### DIFF
--- a/.changeset/dsi1-drop-shadow-context-decomposition.md
+++ b/.changeset/dsi1-drop-shadow-context-decomposition.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Decompose drop-shadow-property and context-modifier residual tokens per
+proposal 004 (closes spectrum-design-data-dsi.1).
+
+- **packages/design-data/registry/structures.json**: add the `drop-shadow`
+  structure entry.
+- **packages/design-data/registry/variants.json**: register `ambient`,
+  `dragged`, `elevated`, `pasteboard`, `elevated-key`, `dragged-key` context
+  variants.
+- **packages/design-data/registry/property-terms.json**: add `x`/`y`
+  property terms for drop-shadow offsets.
+- **tools/token-mapping-analyzer/src/decomposer.js**: remove `drop-shadow`
+  from `COMPOUND_PROPERTIES` and drop the now-redundant `context-modifier`/
+  `drop-shadow-property` `KNOWN_GAP_TERMS` entries.
+- **packages/design-data/tokens/{color-aliases,color-component,layout,
+  layout-component}.tokens.json**: migrate 70 tokens into `structure`/
+  `variant`/`property` fields. `structure` is excluded from legacy-key
+  reconstruction in `naming.rs`, so `name.legacyKey` is pinned on every
+  touched token to keep the decomposition publish-invisible.

--- a/.github/workflows/component-diff-pr-comment.yml
+++ b/.github/workflows/component-diff-pr-comment.yml
@@ -3,9 +3,6 @@ name: Component Schema Diff PR Comment
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "packages/design-data/components/**"
-      - "packages/component-schemas/package.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/token-diff-pr-comment.yml
+++ b/.github/workflows/token-diff-pr-comment.yml
@@ -3,9 +3,6 @@ name: Token Diff PR Comment
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "packages/tokens/src/**"
-      - "packages/tokens/schemas/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/proposals/004-drop-shadow-classification.md
+++ b/docs/proposals/004-drop-shadow-classification.md
@@ -1,7 +1,7 @@
 # Proposal 004: Drop-Shadow Classification
 
-**Status:** Draft\
-**Affects:** 31 active tokens in `color-aliases.json`, `layout.json`, `layout-component.json`\
+**Status:** Implemented (spectrum-design-data-dsi.1)\
+**Affects:** 70 tokens across `color-aliases.tokens.json`, `color-component.tokens.json`, `layout.tokens.json`, `layout-component.tokens.json`\
 **Spec reference:** taxonomy.md — structures registry
 
 ## Problem
@@ -24,7 +24,7 @@ Structures are defined as "individual objects or object categories that have sha
 
 ### Registry change
 
-Add to `packages/design-system-registry/registry/structures.json`:
+Add to `packages/design-data/registry/structures.json`:
 
 ```json
 {
@@ -66,8 +66,16 @@ The terms `ambient`, `dragged`, `elevated`, `transition`, `key` describe drop-sh
 | `drop-shadow-emphasized-hover-color` | `{ structure: "drop-shadow", emphasis: "emphasized", property: "color", state: "hover" }` |
 | `drop-shadow-elevated-key-color`     | `{ structure: "drop-shadow", variant: "elevated-key", property: "color" }`                |
 
+### Non-drop-shadow surface contexts
+
+`background-elevated-color` and `background-pasteboard-color` share the `elevated`
+context term but aren't drop-shadow tokens — they decompose independently as
+`{ object: "background", property: "color", variant: "elevated" | "pasteboard" }`,
+with `pasteboard` added to the variant registry as a plain surface-context term
+(not drop-shadow-specific).
+
 ## Impact
 
-* 31 active tokens gain a proper structural classification
+* 70 tokens gain a proper structural classification
 * Leverages existing `structure` field — no schema change needed
 * Drop-shadow sub-properties and context modifiers cleanly decompose

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -252,6 +252,16 @@
       "id": "space-between",
       "label": "Space Between",
       "description": "Spacing between two named endpoints (e.g. an edge and an anatomy part, or two anatomy parts). The endpoints are carried by the paired `from`/`to` name-object fields, not by this term; the legacy key is reconstructed as {from}-to-{to} and omits this property term."
+    },
+    {
+      "id": "x",
+      "label": "X",
+      "description": "Horizontal offset (e.g. drop-shadow x offset)"
+    },
+    {
+      "id": "y",
+      "label": "Y",
+      "description": "Vertical offset (e.g. drop-shadow y offset)"
     }
   ]
 }

--- a/packages/design-data/registry/structures.json
+++ b/packages/design-data/registry/structures.json
@@ -52,6 +52,11 @@
       "id": "heading",
       "label": "Heading",
       "description": "Heading text typography scale — used for section and page headings"
+    },
+    {
+      "id": "drop-shadow",
+      "label": "Drop Shadow",
+      "description": "Elevated shadow effect applied to components and containers"
     }
   ]
 }

--- a/packages/design-data/registry/variants.json
+++ b/packages/design-data/registry/variants.json
@@ -284,6 +284,48 @@
       "description": "Informational dialog variant (alias for informative in alert contexts)",
       "category": "semantic",
       "usedIn": ["component-schemas"]
+    },
+    {
+      "id": "ambient",
+      "label": "Ambient",
+      "description": "Ambient/diffuse drop-shadow context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "dragged",
+      "label": "Dragged",
+      "description": "Shadow context during drag interaction",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "elevated",
+      "label": "Elevated",
+      "description": "Elevated surface or shadow context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "pasteboard",
+      "label": "Pasteboard",
+      "description": "Pasteboard surface context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "elevated-key",
+      "label": "Elevated Key",
+      "description": "Key-light shadow context on an elevated surface",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "dragged-key",
+      "label": "Dragged Key",
+      "description": "Key-light shadow context during drag interaction",
+      "category": "context",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -240,8 +240,11 @@
   },
   {
     "name": {
-      "property": "background-elevated-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "variant": "elevated",
+      "object": "background",
+      "legacyKey": "background-elevated-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -251,8 +254,11 @@
   },
   {
     "name": {
-      "property": "background-elevated-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "variant": "elevated",
+      "object": "background",
+      "legacyKey": "background-elevated-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
@@ -262,8 +268,11 @@
   },
   {
     "name": {
-      "property": "background-elevated-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "variant": "elevated",
+      "object": "background",
+      "legacyKey": "background-elevated-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -353,8 +362,11 @@
   },
   {
     "name": {
-      "property": "background-pasteboard-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "variant": "pasteboard",
+      "object": "background",
+      "legacyKey": "background-pasteboard-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -364,8 +376,11 @@
   },
   {
     "name": {
-      "property": "background-pasteboard-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "variant": "pasteboard",
+      "object": "background",
+      "legacyKey": "background-pasteboard-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -375,8 +390,11 @@
   },
   {
     "name": {
-      "property": "background-pasteboard-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "variant": "pasteboard",
+      "object": "background",
+      "legacyKey": "background-pasteboard-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -1088,8 +1106,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-ambient-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "structure": "drop-shadow",
+      "variant": "ambient",
+      "legacyKey": "drop-shadow-ambient-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.08)",
@@ -1099,8 +1120,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-ambient-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "structure": "drop-shadow",
+      "variant": "ambient",
+      "legacyKey": "drop-shadow-ambient-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.24)",
@@ -1110,8 +1134,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-ambient-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "structure": "drop-shadow",
+      "variant": "ambient",
+      "legacyKey": "drop-shadow-ambient-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.08)",
@@ -1121,7 +1148,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color"
+      "property": "color",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5c0f0543-7e9b-43d6-9fea-c771b9b524c6",
@@ -1136,8 +1165,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-100",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "structure": "drop-shadow",
+      "scaleIndex": "100",
+      "legacyKey": "drop-shadow-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1147,8 +1179,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-100",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "structure": "drop-shadow",
+      "scaleIndex": "100",
+      "legacyKey": "drop-shadow-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.36)",
@@ -1158,8 +1193,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-100",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "structure": "drop-shadow",
+      "scaleIndex": "100",
+      "legacyKey": "drop-shadow-color-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1169,8 +1207,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-200",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "structure": "drop-shadow",
+      "scaleIndex": "200",
+      "legacyKey": "drop-shadow-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.16)",
@@ -1180,8 +1221,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-200",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "structure": "drop-shadow",
+      "scaleIndex": "200",
+      "legacyKey": "drop-shadow-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.48)",
@@ -1191,8 +1235,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-200",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "structure": "drop-shadow",
+      "scaleIndex": "200",
+      "legacyKey": "drop-shadow-color-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.16)",
@@ -1202,8 +1249,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-300",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "structure": "drop-shadow",
+      "scaleIndex": "300",
+      "legacyKey": "drop-shadow-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.2)",
@@ -1213,8 +1263,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-300",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "structure": "drop-shadow",
+      "scaleIndex": "300",
+      "legacyKey": "drop-shadow-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.6)",
@@ -1224,8 +1277,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-color-300",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "structure": "drop-shadow",
+      "scaleIndex": "300",
+      "legacyKey": "drop-shadow-color-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.2)",
@@ -1235,7 +1291,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged"
+      "property": "drop-shadow",
+      "variant": "dragged",
+      "legacyKey": "drop-shadow-dragged"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [
@@ -1265,7 +1323,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-color"
+      "property": "color",
+      "structure": "drop-shadow",
+      "variant": "dragged",
+      "legacyKey": "drop-shadow-dragged-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebb7effd-f156-41a9-823f-052e5733e53d",
@@ -1273,8 +1334,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-key-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "variant": "dragged-key",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-dragged-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.16)",
@@ -1284,8 +1348,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-key-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "variant": "dragged-key",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-dragged-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.48)",
@@ -1295,8 +1362,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-key-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "variant": "dragged-key",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-dragged-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.16)",
@@ -1306,7 +1376,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated"
+      "property": "drop-shadow",
+      "variant": "elevated",
+      "legacyKey": "drop-shadow-elevated"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [
@@ -1336,7 +1408,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-color"
+      "property": "color",
+      "structure": "drop-shadow",
+      "variant": "elevated",
+      "legacyKey": "drop-shadow-elevated-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
@@ -1344,8 +1419,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-key-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "variant": "elevated-key",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-elevated-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1355,8 +1433,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-key-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "variant": "elevated-key",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-elevated-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.36)",
@@ -1366,8 +1447,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-key-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "variant": "elevated-key",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-elevated-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1379,7 +1463,9 @@
     "name": {
       "property": "drop-shadow",
       "variant": "emphasized",
-      "legacyKey": "drop-shadow-emphasized"
+      "legacyKey": "emphasized-drop-shadow",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [
@@ -1409,7 +1495,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-default-color"
+      "property": "color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "default",
+      "legacyKey": "drop-shadow-emphasized-default-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92619056-db5a-45ab-ba0b-50e67cc497f6",
@@ -1418,7 +1508,10 @@
   {
     "name": {
       "property": "drop-shadow-emphasized",
-      "state": "hover"
+      "state": "hover",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-emphasized-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [
@@ -1448,7 +1541,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-color"
+      "property": "color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "legacyKey": "drop-shadow-emphasized-hover-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1a60435c-ff2d-409c-97de-1b4bbf77eacb",
@@ -1522,8 +1619,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-transition-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "structure": "drop-shadow",
+      "motionRole": "transition",
+      "legacyKey": "drop-shadow-transition-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.04)",
@@ -1533,8 +1633,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-transition-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "structure": "drop-shadow",
+      "motionRole": "transition",
+      "legacyKey": "drop-shadow-transition-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1544,8 +1647,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-transition-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "structure": "drop-shadow",
+      "motionRole": "transition",
+      "legacyKey": "drop-shadow-transition-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.04)",

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1463,9 +1463,7 @@
     "name": {
       "property": "drop-shadow",
       "variant": "emphasized",
-      "legacyKey": "emphasized-drop-shadow",
-      "emphasis": "emphasized",
-      "structure": "drop-shadow"
+      "legacyKey": "drop-shadow-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
     "value": [
@@ -1507,10 +1505,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized",
+      "property": "drop-shadow",
+      "variant": "emphasized",
       "state": "hover",
-      "emphasis": "emphasized",
-      "structure": "drop-shadow",
       "legacyKey": "drop-shadow-emphasized-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -178,7 +178,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "drop-shadow-color"
+      "property": "color",
+      "structure": "drop-shadow",
+      "legacyKey": "color-handle-drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
@@ -226,7 +228,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "drop-shadow-blur"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "legacyKey": "color-loupe-drop-shadow-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f3487a86-3aea-4527-8b5c-287c0bddad6c",
@@ -236,7 +240,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "drop-shadow-color"
+      "property": "color",
+      "structure": "drop-shadow",
+      "legacyKey": "color-loupe-drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e475981f-97af-479c-859b-7619dd87c448",
@@ -248,7 +254,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "drop-shadow-y"
+      "property": "y",
+      "structure": "drop-shadow",
+      "legacyKey": "color-loupe-drop-shadow-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "45f313a5-1749-4b95-b5e3-20944adbea84",
@@ -339,7 +347,9 @@
   {
     "name": {
       "component": "floating-action-button",
-      "property": "drop-shadow-color"
+      "property": "color",
+      "structure": "drop-shadow",
+      "legacyKey": "floating-action-button-drop-shadow-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16a871e1-d9df-42bb-8889-99059d70e82e",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -5658,7 +5658,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "drop-shadow-blur"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "legacyKey": "color-handle-drop-shadow-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0",
@@ -5667,7 +5669,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "drop-shadow-x"
+      "property": "x",
+      "structure": "drop-shadow",
+      "legacyKey": "color-handle-drop-shadow-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0",
@@ -5676,7 +5680,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "drop-shadow-y"
+      "property": "y",
+      "structure": "drop-shadow",
+      "legacyKey": "color-handle-drop-shadow-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0",
@@ -7334,7 +7340,9 @@
   {
     "name": {
       "component": "floating-action-button",
-      "property": "drop-shadow-blur"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "legacyKey": "floating-action-button-drop-shadow-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -7343,7 +7351,9 @@
   {
     "name": {
       "component": "floating-action-button",
-      "property": "drop-shadow-y"
+      "property": "y",
+      "structure": "drop-shadow",
+      "legacyKey": "floating-action-button-drop-shadow-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -3009,7 +3009,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-blur"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "025e39f4-dfe7-4a8a-beb5-bd0577f72eac",
@@ -3018,7 +3020,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-blur-100"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "scaleIndex": "100",
+      "legacyKey": "drop-shadow-blur-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -3026,7 +3031,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-blur-200"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "scaleIndex": "200",
+      "legacyKey": "drop-shadow-blur-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -3034,7 +3042,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-blur-300"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "scaleIndex": "300",
+      "legacyKey": "drop-shadow-blur-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -3042,7 +3053,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-blur"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "variant": "dragged",
+      "legacyKey": "drop-shadow-dragged-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "34812e0c-7ccf-49c2-884a-6fecd45f7c5a",
@@ -3050,7 +3064,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-x"
+      "property": "x",
+      "structure": "drop-shadow",
+      "variant": "dragged",
+      "legacyKey": "drop-shadow-dragged-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cb6d74fe-cc32-47ff-bf8b-74597643a8a6",
@@ -3058,7 +3075,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-dragged-y"
+      "property": "y",
+      "structure": "drop-shadow",
+      "variant": "dragged",
+      "legacyKey": "drop-shadow-dragged-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5d09089b-c0c5-4122-a3be-3e989562acda",
@@ -3066,7 +3086,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-blur"
+      "property": "blur",
+      "structure": "drop-shadow",
+      "variant": "elevated",
+      "legacyKey": "drop-shadow-elevated-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2b08d425-ecf2-4891-83cd-005a2d5e76ce",
@@ -3074,7 +3097,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-x"
+      "property": "x",
+      "structure": "drop-shadow",
+      "variant": "elevated",
+      "legacyKey": "drop-shadow-elevated-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0c76c925-4d29-49a3-b882-e946bd7fe9f1",
@@ -3082,7 +3108,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-elevated-y"
+      "property": "y",
+      "structure": "drop-shadow",
+      "variant": "elevated",
+      "legacyKey": "drop-shadow-elevated-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d2d0320a-6984-4b3f-8f5d-ccb88892a26c",
@@ -3090,7 +3119,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-default-blur"
+      "property": "blur",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "default",
+      "legacyKey": "drop-shadow-emphasized-default-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "025e39f4-dfe7-4a8a-beb5-bd0577f72eac",
@@ -3098,7 +3131,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-default-x"
+      "property": "x",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "default",
+      "legacyKey": "drop-shadow-emphasized-default-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "751d636e-efb5-411e-a5b8-06b11439cc90",
@@ -3106,7 +3143,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-default-y"
+      "property": "y",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "default",
+      "legacyKey": "drop-shadow-emphasized-default-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ed1f46fd-a586-46a5-8cc1-d843a57e2cc2",
@@ -3114,7 +3155,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-blur"
+      "property": "blur",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "legacyKey": "drop-shadow-emphasized-hover-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2b08d425-ecf2-4891-83cd-005a2d5e76ce",
@@ -3122,7 +3167,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-x"
+      "property": "x",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "legacyKey": "drop-shadow-emphasized-hover-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0c76c925-4d29-49a3-b882-e946bd7fe9f1",
@@ -3130,7 +3179,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-y"
+      "property": "y",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "legacyKey": "drop-shadow-emphasized-hover-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d2d0320a-6984-4b3f-8f5d-ccb88892a26c",
@@ -3138,7 +3191,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-x"
+      "property": "x",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "751d636e-efb5-411e-a5b8-06b11439cc90",
@@ -3147,7 +3202,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-x-100"
+      "property": "x",
+      "structure": "drop-shadow",
+      "scaleIndex": "100",
+      "legacyKey": "drop-shadow-x-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3155,7 +3213,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-x-200"
+      "property": "x",
+      "structure": "drop-shadow",
+      "scaleIndex": "200",
+      "legacyKey": "drop-shadow-x-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3163,7 +3224,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-x-300"
+      "property": "x",
+      "structure": "drop-shadow",
+      "scaleIndex": "300",
+      "legacyKey": "drop-shadow-x-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3171,7 +3235,9 @@
   },
   {
     "name": {
-      "property": "drop-shadow-y"
+      "property": "y",
+      "structure": "drop-shadow",
+      "legacyKey": "drop-shadow-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ed1f46fd-a586-46a5-8cc1-d843a57e2cc2",
@@ -3180,7 +3246,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-y-100"
+      "property": "y",
+      "structure": "drop-shadow",
+      "scaleIndex": "100",
+      "legacyKey": "drop-shadow-y-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -3188,7 +3257,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-y-200"
+      "property": "y",
+      "structure": "drop-shadow",
+      "scaleIndex": "200",
+      "legacyKey": "drop-shadow-y-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -3196,7 +3268,10 @@
   },
   {
     "name": {
-      "property": "drop-shadow-y-300"
+      "property": "y",
+      "structure": "drop-shadow",
+      "scaleIndex": "300",
+      "legacyKey": "drop-shadow-y-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -288,6 +288,48 @@ const VARIANTS_JSON: &str = r##"{
       "description": "Informational dialog variant (alias for informative in alert contexts)",
       "category": "semantic",
       "usedIn": ["component-schemas"]
+    },
+    {
+      "id": "ambient",
+      "label": "Ambient",
+      "description": "Ambient/diffuse drop-shadow context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "dragged",
+      "label": "Dragged",
+      "description": "Shadow context during drag interaction",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "elevated",
+      "label": "Elevated",
+      "description": "Elevated surface or shadow context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "pasteboard",
+      "label": "Pasteboard",
+      "description": "Pasteboard surface context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "elevated-key",
+      "label": "Elevated Key",
+      "description": "Key-light shadow context on an elevated surface",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "dragged-key",
+      "label": "Dragged Key",
+      "description": "Key-light shadow context during drag interaction",
+      "category": "context",
+      "usedIn": ["tokens"]
     }
   ]
 }
@@ -814,6 +856,11 @@ const STRUCTURES_JSON: &str = r##"{
       "id": "heading",
       "label": "Heading",
       "description": "Heading text typography scale — used for section and page headings"
+    },
+    {
+      "id": "drop-shadow",
+      "label": "Drop Shadow",
+      "description": "Elevated shadow effect applied to components and containers"
     }
   ]
 }
@@ -1991,6 +2038,16 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "space-between",
       "label": "Space Between",
       "description": "Spacing between two named endpoints (e.g. an edge and an anatomy part, or two anatomy parts). The endpoints are carried by the paired `from`/`to` name-object fields, not by this term; the legacy key is reconstructed as {from}-to-{to} and omits this property term."
+    },
+    {
+      "id": "x",
+      "label": "X",
+      "description": "Horizontal offset (e.g. drop-shadow x offset)"
+    },
+    {
+      "id": "y",
+      "label": "Y",
+      "description": "Vertical offset (e.g. drop-shadow y offset)"
     }
   ]
 }

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -48,7 +48,6 @@ const COMPOUND_PROPERTIES = [
   "maximum-width",
   "maximum-height",
   "underline-gap",
-  "drop-shadow",
   "typography-scale",
 ];
 
@@ -60,10 +59,6 @@ const KNOWN_GAP_TERMS = {
   // Variant qualifiers — subtle, subdued, and static are now in the variant registry.
   // Only "non" remains unregistered (used as a negation prefix, not a standalone variant).
   "variant-qualifier": ["non"],
-  // Context modifiers
-  "context-modifier": ["elevated", "dragged", "ambient", "pasteboard"],
-  // Drop-shadow sub-properties
-  "drop-shadow-property": ["blur", "x", "y"],
   // Spatial qualifiers
   "spatial-qualifier": ["inner", "outer"],
 };

--- a/tools/token-mapping-analyzer/src/generate-exceptions.js
+++ b/tools/token-mapping-analyzer/src/generate-exceptions.js
@@ -55,11 +55,6 @@ function categorize(result) {
     return { category: "variant-qualifier", proposal: "002" };
   }
 
-  // Context modifiers (elevated, pasteboard, ambient)
-  if (gapTypes.includes("context-modifier")) {
-    return { category: "context-modifier", proposal: "004" };
-  }
-
   // Numeric scale index
   if (
     gapTypes.includes("numeric-scale-index") &&
@@ -67,11 +62,6 @@ function categorize(result) {
     result.unmatchedSegments.length === 0
   ) {
     return { category: "numeric-scale-index", proposal: "003" };
-  }
-
-  // Drop-shadow properties
-  if (gapTypes.includes("drop-shadow-property")) {
-    return { category: "drop-shadow-property", proposal: "004" };
   }
 
   // Spacing-between


### PR DESCRIPTION
## Description

Two independent, sequential pieces of work from a beads-driven planning pass:

1. **CI fix** — `token-diff-pr-comment.yml` and `component-diff-pr-comment.yml` both use a
   `paths:` filter on `pull_request` events, which GitHub evaluates against the PR's
   cumulative base…head diff. When a push reverts a token/component change so the diff
   returns to zero, the filter stops matching and the workflow never dispatches at all —
   leaving a stale comment behind instead of refreshing to "no changes detected." Fix:
   remove the filter from both workflows so the existing zero-diff early-exit can run.
2. **`dsi.1` decomposition** — implements proposal 004: registers `drop-shadow` as a
   structure, six context variants (`ambient`, `dragged`, `elevated`, `pasteboard`,
   `elevated-key`, `dragged-key`), and `x`/`y` property terms. Migrates 70 tokens across
   `color-aliases`, `color-component`, `layout`, and `layout-component` into
   `structure`/`variant`/`property` fields. `name.legacyKey` is pinned on every touched
   token because `naming.rs` excludes `structure` from its generic legacy-key
   reconstruction path — this keeps the change publish-invisible.

## Related Issue

Closes spectrum-design-data-ub6, closes spectrum-design-data-dsi.1 (beads)

## Motivation and Context

Beads review surfaced 5 ready issues; these two had established patterns/precedent
(PR #1228) and no open taxonomy decisions, so they were executed. Three sibling
`human`-flagged taxonomy calls (`dsi.2`/`dsi.3`/`dsi.4`, ~716 tokens) were intentionally
left out of scope pending a manual decision.

## How Has This Been Tested?

- `moon run token-mapping-analyzer:analyze` — 0 remaining `context-modifier` /
  `drop-shadow-property` gaps; all 70 touched tokens roundtrip cleanly.
- `moon run sdk:codegen-check` — registry ↔ `registry_data.rs` in sync.
- `moon run design-data:validate` — no new warnings introduced.
- `moon run design-data:roundtrip-verify` — confirms Rust's `extract_legacy_key`
  reconstructs the exact published legacy keys via the pinned `legacyKey` escape hatch.
- `moon run token-mapping-analyzer:test` — 30/30 passing.
- `moon run sdk:test` — full Rust workspace suite passing.
- Changeset linted clean: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
