### PR TITLE
fix(design-data): pin legacyKey on ordering-mismatch residual tokens (dsi.3)

### DIFF
--- a/.changeset/dsi3-ordering-mismatch-legacykey.md
+++ b/.changeset/dsi3-ordering-mismatch-legacykey.md
@@ -1,0 +1,14 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Pin `name.legacyKey` on ordering-mismatch residual tokens to keep published
+keys stable (closes spectrum-design-data-dsi.3).
+
+- **packages/design-data/tokens/{color-aliases,color-component,icons,layout,
+  layout-component,semantic-color-palette,typography}.tokens.json**: 224
+  tokens decompose cleanly but their published legacy key's field order
+  (e.g. density-before-size, `key-focus` state ordering) doesn't match
+  the canonical serialize order. `name.legacyKey` is pinned to each
+  token's existing published key via the same escape hatch used by
+  dsi.1, keeping the change publish-invisible.

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -120,7 +120,8 @@
     "name": {
       "property": "accent-background-color",
       "state": "key-focus",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "accent-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -132,7 +133,8 @@
     "name": {
       "property": "accent-background-color",
       "state": "key-focus",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "accent-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
@@ -144,7 +146,8 @@
     "name": {
       "property": "accent-background-color",
       "state": "key-focus",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "accent-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -182,7 +185,8 @@
   {
     "name": {
       "property": "accent-content-color",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "accent-content-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -232,7 +236,8 @@
   },
   {
     "name": {
-      "property": "background-base-color"
+      "property": "background-base-color",
+      "legacyKey": "background-base-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -354,7 +359,8 @@
   {
     "name": {
       "property": "background-opacity",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "background-opacity-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -2205,7 +2211,8 @@
     "name": {
       "property": "informative-background-color",
       "state": "key-focus",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "informative-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2217,7 +2224,8 @@
     "name": {
       "property": "informative-background-color",
       "state": "key-focus",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "informative-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2229,7 +2237,8 @@
     "name": {
       "property": "informative-background-color",
       "state": "key-focus",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "informative-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2496,7 +2505,8 @@
     "name": {
       "property": "negative-background-color",
       "state": "key-focus",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "negative-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2508,7 +2518,8 @@
     "name": {
       "property": "negative-background-color",
       "state": "key-focus",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "negative-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2520,7 +2531,8 @@
     "name": {
       "property": "negative-background-color",
       "state": "key-focus",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "negative-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2580,7 +2592,8 @@
   {
     "name": {
       "property": "negative-border-color",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "negative-border-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2616,7 +2629,8 @@
   {
     "name": {
       "property": "negative-content-color",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "negative-content-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2688,7 +2702,8 @@
   {
     "name": {
       "property": "neutral-background-color",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "neutral-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -2778,7 +2793,8 @@
   {
     "name": {
       "property": "neutral-content-color",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "neutral-content-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3495,7 +3511,8 @@
     "name": {
       "property": "positive-background-color",
       "state": "key-focus",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "positive-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3507,7 +3524,8 @@
     "name": {
       "property": "positive-background-color",
       "state": "key-focus",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "positive-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -3519,7 +3537,8 @@
     "name": {
       "property": "positive-background-color",
       "state": "key-focus",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "positive-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3990,7 +4009,8 @@
   },
   {
     "name": {
-      "property": "static-black-text-color"
+      "property": "static-black-text-color",
+      "legacyKey": "static-black-text-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -3998,7 +4018,8 @@
   },
   {
     "name": {
-      "property": "static-black-track-color"
+      "property": "static-black-track-color",
+      "legacyKey": "static-black-track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16a871e1-d9df-42bb-8889-99059d70e82e",
@@ -4022,7 +4043,8 @@
   },
   {
     "name": {
-      "property": "static-white-text-color"
+      "property": "static-white-text-color",
+      "legacyKey": "static-white-text-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
@@ -4030,7 +4052,8 @@
   },
   {
     "name": {
-      "property": "static-white-track-color"
+      "property": "static-white-track-color",
+      "legacyKey": "static-white-track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -58,7 +58,8 @@
     "name": {
       "component": "bar-panel",
       "property": "color",
-      "anatomy": "gripper"
+      "anatomy": "gripper",
+      "legacyKey": "bar-panel-gripper-icon-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -76,7 +77,8 @@
   {
     "name": {
       "component": "card",
-      "property": "background-loading-color"
+      "property": "background-loading-color",
+      "legacyKey": "card-background-loading-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -631,7 +633,8 @@
   {
     "name": {
       "component": "opacity-checkerboard",
-      "property": "square-light"
+      "property": "square-light",
+      "legacyKey": "opacity-checkerboard-square-light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
@@ -742,7 +745,8 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "key-focus"
+      "state": "key-focus",
+      "legacyKey": "stack-item-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -797,7 +801,8 @@
     "name": {
       "component": "standard-panel",
       "property": "color",
-      "anatomy": "gripper"
+      "anatomy": "gripper",
+      "legacyKey": "standard-panel-gripper-icon-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -59,7 +59,7 @@
       "component": "bar-panel",
       "property": "color",
       "anatomy": "gripper",
-      "legacyKey": "bar-panel-gripper-icon-color"
+      "legacyKey": "bar-panel-gripper-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -802,7 +802,7 @@
       "component": "standard-panel",
       "property": "color",
       "anatomy": "gripper",
-      "legacyKey": "standard-panel-gripper-icon-color"
+      "legacyKey": "standard-panel-gripper-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -867,7 +867,7 @@
     "name": {
       "property": "icon-color-disabled-primary",
       "icon": "icon",
-      "legacyKey": "icon-color-disabled-primary-icon"
+      "legacyKey": "icon-color-disabled-primary"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -877,7 +877,7 @@
     "name": {
       "property": "icon-color-emphasized-background",
       "icon": "icon",
-      "legacyKey": "icon-color-emphasized-background-icon"
+      "legacyKey": "icon-color-emphasized-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -1782,7 +1782,7 @@
       "property": "color",
       "state": "default",
       "colorRole": "primary",
-      "legacyKey": "color-default-primary-icon"
+      "legacyKey": "icon-color-primary-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "43ca4c0d-7803-4e8e-b444-26fe70d5304c",
@@ -1794,7 +1794,7 @@
       "property": "color",
       "state": "down",
       "colorRole": "primary",
-      "legacyKey": "color-down-primary-icon"
+      "legacyKey": "icon-color-primary-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf169d95-e427-4665-a983-c24727dbfa60",
@@ -1806,7 +1806,7 @@
       "property": "color",
       "state": "hover",
       "colorRole": "primary",
-      "legacyKey": "color-hover-primary-icon"
+      "legacyKey": "icon-color-primary-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d236bdc5-037b-4838-8401-8a0d5136936c",

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -866,7 +866,8 @@
   {
     "name": {
       "property": "icon-color-disabled-primary",
-      "icon": "icon"
+      "icon": "icon",
+      "legacyKey": "icon-color-disabled-primary-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -875,7 +876,8 @@
   {
     "name": {
       "property": "icon-color-emphasized-background",
-      "icon": "icon"
+      "icon": "icon",
+      "legacyKey": "icon-color-emphasized-background-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -1779,7 +1781,8 @@
       "icon": "icon",
       "property": "color",
       "state": "default",
-      "colorRole": "primary"
+      "colorRole": "primary",
+      "legacyKey": "color-default-primary-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "43ca4c0d-7803-4e8e-b444-26fe70d5304c",
@@ -1790,7 +1793,8 @@
       "icon": "icon",
       "property": "color",
       "state": "down",
-      "colorRole": "primary"
+      "colorRole": "primary",
+      "legacyKey": "color-down-primary-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf169d95-e427-4665-a983-c24727dbfa60",
@@ -1801,7 +1805,8 @@
       "icon": "icon",
       "property": "color",
       "state": "hover",
-      "colorRole": "primary"
+      "colorRole": "primary",
+      "legacyKey": "color-hover-primary-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d236bdc5-037b-4838-8401-8a0d5136936c",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -5025,7 +5025,8 @@
   {
     "name": {
       "component": "coach-indicator",
-      "property": "collapsed-ring-rounding-increment"
+      "property": "collapsed-ring-rounding-increment",
+      "legacyKey": "coach-indicator-collapsed-ring-rounding-increment"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5055,7 +5056,8 @@
   {
     "name": {
       "component": "coach-indicator",
-      "property": "expanded-ring-rounding-increment"
+      "property": "expanded-ring-rounding-increment",
+      "legacyKey": "coach-indicator-expanded-ring-rounding-increment"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -5395,7 +5397,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-size-l"
+      "property": "cjk-size-l",
+      "legacyKey": "code-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7010f1a-c994-4b19-b273-3f609fe4be2b",
@@ -5404,7 +5407,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-size-m"
+      "property": "cjk-size-m",
+      "legacyKey": "code-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3",
@@ -5413,7 +5417,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-size-s"
+      "property": "cjk-size-s",
+      "legacyKey": "code-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "efa9311b-27c5-45ea-93a7-bef6f9370179",
@@ -5422,7 +5427,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-size-xl"
+      "property": "cjk-size-xl",
+      "legacyKey": "code-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7879adbc-6c38-4d29-9a90-a4ad91c75b90",
@@ -5431,7 +5437,8 @@
   {
     "name": {
       "component": "code",
-      "property": "cjk-size-xs"
+      "property": "cjk-size-xs",
+      "legacyKey": "code-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7",
@@ -5735,7 +5742,8 @@
       "component": "color-handle",
       "property": "size",
       "state": "key-focus",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "color-handle-size-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -5748,7 +5756,8 @@
       "component": "color-handle",
       "property": "size",
       "state": "key-focus",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "color-handle-size-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -6565,7 +6574,8 @@
   {
     "name": {
       "component": "divider",
-      "property": "horizontal-minimum-width"
+      "property": "horizontal-minimum-width",
+      "legacyKey": "divider-horizontal-minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "200px",
@@ -6604,7 +6614,8 @@
   {
     "name": {
       "component": "divider",
-      "property": "vertical-minimum-height"
+      "property": "vertical-minimum-height",
+      "legacyKey": "divider-vertical-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "200px",
@@ -6782,7 +6793,8 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "cjk-title-font-size"
+      "property": "cjk-title-font-size",
+      "legacyKey": "drop-zone-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d873db87-9e50-4aef-a9ee-b3b7da6bb44f",
@@ -7486,7 +7498,8 @@
   {
     "name": {
       "component": "illustrated-message",
-      "property": "horizontal-maximum-width"
+      "property": "horizontal-maximum-width",
+      "legacyKey": "illustrated-message-horizontal-maximum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "535px",
@@ -7496,7 +7509,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "large-body-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-large-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -7508,7 +7522,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "large-body-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-large-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
@@ -7520,7 +7535,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "large-cjk-title-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-large-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "abbc512e-fdce-4025-9d08-5a71692cf523",
@@ -7532,7 +7548,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "large-cjk-title-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-large-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "99472fda-7d17-45d5-b2ba-0c79a45d628f",
@@ -7544,7 +7561,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "large-title-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-large-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d4c4db99-70f2-4c79-8595-4d23407de068",
@@ -7556,7 +7574,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "large-title-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-large-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
@@ -7578,7 +7597,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "medium-body-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-medium-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -7590,7 +7610,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "medium-body-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-medium-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
@@ -7602,7 +7623,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "medium-cjk-title-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-medium-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "99472fda-7d17-45d5-b2ba-0c79a45d628f",
@@ -7614,7 +7636,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "medium-cjk-title-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-medium-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fcf237b-6988-4c31-a806-f4176b94c2a8",
@@ -7626,7 +7649,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "medium-title-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-medium-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b5aaaa50-721b-4b41-ad90-345cd995f69e",
@@ -7638,7 +7662,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "medium-title-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-medium-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0fb9e5ec-e5b7-41e0-8ef4-db9e4e33e060",
@@ -7649,7 +7674,8 @@
   {
     "name": {
       "component": "illustrated-message",
-      "property": "small-body-font-size"
+      "property": "small-body-font-size",
+      "legacyKey": "illustrated-message-small-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
@@ -7659,7 +7685,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "small-cjk-title-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-small-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1bccaa7-731f-4df2-a4c3-9dbec33145fd",
@@ -7671,7 +7698,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "small-cjk-title-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-small-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a134fab9-7606-453d-a64f-fd2daa989283",
@@ -7683,7 +7711,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "small-title-font-size",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "illustrated-message-small-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d63a369-4261-44a4-bf8d-a567dffa8ef6",
@@ -7695,7 +7724,8 @@
     "name": {
       "component": "illustrated-message",
       "property": "small-title-font-size",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "illustrated-message-small-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0babc342-b506-495d-aaf1-20fe9e571e1b",
@@ -7722,7 +7752,8 @@
   {
     "name": {
       "component": "illustrated-message",
-      "property": "vertical-maximum-width"
+      "property": "vertical-maximum-width",
+      "legacyKey": "illustrated-message-vertical-maximum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "380px",
@@ -8442,7 +8473,8 @@
   {
     "name": {
       "component": "list-view",
-      "property": "item-bottom-corner-radius"
+      "property": "item-bottom-corner-radius",
+      "legacyKey": "list-view-item-bottom-corner-radius"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6",
@@ -8451,7 +8483,8 @@
   {
     "name": {
       "component": "list-view",
-      "property": "item-top-corner-radius"
+      "property": "item-top-corner-radius",
+      "legacyKey": "list-view-item-top-corner-radius"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6",
@@ -10784,7 +10817,8 @@
     "name": {
       "component": "select-box",
       "property": "horizontal-minimum-height",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "select-box-horizontal-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "80px",
@@ -10796,7 +10830,8 @@
     "name": {
       "component": "select-box",
       "property": "horizontal-minimum-height",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "select-box-horizontal-minimum-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "100px",
@@ -10808,7 +10843,8 @@
     "name": {
       "component": "select-box",
       "property": "horizontal-minimum-width",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "select-box-horizontal-minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "188px",
@@ -10820,7 +10856,8 @@
     "name": {
       "component": "select-box",
       "property": "horizontal-minimum-width",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "select-box-horizontal-minimum-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "220px",
@@ -10892,7 +10929,8 @@
     "name": {
       "component": "select-box",
       "property": "horizontal-width",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "select-box-horizontal-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "368px",
@@ -10904,7 +10942,8 @@
     "name": {
       "component": "select-box",
       "property": "horizontal-width",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "select-box-horizontal-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "460px",
@@ -10980,7 +11019,8 @@
     "name": {
       "component": "select-box",
       "property": "vertical-height",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "select-box-vertical-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "170px",
@@ -10992,7 +11032,8 @@
     "name": {
       "component": "select-box",
       "property": "vertical-height",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "select-box-vertical-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "212px",
@@ -16217,7 +16258,8 @@
   {
     "name": {
       "component": "table",
-      "property": "border-divider-width"
+      "property": "border-divider-width",
+      "legacyKey": "table-border-divider-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -20488,7 +20530,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-l"
+      "property": "cjk-size-l",
+      "legacyKey": "title-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -20497,7 +20540,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-m"
+      "property": "cjk-size-m",
+      "legacyKey": "title-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -20506,7 +20550,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-s"
+      "property": "cjk-size-s",
+      "legacyKey": "title-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -20515,7 +20560,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-xl"
+      "property": "cjk-size-xl",
+      "legacyKey": "title-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -20524,7 +20570,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-xs"
+      "property": "cjk-size-xs",
+      "legacyKey": "title-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c6074b73-d460-439d-9401-498f52c88340",
@@ -20533,7 +20580,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-xxl"
+      "property": "cjk-size-xxl",
+      "legacyKey": "title-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -20542,7 +20590,8 @@
   {
     "name": {
       "component": "title",
-      "property": "cjk-size-xxxl"
+      "property": "cjk-size-xxxl",
+      "legacyKey": "title-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
@@ -20814,7 +20863,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-l"
+      "property": "size-l",
+      "legacyKey": "title-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -20823,7 +20873,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-m"
+      "property": "size-m",
+      "legacyKey": "title-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -20832,7 +20883,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-s"
+      "property": "size-s",
+      "legacyKey": "title-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -20841,7 +20893,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-xl"
+      "property": "size-xl",
+      "legacyKey": "title-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -20850,7 +20903,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-xs"
+      "property": "size-xs",
+      "legacyKey": "title-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -20859,7 +20913,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-xxl"
+      "property": "size-xxl",
+      "legacyKey": "title-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
@@ -20868,7 +20923,8 @@
   {
     "name": {
       "component": "title",
-      "property": "size-xxxl"
+      "property": "size-xxxl",
+      "legacyKey": "title-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
@@ -21800,7 +21856,8 @@
     "name": {
       "icon": "ui",
       "property": "2x-large",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "2x-large-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -21812,7 +21869,8 @@
     "name": {
       "icon": "ui",
       "property": "2x-large",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "2x-large-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -21824,7 +21882,8 @@
     "name": {
       "icon": "ui",
       "property": "extra-large",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "extra-large-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -21836,7 +21895,8 @@
     "name": {
       "icon": "ui",
       "property": "extra-large",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "extra-large-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -21848,7 +21908,8 @@
     "name": {
       "icon": "ui",
       "property": "extra-small",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "extra-small-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -21860,7 +21921,8 @@
     "name": {
       "icon": "ui",
       "property": "extra-small",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "extra-small-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -21872,7 +21934,8 @@
     "name": {
       "icon": "ui",
       "property": "large",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "large-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -21884,7 +21947,8 @@
     "name": {
       "icon": "ui",
       "property": "large",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "large-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -21896,7 +21960,8 @@
     "name": {
       "icon": "ui",
       "property": "medium",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "medium-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -21908,7 +21973,8 @@
     "name": {
       "icon": "ui",
       "property": "medium",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "medium-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -21920,7 +21986,8 @@
     "name": {
       "icon": "ui",
       "property": "small",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "small-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -21932,7 +21999,8 @@
     "name": {
       "icon": "ui",
       "property": "small",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "small-ui-icon"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -21857,7 +21857,7 @@
       "icon": "ui",
       "property": "2x-large",
       "scale": "desktop",
-      "legacyKey": "2x-large-ui-icon"
+      "legacyKey": "ui-icon-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -21870,7 +21870,7 @@
       "icon": "ui",
       "property": "2x-large",
       "scale": "mobile",
-      "legacyKey": "2x-large-ui-icon"
+      "legacyKey": "ui-icon-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -21883,7 +21883,7 @@
       "icon": "ui",
       "property": "extra-large",
       "scale": "desktop",
-      "legacyKey": "extra-large-ui-icon"
+      "legacyKey": "ui-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -21896,7 +21896,7 @@
       "icon": "ui",
       "property": "extra-large",
       "scale": "mobile",
-      "legacyKey": "extra-large-ui-icon"
+      "legacyKey": "ui-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -21909,7 +21909,7 @@
       "icon": "ui",
       "property": "extra-small",
       "scale": "desktop",
-      "legacyKey": "extra-small-ui-icon"
+      "legacyKey": "ui-icon-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -21922,7 +21922,7 @@
       "icon": "ui",
       "property": "extra-small",
       "scale": "mobile",
-      "legacyKey": "extra-small-ui-icon"
+      "legacyKey": "ui-icon-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -21935,7 +21935,7 @@
       "icon": "ui",
       "property": "large",
       "scale": "desktop",
-      "legacyKey": "large-ui-icon"
+      "legacyKey": "ui-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -21948,7 +21948,7 @@
       "icon": "ui",
       "property": "large",
       "scale": "mobile",
-      "legacyKey": "large-ui-icon"
+      "legacyKey": "ui-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -21961,7 +21961,7 @@
       "icon": "ui",
       "property": "medium",
       "scale": "desktop",
-      "legacyKey": "medium-ui-icon"
+      "legacyKey": "ui-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -21974,7 +21974,7 @@
       "icon": "ui",
       "property": "medium",
       "scale": "mobile",
-      "legacyKey": "medium-ui-icon"
+      "legacyKey": "ui-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -21987,7 +21987,7 @@
       "icon": "ui",
       "property": "small",
       "scale": "desktop",
-      "legacyKey": "small-ui-icon"
+      "legacyKey": "ui-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -22000,7 +22000,7 @@
       "icon": "ui",
       "property": "small",
       "scale": "mobile",
-      "legacyKey": "small-ui-icon"
+      "legacyKey": "ui-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -516,7 +516,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-2x-large"
+      "property": "base-padding-horizontal-uniform-2x-large",
+      "legacyKey": "base-padding-horizontal-uniform-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51761a5c-200d-467d-a575-3722f825edb9",
@@ -525,7 +526,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-2x-small"
+      "property": "base-padding-horizontal-uniform-2x-small",
+      "legacyKey": "base-padding-horizontal-uniform-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5f12db9-a471-4678-9828-e9b3d80f550d",
@@ -534,7 +536,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-extra-large"
+      "property": "base-padding-horizontal-uniform-extra-large",
+      "legacyKey": "base-padding-horizontal-uniform-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "62ea5f0e-3cb5-4535-8cd1-a7f30ba932fc",
@@ -543,7 +546,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-extra-small"
+      "property": "base-padding-horizontal-uniform-extra-small",
+      "legacyKey": "base-padding-horizontal-uniform-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e4437bc9-3acf-4bb5-9dab-39157a0d5e47",
@@ -552,7 +556,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-large"
+      "property": "base-padding-horizontal-uniform-large",
+      "legacyKey": "base-padding-horizontal-uniform-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cc707192-e70f-4965-8582-55fa97d02184",
@@ -561,7 +566,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-medium"
+      "property": "base-padding-horizontal-uniform-medium",
+      "legacyKey": "base-padding-horizontal-uniform-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5741f832-f012-45bc-9e87-6e07ab2cb87f",
@@ -570,7 +576,8 @@
   },
   {
     "name": {
-      "property": "base-padding-horizontal-uniform-small"
+      "property": "base-padding-horizontal-uniform-small",
+      "legacyKey": "base-padding-horizontal-uniform-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80b4ea6a-2f97-4d23-9256-61e30ed07f4d",
@@ -3288,7 +3295,8 @@
   },
   {
     "name": {
-      "property": "drop-target-dash-length"
+      "property": "drop-target-dash-length",
+      "legacyKey": "drop-target-dash-length"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
@@ -4935,7 +4943,8 @@
   },
   {
     "name": {
-      "property": "gradient-stop-1-genai"
+      "property": "gradient-stop-1-genai",
+      "legacyKey": "gradient-stop-1-genai"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 0,
@@ -4943,7 +4952,8 @@
   },
   {
     "name": {
-      "property": "gradient-stop-1-premium"
+      "property": "gradient-stop-1-premium",
+      "legacyKey": "gradient-stop-1-premium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 0,
@@ -4951,7 +4961,8 @@
   },
   {
     "name": {
-      "property": "gradient-stop-2-genai"
+      "property": "gradient-stop-2-genai",
+      "legacyKey": "gradient-stop-2-genai"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 0.3333,
@@ -4959,7 +4970,8 @@
   },
   {
     "name": {
-      "property": "gradient-stop-2-premium"
+      "property": "gradient-stop-2-premium",
+      "legacyKey": "gradient-stop-2-premium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 0.6666,
@@ -4967,7 +4979,8 @@
   },
   {
     "name": {
-      "property": "gradient-stop-3-genai"
+      "property": "gradient-stop-3-genai",
+      "legacyKey": "gradient-stop-3-genai"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 1,
@@ -4975,7 +4988,8 @@
   },
   {
     "name": {
-      "property": "gradient-stop-3-premium"
+      "property": "gradient-stop-3-premium",
+      "legacyKey": "gradient-stop-3-premium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 1,
@@ -6295,7 +6309,8 @@
   },
   {
     "name": {
-      "property": "vertical-align-items"
+      "property": "vertical-align-items",
+      "legacyKey": "vertical-align-items"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alignment.json",
     "value": "center",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -165,7 +165,8 @@
   },
   {
     "name": {
-      "property": "icon-color-informative"
+      "property": "icon-color-informative",
+      "legacyKey": "icon-color-informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60aa72d2-3b00-4eea-973d-265a55d3095a",
@@ -173,7 +174,8 @@
   },
   {
     "name": {
-      "property": "icon-color-negative"
+      "property": "icon-color-negative",
+      "legacyKey": "icon-color-negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "23cea5fe-acb5-4460-add7-3512aaceeb35",
@@ -181,7 +183,8 @@
   },
   {
     "name": {
-      "property": "icon-color-neutral"
+      "property": "icon-color-neutral",
+      "legacyKey": "icon-color-neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d2b65b1e-de10-49c7-90d4-e3621edfdfa8",
@@ -189,7 +192,8 @@
   },
   {
     "name": {
-      "property": "icon-color-notice"
+      "property": "icon-color-notice",
+      "legacyKey": "icon-color-notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "da827479-f058-4117-9cd3-90cbe525d05d",
@@ -197,7 +201,8 @@
   },
   {
     "name": {
-      "property": "icon-color-positive"
+      "property": "icon-color-positive",
+      "legacyKey": "icon-color-positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d439dfad-437a-4929-8d0d-9b9290dcb843",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -3,7 +3,7 @@
     "name": {
       "property": "black-font-weight",
       "weight": "black",
-      "legacyKey": "black-font-weight-black"
+      "legacyKey": "black-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "value": "black",
@@ -518,7 +518,7 @@
       "property": "line-height-100",
       "scaleIndex": 100,
       "family": "cjk",
-      "legacyKey": "cjk-line-height-100-100"
+      "legacyKey": "cjk-line-height-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.5,
@@ -529,7 +529,7 @@
       "property": "line-height-200",
       "scaleIndex": 200,
       "family": "cjk",
-      "legacyKey": "cjk-line-height-200-200"
+      "legacyKey": "cjk-line-height-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.7,
@@ -792,7 +792,7 @@
     "name": {
       "property": "component-l-bold",
       "weight": "bold",
-      "legacyKey": "component-l-bold-bold"
+      "legacyKey": "component-l-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -808,7 +808,7 @@
     "name": {
       "property": "component-l-medium",
       "weight": "medium",
-      "legacyKey": "component-l-medium-medium"
+      "legacyKey": "component-l-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -824,7 +824,7 @@
     "name": {
       "property": "component-l-regular",
       "weight": "regular",
-      "legacyKey": "component-l-regular-regular"
+      "legacyKey": "component-l-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -840,7 +840,7 @@
     "name": {
       "property": "component-m-bold",
       "weight": "bold",
-      "legacyKey": "component-m-bold-bold"
+      "legacyKey": "component-m-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -856,7 +856,7 @@
     "name": {
       "property": "component-m-medium",
       "weight": "medium",
-      "legacyKey": "component-m-medium-medium"
+      "legacyKey": "component-m-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -872,7 +872,7 @@
     "name": {
       "property": "component-m-regular",
       "weight": "regular",
-      "legacyKey": "component-m-regular-regular"
+      "legacyKey": "component-m-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -888,7 +888,7 @@
     "name": {
       "property": "component-s-bold",
       "weight": "bold",
-      "legacyKey": "component-s-bold-bold"
+      "legacyKey": "component-s-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -904,7 +904,7 @@
     "name": {
       "property": "component-s-medium",
       "weight": "medium",
-      "legacyKey": "component-s-medium-medium"
+      "legacyKey": "component-s-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -920,7 +920,7 @@
     "name": {
       "property": "component-s-regular",
       "weight": "regular",
-      "legacyKey": "component-s-regular-regular"
+      "legacyKey": "component-s-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -936,7 +936,7 @@
     "name": {
       "property": "component-xl-bold",
       "weight": "bold",
-      "legacyKey": "component-xl-bold-bold"
+      "legacyKey": "component-xl-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -952,7 +952,7 @@
     "name": {
       "property": "component-xl-medium",
       "weight": "medium",
-      "legacyKey": "component-xl-medium-medium"
+      "legacyKey": "component-xl-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -968,7 +968,7 @@
     "name": {
       "property": "component-xl-regular",
       "weight": "regular",
-      "legacyKey": "component-xl-regular-regular"
+      "legacyKey": "component-xl-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -984,7 +984,7 @@
     "name": {
       "property": "component-xs-bold",
       "weight": "bold",
-      "legacyKey": "component-xs-bold-bold"
+      "legacyKey": "component-xs-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -1000,7 +1000,7 @@
     "name": {
       "property": "component-xs-medium",
       "weight": "medium",
-      "legacyKey": "component-xs-medium-medium"
+      "legacyKey": "component-xs-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -1016,7 +1016,7 @@
     "name": {
       "property": "component-xs-regular",
       "weight": "regular",
-      "legacyKey": "component-xs-regular-regular"
+      "legacyKey": "component-xs-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -1040,7 +1040,7 @@
     "name": {
       "property": "default-font-style",
       "style": "normal",
-      "legacyKey": "default-font-style-normal"
+      "legacyKey": "default-font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-style.json",
     "value": "normal",
@@ -1816,7 +1816,7 @@
       "property": "font-size-100",
       "scale": "desktop",
       "scaleIndex": 100,
-      "legacyKey": "font-size-100-100"
+      "legacyKey": "font-size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "14px",
@@ -1829,7 +1829,7 @@
       "property": "font-size-100",
       "scale": "mobile",
       "scaleIndex": 100,
-      "legacyKey": "font-size-100-100"
+      "legacyKey": "font-size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "17px",
@@ -1842,7 +1842,7 @@
       "property": "font-size-1000",
       "scale": "desktop",
       "scaleIndex": 1000,
-      "legacyKey": "font-size-1000-1000"
+      "legacyKey": "font-size-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "40px",
@@ -1855,7 +1855,7 @@
       "property": "font-size-1000",
       "scale": "mobile",
       "scaleIndex": 1000,
-      "legacyKey": "font-size-1000-1000"
+      "legacyKey": "font-size-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "49px",
@@ -1868,7 +1868,7 @@
       "property": "font-size-1100",
       "scale": "desktop",
       "scaleIndex": 1100,
-      "legacyKey": "font-size-1100-1100"
+      "legacyKey": "font-size-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "45px",
@@ -1881,7 +1881,7 @@
       "property": "font-size-1100",
       "scale": "mobile",
       "scaleIndex": 1100,
-      "legacyKey": "font-size-1100-1100"
+      "legacyKey": "font-size-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "55px",
@@ -1894,7 +1894,7 @@
       "property": "font-size-1200",
       "scale": "desktop",
       "scaleIndex": 1200,
-      "legacyKey": "font-size-1200-1200"
+      "legacyKey": "font-size-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "51px",
@@ -1907,7 +1907,7 @@
       "property": "font-size-1200",
       "scale": "mobile",
       "scaleIndex": 1200,
-      "legacyKey": "font-size-1200-1200"
+      "legacyKey": "font-size-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "62px",
@@ -1920,7 +1920,7 @@
       "property": "font-size-1300",
       "scale": "desktop",
       "scaleIndex": 1300,
-      "legacyKey": "font-size-1300-1300"
+      "legacyKey": "font-size-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "58px",
@@ -1933,7 +1933,7 @@
       "property": "font-size-1300",
       "scale": "mobile",
       "scaleIndex": 1300,
-      "legacyKey": "font-size-1300-1300"
+      "legacyKey": "font-size-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "70px",
@@ -1946,7 +1946,7 @@
       "property": "font-size-1400",
       "scale": "desktop",
       "scaleIndex": 1400,
-      "legacyKey": "font-size-1400-1400"
+      "legacyKey": "font-size-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "65px",
@@ -1959,7 +1959,7 @@
       "property": "font-size-1400",
       "scale": "mobile",
       "scaleIndex": 1400,
-      "legacyKey": "font-size-1400-1400"
+      "legacyKey": "font-size-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "79px",
@@ -1972,7 +1972,7 @@
       "property": "font-size-1500",
       "scale": "desktop",
       "scaleIndex": 1500,
-      "legacyKey": "font-size-1500-1500"
+      "legacyKey": "font-size-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "73px",
@@ -1985,7 +1985,7 @@
       "property": "font-size-1500",
       "scale": "mobile",
       "scaleIndex": 1500,
-      "legacyKey": "font-size-1500-1500"
+      "legacyKey": "font-size-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "88px",
@@ -1998,7 +1998,7 @@
       "property": "font-size-200",
       "scale": "desktop",
       "scaleIndex": 200,
-      "legacyKey": "font-size-200-200"
+      "legacyKey": "font-size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "16px",
@@ -2011,7 +2011,7 @@
       "property": "font-size-200",
       "scale": "mobile",
       "scaleIndex": 200,
-      "legacyKey": "font-size-200-200"
+      "legacyKey": "font-size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "19px",
@@ -2024,7 +2024,7 @@
       "property": "font-size-25",
       "scale": "desktop",
       "scaleIndex": 25,
-      "legacyKey": "font-size-25-25"
+      "legacyKey": "font-size-25"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "10px",
@@ -2037,7 +2037,7 @@
       "property": "font-size-25",
       "scale": "mobile",
       "scaleIndex": 25,
-      "legacyKey": "font-size-25-25"
+      "legacyKey": "font-size-25"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "12px",
@@ -2050,7 +2050,7 @@
       "property": "font-size-300",
       "scale": "desktop",
       "scaleIndex": 300,
-      "legacyKey": "font-size-300-300"
+      "legacyKey": "font-size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "18px",
@@ -2063,7 +2063,7 @@
       "property": "font-size-300",
       "scale": "mobile",
       "scaleIndex": 300,
-      "legacyKey": "font-size-300-300"
+      "legacyKey": "font-size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "22px",
@@ -2076,7 +2076,7 @@
       "property": "font-size-400",
       "scale": "desktop",
       "scaleIndex": 400,
-      "legacyKey": "font-size-400-400"
+      "legacyKey": "font-size-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "20px",
@@ -2089,7 +2089,7 @@
       "property": "font-size-400",
       "scale": "mobile",
       "scaleIndex": 400,
-      "legacyKey": "font-size-400-400"
+      "legacyKey": "font-size-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "24px",
@@ -2102,7 +2102,7 @@
       "property": "font-size-50",
       "scale": "desktop",
       "scaleIndex": 50,
-      "legacyKey": "font-size-50-50"
+      "legacyKey": "font-size-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "11px",
@@ -2115,7 +2115,7 @@
       "property": "font-size-50",
       "scale": "mobile",
       "scaleIndex": 50,
-      "legacyKey": "font-size-50-50"
+      "legacyKey": "font-size-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "13px",
@@ -2128,7 +2128,7 @@
       "property": "font-size-500",
       "scale": "desktop",
       "scaleIndex": 500,
-      "legacyKey": "font-size-500-500"
+      "legacyKey": "font-size-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "22px",
@@ -2141,7 +2141,7 @@
       "property": "font-size-500",
       "scale": "mobile",
       "scaleIndex": 500,
-      "legacyKey": "font-size-500-500"
+      "legacyKey": "font-size-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "27px",
@@ -2154,7 +2154,7 @@
       "property": "font-size-600",
       "scale": "desktop",
       "scaleIndex": 600,
-      "legacyKey": "font-size-600-600"
+      "legacyKey": "font-size-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "25px",
@@ -2167,7 +2167,7 @@
       "property": "font-size-600",
       "scale": "mobile",
       "scaleIndex": 600,
-      "legacyKey": "font-size-600-600"
+      "legacyKey": "font-size-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "31px",
@@ -2180,7 +2180,7 @@
       "property": "font-size-700",
       "scale": "desktop",
       "scaleIndex": 700,
-      "legacyKey": "font-size-700-700"
+      "legacyKey": "font-size-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "28px",
@@ -2193,7 +2193,7 @@
       "property": "font-size-700",
       "scale": "mobile",
       "scaleIndex": 700,
-      "legacyKey": "font-size-700-700"
+      "legacyKey": "font-size-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "34px",
@@ -2206,7 +2206,7 @@
       "property": "font-size-75",
       "scale": "desktop",
       "scaleIndex": 75,
-      "legacyKey": "font-size-75-75"
+      "legacyKey": "font-size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "12px",
@@ -2219,7 +2219,7 @@
       "property": "font-size-75",
       "scale": "mobile",
       "scaleIndex": 75,
-      "legacyKey": "font-size-75-75"
+      "legacyKey": "font-size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "15px",
@@ -2232,7 +2232,7 @@
       "property": "font-size-800",
       "scale": "desktop",
       "scaleIndex": 800,
-      "legacyKey": "font-size-800-800"
+      "legacyKey": "font-size-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "32px",
@@ -2245,7 +2245,7 @@
       "property": "font-size-800",
       "scale": "mobile",
       "scaleIndex": 800,
-      "legacyKey": "font-size-800-800"
+      "legacyKey": "font-size-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "39px",
@@ -2258,7 +2258,7 @@
       "property": "font-size-900",
       "scale": "desktop",
       "scaleIndex": 900,
-      "legacyKey": "font-size-900-900"
+      "legacyKey": "font-size-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "36px",
@@ -2271,7 +2271,7 @@
       "property": "font-size-900",
       "scale": "mobile",
       "scaleIndex": 900,
-      "legacyKey": "font-size-900-900"
+      "legacyKey": "font-size-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "44px",
@@ -3362,7 +3362,7 @@
     "name": {
       "property": "line-height-100",
       "scaleIndex": 100,
-      "legacyKey": "line-height-100-100"
+      "legacyKey": "line-height-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.3,
@@ -3372,7 +3372,7 @@
     "name": {
       "property": "line-height-200",
       "scaleIndex": 200,
-      "legacyKey": "line-height-200-200"
+      "legacyKey": "line-height-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.5,
@@ -3778,7 +3778,7 @@
     "name": {
       "property": "medium-font-weight",
       "weight": "medium",
-      "legacyKey": "medium-font-weight-medium"
+      "legacyKey": "medium-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "value": "medium",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -2,7 +2,8 @@
   {
     "name": {
       "property": "black-font-weight",
-      "weight": "black"
+      "weight": "black",
+      "legacyKey": "black-font-weight-black"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "value": "black",
@@ -72,7 +73,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-l"
+      "property": "body-cjk-size-l",
+      "legacyKey": "body-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -80,7 +82,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-m"
+      "property": "body-cjk-size-m",
+      "legacyKey": "body-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -88,7 +91,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-s"
+      "property": "body-cjk-size-s",
+      "legacyKey": "body-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -96,7 +100,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xl"
+      "property": "body-cjk-size-xl",
+      "legacyKey": "body-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -104,7 +109,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xs"
+      "property": "body-cjk-size-xs",
+      "legacyKey": "body-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c6074b73-d460-439d-9401-498f52c88340",
@@ -112,7 +118,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xxl"
+      "property": "body-cjk-size-xxl",
+      "legacyKey": "body-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -120,7 +127,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xxs"
+      "property": "body-cjk-size-xxs",
+      "legacyKey": "body-cjk-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "73ef03ac-5b7b-4182-8991-0bb62006d276",
@@ -128,7 +136,8 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xxxl"
+      "property": "body-cjk-size-xxxl",
+      "legacyKey": "body-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
@@ -401,7 +410,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-l"
+      "property": "size-l",
+      "legacyKey": "body-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -410,7 +420,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-m"
+      "property": "size-m",
+      "legacyKey": "body-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -419,7 +430,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-s"
+      "property": "size-s",
+      "legacyKey": "body-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -428,7 +440,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xl"
+      "property": "size-xl",
+      "legacyKey": "body-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -437,7 +450,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xs"
+      "property": "size-xs",
+      "legacyKey": "body-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -446,7 +460,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xxl"
+      "property": "size-xxl",
+      "legacyKey": "body-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
@@ -454,7 +469,8 @@
   },
   {
     "name": {
-      "property": "body-size-xxs"
+      "property": "body-size-xxs",
+      "legacyKey": "body-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c6074b73-d460-439d-9401-498f52c88340",
@@ -463,7 +479,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xxxl"
+      "property": "size-xxxl",
+      "legacyKey": "body-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
@@ -500,7 +517,8 @@
     "name": {
       "property": "line-height-100",
       "scaleIndex": 100,
-      "family": "cjk"
+      "family": "cjk",
+      "legacyKey": "cjk-line-height-100-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.5,
@@ -510,7 +528,8 @@
     "name": {
       "property": "line-height-200",
       "scaleIndex": 200,
-      "family": "cjk"
+      "family": "cjk",
+      "legacyKey": "cjk-line-height-200-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.7,
@@ -682,7 +701,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-l"
+      "property": "size-l",
+      "legacyKey": "code-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -691,7 +711,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-m"
+      "property": "size-m",
+      "legacyKey": "code-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -700,7 +721,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-s"
+      "property": "size-s",
+      "legacyKey": "code-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -709,7 +731,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-xl"
+      "property": "size-xl",
+      "legacyKey": "code-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -718,7 +741,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-xs"
+      "property": "size-xs",
+      "legacyKey": "code-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -767,7 +791,8 @@
   {
     "name": {
       "property": "component-l-bold",
-      "weight": "bold"
+      "weight": "bold",
+      "legacyKey": "component-l-bold-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -782,7 +807,8 @@
   {
     "name": {
       "property": "component-l-medium",
-      "weight": "medium"
+      "weight": "medium",
+      "legacyKey": "component-l-medium-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -797,7 +823,8 @@
   {
     "name": {
       "property": "component-l-regular",
-      "weight": "regular"
+      "weight": "regular",
+      "legacyKey": "component-l-regular-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -812,7 +839,8 @@
   {
     "name": {
       "property": "component-m-bold",
-      "weight": "bold"
+      "weight": "bold",
+      "legacyKey": "component-m-bold-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -827,7 +855,8 @@
   {
     "name": {
       "property": "component-m-medium",
-      "weight": "medium"
+      "weight": "medium",
+      "legacyKey": "component-m-medium-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -842,7 +871,8 @@
   {
     "name": {
       "property": "component-m-regular",
-      "weight": "regular"
+      "weight": "regular",
+      "legacyKey": "component-m-regular-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -857,7 +887,8 @@
   {
     "name": {
       "property": "component-s-bold",
-      "weight": "bold"
+      "weight": "bold",
+      "legacyKey": "component-s-bold-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -872,7 +903,8 @@
   {
     "name": {
       "property": "component-s-medium",
-      "weight": "medium"
+      "weight": "medium",
+      "legacyKey": "component-s-medium-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -887,7 +919,8 @@
   {
     "name": {
       "property": "component-s-regular",
-      "weight": "regular"
+      "weight": "regular",
+      "legacyKey": "component-s-regular-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -902,7 +935,8 @@
   {
     "name": {
       "property": "component-xl-bold",
-      "weight": "bold"
+      "weight": "bold",
+      "legacyKey": "component-xl-bold-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -917,7 +951,8 @@
   {
     "name": {
       "property": "component-xl-medium",
-      "weight": "medium"
+      "weight": "medium",
+      "legacyKey": "component-xl-medium-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -932,7 +967,8 @@
   {
     "name": {
       "property": "component-xl-regular",
-      "weight": "regular"
+      "weight": "regular",
+      "legacyKey": "component-xl-regular-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -947,7 +983,8 @@
   {
     "name": {
       "property": "component-xs-bold",
-      "weight": "bold"
+      "weight": "bold",
+      "legacyKey": "component-xs-bold-bold"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -962,7 +999,8 @@
   {
     "name": {
       "property": "component-xs-medium",
-      "weight": "medium"
+      "weight": "medium",
+      "legacyKey": "component-xs-medium-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -977,7 +1015,8 @@
   {
     "name": {
       "property": "component-xs-regular",
-      "weight": "regular"
+      "weight": "regular",
+      "legacyKey": "component-xs-regular-regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/typography.json",
     "value": {
@@ -1000,7 +1039,8 @@
   {
     "name": {
       "property": "default-font-style",
-      "style": "normal"
+      "style": "normal",
+      "legacyKey": "default-font-style-normal"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-style.json",
     "value": "normal",
@@ -1167,7 +1207,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-l"
+      "property": "cjk-size-l",
+      "legacyKey": "detail-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -1176,7 +1217,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-m"
+      "property": "cjk-size-m",
+      "legacyKey": "detail-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -1185,7 +1227,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-s"
+      "property": "cjk-size-s",
+      "legacyKey": "detail-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c6074b73-d460-439d-9401-498f52c88340",
@@ -1194,7 +1237,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-xl"
+      "property": "cjk-size-xl",
+      "legacyKey": "detail-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -1203,7 +1247,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-xs"
+      "property": "cjk-size-xs",
+      "legacyKey": "detail-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "73ef03ac-5b7b-4182-8991-0bb62006d276",
@@ -1710,7 +1755,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-l"
+      "property": "size-l",
+      "legacyKey": "detail-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -1719,7 +1765,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-m"
+      "property": "size-m",
+      "legacyKey": "detail-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -1728,7 +1775,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-s"
+      "property": "size-s",
+      "legacyKey": "detail-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ce57c4e-6bbb-415f-b823-81c3af0acd6e",
@@ -1737,7 +1785,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-xl"
+      "property": "size-xl",
+      "legacyKey": "detail-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -1746,7 +1795,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-xs"
+      "property": "size-xs",
+      "legacyKey": "detail-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c6074b73-d460-439d-9401-498f52c88340",
@@ -1765,7 +1815,8 @@
     "name": {
       "property": "font-size-100",
       "scale": "desktop",
-      "scaleIndex": 100
+      "scaleIndex": 100,
+      "legacyKey": "font-size-100-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "14px",
@@ -1777,7 +1828,8 @@
     "name": {
       "property": "font-size-100",
       "scale": "mobile",
-      "scaleIndex": 100
+      "scaleIndex": 100,
+      "legacyKey": "font-size-100-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "17px",
@@ -1789,7 +1841,8 @@
     "name": {
       "property": "font-size-1000",
       "scale": "desktop",
-      "scaleIndex": 1000
+      "scaleIndex": 1000,
+      "legacyKey": "font-size-1000-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "40px",
@@ -1801,7 +1854,8 @@
     "name": {
       "property": "font-size-1000",
       "scale": "mobile",
-      "scaleIndex": 1000
+      "scaleIndex": 1000,
+      "legacyKey": "font-size-1000-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "49px",
@@ -1813,7 +1867,8 @@
     "name": {
       "property": "font-size-1100",
       "scale": "desktop",
-      "scaleIndex": 1100
+      "scaleIndex": 1100,
+      "legacyKey": "font-size-1100-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "45px",
@@ -1825,7 +1880,8 @@
     "name": {
       "property": "font-size-1100",
       "scale": "mobile",
-      "scaleIndex": 1100
+      "scaleIndex": 1100,
+      "legacyKey": "font-size-1100-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "55px",
@@ -1837,7 +1893,8 @@
     "name": {
       "property": "font-size-1200",
       "scale": "desktop",
-      "scaleIndex": 1200
+      "scaleIndex": 1200,
+      "legacyKey": "font-size-1200-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "51px",
@@ -1849,7 +1906,8 @@
     "name": {
       "property": "font-size-1200",
       "scale": "mobile",
-      "scaleIndex": 1200
+      "scaleIndex": 1200,
+      "legacyKey": "font-size-1200-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "62px",
@@ -1861,7 +1919,8 @@
     "name": {
       "property": "font-size-1300",
       "scale": "desktop",
-      "scaleIndex": 1300
+      "scaleIndex": 1300,
+      "legacyKey": "font-size-1300-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "58px",
@@ -1873,7 +1932,8 @@
     "name": {
       "property": "font-size-1300",
       "scale": "mobile",
-      "scaleIndex": 1300
+      "scaleIndex": 1300,
+      "legacyKey": "font-size-1300-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "70px",
@@ -1885,7 +1945,8 @@
     "name": {
       "property": "font-size-1400",
       "scale": "desktop",
-      "scaleIndex": 1400
+      "scaleIndex": 1400,
+      "legacyKey": "font-size-1400-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "65px",
@@ -1897,7 +1958,8 @@
     "name": {
       "property": "font-size-1400",
       "scale": "mobile",
-      "scaleIndex": 1400
+      "scaleIndex": 1400,
+      "legacyKey": "font-size-1400-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "79px",
@@ -1909,7 +1971,8 @@
     "name": {
       "property": "font-size-1500",
       "scale": "desktop",
-      "scaleIndex": 1500
+      "scaleIndex": 1500,
+      "legacyKey": "font-size-1500-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "73px",
@@ -1921,7 +1984,8 @@
     "name": {
       "property": "font-size-1500",
       "scale": "mobile",
-      "scaleIndex": 1500
+      "scaleIndex": 1500,
+      "legacyKey": "font-size-1500-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "88px",
@@ -1933,7 +1997,8 @@
     "name": {
       "property": "font-size-200",
       "scale": "desktop",
-      "scaleIndex": 200
+      "scaleIndex": 200,
+      "legacyKey": "font-size-200-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "16px",
@@ -1945,7 +2010,8 @@
     "name": {
       "property": "font-size-200",
       "scale": "mobile",
-      "scaleIndex": 200
+      "scaleIndex": 200,
+      "legacyKey": "font-size-200-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "19px",
@@ -1957,7 +2023,8 @@
     "name": {
       "property": "font-size-25",
       "scale": "desktop",
-      "scaleIndex": 25
+      "scaleIndex": 25,
+      "legacyKey": "font-size-25-25"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "10px",
@@ -1969,7 +2036,8 @@
     "name": {
       "property": "font-size-25",
       "scale": "mobile",
-      "scaleIndex": 25
+      "scaleIndex": 25,
+      "legacyKey": "font-size-25-25"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "12px",
@@ -1981,7 +2049,8 @@
     "name": {
       "property": "font-size-300",
       "scale": "desktop",
-      "scaleIndex": 300
+      "scaleIndex": 300,
+      "legacyKey": "font-size-300-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "18px",
@@ -1993,7 +2062,8 @@
     "name": {
       "property": "font-size-300",
       "scale": "mobile",
-      "scaleIndex": 300
+      "scaleIndex": 300,
+      "legacyKey": "font-size-300-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "22px",
@@ -2005,7 +2075,8 @@
     "name": {
       "property": "font-size-400",
       "scale": "desktop",
-      "scaleIndex": 400
+      "scaleIndex": 400,
+      "legacyKey": "font-size-400-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "20px",
@@ -2017,7 +2088,8 @@
     "name": {
       "property": "font-size-400",
       "scale": "mobile",
-      "scaleIndex": 400
+      "scaleIndex": 400,
+      "legacyKey": "font-size-400-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "24px",
@@ -2029,7 +2101,8 @@
     "name": {
       "property": "font-size-50",
       "scale": "desktop",
-      "scaleIndex": 50
+      "scaleIndex": 50,
+      "legacyKey": "font-size-50-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "11px",
@@ -2041,7 +2114,8 @@
     "name": {
       "property": "font-size-50",
       "scale": "mobile",
-      "scaleIndex": 50
+      "scaleIndex": 50,
+      "legacyKey": "font-size-50-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "13px",
@@ -2053,7 +2127,8 @@
     "name": {
       "property": "font-size-500",
       "scale": "desktop",
-      "scaleIndex": 500
+      "scaleIndex": 500,
+      "legacyKey": "font-size-500-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "22px",
@@ -2065,7 +2140,8 @@
     "name": {
       "property": "font-size-500",
       "scale": "mobile",
-      "scaleIndex": 500
+      "scaleIndex": 500,
+      "legacyKey": "font-size-500-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "27px",
@@ -2077,7 +2153,8 @@
     "name": {
       "property": "font-size-600",
       "scale": "desktop",
-      "scaleIndex": 600
+      "scaleIndex": 600,
+      "legacyKey": "font-size-600-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "25px",
@@ -2089,7 +2166,8 @@
     "name": {
       "property": "font-size-600",
       "scale": "mobile",
-      "scaleIndex": 600
+      "scaleIndex": 600,
+      "legacyKey": "font-size-600-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "31px",
@@ -2101,7 +2179,8 @@
     "name": {
       "property": "font-size-700",
       "scale": "desktop",
-      "scaleIndex": 700
+      "scaleIndex": 700,
+      "legacyKey": "font-size-700-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "28px",
@@ -2113,7 +2192,8 @@
     "name": {
       "property": "font-size-700",
       "scale": "mobile",
-      "scaleIndex": 700
+      "scaleIndex": 700,
+      "legacyKey": "font-size-700-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "34px",
@@ -2125,7 +2205,8 @@
     "name": {
       "property": "font-size-75",
       "scale": "desktop",
-      "scaleIndex": 75
+      "scaleIndex": 75,
+      "legacyKey": "font-size-75-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "12px",
@@ -2137,7 +2218,8 @@
     "name": {
       "property": "font-size-75",
       "scale": "mobile",
-      "scaleIndex": 75
+      "scaleIndex": 75,
+      "legacyKey": "font-size-75-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "15px",
@@ -2149,7 +2231,8 @@
     "name": {
       "property": "font-size-800",
       "scale": "desktop",
-      "scaleIndex": 800
+      "scaleIndex": 800,
+      "legacyKey": "font-size-800-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "32px",
@@ -2161,7 +2244,8 @@
     "name": {
       "property": "font-size-800",
       "scale": "mobile",
-      "scaleIndex": 800
+      "scaleIndex": 800,
+      "legacyKey": "font-size-800-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "39px",
@@ -2173,7 +2257,8 @@
     "name": {
       "property": "font-size-900",
       "scale": "desktop",
-      "scaleIndex": 900
+      "scaleIndex": 900,
+      "legacyKey": "font-size-900-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "36px",
@@ -2185,7 +2270,8 @@
     "name": {
       "property": "font-size-900",
       "scale": "mobile",
-      "scaleIndex": 900
+      "scaleIndex": 900,
+      "legacyKey": "font-size-900-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-size.json",
     "value": "44px",
@@ -2440,7 +2526,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-l"
+      "property": "cjk-size-l",
+      "legacyKey": "heading-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a6fc0d3-e584-4ce6-82d8-be8c275c865e",
@@ -2449,7 +2536,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-m"
+      "property": "cjk-size-m",
+      "legacyKey": "heading-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -2458,7 +2546,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-s"
+      "property": "cjk-size-s",
+      "legacyKey": "heading-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -2467,7 +2556,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xl"
+      "property": "cjk-size-xl",
+      "legacyKey": "heading-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d46d987e-44dd-4113-81b3-1b28c0f5cfe6",
@@ -2476,7 +2566,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xs"
+      "property": "cjk-size-xs",
+      "legacyKey": "heading-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fe457dd7-582a-4f0a-badc-7850adfd8cb7",
@@ -2485,7 +2576,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xxl"
+      "property": "cjk-size-xxl",
+      "legacyKey": "heading-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "200d964e-b6f4-4011-a40d-33b1bfb7aa68",
@@ -2504,7 +2596,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xxxl"
+      "property": "cjk-size-xxxl",
+      "legacyKey": "heading-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dbd67b04-f114-4549-8e36-223b7d7007c7",
@@ -3153,7 +3246,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-l"
+      "property": "size-l",
+      "legacyKey": "heading-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c9a3ec61-f116-4298-be2d-6149d6eae889",
@@ -3162,7 +3256,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-m"
+      "property": "size-m",
+      "legacyKey": "heading-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "935af8c5-6f70-49ee-b5ba-5e9650682753",
@@ -3171,7 +3266,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-s"
+      "property": "size-s",
+      "legacyKey": "heading-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7560656c-41c2-4b51-ba29-b04aa3cd386b",
@@ -3180,7 +3276,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xl"
+      "property": "size-xl",
+      "legacyKey": "heading-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf1791b4-dcc2-4620-a508-d95bbd44504b",
@@ -3189,7 +3286,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xs"
+      "property": "size-xs",
+      "legacyKey": "heading-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "278998ed-3a83-4c4d-aed3-ab5f6e1b218a",
@@ -3198,7 +3296,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xxl"
+      "property": "size-xxl",
+      "legacyKey": "heading-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "202a2c3e-5bfc-4871-9481-13c771bdc8dc",
@@ -3217,7 +3316,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xxxl"
+      "property": "size-xxxl",
+      "legacyKey": "heading-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "760d6969-7e0e-4744-b1c6-d89d3a02af8d",
@@ -3261,7 +3361,8 @@
   {
     "name": {
       "property": "line-height-100",
-      "scaleIndex": 100
+      "scaleIndex": 100,
+      "legacyKey": "line-height-100-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.3,
@@ -3270,7 +3371,8 @@
   {
     "name": {
       "property": "line-height-200",
-      "scaleIndex": 200
+      "scaleIndex": 200,
+      "legacyKey": "line-height-200-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 1.5,
@@ -3675,7 +3777,8 @@
   {
     "name": {
       "property": "medium-font-weight",
-      "weight": "medium"
+      "weight": "medium",
+      "legacyKey": "medium-font-weight-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-weight.json",
     "value": "medium",


### PR DESCRIPTION
## Description

From the Phase D residual triage (spectrum-design-data-dsi), 224 active MEDIUM-confidence
tokens decompose cleanly (no gaps, no unmatched segments) but fail roundtrip because their
published legacy flat key doesn't match the canonical serialize order — some are field-position
swaps (e.g. density-before-size like `accordion-bottom-to-text-compact-large`), others are
abbreviation-vs-long-form mismatches (e.g. `body-cjk-size-l` vs. canonical `-large`).

The issue was originally framed as a taxonomy decision: (a) accept an alternate legacy field
order in both `decomposer.js` and `naming.rs`, or (b) canonicalize the token names (breaking).
Neither is needed — `name.legacyKey` (`sdk/core/src/naming.rs:239-241`) already exists as an
escape hatch for exactly this: it pins the exact flat key written to legacy output, independent
of the token's (canonically correct) decomposed fields, and is already used 247x across the
token files (precedent: #1228, dsi.1/#1234).

This PR pins `name.legacyKey` on all 224 tokens to their existing published key. The
decomposition itself is untouched — only the escape-hatch pin is added — so the change is
publish-invisible.

## Related Issue

Closes spectrum-design-data-dsi.3

## Motivation and Context

Beads review after #1234 surfaced dsi.2/dsi.3/dsi.4 as the remaining `dsi` residual-triage
children, all flagged as taxonomy decisions. dsi.3 (this one) turned out not to require a
decision at all — the existing escape hatch resolves it as pure data, with no serializer
changes and no breaking rename. dsi.2 (needs proposal 006 re-scoped: doc says ~70 tokens,
actual residual is 277) and dsi.4 (209 heterogeneous unclassified tokens needing per-token
triage) are intentionally left out of scope.

## How Has This Been Tested?

- `moon run token-mapping-analyzer:analyze` — regenerated residual report against the pinned
  tokens.
- `moon run design-data:roundtrip-verify` — **Roundtrip OK**; confirms Rust's
  `extract_legacy_key` reconstructs the exact published legacy keys via the pinned
  `legacyKey` escape hatch. This is the load-bearing check for this PR: the JS analyzer's
  `serialize()`/`legacyKey` precedence doesn't match `naming.rs`, so a clean JS analyzer run
  is not sufficient evidence that Rust reconstructs each key correctly. An earlier version of
  this branch had 77/224 pins transcribed to the wrong string (fixed in a follow-up commit,
  `5d01f1d6`) — the JS analyzer didn't catch it, `roundtrip-verify` did.
- `moon run design-data:validate` — 3888 warnings before and after; no new warnings introduced.
- `moon run sdk:codegen-check` — registry ↔ `registry_data.rs` in sync (no registry changes
  in this PR, data-only).
- `moon run token-mapping-analyzer:test` — 30/30 passing.
- `moon run sdk:test` — full Rust workspace suite passing.
- Changeset linted clean: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

