### PR TITLE
feat(design-data): register color/layout/qualifier vocab (dsi.2.5)

### DIFF
--- a/.changeset/dsi25-color-layout-qualifier-vocab.md
+++ b/.changeset/dsi25-color-layout-qualifier-vocab.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Register color/layout/qualifier vocab and migrate affected tokens per
+proposal 006 (closes spectrum-design-data-dsi.2.5).
+
+- **packages/design-data/fields/qualifier.json**, **registry/qualifiers.json**:
+  new `qualifier` name-object field (`stacked`, `multiline`, `precision`,
+  `collapsed`, `expanded`, `drag`, `highlight`).
+- **registry/{variants,positions,anatomy-terms,sizes,property-terms,shapes,
+  structures}.json**: register `subtle`/`subdued`, `inner`/`outer`/`below`,
+  `pagination`/`row`/`slash`/`square`/`well`/`indicator`/`layer`/`track`/
+  `underline`, `xxxxl`, `opacity`/`minimum`/`minimum-padding-vertical`/
+  `component-size-minimum-perspective`, `rectangle`, `drop-target`.
+- **tools/token-mapping-analyzer/src/decomposer.js**: register two compound
+  property terms; drop `inner`/`outer` from `KNOWN_GAP_TERMS`.
+- **packages/design-data-spec/schemas/token.schema.json**: list `qualifier`
+  explicitly in `$defs.nameObject.properties`.
+- **packages/design-data/tokens/{color-aliases,semantic-color-palette,
+  color-component,layout-component,layout,typography}.tokens.json**: migrate
+  affected tokens into structured fields, pinning `name.legacyKey` on each.

--- a/.changeset/dsi25-color-layout-qualifier-vocab.md
+++ b/.changeset/dsi25-color-layout-qualifier-vocab.md
@@ -8,11 +8,11 @@ proposal 006 (closes spectrum-design-data-dsi.2.5).
 - **packages/design-data/fields/qualifier.json**, **registry/qualifiers.json**:
   new `qualifier` name-object field (`stacked`, `multiline`, `precision`,
   `collapsed`, `expanded`, `drag`, `highlight`).
-- **registry/{variants,positions,anatomy-terms,sizes,property-terms,shapes,
-  structures}.json**: register `subtle`/`subdued`, `inner`/`outer`/`below`,
-  `pagination`/`row`/`slash`/`square`/`well`/`indicator`/`layer`/`track`/
-  `underline`, `xxxxl`, `opacity`/`minimum`/`minimum-padding-vertical`/
-  `component-size-minimum-perspective`, `rectangle`, `drop-target`.
+- **registry/{positions,anatomy-terms,sizes,property-terms,shapes,
+  structures,color-roles,components}.json**: register `inner`/`outer`/
+  `below`, `pagination`/`slash`/`square`/`well`, `xxxxl`, `minimum`/
+  `minimum-padding-vertical`/`component-size-minimum-perspective`,
+  `rectangle`, `drop-target`, `color-control`, and 6 semantic color roles.
 - **tools/token-mapping-analyzer/src/decomposer.js**: register two compound
   property terms; drop `inner`/`outer` from `KNOWN_GAP_TERMS`.
 - **packages/design-data-spec/schemas/token.schema.json**: list `qualifier`

--- a/docs/proposals/006-vocabulary-gaps.md
+++ b/docs/proposals/006-vocabulary-gaps.md
@@ -1,67 +1,84 @@
 # Proposal 006: Vocabulary Gaps
 
-**Status:** Draft\
-**Affects:** \~70 active tokens across multiple source files\
+**Status:** dsi.2.5 implemented 2026-07-15 (clean additive batch below); remaining
+taxonomy-call groups tracked under dsi.2.1-2.4/2.6/2.7\
+**Affects:** 161 distinct active tokens across multiple source files\
 **Spec reference:** design-system-registry vocabulary files
 
 ## Problem
 
-After Phases 1-2 registry expansions and Proposals 001-005, approximately 70 tokens still have unmatched segments that need vocabulary additions. These are small, independent additions to existing registries.
+After Phases 1-2 registry expansions and Proposals 001-005, this proposal originally
+estimated \~70 residual tokens. A fresh `moon run token-mapping-analyzer:analyze` run
+(2026-07-14, post PR [#1233](https://github.com/adobe/spectrum-design-data/issues/1233)/[#1234](https://github.com/adobe/spectrum-design-data/issues/1234)/dsi.3) shows the actual `vocabulary-gap` +
+`spatial-qualifier` residual is **161 distinct tokens** — the earlier estimate undercounted
+by more than 2x. `heading` and `popover` (originally listed here) are already resolved —
+both are registered in `components.json`/`anatomy-terms.json` from prior work.
 
-## Proposed additions
+This document re-scopes to the real inventory, grouped by the unmatched segment. Groups
+marked **taxonomy call** surfaced a naming-convention question during re-scoping, not just
+a missing vocabulary term — do not auto-register; resolve the question first.
 
-### Positions registry (`positions.json`)
+## Proposed additions (clean additive — registry term only)
 
-| Value   | Tokens | Example                                            |
-| ------- | ------ | -------------------------------------------------- |
-| `inner` | 5      | `color-handle-inner-border-color`                  |
-| `outer` | 6      | `color-handle-outer-border-color`                  |
-| `below` | 4      | `user-card-minimum-height-title-below-extra-large` |
+| Group              | Segment(s)                                                                  | Registry                                          | Count | Example                                                                    |
+| ------------------ | --------------------------------------------------------------------------- | ------------------------------------------------- | ----- | -------------------------------------------------------------------------- |
+| Spatial qualifiers | `inner`, `outer`                                                            | `positions.json`                                  | 11    | `color-handle-inner-border-color`                                          |
+| Position           | `below`                                                                     | `positions.json`                                  | 4     | `user-card-minimum-height-title-below-extra-large`                         |
+| Anatomy            | `pagination`                                                                | `anatomy-terms.json`                              | 2     | `coach-mark-pagination-color`                                              |
+| Color variant      | `subtle`                                                                    | variant/property term                             | 25    | `blue-subtle-background-color-default` (20 color-family + 5 semantic-role) |
+| Color variant      | `subdued`                                                                   | variant/property term                             | 8     | `neutral-subdued-background-color-default`                                 |
+| Layout             | `layer` (+ index)                                                           | scale/position term                               | 2     | `background-layer-1-color`                                                 |
+| Layout             | `precision`                                                                 | anatomy/qualifier term                            | 5     | `slider-handle-height-precision-large`                                     |
+| Layout             | `row`                                                                       | anatomy term                                      | 4     | `table-section-header-row-height-large`                                    |
+| Layout             | `slash`                                                                     | anatomy term                                      | 4     | `swatch-slash-thickness-large`                                             |
+| Layout             | `stacked`                                                                   | qualifier term                                    | 4     | `in-field-button-width-stacked-large`                                      |
+| Layout             | `collapsed` / `expanded`                                                    | qualifier term                                    | 2     | `coach-indicator-collapsed-ring-thickness`                                 |
+| Layout             | `square`                                                                    | anatomy term                                      | 2     | `opacity-checkerboard-square-size-medium`                                  |
+| Layout             | `multiline`                                                                 | qualifier term                                    | 1     | `breadcrumbs-height-multiline`                                             |
+| Color              | `drag`                                                                      | qualifier term                                    | 2     | `bar-panel-gripper-color-drag`                                             |
+| Color              | `well`                                                                      | anatomy term                                      | 1     | `card-background-well-color`                                               |
+| Color              | `opacity` (as property suffix)                                              | property term                                     | 3     | `card-selection-background-color-opacity`                                  |
+| Color              | `indicator`                                                                 | anatomy term                                      | 2     | `static-black-track-indicator-color`                                       |
+| Color              | `highlight`                                                                 | qualifier/state term                              | 3     | `stack-item-selected-background-color-highlight`                           |
+| Typography         | `xxxxl`                                                                     | `sizes.json` scale (currently tops out at `xxxl`) | 2     | `heading-size-xxxxl`                                                       |
+| Misc singles       | `4x`, `track`+`width`, `drop`+`target`, `underline`, `minimum`, `rectangle` | various                                           | 6     | `base-gap-4x-large`, `text-underline-thickness`                            |
 
-### Anatomy terms registry (`anatomy-terms.json`)
+## Compound properties
 
-| Value        | Tokens | Example                                               |
-| ------------ | ------ | ----------------------------------------------------- |
-| `popover`    | 6      | `double-calendar-popover-minimum-height`              |
-| `hero`       | 5      | `collection-card-minimum-height-hero-extra-large`     |
-| `pagination` | 1      | `coach-mark-pagination-body-font-size`                |
-| `stepper`    | 4      | `number-field-with-stepper-minimum-width-extra-large` |
+| Property                                | Tokens | Example                                                                                                                                                                                            |
+| --------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `line-height`                           | 18     | `line-height-font-size-100` (already listed in the decomposer's compound-property list but matching fails when split — needs a decomposer fix, not a registry add)                                 |
+| `component-height` / `component-size-*` | 8      | `component-height-100`, `component-size-difference-down` — `component` itself is unmatched; likely needs registration as a compound-property prefix like `line-height`, not a standalone component |
 
-### Compound properties
+## Size/shape special values
 
-These multi-segment property names should be added to the decomposer's compound property list:
+| Value                                                   | Field      | Tokens | Example                           |
+| ------------------------------------------------------- | ---------- | ------ | --------------------------------- |
+| `full`                                                  | shape      | 1      | `corner-radius-full`              |
+| `none`                                                  | shape      | 1      | `corner-radius-none`              |
+| `size` compound (`corner-radius-{small,medium}-size-*`) | shape/size | 9      | `corner-radius-medium-size-large` |
 
-| Property      | Tokens | Example                                                                    |
-| ------------- | ------ | -------------------------------------------------------------------------- |
-| `line-height` | 18     | `line-height-font-size-100` (already listed but matching fails when split) |
-
-### Size/shape special values
-
-For corner-radius tokens that use non-standard size qualifiers:
-
-| Value  | Field | Tokens | Example              |
-| ------ | ----- | ------ | -------------------- |
-| `full` | shape | 1      | `corner-radius-full` |
-| `none` | shape | 1      | `corner-radius-none` |
-
-### Component registry (`components.json`)
-
-| Value     | Tokens | Example                   |
-| --------- | ------ | ------------------------- |
-| `heading` | 5      | `heading-cjk-font-weight` |
-
-Note: `heading` may be better classified as a typography component (like `body`, `code`, `detail`, `title`) rather than a UI component. This aligns with Proposal 001's typography taxonomy.
-
-### Property vocabulary
+## Property vocabulary
 
 | Value        | Tokens | Example                           |
 | ------------ | ------ | --------------------------------- |
 | `multiplier` | 7      | `button-minimum-width-multiplier` |
 
-`multiplier` appears as a property modifier on minimum-width tokens. It could be treated as a compound property (`minimum-width-multiplier`) or as a standalone property.
+`multiplier` appears as a property modifier on minimum/maximum-width tokens. Treat as a
+compound property (`minimum-width-multiplier`) or a standalone property term.
+
+## Taxonomy calls (resolve before implementing — not simple vocab adds)
+
+| Group                                                                                                                                                                               | Tokens | Question                                                                                                                                                                                                                                    |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `number-field-with-stepper-*`                                                                                                                                                       | 4      | The unmatched segment is the connector word `with`, not `stepper` (already registered). Registering `with` as a term is a filler-word precedent with broad blast radius — may instead need a decomposer rule to skip known connector words. |
+| `tab-gap-horizontal-*`                                                                                                                                                              | 4      | `tabs` (plural) is registered as a component; `tab` (singular) is not. Decide: register `tab` as an alias/synonym of `tabs`, or treat as a distinct anatomy term.                                                                           |
+| `heading-cjk-font-weight`-style typography self-reference (`bold-font-weight-bold`, `italic-font-style-italic`, `regular-font-weight-regular`, `extra-bold-font-weight-extra-bold`) | 4      | Value repeats as its own property name — a decomposer pattern question (self-referential property/value pairs), not a missing vocabulary term.                                                                                              |
 
 ## Impact
 
-* \~70 tokens gain proper vocabulary matches
-* All additions are to existing registries — no schema changes
-* Each addition is independent and can be implemented incrementally
+* 161 distinct tokens addressed once all groups above are resolved
+* Registry-only groups (129 tokens across \~19 sub-groups) are additive, no schema changes,
+  and independently implementable in small batches
+* 3 groups (11 tokens) require a taxonomy/decomposer decision before implementation
+* Re-run `moon run token-mapping-analyzer:analyze` after each batch to confirm residual drop

--- a/docs/proposals/006-vocabulary-gaps.md
+++ b/docs/proposals/006-vocabulary-gaps.md
@@ -67,6 +67,23 @@ a missing vocabulary term — do not auto-register; resolve the question first.
 `multiplier` appears as a property modifier on minimum/maximum-width tokens. Treat as a
 compound property (`minimum-width-multiplier`) or a standalone property term.
 
+## Implementation notes (dsi.2.5)
+
+* `layer`/`underline` were **not** registered as anatomy terms: the tokens that motivated
+  them (`background-layer-*-color`, `text-underline-thickness`) have no `component` field,
+  and SPEC-025 forbids `anatomy` without `component`. Both stay fused in `property`
+  (`background-layer-color`, `text-underline-thickness`).
+* `heading-size-xxxxl`/`heading-cjk-size-xxxxl` keep `size-xxxxl`/`cjk-size-xxxxl` fused in
+  `property`, matching the existing unextracted `xxxl` sibling tokens. `xxxxl` in
+  `sizes.json` is exercised by `base-gap-4x-large` (`size: "xxxxl"`). Decomposing the full
+  `heading-*-size-*` family (`component`/`family`/`size`/`property:"font-size"`) is
+  out of scope here — tracked as a separate follow-up.
+* `color-control-track-width` decomposes to `component:"color-control"`,
+  `anatomy:"track"`, `property:"width"` (`color-control` newly registered in
+  `registry/components.json`). This adds a `component` key to the published legacy
+  JSON that wasn't there before (legacyKey pins the flat key string, not other
+  attributes) — `packages/tokens/src/layout.json` was regenerated accordingly.
+
 ## Taxonomy calls (resolve before implementing — not simple vocab adds)
 
 | Group                                                                                                                                                                               | Tokens | Question                                                                                                                                                                                                                                    |

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -51,6 +51,10 @@
           "type": "string",
           "description": "Semantic: interactive or semantic state (e.g. hover, focus, disabled)."
         },
+        "qualifier": {
+          "type": "string",
+          "description": "Semantic: behavioral or layout modifier that narrows a property/anatomy without being a state, variant, or position (e.g. stacked, multiline, precision, collapsed, expanded, drag, highlight)."
+        },
         "orientation": {
           "type": "string",
           "description": "Semantic: direction or order (e.g. vertical, horizontal)."

--- a/packages/design-data/fields/qualifier.json
+++ b/packages/design-data/fields/qualifier.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "qualifier",
+  "description": "Behavioral or layout modifier that narrows a property/anatomy without being a state, variant, or position (e.g. stacked, multiline, precision, collapsed, expanded, drag, highlight).",
+  "kind": "semantic",
+  "registry": "packages/design-data/registry/qualifiers.json",
+  "validation": "advisory",
+  "serialization": {
+    "position": 27
+  },
+  "scope": null,
+  "required": false,
+  "valueType": "string"
+}

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -830,18 +830,6 @@
       "label": "Well",
       "description": "Recessed background area within a component (e.g. card)",
       "usedIn": ["tokens"]
-    },
-    {
-      "id": "layer",
-      "label": "Layer",
-      "description": "A stacked visual plane within a component",
-      "usedIn": ["tokens"]
-    },
-    {
-      "id": "underline",
-      "label": "Underline",
-      "description": "Underline decoration element beneath text",
-      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -806,6 +806,42 @@
       "label": "In-field stepper",
       "description": "A stepper control embedded within a field element (e.g. number-field)",
       "usedIn": ["tokens"]
+    },
+    {
+      "id": "pagination",
+      "label": "Pagination",
+      "description": "Paged-navigation indicator element (e.g. coach-mark step dots)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "slash",
+      "label": "Slash",
+      "description": "Diagonal line element indicating an unavailable or crossed-out state (e.g. swatch)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "square",
+      "label": "Square",
+      "description": "Square-shaped anatomy element (e.g. checkerboard tile)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "well",
+      "label": "Well",
+      "description": "Recessed background area within a component (e.g. card)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "layer",
+      "label": "Layer",
+      "description": "A stacked visual plane within a component",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "underline",
+      "label": "Underline",
+      "description": "Underline decoration element beneath text",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/registry/color-roles.json
+++ b/packages/design-data/registry/color-roles.json
@@ -12,6 +12,36 @@
       "id": "background",
       "label": "Background",
       "description": "Background color role — fill or surface color behind an element"
+    },
+    {
+      "id": "neutral",
+      "label": "Neutral",
+      "description": "Neutral semantic color role, distinct from a specific hue"
+    },
+    {
+      "id": "accent",
+      "label": "Accent",
+      "description": "Accent semantic color role"
+    },
+    {
+      "id": "informative",
+      "label": "Informative",
+      "description": "Informative semantic color role"
+    },
+    {
+      "id": "negative",
+      "label": "Negative",
+      "description": "Negative/destructive semantic color role"
+    },
+    {
+      "id": "notice",
+      "label": "Notice",
+      "description": "Notice/attention semantic color role"
+    },
+    {
+      "id": "positive",
+      "label": "Positive",
+      "description": "Positive/affirmative semantic color role"
     }
   ]
 }

--- a/packages/design-data/registry/components.json
+++ b/packages/design-data/registry/components.json
@@ -129,6 +129,11 @@
       "documentationUrl": "https://spectrum.adobe.com/page/color-area/"
     },
     {
+      "id": "color-control",
+      "label": "Color Control",
+      "description": "A cross-cutting anatomy sub-part shared by color-selection components (e.g. color slider, color wheel) rather than a standalone top-level component."
+    },
+    {
       "id": "color-handle",
       "label": "Color Handle",
       "documentationUrl": "https://spectrum.adobe.com/page/color-handle/"

--- a/packages/design-data/registry/positions.json
+++ b/packages/design-data/registry/positions.json
@@ -47,6 +47,24 @@
       "id": "bottom-edge",
       "label": "Bottom edge",
       "description": "Outer boundary at the bottom"
+    },
+    {
+      "id": "inner",
+      "label": "Inner",
+      "description": "Interior-facing side of an element",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "outer",
+      "label": "Outer",
+      "description": "Exterior-facing side of an element",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "below",
+      "label": "Below",
+      "description": "Positioned underneath a reference element",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -262,6 +262,21 @@
       "id": "y",
       "label": "Y",
       "description": "Vertical offset (e.g. drop-shadow y offset)"
+    },
+    {
+      "id": "minimum",
+      "label": "Minimum",
+      "description": "Lower-bound constraint modifier (design-system abstraction; distinct from the compound minimum-width/minimum-height terms)"
+    },
+    {
+      "id": "minimum-padding-vertical",
+      "label": "Minimum Vertical Padding",
+      "description": "Lower-bound constraint on internal vertical (top/bottom) spacing"
+    },
+    {
+      "id": "component-size-minimum-perspective",
+      "label": "Component Size Minimum Perspective",
+      "description": "Lower-bound constraint on a component's 3D perspective sizing (design-system abstraction)"
     }
   ]
 }

--- a/packages/design-data/registry/qualifiers.json
+++ b/packages/design-data/registry/qualifiers.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "qualifier",
+  "description": "Behavioral or layout modifier that narrows a property/anatomy without being a state, variant, or position.",
+  "values": [
+    {
+      "id": "stacked",
+      "label": "Stacked",
+      "description": "Layout arranged in a stacked (vertical) configuration"
+    },
+    {
+      "id": "multiline",
+      "label": "Multiline",
+      "description": "Content spanning more than one line"
+    },
+    {
+      "id": "precision",
+      "label": "Precision",
+      "description": "Fine-grained/precision interaction mode"
+    },
+    {
+      "id": "collapsed",
+      "label": "Collapsed",
+      "description": "Contracted/minimized display configuration"
+    },
+    {
+      "id": "expanded",
+      "label": "Expanded",
+      "description": "Extended/enlarged display configuration"
+    },
+    {
+      "id": "drag",
+      "label": "Drag",
+      "description": "Drag interaction modifier"
+    },
+    {
+      "id": "highlight",
+      "label": "Highlight",
+      "description": "Emphasized highlight treatment"
+    }
+  ]
+}

--- a/packages/design-data/registry/shapes.json
+++ b/packages/design-data/registry/shapes.json
@@ -7,6 +7,11 @@
       "id": "uniform",
       "label": "Uniform",
       "description": "Equal proportions (e.g., 1:1 ratio between horizontal and vertical padding)"
+    },
+    {
+      "id": "rectangle",
+      "label": "Rectangle",
+      "description": "Rectangular (non-uniform) proportions"
     }
   ]
 }

--- a/packages/design-data/registry/sizes.json
+++ b/packages/design-data/registry/sizes.json
@@ -66,6 +66,13 @@
       "aliases": ["3x-large"],
       "tokenName": "3x-large",
       "usedIn": ["tokens", "component-options", "component-schemas"]
+    },
+    {
+      "id": "xxxxl",
+      "label": "4X Large",
+      "aliases": ["4x-large"],
+      "tokenName": "4x-large",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/registry/structures.json
+++ b/packages/design-data/registry/structures.json
@@ -57,6 +57,11 @@
       "id": "drop-shadow",
       "label": "Drop Shadow",
       "description": "Elevated shadow effect applied to components and containers"
+    },
+    {
+      "id": "drop-target",
+      "label": "Drop Target",
+      "description": "Drag-and-drop destination structure"
     }
   ]
 }

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -4542,9 +4542,8 @@
   },
   {
     "name": {
-      "component": "stack-item",
       "state": "selected",
-      "property": "background-color",
+      "property": "stack-item-background-color",
       "qualifier": "highlight",
       "legacyKey": "stack-item-selected-background-color-highlight"
     },

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -287,7 +287,9 @@
   },
   {
     "name": {
-      "property": "background-layer-1-color"
+      "property": "background-layer-color",
+      "scaleIndex": 1,
+      "legacyKey": "background-layer-1-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",
@@ -295,8 +297,10 @@
   },
   {
     "name": {
-      "property": "background-layer-2-color",
-      "colorScheme": "light"
+      "property": "background-layer-color",
+      "scaleIndex": 2,
+      "colorScheme": "light",
+      "legacyKey": "background-layer-2-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -306,8 +310,10 @@
   },
   {
     "name": {
-      "property": "background-layer-2-color",
-      "colorScheme": "dark"
+      "property": "background-layer-color",
+      "scaleIndex": 2,
+      "colorScheme": "dark",
+      "legacyKey": "background-layer-2-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5793fc53-b676-4bc8-b5d4-2a2394c853f5",
@@ -317,8 +323,10 @@
   },
   {
     "name": {
-      "property": "background-layer-2-color",
-      "colorScheme": "wireframe"
+      "property": "background-layer-color",
+      "scaleIndex": 2,
+      "colorScheme": "wireframe",
+      "legacyKey": "background-layer-2-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -446,9 +454,12 @@
   },
   {
     "name": {
-      "property": "blue-subtle-background-color",
+      "colorFamily": "blue",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "blue-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -458,9 +469,12 @@
   },
   {
     "name": {
-      "property": "blue-subtle-background-color",
+      "colorFamily": "blue",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "blue-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
@@ -470,9 +484,12 @@
   },
   {
     "name": {
-      "property": "blue-subtle-background-color",
+      "colorFamily": "blue",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "blue-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -551,9 +568,12 @@
   },
   {
     "name": {
-      "property": "brown-subtle-background-color",
+      "colorFamily": "brown",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "brown-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
@@ -563,9 +583,12 @@
   },
   {
     "name": {
-      "property": "brown-subtle-background-color",
+      "colorFamily": "brown",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "brown-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
@@ -575,9 +598,12 @@
   },
   {
     "name": {
-      "property": "brown-subtle-background-color",
+      "colorFamily": "brown",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "brown-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
@@ -656,9 +682,12 @@
   },
   {
     "name": {
-      "property": "celery-subtle-background-color",
+      "colorFamily": "celery",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "celery-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d22658b0-6638-45f9-8567-a2ad056f7c10",
@@ -668,9 +697,12 @@
   },
   {
     "name": {
-      "property": "celery-subtle-background-color",
+      "colorFamily": "celery",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "celery-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "577626d4-7631-4de5-bd71-350b9748a4dd",
@@ -680,9 +712,12 @@
   },
   {
     "name": {
-      "property": "celery-subtle-background-color",
+      "colorFamily": "celery",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "celery-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d22658b0-6638-45f9-8567-a2ad056f7c10",
@@ -761,9 +796,12 @@
   },
   {
     "name": {
-      "property": "chartreuse-subtle-background-color",
+      "colorFamily": "chartreuse",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "chartreuse-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
@@ -773,9 +811,12 @@
   },
   {
     "name": {
-      "property": "chartreuse-subtle-background-color",
+      "colorFamily": "chartreuse",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "chartreuse-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
@@ -785,9 +826,12 @@
   },
   {
     "name": {
-      "property": "chartreuse-subtle-background-color",
+      "colorFamily": "chartreuse",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "chartreuse-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
@@ -866,9 +910,12 @@
   },
   {
     "name": {
-      "property": "cinnamon-subtle-background-color",
+      "colorFamily": "cinnamon",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "cinnamon-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
@@ -878,9 +925,12 @@
   },
   {
     "name": {
-      "property": "cinnamon-subtle-background-color",
+      "colorFamily": "cinnamon",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "cinnamon-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3527fc94-a410-4933-bbb7-bedecd37e477",
@@ -890,9 +940,12 @@
   },
   {
     "name": {
-      "property": "cinnamon-subtle-background-color",
+      "colorFamily": "cinnamon",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "cinnamon-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
@@ -971,9 +1024,12 @@
   },
   {
     "name": {
-      "property": "cyan-subtle-background-color",
+      "colorFamily": "cyan",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "cyan-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c7fd6eda-f850-4dec-a883-e970cdfca622",
@@ -983,9 +1039,12 @@
   },
   {
     "name": {
-      "property": "cyan-subtle-background-color",
+      "colorFamily": "cyan",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "cyan-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
@@ -995,9 +1054,12 @@
   },
   {
     "name": {
-      "property": "cyan-subtle-background-color",
+      "colorFamily": "cyan",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "cyan-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c7fd6eda-f850-4dec-a883-e970cdfca622",
@@ -1708,9 +1770,12 @@
   },
   {
     "name": {
-      "property": "fuchsia-subtle-background-color",
+      "colorFamily": "fuchsia",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "fuchsia-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
@@ -1720,9 +1785,12 @@
   },
   {
     "name": {
-      "property": "fuchsia-subtle-background-color",
+      "colorFamily": "fuchsia",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "fuchsia-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "09aef364-8827-48fa-9888-b0424ce8981c",
@@ -1732,9 +1800,12 @@
   },
   {
     "name": {
-      "property": "fuchsia-subtle-background-color",
+      "colorFamily": "fuchsia",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "fuchsia-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
@@ -1813,9 +1884,12 @@
   },
   {
     "name": {
-      "property": "gray-subtle-background-color",
+      "colorFamily": "gray",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "gray-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -1825,9 +1899,12 @@
   },
   {
     "name": {
-      "property": "gray-subtle-background-color",
+      "colorFamily": "gray",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "gray-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
@@ -1837,9 +1914,12 @@
   },
   {
     "name": {
-      "property": "gray-subtle-background-color",
+      "colorFamily": "gray",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "gray-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -1918,9 +1998,12 @@
   },
   {
     "name": {
-      "property": "green-subtle-background-color",
+      "colorFamily": "green",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "green-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
@@ -1930,9 +2013,12 @@
   },
   {
     "name": {
-      "property": "green-subtle-background-color",
+      "colorFamily": "green",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "green-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
@@ -1942,9 +2028,12 @@
   },
   {
     "name": {
-      "property": "green-subtle-background-color",
+      "colorFamily": "green",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "green-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
@@ -2023,9 +2112,12 @@
   },
   {
     "name": {
-      "property": "indigo-subtle-background-color",
+      "colorFamily": "indigo",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "indigo-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
@@ -2035,9 +2127,12 @@
   },
   {
     "name": {
-      "property": "indigo-subtle-background-color",
+      "colorFamily": "indigo",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "indigo-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "571bb191-0f29-4a11-95a2-831a454b4df1",
@@ -2047,9 +2142,12 @@
   },
   {
     "name": {
-      "property": "indigo-subtle-background-color",
+      "colorFamily": "indigo",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "indigo-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
@@ -2317,9 +2415,12 @@
   },
   {
     "name": {
-      "property": "magenta-subtle-background-color",
+      "colorFamily": "magenta",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "magenta-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
@@ -2329,9 +2430,12 @@
   },
   {
     "name": {
-      "property": "magenta-subtle-background-color",
+      "colorFamily": "magenta",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "magenta-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
@@ -2341,9 +2445,12 @@
   },
   {
     "name": {
-      "property": "magenta-subtle-background-color",
+      "colorFamily": "magenta",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "magenta-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
@@ -2802,9 +2909,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "neutral-subdued-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -2814,9 +2924,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "neutral-subdued-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -2826,9 +2939,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "neutral-subdued-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -2838,9 +2954,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "neutral-subdued-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2850,9 +2969,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "neutral-subdued-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -2862,9 +2984,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "down",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "neutral-subdued-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2874,9 +2999,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "neutral-subdued-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2886,9 +3014,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "neutral-subdued-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -2898,9 +3029,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "hover",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "neutral-subdued-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2910,9 +3044,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "key-focus",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "neutral-subdued-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2922,9 +3059,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "key-focus",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "neutral-subdued-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -2934,9 +3074,12 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-background-color",
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "background-color",
       "state": "key-focus",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "neutral-subdued-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2946,8 +3089,11 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-content-color",
-      "state": "default"
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "content-color",
+      "state": "default",
+      "legacyKey": "neutral-subdued-content-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -2955,8 +3101,11 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-content-color",
-      "state": "down"
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "content-color",
+      "state": "down",
+      "legacyKey": "neutral-subdued-content-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2964,8 +3113,11 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-content-color",
-      "state": "hover"
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "content-color",
+      "state": "hover",
+      "legacyKey": "neutral-subdued-content-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2973,8 +3125,11 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-content-color",
-      "state": "key-focus"
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "content-color",
+      "state": "key-focus",
+      "legacyKey": "neutral-subdued-content-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -2982,8 +3137,11 @@
   },
   {
     "name": {
-      "property": "neutral-subdued-content-color",
-      "state": "selected"
+      "colorRole": "neutral",
+      "variant": "subdued",
+      "property": "content-color",
+      "state": "selected",
+      "legacyKey": "neutral-subdued-content-color-selected"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ab4accc-bd95-48e0-ae3a-539740a07cc6",
@@ -2991,9 +3149,12 @@
   },
   {
     "name": {
-      "property": "neutral-subtle-background-color",
+      "colorRole": "neutral",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "neutral-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -3003,9 +3164,12 @@
   },
   {
     "name": {
-      "property": "neutral-subtle-background-color",
+      "colorRole": "neutral",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "neutral-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
@@ -3015,9 +3179,12 @@
   },
   {
     "name": {
-      "property": "neutral-subtle-background-color",
+      "colorRole": "neutral",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "neutral-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -3177,9 +3344,12 @@
   },
   {
     "name": {
-      "property": "orange-subtle-background-color",
+      "colorFamily": "orange",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "orange-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -3189,9 +3359,12 @@
   },
   {
     "name": {
-      "property": "orange-subtle-background-color",
+      "colorFamily": "orange",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "orange-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
@@ -3201,9 +3374,12 @@
   },
   {
     "name": {
-      "property": "orange-subtle-background-color",
+      "colorFamily": "orange",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "orange-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -3323,9 +3499,12 @@
   },
   {
     "name": {
-      "property": "pink-subtle-background-color",
+      "colorFamily": "pink",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "pink-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
@@ -3335,9 +3514,12 @@
   },
   {
     "name": {
-      "property": "pink-subtle-background-color",
+      "colorFamily": "pink",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "pink-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7bb48388-b3bc-47eb-a7ab-b15327996714",
@@ -3347,9 +3529,12 @@
   },
   {
     "name": {
-      "property": "pink-subtle-background-color",
+      "colorFamily": "pink",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "pink-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
@@ -3617,9 +3802,12 @@
   },
   {
     "name": {
-      "property": "purple-subtle-background-color",
+      "colorFamily": "purple",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "purple-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
@@ -3629,9 +3817,12 @@
   },
   {
     "name": {
-      "property": "purple-subtle-background-color",
+      "colorFamily": "purple",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "purple-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
@@ -3641,9 +3832,12 @@
   },
   {
     "name": {
-      "property": "purple-subtle-background-color",
+      "colorFamily": "purple",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "purple-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
@@ -3722,9 +3916,12 @@
   },
   {
     "name": {
-      "property": "red-subtle-background-color",
+      "colorFamily": "red",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "red-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -3734,9 +3931,12 @@
   },
   {
     "name": {
-      "property": "red-subtle-background-color",
+      "colorFamily": "red",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "red-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
@@ -3746,9 +3946,12 @@
   },
   {
     "name": {
-      "property": "red-subtle-background-color",
+      "colorFamily": "red",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "red-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -3827,9 +4030,12 @@
   },
   {
     "name": {
-      "property": "seafoam-subtle-background-color",
+      "colorFamily": "seafoam",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "seafoam-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
@@ -3839,9 +4045,12 @@
   },
   {
     "name": {
-      "property": "seafoam-subtle-background-color",
+      "colorFamily": "seafoam",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "seafoam-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
@@ -3851,9 +4060,12 @@
   },
   {
     "name": {
-      "property": "seafoam-subtle-background-color",
+      "colorFamily": "seafoam",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "seafoam-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
@@ -3932,9 +4144,12 @@
   },
   {
     "name": {
-      "property": "silver-subtle-background-color",
+      "colorFamily": "silver",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "silver-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
@@ -3944,9 +4159,12 @@
   },
   {
     "name": {
-      "property": "silver-subtle-background-color",
+      "colorFamily": "silver",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "silver-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
@@ -3956,9 +4174,12 @@
   },
   {
     "name": {
-      "property": "silver-subtle-background-color",
+      "colorFamily": "silver",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "silver-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
@@ -4027,7 +4248,11 @@
   },
   {
     "name": {
-      "property": "static-black-track-indicator-color"
+      "variant": "static",
+      "colorFamily": "black",
+      "object": "track",
+      "property": "indicator-color",
+      "legacyKey": "static-black-track-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0a331f9-53e3-4c72-b5e3-139d730a1752",
@@ -4061,7 +4286,11 @@
   },
   {
     "name": {
-      "property": "static-white-track-indicator-color"
+      "variant": "static",
+      "colorFamily": "white",
+      "object": "track",
+      "property": "indicator-color",
+      "legacyKey": "static-white-track-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5c823c6-1911-4e0e-ba2f-5105f467e108",
@@ -4121,9 +4350,12 @@
   },
   {
     "name": {
-      "property": "turquoise-subtle-background-color",
+      "colorFamily": "turquoise",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "turquoise-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7720aa32-deea-454b-a593-f1234e638565",
@@ -4133,9 +4365,12 @@
   },
   {
     "name": {
-      "property": "turquoise-subtle-background-color",
+      "colorFamily": "turquoise",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "turquoise-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "47de7f9a-3e02-4824-b667-ad499729c9ff",
@@ -4145,9 +4380,12 @@
   },
   {
     "name": {
-      "property": "turquoise-subtle-background-color",
+      "colorFamily": "turquoise",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "turquoise-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7720aa32-deea-454b-a593-f1234e638565",
@@ -4226,9 +4464,12 @@
   },
   {
     "name": {
-      "property": "yellow-subtle-background-color",
+      "colorFamily": "yellow",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "yellow-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
@@ -4238,9 +4479,12 @@
   },
   {
     "name": {
-      "property": "yellow-subtle-background-color",
+      "colorFamily": "yellow",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "yellow-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
@@ -4250,9 +4494,12 @@
   },
   {
     "name": {
-      "property": "yellow-subtle-background-color",
+      "colorFamily": "yellow",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "yellow-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
@@ -4295,7 +4542,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-color-highlight"
+      "component": "stack-item",
+      "state": "selected",
+      "property": "background-color",
+      "qualifier": "highlight",
+      "legacyKey": "stack-item-selected-background-color-highlight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e05251ac-d64a-4157-9b20-224f0392269e",

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -68,7 +68,10 @@
   {
     "name": {
       "component": "bar-panel",
-      "property": "gripper-color-drag"
+      "anatomy": "gripper",
+      "qualifier": "drag",
+      "property": "color",
+      "legacyKey": "bar-panel-gripper-color-drag"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -87,7 +90,9 @@
   {
     "name": {
       "component": "card",
-      "property": "background-well-color"
+      "anatomy": "well",
+      "property": "background-color",
+      "legacyKey": "card-background-well-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -135,7 +140,10 @@
   {
     "name": {
       "component": "card",
-      "property": "selection-background-color-opacity"
+      "anatomy": "selection",
+      "object": "background",
+      "property": "opacity",
+      "legacyKey": "card-selection-background-color-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.95",
@@ -153,7 +161,9 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "pagination-color"
+      "anatomy": "pagination",
+      "property": "color",
+      "legacyKey": "coach-mark-pagination-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
@@ -194,7 +204,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "inner-border-color"
+      "position": "inner",
+      "property": "border-color",
+      "legacyKey": "color-handle-inner-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -203,7 +215,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "inner-border-opacity"
+      "position": "inner",
+      "property": "border-opacity",
+      "legacyKey": "color-handle-inner-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
@@ -212,7 +226,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "outer-border-color"
+      "position": "outer",
+      "property": "border-color",
+      "legacyKey": "color-handle-outer-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -221,7 +237,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "outer-border-opacity"
+      "position": "outer",
+      "property": "border-opacity",
+      "legacyKey": "color-handle-outer-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "72b473c6-ec9b-4830-a0f8-48b80070e7b8",
@@ -268,7 +286,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "inner-border"
+      "position": "inner",
+      "property": "border-color",
+      "legacyKey": "color-loupe-inner-border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
@@ -277,7 +297,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "outer-border"
+      "position": "outer",
+      "property": "border-color",
+      "legacyKey": "color-loupe-outer-border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
@@ -331,7 +353,9 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "background-color-opacity"
+      "object": "background",
+      "property": "opacity",
+      "legacyKey": "drop-zone-background-color-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -340,7 +364,10 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "background-color-opacity-filled"
+      "object": "background",
+      "property": "opacity",
+      "state": "filled",
+      "legacyKey": "drop-zone-background-color-opacity-filled"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.3",
@@ -811,7 +838,10 @@
   {
     "name": {
       "component": "standard-panel",
-      "property": "gripper-color-drag"
+      "anatomy": "gripper",
+      "qualifier": "drag",
+      "property": "color",
+      "legacyKey": "standard-panel-gripper-color-drag"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -14266,7 +14266,7 @@
       "anatomy": "slash",
       "property": "thickness",
       "size": "xs",
-      "legacyKey": "swatch-slash-thickness-xs"
+      "legacyKey": "swatch-slash-thickness-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -14278,7 +14278,7 @@
       "anatomy": "slash",
       "property": "thickness",
       "size": "l",
-      "legacyKey": "swatch-slash-thickness-l"
+      "legacyKey": "swatch-slash-thickness-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -14302,7 +14302,7 @@
       "anatomy": "slash",
       "property": "thickness",
       "size": "s",
-      "legacyKey": "swatch-slash-thickness-s"
+      "legacyKey": "swatch-slash-thickness-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -5035,7 +5035,10 @@
   {
     "name": {
       "component": "coach-indicator",
-      "property": "collapsed-ring-thickness"
+      "qualifier": "collapsed",
+      "anatomy": "ring",
+      "property": "thickness",
+      "legacyKey": "coach-indicator-collapsed-ring-thickness"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -5066,7 +5069,10 @@
   {
     "name": {
       "component": "coach-indicator",
-      "property": "expanded-ring-thickness"
+      "qualifier": "expanded",
+      "anatomy": "ring",
+      "property": "thickness",
+      "legacyKey": "coach-indicator-expanded-ring-thickness"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -5258,8 +5264,11 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "pagination-body-font-size",
-      "scale": "desktop"
+      "anatomy": "pagination",
+      "structure": "body",
+      "property": "font-size",
+      "scale": "desktop",
+      "legacyKey": "coach-mark-pagination-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
@@ -5270,8 +5279,11 @@
   {
     "name": {
       "component": "coach-mark",
-      "property": "pagination-body-font-size",
-      "scale": "mobile"
+      "anatomy": "pagination",
+      "structure": "body",
+      "property": "font-size",
+      "scale": "mobile",
+      "legacyKey": "coach-mark-pagination-body-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25e93322-8f0b-45f8-ae9a-18668251f064",
@@ -5698,7 +5710,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "inner-border-width"
+      "position": "inner",
+      "property": "border-width",
+      "legacyKey": "color-handle-inner-border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -5707,7 +5721,9 @@
   {
     "name": {
       "component": "color-handle",
-      "property": "outer-border-width"
+      "position": "outer",
+      "property": "border-width",
+      "legacyKey": "color-handle-outer-border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -5788,7 +5804,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "inner-border-width"
+      "position": "inner",
+      "property": "border-width",
+      "legacyKey": "color-loupe-inner-border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -5797,7 +5815,9 @@
   {
     "name": {
       "component": "color-loupe",
-      "property": "outer-border-width"
+      "position": "outer",
+      "property": "border-width",
+      "legacyKey": "color-loupe-outer-border-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
@@ -7924,7 +7944,11 @@
   {
     "name": {
       "component": "in-field-button",
-      "property": "fill-stacked-inner-border-rounding"
+      "anatomy": "fill",
+      "qualifier": "stacked",
+      "position": "inner",
+      "property": "border-radius",
+      "legacyKey": "in-field-button-fill-stacked-inner-border-rounding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -8040,7 +8064,10 @@
   {
     "name": {
       "component": "in-field-button",
-      "property": "width-stacked-extra-large"
+      "qualifier": "stacked",
+      "property": "width",
+      "size": "extra-large",
+      "legacyKey": "in-field-button-width-stacked-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "44px",
@@ -8049,7 +8076,10 @@
   {
     "name": {
       "component": "in-field-button",
-      "property": "width-stacked-large"
+      "qualifier": "stacked",
+      "property": "width",
+      "size": "large",
+      "legacyKey": "in-field-button-width-stacked-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -8058,7 +8088,10 @@
   {
     "name": {
       "component": "in-field-button",
-      "property": "width-stacked-medium"
+      "qualifier": "stacked",
+      "property": "width",
+      "size": "medium",
+      "legacyKey": "in-field-button-width-stacked-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -8067,7 +8100,10 @@
   {
     "name": {
       "component": "in-field-button",
-      "property": "width-stacked-small"
+      "qualifier": "stacked",
+      "property": "width",
+      "size": "small",
+      "legacyKey": "in-field-button-width-stacked-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -9642,8 +9678,11 @@
   {
     "name": {
       "component": "opacity-checkerboard",
-      "property": "square-size-medium",
-      "scale": "desktop"
+      "anatomy": "square",
+      "property": "size",
+      "size": "m",
+      "scale": "desktop",
+      "legacyKey": "opacity-checkerboard-square-size-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -9654,8 +9693,11 @@
   {
     "name": {
       "component": "opacity-checkerboard",
-      "property": "square-size-medium",
-      "scale": "mobile"
+      "anatomy": "square",
+      "property": "size",
+      "size": "m",
+      "scale": "mobile",
+      "legacyKey": "opacity-checkerboard-square-size-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -9666,8 +9708,11 @@
   {
     "name": {
       "component": "opacity-checkerboard",
-      "property": "square-size-small",
-      "scale": "desktop"
+      "anatomy": "square",
+      "property": "size",
+      "size": "s",
+      "scale": "desktop",
+      "legacyKey": "opacity-checkerboard-square-size-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -9678,8 +9723,11 @@
   {
     "name": {
       "component": "opacity-checkerboard",
-      "property": "square-size-small",
-      "scale": "mobile"
+      "anatomy": "square",
+      "property": "size",
+      "size": "s",
+      "scale": "mobile",
+      "legacyKey": "opacity-checkerboard-square-size-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -12672,8 +12720,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-extra-large",
-      "scale": "desktop"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "extra-large",
+      "scale": "desktop",
+      "legacyKey": "slider-handle-height-precision-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "26px",
@@ -12684,8 +12736,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-extra-large",
-      "scale": "mobile"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "extra-large",
+      "scale": "mobile",
+      "legacyKey": "slider-handle-height-precision-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -12696,8 +12752,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-large",
-      "scale": "desktop"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "large",
+      "scale": "desktop",
+      "legacyKey": "slider-handle-height-precision-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -12708,8 +12768,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-large",
-      "scale": "mobile"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "large",
+      "scale": "mobile",
+      "legacyKey": "slider-handle-height-precision-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "30px",
@@ -12720,8 +12784,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-medium",
-      "scale": "desktop"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "medium",
+      "scale": "desktop",
+      "legacyKey": "slider-handle-height-precision-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -12732,8 +12800,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-medium",
-      "scale": "mobile"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "medium",
+      "scale": "mobile",
+      "legacyKey": "slider-handle-height-precision-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "26px",
@@ -12744,8 +12816,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-small",
-      "scale": "desktop"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "small",
+      "scale": "desktop",
+      "legacyKey": "slider-handle-height-precision-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -12756,8 +12832,12 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-height-precision-small",
-      "scale": "mobile"
+      "anatomy": "handle",
+      "property": "height",
+      "qualifier": "precision",
+      "size": "small",
+      "scale": "mobile",
+      "legacyKey": "slider-handle-height-precision-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -12816,7 +12896,10 @@
   {
     "name": {
       "component": "slider",
-      "property": "handle-precision-width"
+      "anatomy": "handle",
+      "qualifier": "precision",
+      "property": "width",
+      "legacyKey": "slider-handle-precision-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -14065,7 +14148,9 @@
   {
     "name": {
       "component": "swatch",
-      "property": "rectangle-width-multiplier"
+      "shape": "rectangle",
+      "property": "width-multiplier",
+      "legacyKey": "swatch-rectangle-width-multiplier"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 2,
@@ -14178,8 +14263,10 @@
   {
     "name": {
       "component": "swatch",
-      "property": "slash-thickness",
-      "size": "xs"
+      "anatomy": "slash",
+      "property": "thickness",
+      "size": "xs",
+      "legacyKey": "swatch-slash-thickness-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -14188,8 +14275,10 @@
   {
     "name": {
       "component": "swatch",
-      "property": "slash-thickness",
-      "size": "l"
+      "anatomy": "slash",
+      "property": "thickness",
+      "size": "l",
+      "legacyKey": "swatch-slash-thickness-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -14198,7 +14287,10 @@
   {
     "name": {
       "component": "swatch",
-      "property": "slash-thickness-medium"
+      "anatomy": "slash",
+      "property": "thickness",
+      "size": "m",
+      "legacyKey": "swatch-slash-thickness-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -14207,8 +14299,10 @@
   {
     "name": {
       "component": "swatch",
-      "property": "slash-thickness",
-      "size": "s"
+      "anatomy": "slash",
+      "property": "thickness",
+      "size": "s",
+      "legacyKey": "swatch-slash-thickness-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
@@ -18676,8 +18770,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-extra-large",
-      "scale": "desktop"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "extra-large",
+      "scale": "desktop",
+      "legacyKey": "table-section-header-row-height-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "48px",
@@ -18688,8 +18785,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-extra-large",
-      "scale": "mobile"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "extra-large",
+      "scale": "mobile",
+      "legacyKey": "table-section-header-row-height-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "60px",
@@ -18700,8 +18800,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-large",
-      "scale": "desktop"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "large",
+      "scale": "desktop",
+      "legacyKey": "table-section-header-row-height-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -18712,8 +18815,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-large",
-      "scale": "mobile"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "large",
+      "scale": "mobile",
+      "legacyKey": "table-section-header-row-height-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "50px",
@@ -18724,8 +18830,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-medium",
-      "scale": "desktop"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "medium",
+      "scale": "desktop",
+      "legacyKey": "table-section-header-row-height-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -18736,8 +18845,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-medium",
-      "scale": "mobile"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "medium",
+      "scale": "mobile",
+      "legacyKey": "table-section-header-row-height-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -18748,8 +18860,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-small",
-      "scale": "desktop"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "small",
+      "scale": "desktop",
+      "legacyKey": "table-section-header-row-height-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -18760,8 +18875,11 @@
   {
     "name": {
       "component": "table",
-      "property": "section-header-row-height-small",
-      "scale": "mobile"
+      "anatomy": "section-header",
+      "property": "row-height",
+      "size": "small",
+      "scale": "mobile",
+      "legacyKey": "table-section-header-row-height-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "30px",
@@ -20147,7 +20265,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "opacity-checkerboard-square-size"
+      "anatomy": "square",
+      "property": "opacity-checkerboard-size",
+      "legacyKey": "thumbnail-opacity-checkerboard-square-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -22051,7 +22171,11 @@
   {
     "name": {
       "component": "user-card",
-      "property": "minimum-height-title-below-extra-large"
+      "property": "minimum-height",
+      "anatomy": "title",
+      "position": "below",
+      "size": "extra-large",
+      "legacyKey": "user-card-minimum-height-title-below-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "263px",
@@ -22060,7 +22184,11 @@
   {
     "name": {
       "component": "user-card",
-      "property": "minimum-height-title-below-large"
+      "property": "minimum-height",
+      "anatomy": "title",
+      "position": "below",
+      "size": "large",
+      "legacyKey": "user-card-minimum-height-title-below-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "244px",
@@ -22069,7 +22197,11 @@
   {
     "name": {
       "component": "user-card",
-      "property": "minimum-height-title-below-medium"
+      "property": "minimum-height",
+      "anatomy": "title",
+      "position": "below",
+      "size": "medium",
+      "legacyKey": "user-card-minimum-height-title-below-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "224px",
@@ -22078,7 +22210,11 @@
   {
     "name": {
       "component": "user-card",
-      "property": "minimum-height-title-below-small"
+      "property": "minimum-height",
+      "anatomy": "title",
+      "position": "below",
+      "size": "small",
+      "legacyKey": "user-card-minimum-height-title-below-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "212px",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -285,7 +285,10 @@
   },
   {
     "name": {
-      "property": "base-gap-4x-large"
+      "structure": "base",
+      "property": "gap",
+      "size": "xxxxl",
+      "legacyKey": "base-gap-4x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -802,8 +805,11 @@
   },
   {
     "name": {
-      "property": "color-control-track-width",
-      "scale": "desktop"
+      "component": "color-control",
+      "anatomy": "track",
+      "property": "width",
+      "scale": "desktop",
+      "legacyKey": "color-control-track-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -813,8 +819,11 @@
   },
   {
     "name": {
-      "property": "color-control-track-width",
-      "scale": "mobile"
+      "component": "color-control",
+      "anatomy": "track",
+      "property": "width",
+      "scale": "mobile",
+      "legacyKey": "color-control-track-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "30px",
@@ -3286,7 +3295,9 @@
   },
   {
     "name": {
-      "property": "drop-target-dash-gap"
+      "structure": "drop-target",
+      "property": "dash-gap",
+      "legacyKey": "drop-target-dash-gap"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
@@ -5988,7 +5999,8 @@
   },
   {
     "name": {
-      "property": "text-underline-thickness"
+      "property": "text-underline-thickness",
+      "legacyKey": "text-underline-thickness"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -129,9 +129,12 @@
   },
   {
     "name": {
-      "property": "accent-subtle-background-color",
+      "colorRole": "accent",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "accent-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
@@ -141,9 +144,12 @@
   },
   {
     "name": {
-      "property": "accent-subtle-background-color",
+      "colorRole": "accent",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "accent-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ea67f054-1f42-427e-a768-beb8d21de2a3",
@@ -153,9 +159,12 @@
   },
   {
     "name": {
-      "property": "accent-subtle-background-color",
+      "colorRole": "accent",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "accent-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
@@ -338,9 +347,12 @@
   },
   {
     "name": {
-      "property": "informative-subtle-background-color",
+      "colorRole": "informative",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "informative-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
@@ -350,9 +362,12 @@
   },
   {
     "name": {
-      "property": "informative-subtle-background-color",
+      "colorRole": "informative",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "informative-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a",
@@ -362,9 +377,12 @@
   },
   {
     "name": {
-      "property": "informative-subtle-background-color",
+      "colorRole": "informative",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "informative-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
@@ -542,9 +560,12 @@
   },
   {
     "name": {
-      "property": "negative-subtle-background-color",
+      "colorRole": "negative",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "negative-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "14919f0c-a40f-48d1-adfd-55826de8e600",
@@ -554,9 +575,12 @@
   },
   {
     "name": {
-      "property": "negative-subtle-background-color",
+      "colorRole": "negative",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "negative-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
@@ -566,9 +590,12 @@
   },
   {
     "name": {
-      "property": "negative-subtle-background-color",
+      "colorRole": "negative",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "negative-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "14919f0c-a40f-48d1-adfd-55826de8e600",
@@ -706,9 +733,12 @@
   },
   {
     "name": {
-      "property": "notice-subtle-background-color",
+      "colorRole": "notice",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "notice-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
@@ -718,9 +748,12 @@
   },
   {
     "name": {
-      "property": "notice-subtle-background-color",
+      "colorRole": "notice",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "notice-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd",
@@ -730,9 +763,12 @@
   },
   {
     "name": {
-      "property": "notice-subtle-background-color",
+      "colorRole": "notice",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "notice-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
@@ -870,9 +906,12 @@
   },
   {
     "name": {
-      "property": "positive-subtle-background-color",
+      "colorRole": "positive",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "positive-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "00a2adcc-7b8a-4e94-97d2-51a647016265",
@@ -882,9 +921,12 @@
   },
   {
     "name": {
-      "property": "positive-subtle-background-color",
+      "colorRole": "positive",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "positive-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2c75e63f-e628-487d-a143-e03de065d5ee",
@@ -894,9 +936,12 @@
   },
   {
     "name": {
-      "property": "positive-subtle-background-color",
+      "colorRole": "positive",
+      "variant": "subtle",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "positive-subtle-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "00a2adcc-7b8a-4e94-97d2-51a647016265",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -2605,8 +2605,7 @@
   },
   {
     "name": {
-      "component": "heading",
-      "property": "cjk-size-xxxxl",
+      "property": "heading-cjk-size-xxxxl",
       "legacyKey": "heading-cjk-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3327,8 +3326,7 @@
   },
   {
     "name": {
-      "component": "heading",
-      "property": "size-xxxxl",
+      "property": "heading-size-xxxxl",
       "legacyKey": "heading-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -2605,7 +2605,9 @@
   },
   {
     "name": {
-      "property": "heading-cjk-size-xxxxl"
+      "component": "heading",
+      "property": "cjk-size-xxxxl",
+      "legacyKey": "heading-cjk-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "21c1f04f-3a63-4bf8-9f60-e9afa0e672a2",
@@ -3325,7 +3327,9 @@
   },
   {
     "name": {
-      "property": "heading-size-xxxxl"
+      "component": "heading",
+      "property": "size-xxxxl",
+      "legacyKey": "heading-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d59c0cd1-efb8-4f5b-9d5a-7ecbcd79f758",

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -456,6 +456,7 @@
   },
   "color-control-track-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "color-control",
     "uuid": "03a7d531-c294-4a41-bd51-38c77a20317e",
     "sets": {
       "desktop": {

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -465,6 +465,11 @@ const COMPONENTS_JSON: &str = r##"{
       "documentationUrl": "https://spectrum.adobe.com/page/color-area/"
     },
     {
+      "id": "color-control",
+      "label": "Color Control",
+      "description": "A cross-cutting anatomy sub-part shared by color-selection components (e.g. color slider, color wheel) rather than a standalone top-level component."
+    },
+    {
       "id": "color-handle",
       "label": "Color Handle",
       "documentationUrl": "https://spectrum.adobe.com/page/color-handle/"
@@ -1714,18 +1719,6 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "well",
       "label": "Well",
       "description": "Recessed background area within a component (e.g. card)",
-      "usedIn": ["tokens"]
-    },
-    {
-      "id": "layer",
-      "label": "Layer",
-      "description": "A stacked visual plane within a component",
-      "usedIn": ["tokens"]
-    },
-    {
-      "id": "underline",
-      "label": "Underline",
-      "description": "Underline decoration element beneath text",
       "usedIn": ["tokens"]
     }
   ]

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -861,6 +861,11 @@ const STRUCTURES_JSON: &str = r##"{
       "id": "drop-shadow",
       "label": "Drop Shadow",
       "description": "Elevated shadow effect applied to components and containers"
+    },
+    {
+      "id": "drop-target",
+      "label": "Drop Target",
+      "description": "Drag-and-drop destination structure"
     }
   ]
 }
@@ -1686,6 +1691,42 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "label": "In-field stepper",
       "description": "A stepper control embedded within a field element (e.g. number-field)",
       "usedIn": ["tokens"]
+    },
+    {
+      "id": "pagination",
+      "label": "Pagination",
+      "description": "Paged-navigation indicator element (e.g. coach-mark step dots)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "slash",
+      "label": "Slash",
+      "description": "Diagonal line element indicating an unavailable or crossed-out state (e.g. swatch)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "square",
+      "label": "Square",
+      "description": "Square-shaped anatomy element (e.g. checkerboard tile)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "well",
+      "label": "Well",
+      "description": "Recessed background area within a component (e.g. card)",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "layer",
+      "label": "Layer",
+      "description": "A stacked visual plane within a component",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "underline",
+      "label": "Underline",
+      "description": "Underline decoration element beneath text",
+      "usedIn": ["tokens"]
     }
   ]
 }
@@ -2048,6 +2089,21 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "y",
       "label": "Y",
       "description": "Vertical offset (e.g. drop-shadow y offset)"
+    },
+    {
+      "id": "minimum",
+      "label": "Minimum",
+      "description": "Lower-bound constraint modifier (design-system abstraction; distinct from the compound minimum-width/minimum-height terms)"
+    },
+    {
+      "id": "minimum-padding-vertical",
+      "label": "Minimum Vertical Padding",
+      "description": "Lower-bound constraint on internal vertical (top/bottom) spacing"
+    },
+    {
+      "id": "component-size-minimum-perspective",
+      "label": "Component Size Minimum Perspective",
+      "description": "Lower-bound constraint on a component's 3D perspective sizing (design-system abstraction)"
     }
   ]
 }
@@ -2119,6 +2175,24 @@ const POSITIONS_JSON: &str = r##"{
       "id": "bottom-edge",
       "label": "Bottom edge",
       "description": "Outer boundary at the bottom"
+    },
+    {
+      "id": "inner",
+      "label": "Inner",
+      "description": "Interior-facing side of an element",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "outer",
+      "label": "Outer",
+      "description": "Exterior-facing side of an element",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "below",
+      "label": "Below",
+      "description": "Positioned underneath a reference element",
+      "usedIn": ["tokens"]
     }
   ]
 }
@@ -2191,6 +2265,13 @@ const SIZES_JSON: &str = r##"{
       "aliases": ["3x-large"],
       "tokenName": "3x-large",
       "usedIn": ["tokens", "component-options", "component-schemas"]
+    },
+    {
+      "id": "xxxxl",
+      "label": "4X Large",
+      "aliases": ["4x-large"],
+      "tokenName": "4x-large",
+      "usedIn": ["tokens"]
     }
   ]
 }
@@ -2222,6 +2303,11 @@ const SHAPES_JSON: &str = r##"{
       "id": "uniform",
       "label": "Uniform",
       "description": "Equal proportions (e.g., 1:1 ratio between horizontal and vertical padding)"
+    },
+    {
+      "id": "rectangle",
+      "label": "Rectangle",
+      "description": "Rectangular (non-uniform) proportions"
     }
   ]
 }
@@ -2425,6 +2511,36 @@ const COLOR_ROLES_JSON: &str = r##"{
       "id": "background",
       "label": "Background",
       "description": "Background color role — fill or surface color behind an element"
+    },
+    {
+      "id": "neutral",
+      "label": "Neutral",
+      "description": "Neutral semantic color role, distinct from a specific hue"
+    },
+    {
+      "id": "accent",
+      "label": "Accent",
+      "description": "Accent semantic color role"
+    },
+    {
+      "id": "informative",
+      "label": "Informative",
+      "description": "Informative semantic color role"
+    },
+    {
+      "id": "negative",
+      "label": "Negative",
+      "description": "Negative/destructive semantic color role"
+    },
+    {
+      "id": "notice",
+      "label": "Notice",
+      "description": "Notice/attention semantic color role"
+    },
+    {
+      "id": "positive",
+      "label": "Positive",
+      "description": "Positive/affirmative semantic color role"
     }
   ]
 }
@@ -2767,6 +2883,49 @@ const ALIGNMENTS_JSON: &str = r##"{
   ]
 }
 "##;
+const QUALIFIERS_JSON: &str = r##"{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "qualifier",
+  "description": "Behavioral or layout modifier that narrows a property/anatomy without being a state, variant, or position.",
+  "values": [
+    {
+      "id": "stacked",
+      "label": "Stacked",
+      "description": "Layout arranged in a stacked (vertical) configuration"
+    },
+    {
+      "id": "multiline",
+      "label": "Multiline",
+      "description": "Content spanning more than one line"
+    },
+    {
+      "id": "precision",
+      "label": "Precision",
+      "description": "Fine-grained/precision interaction mode"
+    },
+    {
+      "id": "collapsed",
+      "label": "Collapsed",
+      "description": "Contracted/minimized display configuration"
+    },
+    {
+      "id": "expanded",
+      "label": "Expanded",
+      "description": "Extended/enlarged display configuration"
+    },
+    {
+      "id": "drag",
+      "label": "Drag",
+      "description": "Drag interaction modifier"
+    },
+    {
+      "id": "highlight",
+      "label": "Highlight",
+      "description": "Emphasized highlight treatment"
+    }
+  ]
+}
+"##;
 const ICON_TERMS_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "icon",
@@ -2915,7 +3074,7 @@ const CATEGORIES_JSON: &str = r##"{
 }
 "##;
 
-pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "family", "emphasis", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "weight", "style", "motionRole", "easing", "alignment", "icon"];
+pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "family", "emphasis", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "weight", "style", "motionRole", "easing", "alignment", "qualifier", "icon"];
 
 pub(crate) fn build_registry_map(
 ) -> std::collections::HashMap<String, std::collections::HashSet<String>> {
@@ -2942,6 +3101,7 @@ pub(crate) fn build_registry_map(
     map.insert("motionRole".to_string(), parse_registry(MOTION_ROLES_JSON));
     map.insert("easing".to_string(), parse_registry(EASING_CURVES_JSON));
     map.insert("alignment".to_string(), parse_registry(ALIGNMENTS_JSON));
+    map.insert("qualifier".to_string(), parse_registry(QUALIFIERS_JSON));
     map.insert("icon".to_string(), parse_registry(ICON_TERMS_JSON));
     map.insert("categories".to_string(), parse_registry(CATEGORIES_JSON));
     map
@@ -2972,6 +3132,7 @@ pub(crate) fn build_token_name_map(
     map.insert("motionRole".to_string(), parse_token_name_map(MOTION_ROLES_JSON));
     map.insert("easing".to_string(), parse_token_name_map(EASING_CURVES_JSON));
     map.insert("alignment".to_string(), parse_token_name_map(ALIGNMENTS_JSON));
+    map.insert("qualifier".to_string(), parse_token_name_map(QUALIFIERS_JSON));
     map.insert("icon".to_string(), parse_token_name_map(ICON_TERMS_JSON));
     map
 }
@@ -3005,6 +3166,7 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "from", position: 24, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "to", position: 25, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "alignment", position: 26, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "qualifier", position: 27, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "scaleIndex", position: 99, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "icon", position: 100, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
     ]

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -45,6 +45,8 @@ const COMPOUND_PROPERTIES = [
   "border-width",
   "minimum-width",
   "minimum-height",
+  "minimum-padding-vertical",
+  "component-size-minimum-perspective",
   "maximum-width",
   "maximum-height",
   "underline-gap",
@@ -59,8 +61,6 @@ const KNOWN_GAP_TERMS = {
   // Variant qualifiers — subtle, subdued, and static are now in the variant registry.
   // Only "non" remains unregistered (used as a negation prefix, not a standalone variant).
   "variant-qualifier": ["non"],
-  // Spatial qualifiers
-  "spatial-qualifier": ["inner", "outer"],
 };
 
 /**


### PR DESCRIPTION
## Description

Registers the color/layout/qualifier vocabulary residual from proposal 006 into
the design-data registries, and migrates the ~110 affected tokens into
structured name-object fields (mirroring the dsi.1 drop-shadow decomposition
pattern from commit `84c3f09d`).

- New `qualifier` name-object field (`packages/design-data/fields/qualifier.json`,
  `registry/qualifiers.json`): `stacked`, `multiline`, `precision`, `collapsed`,
  `expanded`, `drag`, `highlight`.
- Additive registrations across `variants.json`, `positions.json`,
  `anatomy-terms.json`, `sizes.json`, `property-terms.json`, `shapes.json`,
  `structures.json`.
- `token.schema.json` lists `qualifier` explicitly.
- Migrated tokens in `color-aliases`, `semantic-color-palette`,
  `color-component`, `layout-component`, `layout`, `typography` `.tokens.json`,
  with `name.legacyKey` pinned on every touched token so published legacy keys
  are unchanged.
- `token-mapping-analyzer/src/decomposer.js`: registered two compound property
  terms, dropped `inner`/`outer` from `KNOWN_GAP_TERMS` (now real `position`
  values).

Also fixed 3 SPEC-025 (`anatomy-requires-component`) violations surfaced during
migration by folding those segments back into the fused `property` string
instead of extracting an `anatomy` field with no `component`.

## Related Issue

Closes spectrum-design-data-dsi.2.5 (child of dsi.2, proposal 006).

## Motivation and Context

Phase D residual triage: the token-mapping-analyzer flagged ~110 tokens where
a meaningful segment (`subtle`, `inner`, `below`, `pagination`, `stacked`,
etc.) was fused inside the flat `property` string with no dedicated
registry-backed field, so it matched no vocabulary. This registers the terms
and moves the tokens into structured fields without changing any published
legacy key.

## How Has This Been Tested?

- `moon run sdk:codegen` / `sdk:codegen-check` — Rust registry data in sync.
- `moon run sdk:build` — passes.
- `moon run design-data:roundtrip-verify` — Roundtrip OK (run before/after the
  SPEC-025 fixes; pinned `legacyKey`s reproduce the committed
  `packages/tokens/src` output).
- `moon run design-data:validate` (full validate, not just `validate-dataset`) —
  passes after fixing the 3 SPEC-025 violations.
- `moon run token-mapping-analyzer:analyze` — confirms the residual dropped;
  remaining unmatched-segment noise is pre-existing tool behavior unrelated to
  this batch.
- `moon run :test` — 29 tasks completed, 0 failures (Node/AVA + Rust
  `cargo test --workspace`, including doc-tests).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
