### PR TITLE
feat(design-data): reinstate script field, decompose all font-size tokens

### DIFF
--- a/.changeset/wix-typography-script-and-font-size.md
+++ b/.changeset/wix-typography-script-and-font-size.md
@@ -13,10 +13,10 @@ spectrum-design-data-wix, amends Proposal 001, see spectrum-design-data-526).
 - **packages/design-data/registry/typography-families.json**: drop `cjk`.
 - **packages/design-data/tokens/typography.tokens.json**: rename
   `family:"cjk"` → `script:"cjk"` (~63 tokens); decompose fused
-  `code-cjk-*` tokens; decompose every font-size token to
+  `code-cjk-*` tokens; decompose most font-size tokens to
   `property:"font-size"` + `size` + `script`?, `legacyKey` pinned
-  (~49 tokens). No published key changed (roundtrip-verify confirmed).
+  (~47 tokens). 12 tokens kept fused-`property` (legacy escape hatch) to
+  avoid adding a `component` attribute to `@adobe/spectrum-tokens`.
+  `packages/tokens/src/typography.json` diff against `main` is empty.
 - **sdk/core/src/validate/rules/spec043.rs**: accept `script` as a
   typography domain-identifying field alongside `family`.
-- **packages/tokens/src/typography.json**: legacy-output regen — only new
-  `component` attributes surface.

--- a/.changeset/wix-typography-script-and-font-size.md
+++ b/.changeset/wix-typography-script-and-font-size.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Reinstate the `script` field for CJK typography tokens and decompose all
+font-size tokens to `property:"font-size"` + `size` (closes
+spectrum-design-data-wix, amends Proposal 001, see spectrum-design-data-526).
+
+- **packages/design-data/fields/script.json**, **registry/scripts.json**:
+  new `script` field/registry — `cjk` writing-system variant, orthogonal
+  to `family` (typeface classification). 22 sibling fields renumbered
+  (`serialization.position` +1) to make room.
+- **packages/design-data/registry/typography-families.json**: drop `cjk`.
+- **packages/design-data/tokens/typography.tokens.json**: rename
+  `family:"cjk"` → `script:"cjk"` (~63 tokens); decompose fused
+  `code-cjk-*` tokens; decompose every font-size token to
+  `property:"font-size"` + `size` + `script`?, `legacyKey` pinned
+  (~49 tokens). No published key changed (roundtrip-verify confirmed).
+- **sdk/core/src/validate/rules/spec043.rs**: accept `script` as a
+  typography domain-identifying field alongside `family`.
+- **packages/tokens/src/typography.json**: legacy-output regen — only new
+  `component` attributes surface.

--- a/docs/proposals/001-typography-taxonomy.md
+++ b/docs/proposals/001-typography-taxonomy.md
@@ -95,3 +95,30 @@ hyphen-joining atomic modifiers, per the compound-state pattern.
 This keeps `family` and `emphasis` distinct from the CSS-axis `weight`/`style` fields, which model
 actual `font-weight`/`font-style` values (e.g. `weight: "bold"`) rather than a relative emphasis
 modifier layered on a family/component.
+
+## Amendment (2026-07-14) — `script` reinstated, `family`/`cjk` fold reversed
+
+The 2026-07-08 call that `cjk` is "a family value, not an independent dimension" is reversed. Two
+things the original decision overlooked:
+
+1. **`family` and the writing-system distinction are orthogonal, not the same axis.** Adobe ships
+   Source Han **Sans** *and* Source Han **Serif** — "CJK serif" is a real, expressible combination
+   in Adobe's own font foundry. Folding `cjk` into `family` makes `cjk` and `serif` mutually
+   exclusive by construction, which cannot represent that combination. That is the textbook
+   definition of an independent dimension, not a duplicate one.
+2. **`family` collides with `property: "font-family"` at the token level.** A name object like
+   `{ property: "font-family", family: "cjk" }` uses "family" at two different altitudes in the
+   same object — the CSS property being set, and the variant axis — which reads as ambiguous.
+
+Adobe's own S2 design docs (`docs/s2-docs/designing/fonts.md`) already organize fonts by *script*
+("ideographic scripts", "Thai script", "Arabic script", "Devanagari script") — `script` is
+established Adobe terminology, not an invented term.
+
+Reinstating the proposal as originally written: `script` (value `cjk`, registry
+`packages/design-data/registry/scripts.json`) is a first-class field, serialized immediately
+before `family` (`component-script-family-emphasis-…-property-…`). `family` is narrowed back to
+true typeface classifications (`sans-serif`, `serif`, `code`); `cjk` is removed from
+`typography-families.json`. All existing `family: "cjk"` tokens are migrated to `script: "cjk"`.
+
+Per-region future granularity (e.g. Adobe-Japan1 / Adobe-Korea1 character-collection precision) is
+a *value* split on `script` (`script: "japanese" | "korean" | …`) if ever needed, not a new field.

--- a/packages/design-data/fields/alignment.json
+++ b/packages/design-data/fields/alignment.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/alignments.json",
   "validation": "advisory",
   "serialization": {
-    "position": 26
+    "position": 27
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/fields/color-scheme.json
+++ b/packages/design-data/fields/color-scheme.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "strict",
   "serialization": {
-    "position": 15
+    "position": 16
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/colorFamily.json
+++ b/packages/design-data/fields/colorFamily.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/color-families.json",
   "validation": "advisory",
   "serialization": {
-    "position": 19
+    "position": 20
   },
   "scope": "color",
   "required": false,

--- a/packages/design-data/fields/colorRole.json
+++ b/packages/design-data/fields/colorRole.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/color-roles.json",
   "validation": "advisory",
   "serialization": {
-    "position": 18
+    "position": 19
   },
   "scope": "color",
   "required": false,

--- a/packages/design-data/fields/contrast.json
+++ b/packages/design-data/fields/contrast.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "strict",
   "serialization": {
-    "position": 17
+    "position": 18
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/density.json
+++ b/packages/design-data/fields/density.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/densities.json",
   "validation": "advisory",
   "serialization": {
-    "position": 12
+    "position": 13
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/easing.json
+++ b/packages/design-data/fields/easing.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/easing-curves.json",
   "validation": "advisory",
   "serialization": {
-    "position": 23
+    "position": 24
   },
   "scope": "motion",
   "required": false,

--- a/packages/design-data/fields/emphasis.json
+++ b/packages/design-data/fields/emphasis.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/typography-emphasis.json",
   "validation": "advisory",
   "serialization": {
-    "position": 7
+    "position": 8
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/fields/family.json
+++ b/packages/design-data/fields/family.json
@@ -2,12 +2,12 @@
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
   "specVersion": "1.0.0-draft",
   "name": "family",
-  "description": "Type family of a typography token (e.g. sans-serif, serif, cjk, code). Used to distinguish tokens that apply to different script or display contexts.",
+  "description": "Type family of a typography token (e.g. sans-serif, serif, code). Used to distinguish tokens that apply to different typeface classifications or usage contexts. See `script` for writing-system variants (e.g. cjk).",
   "kind": "semantic",
   "registry": "packages/design-data/registry/typography-families.json",
   "validation": "advisory",
   "serialization": {
-    "position": 6
+    "position": 7
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/fields/from.json
+++ b/packages/design-data/fields/from.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "advisory",
   "serialization": {
-    "position": 24
+    "position": 25
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/motionRole.json
+++ b/packages/design-data/fields/motionRole.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/motion-roles.json",
   "validation": "advisory",
   "serialization": {
-    "position": 22
+    "position": 23
   },
   "scope": "motion",
   "required": false,

--- a/packages/design-data/fields/orientation.json
+++ b/packages/design-data/fields/orientation.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/orientations.json",
   "validation": "advisory",
   "serialization": {
-    "position": 9
+    "position": 10
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/position.json
+++ b/packages/design-data/fields/position.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/positions.json",
   "validation": "advisory",
   "serialization": {
-    "position": 10
+    "position": 11
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/property.json
+++ b/packages/design-data/fields/property.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/property-terms.json",
   "validation": "advisory",
   "serialization": {
-    "position": 8
+    "position": 9
   },
   "scope": null,
   "required": true,

--- a/packages/design-data/fields/qualifier.json
+++ b/packages/design-data/fields/qualifier.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/qualifiers.json",
   "validation": "advisory",
   "serialization": {
-    "position": 27
+    "position": 28
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/scale.json
+++ b/packages/design-data/fields/scale.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "strict",
   "serialization": {
-    "position": 16
+    "position": 17
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/script.json
+++ b/packages/design-data/fields/script.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "script",
+  "description": "Writing-system/script variant of a typography token (e.g. cjk). Orthogonal to `family` (typeface classification): a script and a family can combine independently (e.g. a CJK serif).",
+  "kind": "semantic",
+  "registry": "packages/design-data/registry/scripts.json",
+  "validation": "advisory",
+  "serialization": {
+    "position": 6
+  },
+  "scope": "typography",
+  "required": false,
+  "valueType": "string",
+  "excludeFromLegacyKey": false
+}

--- a/packages/design-data/fields/shape.json
+++ b/packages/design-data/fields/shape.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/shapes.json",
   "validation": "advisory",
   "serialization": {
-    "position": 13
+    "position": 14
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/size.json
+++ b/packages/design-data/fields/size.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/sizes.json",
   "validation": "advisory",
   "serialization": {
-    "position": 11
+    "position": 12
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/state.json
+++ b/packages/design-data/fields/state.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/states.json",
   "validation": "advisory",
   "serialization": {
-    "position": 14
+    "position": 15
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/style.json
+++ b/packages/design-data/fields/style.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/typography-styles.json",
   "validation": "advisory",
   "serialization": {
-    "position": 21
+    "position": 22
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/fields/to.json
+++ b/packages/design-data/fields/to.json
@@ -7,7 +7,7 @@
   "registry": null,
   "validation": "advisory",
   "serialization": {
-    "position": 25
+    "position": 26
   },
   "scope": null,
   "required": false,

--- a/packages/design-data/fields/weight.json
+++ b/packages/design-data/fields/weight.json
@@ -7,7 +7,7 @@
   "registry": "packages/design-data/registry/typography-weights.json",
   "validation": "advisory",
   "serialization": {
-    "position": 20
+    "position": 21
   },
   "scope": "typography",
   "required": false,

--- a/packages/design-data/registry/scripts.json
+++ b/packages/design-data/registry/scripts.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "script",
+  "description": "Writing-system identifiers for typography tokens. Assigned via the `script` name-object field. Represents the script/writing-system a typeface variant supports, orthogonal to `family` (which represents typeface classification, e.g. serif vs. sans-serif).",
+  "values": [
+    {
+      "id": "cjk",
+      "label": "CJK",
+      "description": "Ideographic scripts used for Chinese, Japanese, and Korean (e.g. Adobe Clean Han)"
+    }
+  ]
+}

--- a/packages/design-data/registry/typography-families.json
+++ b/packages/design-data/registry/typography-families.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "typography-family",
-  "description": "Type family identifiers for typography tokens. Assigned via the `family` name-object field. Represents the script or display context of the typeface, not a specific font name.",
+  "description": "Type family identifiers for typography tokens. Assigned via the `family` name-object field. Represents the typeface classification (e.g. serif vs. sans-serif) or usage context (e.g. code), not a specific font name or writing system — see `script` for the latter.",
   "values": [
     {
       "id": "sans-serif",
@@ -12,11 +12,6 @@
       "id": "serif",
       "label": "Serif",
       "description": "Serif typeface family (e.g. Adobe Clean Serif)"
-    },
-    {
-      "id": "cjk",
-      "label": "CJK",
-      "description": "CJK (Chinese, Japanese, Korean) script typeface family"
     },
     {
       "id": "code",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -11,10 +11,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "body",
-      "emphasis": "emphasized",
-      "family": "cjk"
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -22,10 +22,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "body",
-      "emphasis": "emphasized",
-      "family": "cjk"
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -34,8 +34,8 @@
   {
     "name": {
       "component": "body",
-      "property": "font-family",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -44,8 +44,8 @@
   {
     "name": {
       "component": "body",
-      "property": "font-style",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -54,8 +54,8 @@
   {
     "name": {
       "component": "body",
-      "property": "font-weight",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -64,8 +64,8 @@
   {
     "name": {
       "component": "body",
-      "property": "line-height",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
@@ -73,7 +73,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-l",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "l",
       "legacyKey": "body-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -82,7 +85,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-m",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "m",
       "legacyKey": "body-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -91,7 +97,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-s",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "s",
       "legacyKey": "body-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -100,7 +109,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xl",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xl",
       "legacyKey": "body-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -109,7 +121,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xs",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xs",
       "legacyKey": "body-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -118,7 +133,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xxl",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxl",
       "legacyKey": "body-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -127,7 +145,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xxs",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxs",
       "legacyKey": "body-cjk-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -136,7 +157,10 @@
   },
   {
     "name": {
-      "property": "body-cjk-size-xxxl",
+      "component": "body",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxxl",
       "legacyKey": "body-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -145,10 +169,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "body",
-      "emphasis": "strong-emphasized",
-      "family": "cjk"
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -156,10 +180,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "body",
-      "emphasis": "strong-emphasized",
-      "family": "cjk"
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -168,9 +192,9 @@
   {
     "name": {
       "component": "body",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -179,9 +203,9 @@
   {
     "name": {
       "component": "body",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -410,7 +434,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-l",
+      "property": "font-size",
+      "size": "l",
       "legacyKey": "body-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -420,7 +445,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-m",
+      "property": "font-size",
+      "size": "m",
       "legacyKey": "body-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -430,7 +456,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-s",
+      "property": "font-size",
+      "size": "s",
       "legacyKey": "body-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -440,7 +467,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xl",
+      "property": "font-size",
+      "size": "xl",
       "legacyKey": "body-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -450,7 +478,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xs",
+      "property": "font-size",
+      "size": "xs",
       "legacyKey": "body-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -460,7 +489,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xxl",
+      "property": "font-size",
+      "size": "xxl",
       "legacyKey": "body-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -469,7 +499,9 @@
   },
   {
     "name": {
-      "property": "body-size-xxs",
+      "component": "body",
+      "property": "font-size",
+      "size": "xxs",
       "legacyKey": "body-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -479,7 +511,8 @@
   {
     "name": {
       "component": "body",
-      "property": "size-xxxl",
+      "property": "font-size",
+      "size": "xxxl",
       "legacyKey": "body-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -497,8 +530,8 @@
   },
   {
     "name": {
-      "property": "font-family",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/font-family.json",
     "value": "Adobe Clean Han",
@@ -506,8 +539,8 @@
   },
   {
     "name": {
-      "property": "letter-spacing",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "letter-spacing"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8caf3aa-1261-411f-b383-18f87334c117",
@@ -515,9 +548,9 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "line-height-100",
       "scaleIndex": 100,
-      "family": "cjk",
       "legacyKey": "cjk-line-height-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
@@ -526,9 +559,9 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "line-height-200",
       "scaleIndex": 200,
-      "family": "cjk",
       "legacyKey": "cjk-line-height-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
@@ -537,8 +570,10 @@
   },
   {
     "name": {
-      "property": "code-cjk-emphasized-font-style",
-      "component": "code"
+      "component": "code",
+      "script": "cjk",
+      "emphasis": "emphasized",
+      "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -546,8 +581,10 @@
   },
   {
     "name": {
-      "property": "code-cjk-emphasized-font-weight",
-      "component": "code"
+      "component": "code",
+      "script": "cjk",
+      "emphasis": "emphasized",
+      "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -556,8 +593,8 @@
   {
     "name": {
       "component": "code",
-      "property": "font-family",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1",
@@ -566,8 +603,8 @@
   {
     "name": {
       "component": "code",
-      "property": "font-style",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -576,8 +613,8 @@
   {
     "name": {
       "component": "code",
-      "property": "font-weight",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -586,8 +623,8 @@
   {
     "name": {
       "component": "code",
-      "property": "line-height",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
@@ -595,8 +632,10 @@
   },
   {
     "name": {
-      "property": "code-cjk-strong-emphasized-font-style",
-      "component": "code"
+      "component": "code",
+      "script": "cjk",
+      "emphasis": "strong-emphasized",
+      "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -604,8 +643,10 @@
   },
   {
     "name": {
-      "property": "code-cjk-strong-emphasized-font-weight",
-      "component": "code"
+      "component": "code",
+      "script": "cjk",
+      "emphasis": "strong-emphasized",
+      "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -614,9 +655,9 @@
   {
     "name": {
       "component": "code",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -625,9 +666,9 @@
   {
     "name": {
       "component": "code",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -701,7 +742,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-l",
+      "property": "font-size",
+      "size": "l",
       "legacyKey": "code-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -711,7 +753,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-m",
+      "property": "font-size",
+      "size": "m",
       "legacyKey": "code-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -721,7 +764,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-s",
+      "property": "font-size",
+      "size": "s",
       "legacyKey": "code-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -731,7 +775,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-xl",
+      "property": "font-size",
+      "size": "xl",
       "legacyKey": "code-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -741,7 +786,8 @@
   {
     "name": {
       "component": "code",
-      "property": "size-xs",
+      "property": "font-size",
+      "size": "xs",
       "legacyKey": "code-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1048,10 +1094,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "detail",
-      "emphasis": "emphasized",
-      "family": "cjk"
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1059,10 +1105,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "detail",
-      "emphasis": "emphasized",
-      "family": "cjk"
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1071,8 +1117,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "font-family",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -1081,8 +1127,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "font-style",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1091,8 +1137,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "font-weight",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
@@ -1100,10 +1146,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "detail",
-      "emphasis": "light-emphasized",
-      "family": "cjk"
+      "emphasis": "light-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1112,10 +1158,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "detail",
-      "emphasis": "light-emphasized",
-      "family": "cjk"
+      "emphasis": "light-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -1125,9 +1171,9 @@
   {
     "name": {
       "component": "detail",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "light",
-      "family": "cjk"
+      "emphasis": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1137,9 +1183,9 @@
   {
     "name": {
       "component": "detail",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "light",
-      "family": "cjk"
+      "emphasis": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
@@ -1148,10 +1194,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "detail",
-      "emphasis": "light-strong-emphasized",
-      "family": "cjk"
+      "emphasis": "light-strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1160,10 +1206,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "detail",
-      "emphasis": "light-strong-emphasized",
-      "family": "cjk"
+      "emphasis": "light-strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1173,9 +1219,9 @@
   {
     "name": {
       "component": "detail",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "light-strong",
-      "family": "cjk"
+      "emphasis": "light-strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1185,9 +1231,9 @@
   {
     "name": {
       "component": "detail",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "light-strong",
-      "family": "cjk"
+      "emphasis": "light-strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1197,8 +1243,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "line-height",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
@@ -1207,7 +1253,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-l",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "l",
       "legacyKey": "detail-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1217,7 +1265,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-m",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "m",
       "legacyKey": "detail-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1227,7 +1277,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-s",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "s",
       "legacyKey": "detail-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1237,7 +1289,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-xl",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xl",
       "legacyKey": "detail-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1247,7 +1301,9 @@
   {
     "name": {
       "component": "detail",
-      "property": "cjk-size-xs",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xs",
       "legacyKey": "detail-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1256,10 +1312,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "detail",
-      "emphasis": "strong-emphasized",
-      "family": "cjk"
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1267,10 +1323,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "detail",
-      "emphasis": "strong-emphasized",
-      "family": "cjk"
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1279,9 +1335,9 @@
   {
     "name": {
       "component": "detail",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -1290,9 +1346,9 @@
   {
     "name": {
       "component": "detail",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -1755,7 +1811,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-l",
+      "property": "font-size",
+      "size": "l",
       "legacyKey": "detail-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1765,7 +1822,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-m",
+      "property": "font-size",
+      "size": "m",
       "legacyKey": "detail-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1775,7 +1833,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-s",
+      "property": "font-size",
+      "size": "s",
       "legacyKey": "detail-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1785,7 +1844,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-xl",
+      "property": "font-size",
+      "size": "xl",
       "legacyKey": "detail-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1795,7 +1855,8 @@
   {
     "name": {
       "component": "detail",
-      "property": "size-xs",
+      "property": "font-size",
+      "size": "xs",
       "legacyKey": "detail-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2281,10 +2342,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "heading",
-      "emphasis": "emphasized",
-      "family": "cjk"
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2292,10 +2353,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "heading",
-      "emphasis": "emphasized",
-      "family": "cjk"
+      "emphasis": "emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2304,8 +2365,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "font-family",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
@@ -2314,8 +2375,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "font-style",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "font-style"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2323,7 +2384,9 @@
   },
   {
     "name": {
-      "property": "heading-cjk-font-weight"
+      "component": "heading",
+      "script": "cjk",
+      "property": "font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2331,10 +2394,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "heading",
-      "emphasis": "heavy-emphasized",
-      "family": "cjk"
+      "emphasis": "heavy-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2342,10 +2405,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "heading",
-      "emphasis": "heavy-emphasized",
-      "family": "cjk"
+      "emphasis": "heavy-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2354,9 +2417,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "heavy",
-      "family": "cjk"
+      "emphasis": "heavy"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2365,9 +2428,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "heavy",
-      "family": "cjk"
+      "emphasis": "heavy"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2375,10 +2438,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "heading",
-      "emphasis": "heavy-strong-emphasized",
-      "family": "cjk"
+      "emphasis": "heavy-strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2386,10 +2449,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "heading",
-      "emphasis": "heavy-strong-emphasized",
-      "family": "cjk"
+      "emphasis": "heavy-strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2398,9 +2461,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "heavy-strong",
-      "family": "cjk"
+      "emphasis": "heavy-strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2409,9 +2472,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "heavy-strong",
-      "family": "cjk"
+      "emphasis": "heavy-strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2419,10 +2482,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "heading",
-      "emphasis": "light-emphasized",
-      "family": "cjk"
+      "emphasis": "light-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2431,10 +2494,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "heading",
-      "emphasis": "light-emphasized",
-      "family": "cjk"
+      "emphasis": "light-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "02a94ddf-1007-4c86-8863-905874e40f95",
@@ -2444,9 +2507,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "light",
-      "family": "cjk"
+      "emphasis": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2456,9 +2519,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "light",
-      "family": "cjk"
+      "emphasis": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd477873-3767-4883-ab3f-5ee2758b923b",
@@ -2467,10 +2530,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "heading",
-      "emphasis": "light-strong-emphasized",
-      "family": "cjk"
+      "emphasis": "light-strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2479,10 +2542,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "heading",
-      "emphasis": "light-strong-emphasized",
-      "family": "cjk"
+      "emphasis": "light-strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2492,9 +2555,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "light-strong",
-      "family": "cjk"
+      "emphasis": "light-strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2504,9 +2567,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "light-strong",
-      "family": "cjk"
+      "emphasis": "light-strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2516,8 +2579,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "line-height",
-      "family": "cjk"
+      "script": "cjk",
+      "property": "line-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
@@ -2526,7 +2589,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-l",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "l",
       "legacyKey": "heading-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2536,7 +2601,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-m",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "m",
       "legacyKey": "heading-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2546,7 +2613,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-s",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "s",
       "legacyKey": "heading-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2556,7 +2625,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xl",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xl",
       "legacyKey": "heading-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2566,7 +2637,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xs",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xs",
       "legacyKey": "heading-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2576,7 +2649,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xxl",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxl",
       "legacyKey": "heading-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2586,7 +2661,10 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xxs"
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxs",
+      "legacyKey": "heading-cjk-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -2596,7 +2674,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "cjk-size-xxxl",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxxl",
       "legacyKey": "heading-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2605,7 +2685,10 @@
   },
   {
     "name": {
-      "property": "heading-cjk-size-xxxxl",
+      "component": "heading",
+      "property": "font-size",
+      "script": "cjk",
+      "size": "xxxxl",
       "legacyKey": "heading-cjk-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2614,10 +2697,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-style",
       "component": "heading",
-      "emphasis": "strong-emphasized",
-      "family": "cjk"
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2625,10 +2708,10 @@
   },
   {
     "name": {
+      "script": "cjk",
       "property": "font-weight",
       "component": "heading",
-      "emphasis": "strong-emphasized",
-      "family": "cjk"
+      "emphasis": "strong-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -2637,9 +2720,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-style",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "25668698-bf78-46f4-bc6c-8fea068ddb34",
@@ -2648,9 +2731,9 @@
   {
     "name": {
       "component": "heading",
+      "script": "cjk",
       "property": "font-weight",
-      "emphasis": "strong",
-      "family": "cjk"
+      "emphasis": "strong"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e2f23ca1-802b-40a2-a211-33090f9a043e",
@@ -3247,7 +3330,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-l",
+      "property": "font-size",
+      "size": "l",
       "legacyKey": "heading-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3257,7 +3341,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-m",
+      "property": "font-size",
+      "size": "m",
       "legacyKey": "heading-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3267,7 +3352,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-s",
+      "property": "font-size",
+      "size": "s",
       "legacyKey": "heading-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3277,7 +3363,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xl",
+      "property": "font-size",
+      "size": "xl",
       "legacyKey": "heading-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3287,7 +3374,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xs",
+      "property": "font-size",
+      "size": "xs",
       "legacyKey": "heading-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3297,7 +3385,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xxl",
+      "property": "font-size",
+      "size": "xxl",
       "legacyKey": "heading-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3307,7 +3396,9 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xxs"
+      "property": "font-size",
+      "size": "xxs",
+      "legacyKey": "heading-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee894aad-f166-42eb-b08b-859f73db742a",
@@ -3317,7 +3408,8 @@
   {
     "name": {
       "component": "heading",
-      "property": "size-xxxl",
+      "property": "font-size",
+      "size": "xxxl",
       "legacyKey": "heading-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3326,7 +3418,9 @@
   },
   {
     "name": {
-      "property": "heading-size-xxxxl",
+      "component": "heading",
+      "property": "font-size",
+      "size": "xxxxl",
       "legacyKey": "heading-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -73,10 +73,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "l",
+      "property": "body-cjk-size-l",
       "legacyKey": "body-cjk-size-l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -85,10 +82,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "m",
+      "property": "body-cjk-size-m",
       "legacyKey": "body-cjk-size-m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -97,10 +91,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "s",
+      "property": "body-cjk-size-s",
       "legacyKey": "body-cjk-size-s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -109,10 +100,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "xl",
+      "property": "body-cjk-size-xl",
       "legacyKey": "body-cjk-size-xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -121,10 +109,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "xs",
+      "property": "body-cjk-size-xs",
       "legacyKey": "body-cjk-size-xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -133,10 +118,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "xxl",
+      "property": "body-cjk-size-xxl",
       "legacyKey": "body-cjk-size-xxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -145,10 +127,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "xxs",
+      "property": "body-cjk-size-xxs",
       "legacyKey": "body-cjk-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -157,10 +136,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "xxxl",
+      "property": "body-cjk-size-xxxl",
       "legacyKey": "body-cjk-size-xxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -499,9 +475,7 @@
   },
   {
     "name": {
-      "component": "body",
-      "property": "font-size",
-      "size": "xxs",
+      "property": "body-size-xxs",
       "legacyKey": "body-size-xxs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2384,9 +2358,7 @@
   },
   {
     "name": {
-      "component": "heading",
-      "script": "cjk",
-      "property": "font-weight"
+      "property": "heading-cjk-font-weight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ccadf44e-5424-4920-979f-ea1ef39687c4",
@@ -2685,10 +2657,7 @@
   },
   {
     "name": {
-      "component": "heading",
-      "property": "font-size",
-      "script": "cjk",
-      "size": "xxxxl",
+      "property": "heading-cjk-size-xxxxl",
       "legacyKey": "heading-cjk-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3418,9 +3387,7 @@
   },
   {
     "name": {
-      "component": "heading",
-      "property": "font-size",
-      "size": "xxxxl",
+      "property": "heading-size-xxxxl",
       "legacyKey": "heading-size-xxxxl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -42,49 +42,41 @@
   },
   "body-cjk-size-l": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-200}",
     "uuid": "9f0e0ddb-a4d2-416e-a425-8d71527f77b2"
   },
   "body-cjk-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-100}",
     "uuid": "7e01bc65-5823-456f-a830-9848a96ad85a"
   },
   "body-cjk-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-75}",
     "uuid": "081aa502-e2f1-4bc8-8fb2-a00dcd4236dd"
   },
   "body-cjk-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-300}",
     "uuid": "25d65a6e-e8e1-4849-848a-984373fd9cf9"
   },
   "body-cjk-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-50}",
     "uuid": "ba73926d-2ef4-4d7b-86c2-9044aa1cdf95"
   },
   "body-cjk-size-xxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-400}",
     "uuid": "9aab03eb-c0c1-462c-aa7c-88c93b06f714"
   },
   "body-cjk-size-xxs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-25}",
     "uuid": "218f04ed-0679-4090-b1ad-76ef062dd07c"
   },
   "body-cjk-size-xxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-500}",
     "uuid": "71a41f9e-73da-4632-8877-7af7acf4db03"
   },
@@ -276,7 +268,6 @@
   },
   "body-size-xxs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "body",
     "value": "{font-size-50}",
     "uuid": "3aa79ac7-9e78-4413-b500-b8d1937705cb"
   },
@@ -1402,7 +1393,6 @@
   },
   "heading-cjk-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "heading",
     "value": "{extra-bold-font-weight}",
     "uuid": "bd54516c-2fda-4421-ab62-720c3a887a34"
   },
@@ -1567,7 +1557,6 @@
   },
   "heading-cjk-size-xxxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "heading",
     "value": "{font-size-1400}",
     "uuid": "3b954e15-341a-40f4-a47e-9abd2813fec4"
   },
@@ -1982,7 +1971,6 @@
   },
   "heading-size-xxxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "component": "heading",
     "value": "{font-size-1500}",
     "uuid": "517d86cc-2e66-4cdc-8841-cb32db9e56f4"
   },

--- a/packages/tokens/src/typography.json
+++ b/packages/tokens/src/typography.json
@@ -42,41 +42,49 @@
   },
   "body-cjk-size-l": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-200}",
     "uuid": "9f0e0ddb-a4d2-416e-a425-8d71527f77b2"
   },
   "body-cjk-size-m": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-100}",
     "uuid": "7e01bc65-5823-456f-a830-9848a96ad85a"
   },
   "body-cjk-size-s": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-75}",
     "uuid": "081aa502-e2f1-4bc8-8fb2-a00dcd4236dd"
   },
   "body-cjk-size-xl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-300}",
     "uuid": "25d65a6e-e8e1-4849-848a-984373fd9cf9"
   },
   "body-cjk-size-xs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-50}",
     "uuid": "ba73926d-2ef4-4d7b-86c2-9044aa1cdf95"
   },
   "body-cjk-size-xxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-400}",
     "uuid": "9aab03eb-c0c1-462c-aa7c-88c93b06f714"
   },
   "body-cjk-size-xxs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-25}",
     "uuid": "218f04ed-0679-4090-b1ad-76ef062dd07c"
   },
   "body-cjk-size-xxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-500}",
     "uuid": "71a41f9e-73da-4632-8877-7af7acf4db03"
   },
@@ -268,6 +276,7 @@
   },
   "body-size-xxs": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "body",
     "value": "{font-size-50}",
     "uuid": "3aa79ac7-9e78-4413-b500-b8d1937705cb"
   },
@@ -1393,6 +1402,7 @@
   },
   "heading-cjk-font-weight": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
     "value": "{extra-bold-font-weight}",
     "uuid": "bd54516c-2fda-4421-ab62-720c3a887a34"
   },
@@ -1557,6 +1567,7 @@
   },
   "heading-cjk-size-xxxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
     "value": "{font-size-1400}",
     "uuid": "3b954e15-341a-40f4-a47e-9abd2813fec4"
   },
@@ -1971,6 +1982,7 @@
   },
   "heading-size-xxxxl": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "heading",
     "value": "{font-size-1500}",
     "uuid": "517d86cc-2e66-4cdc-8841-cb32db9e56f4"
   },

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -16,8 +16,8 @@
 //!
 //! ```text
 //! {variant?}-{component?}-{structure?}-{substructure?}-{anatomy?}-{object?}
-//! -{family?}-{emphasis?}-{property}-{orientation?}-{position?}-{size?}-{density?}
-//! -{shape?}-{state?}
+//! -{script?}-{family?}-{emphasis?}-{property}-{orientation?}-{position?}-{size?}
+//! -{density?}-{shape?}-{state?}
 //! ```
 //!
 //! Registry ids are expanded to their `tokenName` long-forms before joining
@@ -28,7 +28,7 @@
 //! (`colorFamily`, `colorRole`), and `scaleIndex` are excluded from the general key.
 //! Color-palette tokens have their own path: `{variant?}-{colorFamily}-{scaleIndex?}`.
 //! `weight`/`style` (CSS font-weight/font-style values) remain excluded pending their
-//! own decomposition pass — only `family`/`emphasis` are enabled so far.
+//! own decomposition pass — only `script`/`family`/`emphasis` are enabled so far.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -668,6 +668,22 @@ mod tests {
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("button-background-color-extra-large")
+        );
+    }
+
+    #[test]
+    fn extract_key_script_sorts_before_family_and_property() {
+        // script (pos 6) before family (pos 7) before emphasis (pos 8) before property (pos 9).
+        let name = json!({
+            "component": "body",
+            "script": "cjk",
+            "family": "serif",
+            "emphasis": "strong",
+            "property": "font-weight"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("body-cjk-serif-strong-font-weight")
         );
     }
 

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1757,10 +1757,23 @@ const TOKEN_OBJECTS_JSON: &str = r##"{
   ]
 }
 "##;
+const SCRIPTS_JSON: &str = r##"{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
+  "type": "script",
+  "description": "Writing-system identifiers for typography tokens. Assigned via the `script` name-object field. Represents the script/writing-system a typeface variant supports, orthogonal to `family` (which represents typeface classification, e.g. serif vs. sans-serif).",
+  "values": [
+    {
+      "id": "cjk",
+      "label": "CJK",
+      "description": "Ideographic scripts used for Chinese, Japanese, and Korean (e.g. Adobe Clean Han)"
+    }
+  ]
+}
+"##;
 const TYPOGRAPHY_FAMILIES_JSON: &str = r##"{
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/registry-value.json",
   "type": "typography-family",
-  "description": "Type family identifiers for typography tokens. Assigned via the `family` name-object field. Represents the script or display context of the typeface, not a specific font name.",
+  "description": "Type family identifiers for typography tokens. Assigned via the `family` name-object field. Represents the typeface classification (e.g. serif vs. sans-serif) or usage context (e.g. code), not a specific font name or writing system — see `script` for the latter.",
   "values": [
     {
       "id": "sans-serif",
@@ -1771,11 +1784,6 @@ const TYPOGRAPHY_FAMILIES_JSON: &str = r##"{
       "id": "serif",
       "label": "Serif",
       "description": "Serif typeface family (e.g. Adobe Clean Serif)"
-    },
-    {
-      "id": "cjk",
-      "label": "CJK",
-      "description": "CJK (Chinese, Japanese, Korean) script typeface family"
     },
     {
       "id": "code",
@@ -3067,7 +3075,7 @@ const CATEGORIES_JSON: &str = r##"{
 }
 "##;
 
-pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "family", "emphasis", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "weight", "style", "motionRole", "easing", "alignment", "qualifier", "icon"];
+pub(crate) const FIELD_ADVISORY_FIELDS: &[&str] = &["variant", "component", "structure", "substructure", "anatomy", "object", "script", "family", "emphasis", "property", "orientation", "position", "size", "density", "shape", "state", "colorRole", "colorFamily", "weight", "style", "motionRole", "easing", "alignment", "qualifier", "icon"];
 
 pub(crate) fn build_registry_map(
 ) -> std::collections::HashMap<String, std::collections::HashSet<String>> {
@@ -3078,6 +3086,7 @@ pub(crate) fn build_registry_map(
     map.insert("substructure".to_string(), parse_registry(SUBSTRUCTURES_JSON));
     map.insert("anatomy".to_string(), parse_registry(ANATOMY_TERMS_JSON));
     map.insert("object".to_string(), parse_registry(TOKEN_OBJECTS_JSON));
+    map.insert("script".to_string(), parse_registry(SCRIPTS_JSON));
     map.insert("family".to_string(), parse_registry(TYPOGRAPHY_FAMILIES_JSON));
     map.insert("emphasis".to_string(), parse_registry(TYPOGRAPHY_EMPHASIS_JSON));
     map.insert("property".to_string(), parse_registry(PROPERTY_TERMS_JSON));
@@ -3109,6 +3118,7 @@ pub(crate) fn build_token_name_map(
     map.insert("substructure".to_string(), parse_token_name_map(SUBSTRUCTURES_JSON));
     map.insert("anatomy".to_string(), parse_token_name_map(ANATOMY_TERMS_JSON));
     map.insert("object".to_string(), parse_token_name_map(TOKEN_OBJECTS_JSON));
+    map.insert("script".to_string(), parse_token_name_map(SCRIPTS_JSON));
     map.insert("family".to_string(), parse_token_name_map(TYPOGRAPHY_FAMILIES_JSON));
     map.insert("emphasis".to_string(), parse_token_name_map(TYPOGRAPHY_EMPHASIS_JSON));
     map.insert("property".to_string(), parse_token_name_map(PROPERTY_TERMS_JSON));
@@ -3138,28 +3148,29 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "substructure", position: 3, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "anatomy", position: 4, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "object", position: 5, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "family", position: 6, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "emphasis", position: 7, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "property", position: 8, validation: FieldValidation::Advisory, scope: None, required: true, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "orientation", position: 9, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "position", position: 10, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "size", position: 11, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "density", position: 12, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "shape", position: 13, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "state", position: 14, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "colorScheme", position: 15, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "scale", position: 16, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "contrast", position: 17, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "colorRole", position: 18, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "colorFamily", position: 19, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "weight", position: 20, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "style", position: 21, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "motionRole", position: 22, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "easing", position: 23, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "from", position: 24, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "to", position: 25, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
-        FieldCatalogEntry { name: "alignment", position: 26, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "qualifier", position: 27, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "script", position: 6, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "family", position: 7, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "emphasis", position: 8, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "property", position: 9, validation: FieldValidation::Advisory, scope: None, required: true, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "orientation", position: 10, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "position", position: 11, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "size", position: 12, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "density", position: 13, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "shape", position: 14, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "state", position: 15, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "colorScheme", position: 16, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "scale", position: 17, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "contrast", position: 18, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "colorRole", position: 19, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "colorFamily", position: 20, validation: FieldValidation::Advisory, scope: Some("color"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "weight", position: 21, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "style", position: 22, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "motionRole", position: 23, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "easing", position: 24, validation: FieldValidation::Advisory, scope: Some("motion"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "from", position: 25, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "to", position: 26, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
+        FieldCatalogEntry { name: "alignment", position: 27, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "qualifier", position: 28, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "scaleIndex", position: 99, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "icon", position: 100, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
     ]

--- a/sdk/core/src/validate/rules/spec043.rs
+++ b/sdk/core/src/validate/rules/spec043.rs
@@ -19,10 +19,12 @@
 //!   (ramp step without family context) is still sortable, and a token with only
 //!   `colorFamily` (non-ramp token such as transparent-black) is also valid.
 //! - Typography tokens (font-*.json, typography.json, multiplier.json) SHOULD have
-//!   `family`, `weight`, `style`, `scaleIndex`, or `structure`. The last two cover
-//!   typography-domain multiplier tokens (line-height ratios, margin multipliers)
-//!   which are identified by scale position or typography-scale category rather than
-//!   typeface attributes.
+//!   `family`, `script`, `weight`, `style`, `scaleIndex`, or `structure`. `script`
+//!   covers writing-system variants (e.g. cjk), orthogonal to `family` (typeface
+//!   classification) — see `docs/proposals/001-typography-taxonomy.md`. The last two
+//!   (`scaleIndex`, `structure`) cover typography-domain multiplier tokens
+//!   (line-height ratios, margin multipliers) which are identified by scale position
+//!   or typography-scale category rather than typeface attributes.
 //! - Motion tokens (duration.json, easing.json, motion.json) SHOULD have
 //!   `motionRole` or `easing`.
 //!
@@ -46,6 +48,7 @@ fn has_required_fields(
         "color" => name_obj.contains_key("colorFamily") || name_obj.contains_key("scaleIndex"),
         "typography" => {
             name_obj.contains_key("family")
+                || name_obj.contains_key("script")
                 || name_obj.contains_key("weight")
                 || name_obj.contains_key("style")
                 || name_obj.contains_key("scaleIndex")
@@ -107,7 +110,7 @@ impl ValidationRule for Rule {
 fn required_fields_description(domain: &str) -> &'static str {
     match domain {
         "color" => "colorFamily, scaleIndex",
-        "typography" => "family, weight, style, scaleIndex, structure",
+        "typography" => "family, script, weight, style, scaleIndex, structure",
         "motion" => "motionRole, easing",
         _ => "(unknown)",
     }
@@ -181,6 +184,15 @@ mod tests {
         let g = make_token(
             FONT_WEIGHT_SCHEMA,
             json!({ "property": "font-weight", "weight": "bold" }),
+        );
+        assert!(diagnostics_for_rule(&g, "SPEC-043").is_empty());
+    }
+
+    #[test]
+    fn typography_with_script_no_warning() {
+        let g = make_token(
+            FONT_WEIGHT_SCHEMA,
+            json!({ "property": "font-weight", "script": "cjk" }),
         );
         assert!(diagnostics_for_rule(&g, "SPEC-043").is_empty());
     }


### PR DESCRIPTION
## Description

Splits the CJK writing-system axis out of `family` into a new `script` field, and decomposes every typography font-size token to `property:"font-size"` + `size` instead of baking the t-shirt size into the flat `property` string.

`cjk` is not a font family — `serif`/`sans-serif`/`code` are typeface classifications (Adobe Clean / Clean Serif / Clean Mono); `cjk` is a script/writing-system (Adobe Clean Han). They're orthogonal — Adobe ships Source Han **Sans** and **Serif**, so "CJK serif" is a real combination a shared field can't express. Adobe's own S2 foundry docs organize fonts by script (Han, Thai, Arabic, Devanagari), so `script` is Adobe's own terminology.

This reverses the 2026-07-08 decision on Proposal 001 (`docs/proposals/001-typography-taxonomy.md`), which folded `cjk` into `family`. See the new "Amendment (2026-07-14)" section in that doc for the full rationale.

## Related Issue

Closes spectrum-design-data-wix. Taxonomy call spectrum-design-data-526 remains open for Nate's retroactive vocabulary review/ratification.

## Motivation and Context

`cjk` was encoded four incompatible ways across `typography.tokens.json`: as `family:"cjk"`, and fused into the flat `property` string three different ways for size and code-emphasis tokens. This gives it one canonical slot, and — while touching every font-size token anyway — fully decomposes the t-shirt size segment that was previously fused into `property` (e.g. `cjk-size-l`, `heading-size-xxxxl`) for every component, not just headings.

## How Has This Been Tested?

- `moon run design-data:roundtrip-verify` — passed before and after; every legacy key string is byte-for-byte unchanged (verified via pinned `legacyKey` on all size tokens).
- `moon run design-data:validate` — diffed pre/post; no new warning categories introduced (only pre-existing SPEC-009 emphasis-vocab gaps and a pre-existing per-file SPEC-043 warning unrelated to this change).
- `moon run sdk:test` (full Rust workspace) and `moon run :test` (full JS/AVA suite) — both green, including a new unit test for `spec043.rs` recognizing `script` as a typography domain-identifying field.
- `packages/tokens/src/typography.json` (legacy-output) diff reviewed — only new `component` attributes surface; zero published keys changed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
