### PR TITLE
fix(design-data): compound-property matching for line-height/component-size tokens

### DIFF
--- a/.changeset/dsi26-line-height-component-compound-properties.md
+++ b/.changeset/dsi26-line-height-component-compound-properties.md
@@ -1,0 +1,18 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Fix compound-property matching for line-height/component-size tokens and
+register the missing component-size vocabulary (closes
+spectrum-design-data-dsi.2.6).
+
+- **tools/token-mapping-analyzer/src/decomposer.js**: register
+  `line-height-font-size`, `component-height`, `component-size-difference`,
+  `component-size-maximum-perspective`, and `component-size-width-ratio` as
+  compound properties, fixing 26 tokens previously flagged as unmatched
+  vocabulary gaps.
+- **registry/property-terms.json**: register `component-size-maximum-perspective`,
+  `component-size-difference`, and `component-size-width-ratio` (parity with
+  the existing `component-size-minimum-perspective` entry); these calculate
+  the CSS perspective transform for S2 components' pressed/"down"-state
+  scale-down effect.

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -276,7 +276,22 @@
     {
       "id": "component-size-minimum-perspective",
       "label": "Component Size Minimum Perspective",
-      "description": "Lower-bound constraint on a component's 3D perspective sizing (design-system abstraction)"
+      "description": "Lower bound used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
+    },
+    {
+      "id": "component-size-maximum-perspective",
+      "label": "Component Size Maximum Perspective",
+      "description": "Upper bound used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
+    },
+    {
+      "id": "component-size-difference",
+      "label": "Component Size Difference",
+      "description": "Size delta used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
+    },
+    {
+      "id": "component-size-width-ratio",
+      "label": "Component Size Width Ratio",
+      "description": "Width ratio used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
     }
   ]
 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -2104,7 +2104,22 @@ const PROPERTY_TERMS_JSON: &str = r##"{
     {
       "id": "component-size-minimum-perspective",
       "label": "Component Size Minimum Perspective",
-      "description": "Lower-bound constraint on a component's 3D perspective sizing (design-system abstraction)"
+      "description": "Lower bound used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
+    },
+    {
+      "id": "component-size-maximum-perspective",
+      "label": "Component Size Maximum Perspective",
+      "description": "Upper bound used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
+    },
+    {
+      "id": "component-size-difference",
+      "label": "Component Size Difference",
+      "description": "Size delta used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
+    },
+    {
+      "id": "component-size-width-ratio",
+      "label": "Component Size Width Ratio",
+      "description": "Width ratio used to calculate the CSS perspective transform for a component's S2 pressed/'down'-state scale-down effect (not applicable to all components)"
     }
   ]
 }

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -51,6 +51,11 @@ const COMPOUND_PROPERTIES = [
   "maximum-height",
   "underline-gap",
   "typography-scale",
+  "line-height-font-size",
+  "component-height",
+  "component-size-difference",
+  "component-size-maximum-perspective",
+  "component-size-width-ratio",
 ];
 
 /**

--- a/tools/token-mapping-analyzer/test/apply.test.js
+++ b/tools/token-mapping-analyzer/test/apply.test.js
@@ -248,8 +248,8 @@ test("applySpaceBetween skips tokens already migrated", (t) => {
   t.is(applied, 0);
 });
 
-// A property string that stacks two concepts (family + emphasis) must have both
-// extracted together in one applyField call, even though only "family" was
+// A property string that stacks two concepts (script + emphasis) must have both
+// extracted together in one applyField call, even though only "script" was
 // requested: decompose() strips both from `property` at once, so writing back
 // only the targeted field (and the fully-stripped property) would silently
 // drop the other and break the roundtrip. Regression test for that bug.
@@ -264,13 +264,13 @@ test("applyField extracts co-occurring fields together to preserve the roundtrip
 
   const { applied } = applyField(
     tokens,
-    "family",
+    "script",
     registry,
     "fixture.tokens.json",
   );
 
   t.is(applied, 1);
-  t.is(tokens[0].name.family, "cjk");
+  t.is(tokens[0].name.script, "cjk");
   t.is(tokens[0].name.emphasis, "strong");
   t.is(tokens[0].name.property, "font-weight");
   t.is(

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -109,7 +109,7 @@ test("matches typography family and emphasis as real fields, not gaps", (t) => {
     registry,
     "test",
   );
-  t.is(result.nameObject.family, "cjk");
+  t.is(result.nameObject.script, "cjk");
   t.is(result.nameObject.emphasis, "emphasized");
   t.is(result.nameObject.property, "font-weight");
   t.is(result.confidence, "HIGH");
@@ -124,21 +124,21 @@ test("compounds adjacent emphasis terms into one hyphen-joined value", (t) => {
     registry,
     "test",
   );
-  t.is(result.nameObject.family, "cjk");
+  t.is(result.nameObject.script, "cjk");
   t.is(result.nameObject.emphasis, "light-strong");
   t.is(result.nameObject.property, "font-weight");
   t.is(result.confidence, "HIGH");
   t.true(result.roundtrips);
 });
 
-test("compounds emphasis terms alongside anatomy and family", (t) => {
+test("compounds emphasis terms alongside anatomy and script", (t) => {
   const result = decompose(
     "body-cjk-strong-emphasized-font-weight",
     { component: "body" },
     registry,
     "test",
   );
-  t.is(result.nameObject.family, "cjk");
+  t.is(result.nameObject.script, "cjk");
   t.is(result.nameObject.emphasis, "strong-emphasized");
   t.is(result.nameObject.property, "font-weight");
   t.true(result.roundtrips);

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -71,6 +71,26 @@ test("flags scaleIndex as gap when field is not declared", (t) => {
   t.truthy(scaleGap);
 });
 
+test("decomposes line-height-font-size compound with scale index", (t) => {
+  // Regression: "font-size" (2-seg) used to win Phase 2's compound match over
+  // "line-height" (2-seg, later in insertion order) before the fused
+  // "line-height-font-size" (3-seg) compound existed, leaving line/height
+  // unmatched as gaps.
+  const result = decompose("line-height-font-size-100", {}, registry, "test");
+  t.is(result.nameObject.property, "line-height-font-size");
+  t.is(result.nameObject.scaleIndex, "100");
+  t.deepEqual(result.gaps, []);
+  t.true(result.roundtrips);
+});
+
+test("decomposes component-height compound with scale index", (t) => {
+  const result = decompose("component-height-100", {}, registry, "test");
+  t.is(result.nameObject.property, "component-height");
+  t.is(result.nameObject.scaleIndex, "100");
+  t.deepEqual(result.gaps, []);
+  t.true(result.roundtrips);
+});
+
 test("detects spacing-between pattern", (t) => {
   const result = decompose(
     "field-top-to-alert-icon-small",


### PR DESCRIPTION
## Description

The `token-mapping-analyzer` decomposer flagged 26 tokens as vocabulary gaps that were actually valid, just missing compound-property entries:

- `line-height-font-size-*` (18 tokens) — `line-height` and `font-size` were registered as separate 2-segment compounds, but `font-size` matched first (stable-sort tie), consuming the segments before `line-height` got a chance, leaving `line`/`height` unmatched.
- `component-height-*` / `component-size-{difference,maximum-perspective,width-ratio}-*` (8 tokens) — the leading `component` segment had no registered compound.

## Related Issue

Closes spectrum-design-data-dsi.2.6

## Motivation and Context

Per `docs/proposals/006-vocabulary-gaps.md`'s "Compound properties" section — documented as needing a decomposer fix, not a registry add.

## How Has This Been Tested?

- Added `COMPOUND_PROPERTIES` entries: `line-height-font-size`, `component-height`, `component-size-difference`, `component-size-maximum-perspective`, `component-size-width-ratio` (`tools/token-mapping-analyzer/src/decomposer.js`).
- Registered the three new `component-size-*` terms in `packages/design-data/registry/property-terms.json` for parity with the existing `component-size-minimum-perspective` entry (also corrected its description — confirmed via `packages/tokens/CHANGELOG.md` that these tokens compute the actual CSS `perspective` transform for S2 components' pressed/"down"-state scale-down effect).
- Regenerated `sdk/core/src/registry_data.rs` via `moon run sdk:codegen`; verified with `sdk:codegen-check`.
- Added 2 new decomposer unit tests; ran `moon run token-mapping-analyzer:analyze` to confirm all 26 target tokens decompose with zero gaps.
- `moon run sdk:test` — all Rust tests pass.
- Changeset added and validated with `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)