### PR TITLE
fix(design-data): resolve number-field stepper qualifier taxonomy call (dsi.2.1)

### DIFF
--- a/.changeset/dsi21-stepper-qualifier-default-width.md
+++ b/.changeset/dsi21-stepper-qualifier-default-width.md
@@ -1,0 +1,18 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Register `has-stepper` qualifier + `default-width` property and decompose the
+number-field stepper and field default-width tokens (closes spectrum-design-data-dsi.2.1).
+
+- **packages/design-data/registry/{qualifiers,property-terms}.json**: add
+  `has-stepper` qualifier and `default-width` property term.
+- **packages/design-data/tokens/layout-component.tokens.json**: decompose 4
+  `number-field-with-stepper-minimum-width-*` tokens to `qualifier: has-stepper`
+  + `property: minimum-width`, pinning `name.legacyKey`; decompose
+  `field-default-width-*` to `{component: field, property: default-width, size}`
+  (roundtrips clean, no legacyKey needed).
+- **tools/token-mapping-analyzer/src/decomposer.js**: register the `with`+
+  `stepper` phrase as the `has-stepper` qualifier so the published key still
+  decomposes cleanly.
+- **sdk/core/src/registry_data.rs**: regenerated from the registry changes.

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -234,6 +234,11 @@
       "description": "CSS min-width constraint (design-system abstraction)"
     },
     {
+      "id": "default-width",
+      "label": "Default Width",
+      "description": "Default width sizing for field components (design-system abstraction)"
+    },
+    {
       "id": "minimum-height",
       "label": "Minimum Height",
       "description": "CSS min-height constraint (design-system abstraction)"

--- a/packages/design-data/registry/qualifiers.json
+++ b/packages/design-data/registry/qualifiers.json
@@ -37,6 +37,11 @@
       "id": "highlight",
       "label": "Highlight",
       "description": "Emphasized highlight treatment"
+    },
+    {
+      "id": "has-stepper",
+      "label": "Has stepper",
+      "description": "Configuration where the in-field stepper buttons are shown; inverse of the hideStepper component option."
     }
   ]
 }

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -6876,8 +6876,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-extra-large",
       "component": "field",
+      "property": "default-width",
+      "size": "xl",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6888,8 +6889,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-extra-large",
       "component": "field",
+      "property": "default-width",
+      "size": "xl",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6900,8 +6902,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-large",
       "component": "field",
+      "property": "default-width",
+      "size": "l",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6912,8 +6915,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-large",
       "component": "field",
+      "property": "default-width",
+      "size": "l",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6924,8 +6928,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-medium",
       "component": "field",
+      "property": "default-width",
+      "size": "m",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6936,8 +6941,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-medium",
       "component": "field",
+      "property": "default-width",
+      "size": "m",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6948,8 +6954,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-small",
       "component": "field",
+      "property": "default-width",
+      "size": "s",
       "scale": "desktop"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -6960,8 +6967,9 @@
   },
   {
     "name": {
-      "property": "field-default-width-small",
       "component": "field",
+      "property": "default-width",
+      "size": "s",
       "scale": "mobile"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -9552,8 +9560,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-extra-large",
-      "scale": "desktop"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "xl",
+      "scale": "desktop",
+      "legacyKey": "number-field-with-stepper-minimum-width-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "168px",
@@ -9564,8 +9575,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-extra-large",
-      "scale": "mobile"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "xl",
+      "scale": "mobile",
+      "legacyKey": "number-field-with-stepper-minimum-width-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "198px",
@@ -9576,8 +9590,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-large",
-      "scale": "desktop"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "l",
+      "scale": "desktop",
+      "legacyKey": "number-field-with-stepper-minimum-width-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "144px",
@@ -9588,8 +9605,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-large",
-      "scale": "mobile"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "l",
+      "scale": "mobile",
+      "legacyKey": "number-field-with-stepper-minimum-width-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "174px",
@@ -9600,8 +9620,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-medium",
-      "scale": "desktop"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "m",
+      "scale": "desktop",
+      "legacyKey": "number-field-with-stepper-minimum-width-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "120px",
@@ -9612,8 +9635,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-medium",
-      "scale": "mobile"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "m",
+      "scale": "mobile",
+      "legacyKey": "number-field-with-stepper-minimum-width-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "150px",
@@ -9624,8 +9650,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-small",
-      "scale": "desktop"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "s",
+      "scale": "desktop",
+      "legacyKey": "number-field-with-stepper-minimum-width-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "104px",
@@ -9636,8 +9665,11 @@
   {
     "name": {
       "component": "number-field",
-      "property": "with-stepper-minimum-width-small",
-      "scale": "mobile"
+      "qualifier": "has-stepper",
+      "property": "minimum-width",
+      "size": "s",
+      "scale": "mobile",
+      "legacyKey": "number-field-with-stepper-minimum-width-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "126px",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -2062,6 +2062,11 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "description": "CSS min-width constraint (design-system abstraction)"
     },
     {
+      "id": "default-width",
+      "label": "Default Width",
+      "description": "Default width sizing for field components (design-system abstraction)"
+    },
+    {
       "id": "minimum-height",
       "label": "Minimum Height",
       "description": "CSS min-height constraint (design-system abstraction)"
@@ -2938,6 +2943,11 @@ const QUALIFIERS_JSON: &str = r##"{
       "id": "highlight",
       "label": "Highlight",
       "description": "Emphasized highlight treatment"
+    },
+    {
+      "id": "has-stepper",
+      "label": "Has stepper",
+      "description": "Configuration where the in-field stepper buttons are shown; inverse of the hideStepper component option."
     }
   ]
 }

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -79,6 +79,10 @@ const KNOWN_GAP_TERMS = {
 const EXTRA_TERMS = [
   // State aliases used in tokens (registry has keyboard-focus, tokens use key-focus)
   { segments: ["key", "focus"], field: "state", id: "key-focus" },
+  // "with stepper" is the published phrasing for the has-stepper qualifier
+  // (number-field's hideStepper option, inverted). "with" alone isn't a
+  // registered term; this two-segment phrase is what's recognizable.
+  { segments: ["with", "stepper"], field: "qualifier", id: "has-stepper" },
 ];
 
 /**

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -162,6 +162,18 @@ test("matches key-focus as keyboard-focus state", (t) => {
   t.is(result.nameObject.state, "keyboard-focus");
 });
 
+test("matches with-stepper as has-stepper qualifier", (t) => {
+  const result = decompose(
+    "number-field-with-stepper-minimum-width-small",
+    {},
+    registry,
+    "test",
+  );
+  t.is(result.nameObject.qualifier, "has-stepper");
+  t.is(result.nameObject.property, "minimum-width");
+  t.is(result.nameObject.size, "s");
+});
+
 test("serializes name object in spec order", (t) => {
   const nameObj = {
     variant: "accent",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Resolves the `number-field-with-stepper-*` taxonomy call flagged in proposal 006: the segment
`with` in `number-field-with-stepper-minimum-width-{small,medium,large,extra-large}` matched no
registered vocabulary, and the proposal explicitly deferred a decision rather than guessing
(register `with` as a filler-word term, or add a generic connector-skip rule to the decomposer).

Decision made here: `with` is unstored readability sugar. The real distinction it encodes —
number field with stepper buttons vs. without — is a **configuration axis** matching the
component's `hideStepper` boolean option (`packages/design-data/components/number-field.json`).
That's exactly what the `qualifier` field (introduced in dsi.2.5) already models, so:

- Registered `has-stepper` as a new `qualifier` value (mirrors `hideStepper`, inverted).
- Decomposed the 4 tokens (8 name entries, desktop+mobile) to
  `{component: number-field, qualifier: has-stepper, property: minimum-width, size, scale}`,
  pinning `name.legacyKey` to keep the published key byte-identical (same escape hatch as dsi.3).
- Taught `tools/token-mapping-analyzer/src/decomposer.js` to recognize the `with`+`stepper`
  phrase as the `has-stepper` qualifier (analogous to the existing `key`+`focus` → `key-focus`
  state alias) — this is a targeted phrase recognition, not a generic filler-word skip, so it
  doesn't reopen the broad-blast-radius concern the proposal raised.

**Out-of-bead scope, fixed opportunistically in the same file:** the co-located
`field-default-width-*` tokens (8 name entries) were also mis-fused
(`property: "field-default-width-small"` instead of a decomposed name). These are not part of
proposal 006's dsi.2.1 group, but sat right next to the tokens I was already editing and
decompose cleanly to `{component: field, property: default-width, size}` — no `legacyKey` needed,
since the canonical serialization already reproduces the published key exactly.

## Related Issue

Closes spectrum-design-data-dsi.2.1 (beads). See `docs/proposals/006-vocabulary-gaps.md`,
"Taxonomy calls" section.

## Motivation and Context

The token-mapping-analyzer's residual/unmatched-segment report is how this repo tracks token
names that don't yet decompose into structured, spec-compliant `name` objects. `with` was one of
three flagged "taxonomy calls" — cases needing a naming-convention decision, not just a missing
vocab term — left unresolved by proposal 006 pending human triage.

## How Has This Been Tested?

- `moon run sdk:codegen` / `moon run sdk:codegen-check` — `registry_data.rs` regenerated and
  in sync with the registry JSON changes.
- `moon run design-data:roundtrip-verify` — legacy → cascade → legacy roundtrip is clean;
  `packages/tokens/src/*.json` published keys are unchanged (confirms both the `legacyKey` pin
  and the natural `field-default-width` decomposition are publish-invisible).
- `moon run design-data:validate` / `validate-registry` — no new warnings introduced.
- `moon run token-mapping-analyzer:analyze` — the `with` segment no longer appears anywhere in
  the unmatched-segment report (unmatched-segment count dropped 89 → 81, exactly the 8 affected
  name entries); overall HIGH-confidence roundtrip count increased accordingly.
- `moon run sdk:test` — full Rust workspace suite green (0 failed across all crates).
- `npx ava` in `tools/token-mapping-analyzer` — 33/33 passed, including a new test asserting
  `number-field-with-stepper-minimum-width-small` decomposes to
  `qualifier: has-stepper, property: minimum-width, size: s`.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset valid.

## Screenshots (if appropriate):

N/A — data/schema change, no visual surface.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — new `has-stepper` qualifier
      and `default-width` property vocab
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
