### PR TITLE
fix(design-data): register width-multiplier vocab + quiet variant (dsi.2.2)

### DIFF
--- a/.changeset/dsi22-width-multiplier-vocab.md
+++ b/.changeset/dsi22-width-multiplier-vocab.md
@@ -1,0 +1,21 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Register `width-multiplier`/`minimum-width-multiplier`/`maximum-width-multiplier`
+property terms and `quiet` variant (closes spectrum-design-data-dsi.2.2).
+
+- **packages/design-data/registry/property-terms.json**: add
+  `width-multiplier`, `minimum-width-multiplier`, `maximum-width-multiplier` —
+  unitless ratios used at the implementation level to derive a dimension from
+  another dimension (design-data has no `calc()`; reuses the existing
+  `multiplier.json` value schema shared with line-height/margin multipliers).
+- **packages/design-data/registry/variants.json**: add `quiet` emphasis variant.
+- **packages/design-data/tokens/layout-component.tokens.json**: decompose
+  `combo-box-quiet-minimum-width-multiplier` to `variant: quiet` +
+  `property: minimum-width-multiplier` (was fused into `property`).
+- **tools/token-mapping-analyzer/src/decomposer.js**: register the three
+  compounds in `COMPOUND_PROPERTIES` so they decompose cleanly.
+- **packages/tokens/schemas/token-types/multiplier.json**: broaden description
+  to mention width/height (dimension) multipliers.
+- **sdk/core/src/registry_data.rs**: regenerated from the registry changes.

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -249,6 +249,21 @@
       "description": "CSS max-width constraint (design-system abstraction)"
     },
     {
+      "id": "width-multiplier",
+      "label": "Width Multiplier",
+      "description": "Unitless ratio used at the implementation level to derive a width from another dimension (design-system abstraction; design-data has no calc(), reuses the multiplier value schema shared with line-height/margin)"
+    },
+    {
+      "id": "minimum-width-multiplier",
+      "label": "Minimum Width Multiplier",
+      "description": "Unitless ratio used at the implementation level to derive a minimum width from another dimension (design-system abstraction; design-data has no calc(), reuses the multiplier value schema shared with line-height/margin)"
+    },
+    {
+      "id": "maximum-width-multiplier",
+      "label": "Maximum Width Multiplier",
+      "description": "Unitless ratio used at the implementation level to derive a maximum width from another dimension (design-system abstraction; design-data has no calc(), reuses the multiplier value schema shared with line-height/margin)"
+    },
+    {
       "id": "thickness",
       "label": "Thickness",
       "description": "Stroke or line thickness (design-system abstraction; not a standard CSS property)"

--- a/packages/design-data/registry/variants.json
+++ b/packages/design-data/registry/variants.json
@@ -32,6 +32,13 @@
       "usedIn": ["component-schemas"]
     },
     {
+      "id": "quiet",
+      "label": "Quiet",
+      "description": "Reduced-visual-weight emphasis variant (e.g. no visible border/background until interaction)",
+      "category": "emphasis",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "positive",
       "label": "Positive",
       "description": "Affirmative or positive action variant",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -5968,7 +5968,9 @@
   {
     "name": {
       "component": "combo-box",
-      "property": "quiet-minimum-width-multiplier"
+      "variant": "quiet",
+      "property": "minimum-width-multiplier",
+      "legacyKey": "combo-box-quiet-minimum-width-multiplier"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 2,

--- a/packages/tokens/schemas/token-types/multiplier.json
+++ b/packages/tokens/schemas/token-types/multiplier.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
   "title": "Multiplier",
-  "description": "A float used to multiply a value by a given amount. Used for line-height and margin multipliers.",
+  "description": "A float used to multiply a value by a given amount. Used for line-height, margin, and width/height (dimension) multipliers.",
   "type": "object",
   "allOf": [
     {

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -36,6 +36,13 @@ const VARIANTS_JSON: &str = r##"{
       "usedIn": ["component-schemas"]
     },
     {
+      "id": "quiet",
+      "label": "Quiet",
+      "description": "Reduced-visual-weight emphasis variant (e.g. no visible border/background until interaction)",
+      "category": "emphasis",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "positive",
       "label": "Positive",
       "description": "Affirmative or positive action variant",
@@ -2075,6 +2082,21 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "maximum-width",
       "label": "Maximum Width",
       "description": "CSS max-width constraint (design-system abstraction)"
+    },
+    {
+      "id": "width-multiplier",
+      "label": "Width Multiplier",
+      "description": "Unitless ratio used at the implementation level to derive a width from another dimension (design-system abstraction; design-data has no calc(), reuses the multiplier value schema shared with line-height/margin)"
+    },
+    {
+      "id": "minimum-width-multiplier",
+      "label": "Minimum Width Multiplier",
+      "description": "Unitless ratio used at the implementation level to derive a minimum width from another dimension (design-system abstraction; design-data has no calc(), reuses the multiplier value schema shared with line-height/margin)"
+    },
+    {
+      "id": "maximum-width-multiplier",
+      "label": "Maximum Width Multiplier",
+      "description": "Unitless ratio used at the implementation level to derive a maximum width from another dimension (design-system abstraction; design-data has no calc(), reuses the multiplier value schema shared with line-height/margin)"
     },
     {
       "id": "thickness",

--- a/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.4.0
+  Spectrum Design Data  v0.5.0
   ↑↓ history/list · Tab complete · Enter run · Esc back · Ctrl+C quit
   ──────────────────────────────────────────────────────────────────────────────
   > :

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.4.0
+  Spectrum Design Data  v0.5.0
   ↑↓ hi┌ Step 1 of 4 — Intent ──────────────────────────────────────────┐
   ─────│Intent: background-color                                        │───────
   >    │  These tokens already exist for similar intents.               │

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -57,6 +57,9 @@ const COMPOUND_PROPERTIES = [
   "component-size-difference",
   "component-size-maximum-perspective",
   "component-size-width-ratio",
+  "width-multiplier",
+  "minimum-width-multiplier",
+  "maximum-width-multiplier",
 ];
 
 /**


### PR DESCRIPTION
## Description

Registers `width-multiplier`/`minimum-width-multiplier`/`maximum-width-multiplier` as property vocabulary and `quiet` as an emphasis variant, then decomposes the one remaining fused token (`combo-box-quiet-minimum-width-multiplier`) that depended on them, with a pinned `legacyKey` to keep legacy output byte-identical.

This re-lands work original done for `spectrum-design-data-dsi.2.2`. That bead was closed 2026-07-15 with a documented changeset, but the underlying edits were never committed — they existed only in a working tree that was cleaned when the source branch was discarded, so nothing reached `main`. The changeset survived (it was a new untracked file) and served as the spec for this reconstruction, re-verified against current `main` since several other Phase D PRs landed in between.

## Related Issue

Closes spectrum-design-data-dsi.2.2 (beads).

## Motivation and Context

10 of 11 `*-width-multiplier` tokens already had decomposed `property` values on `main`, but none of the three width-multiplier terms were registered, so those tokens referenced unregistered vocabulary. The 11th (`combo-box-quiet`) was still fused. This closes both gaps.

## How Has This Been Tested?

- `moon run sdk:codegen-check` — Rust registry matches JSON registry.
- `moon run token-mapping-analyzer:analyze` — all 10 `*-width-multiplier` tokens now decompose at HIGH confidence with zero gaps/unmatched segments (verified individually).
- `moon run design-data:roundtrip-verify` then `moon run design-data:legacy-output` — `packages/tokens/src/` diff-free.
- `moon run design-data:validate` / `design-data:validate-registry` — no new errors (pre-existing unrelated warnings only).
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.
- `moon run sdk:test` — 2 pre-existing TUI snapshot failures (`wizard_screen1`, `palette_open`) reproduce identically on unmodified `main`; confirmed unrelated via `git stash`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
