### PR TITLE
fix(design-data): tab->tab-item anatomy alias, decompose tab-gap-horizontal-* tokens

### DIFF
--- a/.changeset/iqn-tab-item-alias.md
+++ b/.changeset/iqn-tab-item-alias.md
@@ -1,0 +1,16 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Add a `tab` → `tab-item` anatomy alias and decompose the 4 `tab-gap-horizontal-*` tokens
+(closes spectrum-design-data-iqn).
+
+- **registry/anatomy-terms.json**: register `tab` as an alias of the existing `tab-item`
+  anatomy term, per the dsi.2.4 taxonomy call (tab is an anatomy part nested inside the
+  `tabs` component, not a component alias).
+- **tokens/layout.tokens.json**: decompose `tab-gap-horizontal-{extra-large,large,medium,small}`
+  to `component=tabs, anatomy=tab-item, property=gap, orientation=horizontal, size`,
+  pinning `legacyKey` to preserve the published token names.
+- **packages/tokens/naming-exceptions.json**, **snapshots/validation-snapshot.json**: the
+  `tab-item` alias changes the tokens' canonical re-serialization, so the 4 keys are added
+  to the anatomy-decomposition exceptions allowlist and the golden snapshot is refreshed.

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -636,6 +636,7 @@
     {
       "id": "tab-item",
       "label": "Tab Item",
+      "aliases": ["tab"],
       "description": "Individual tab button within a tabs component",
       "usedIn": ["tokens", "s2-docs"]
     },

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -5603,7 +5603,12 @@
   },
   {
     "name": {
-      "property": "tab-gap-horizontal-extra-large"
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "property": "gap",
+      "orientation": "horizontal",
+      "size": "xl",
+      "legacyKey": "tab-gap-horizontal-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",
@@ -5612,7 +5617,12 @@
   },
   {
     "name": {
-      "property": "tab-gap-horizontal-large"
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "property": "gap",
+      "orientation": "horizontal",
+      "size": "l",
+      "legacyKey": "tab-gap-horizontal-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
@@ -5621,7 +5631,12 @@
   },
   {
     "name": {
-      "property": "tab-gap-horizontal-medium"
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "property": "gap",
+      "orientation": "horizontal",
+      "size": "m",
+      "legacyKey": "tab-gap-horizontal-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
@@ -5630,7 +5645,12 @@
   },
   {
     "name": {
-      "property": "tab-gap-horizontal-small"
+      "component": "tabs",
+      "anatomy": "tab-item",
+      "property": "gap",
+      "orientation": "horizontal",
+      "size": "s",
+      "legacyKey": "tab-gap-horizontal-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b352f0f0-5843-4c65-8357-625b938ccaa0",

--- a/packages/tokens/naming-exceptions.json
+++ b/packages/tokens/naming-exceptions.json
@@ -1191,6 +1191,30 @@
       "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
     },
     {
+      "token": "tab-gap-horizontal-extra-large",
+      "file": "layout.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key; 'tab' resolves via decomposer alias to anatomy term tab-item, whose canonical serialization diverges from the original 'tab' segment"
+    },
+    {
+      "token": "tab-gap-horizontal-large",
+      "file": "layout.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key; 'tab' resolves via decomposer alias to anatomy term tab-item, whose canonical serialization diverges from the original 'tab' segment"
+    },
+    {
+      "token": "tab-gap-horizontal-medium",
+      "file": "layout.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key; 'tab' resolves via decomposer alias to anatomy term tab-item, whose canonical serialization diverges from the original 'tab' segment"
+    },
+    {
+      "token": "tab-gap-horizontal-small",
+      "file": "layout.json",
+      "category": "anatomy-decomposition",
+      "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key; 'tab' resolves via decomposer alias to anatomy term tab-item, whose canonical serialization diverges from the original 'tab' segment"
+    },
+    {
       "token": "tab-item-bottom-to-text-compact-extra-large",
       "file": "layout-component.json",
       "category": "anatomy-decomposition",

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -1157,6 +1157,34 @@
       "message": "Known naming exception: 'side-focus-indicator' does not match canonical generation rules (tracked in naming-exceptions.json)"
     },
     {
+      "file": "./src/layout.json",
+      "token": "tab-gap-horizontal-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-gap-horizontal-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "tab-gap-horizontal-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-gap-horizontal-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "tab-gap-horizontal-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-gap-horizontal-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "tab-gap-horizontal-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'tab-gap-horizontal-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
       "file": "./src/typography.json",
       "token": "body-cjk-emphasized-font-style",
       "rule_id": "SPEC-007",

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -3531,24 +3531,28 @@
   },
   "tab-gap-horizontal-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tabs",
     "value": "{spacing-600}",
     "uuid": "0c958750-2c96-453b-9464-f041ac126749",
     "description": "Spacing between child elements for tab components at extra-large size"
   },
   "tab-gap-horizontal-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tabs",
     "value": "{spacing-500}",
     "uuid": "8932b4cf-300f-4377-bbda-7fc02011cd37",
     "description": "Spacing between child elements for tab components at large size"
   },
   "tab-gap-horizontal-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tabs",
     "value": "{spacing-400}",
     "uuid": "7a5f3049-0c20-4ff8-84ea-d161e58546fb",
     "description": "Spacing between child elements for tab components at medium size"
   },
   "tab-gap-horizontal-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "component": "tabs",
     "value": "{spacing-350}",
     "uuid": "a41aaa58-77af-476e-9050-4f4864c8c3f9",
     "description": "Spacing between child elements for tab components at small size"

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "design-data-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1526,6 +1526,7 @@ const ANATOMY_TERMS_JSON: &str = r##"{
     {
       "id": "tab-item",
       "label": "Tab Item",
+      "aliases": ["tab"],
       "description": "Individual tab button within a tabs component",
       "usedIn": ["tokens", "s2-docs"]
     },


### PR DESCRIPTION
## Description

Implements the `dsi.2.4` taxonomy call: the literal token segment `tab` resolves
via a decomposer-level `aliases` entry to the existing registered anatomy term
`tab-item` (no new registry entry — `tab` is nested inside `tabs`, same
relationship as `menu-item`/`menu`). Decomposes the 4
`tab-gap-horizontal-{extra-large,large,medium,small}` tokens in
`packages/tokens/src/layout.json` to
`component=tabs, anatomy=tab-item, property=gap, orientation=horizontal, size`.

## Related Issue

Closes spectrum-design-data-iqn (parent `dsi.2`, taxonomy call resolved in `dsi.2.4`).

## Motivation and Context

Phase D residual triage (`dsi.2`) surfaced these 4 semantic tokens with a
degenerate name object (the whole key dumped into `property`). This gives them
a proper structured decomposition consistent with the rest of the `tabs`
component's anatomy tokens.

**Known, accepted tradeoff:** SPEC-025 (`anatomy-requires-component`) requires
any token with an `anatomy` field to also carry `component`. Adding
`component: "tabs"` causes a 4-line diff in `packages/tokens/src/layout.json`
(each entry gains a `component: "tabs"` field in the flat legacy output).
`legacyKey` cannot suppress this — it only pins the reconstructed key string,
not the separate `component`-hoisting code path in `sdk/core/src/legacy.rs`
(`build_flat_entry` / `resolve_owner_component`). This diff was reviewed and
explicitly accepted rather than escalating for a new taxonomy call or dropping
`anatomy`.

## How Has This Been Tested?

Full verification chain (per repo trust-boundary convention — JS analyzer
passing is not a proxy for Rust agreement):

- `moon run sdk:codegen-check` — registry embed in sync
- `moon run design-data:roundtrip-verify` — OK
- `moon run design-data:legacy-output` + `git diff --stat packages/tokens/src/`
  — diff limited to the expected 4-line `component: "tabs"` addition
- `moon run token-mapping-analyzer:analyze` — all 4 tokens HIGH confidence,
  roundtrip true, no regressions to other tab-item-matched or table-item tokens
- `moon run token-mapping-analyzer:test` — 37 passed
- `moon run design-data:validate` — no new errors (pre-existing unrelated
  SPEC-043 warnings only)
- `moon run tokens:verifyDesignDataSnapshot` — Snapshot OK (4 tokens allowlisted
  under `naming-exceptions.json` category `anatomy-decomposition`, golden
  snapshot regenerated)
- `moon run design-data-spec:check` — OK
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — valid

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)