### PR TITLE
fix(design-data): decompose fused colorFamily from property in color-aliases

### DIFF
--- a/.changeset/colorfamily-aliases-decompose.md
+++ b/.changeset/colorfamily-aliases-decompose.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Decompose fused `{colorFamily}-{background|visual}-color` properties in
+color-aliases into `colorFamily` + `property`, preserving legacy output
+via `legacyKey`.
+
+- **packages/design-data/tokens/color-aliases.tokens.json**: split 114
+  fused-property tokens (19 color families × background/visual-color ×
+  light/dark/wireframe) into `colorFamily` + plain `property`, pinning
+  `legacyKey` to keep serialized output byte-identical.

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -445,9 +445,11 @@
   },
   {
     "name": {
-      "property": "blue-background-color",
+      "colorFamily": "blue",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "blue-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -457,9 +459,11 @@
   },
   {
     "name": {
-      "property": "blue-background-color",
+      "colorFamily": "blue",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "blue-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -469,9 +473,11 @@
   },
   {
     "name": {
-      "property": "blue-background-color",
+      "colorFamily": "blue",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "blue-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -526,8 +532,10 @@
   },
   {
     "name": {
-      "property": "blue-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "blue",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "blue-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -537,8 +545,10 @@
   },
   {
     "name": {
-      "property": "blue-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "blue",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "blue-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -548,8 +558,10 @@
   },
   {
     "name": {
-      "property": "blue-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "blue",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "blue-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -559,9 +571,11 @@
   },
   {
     "name": {
-      "property": "brown-background-color",
+      "colorFamily": "brown",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "brown-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -571,9 +585,11 @@
   },
   {
     "name": {
-      "property": "brown-background-color",
+      "colorFamily": "brown",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "brown-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -583,9 +599,11 @@
   },
   {
     "name": {
-      "property": "brown-background-color",
+      "colorFamily": "brown",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "brown-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -640,8 +658,10 @@
   },
   {
     "name": {
-      "property": "brown-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "brown",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "brown-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -651,8 +671,10 @@
   },
   {
     "name": {
-      "property": "brown-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "brown",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "brown-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -662,8 +684,10 @@
   },
   {
     "name": {
-      "property": "brown-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "brown",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "brown-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -673,9 +697,11 @@
   },
   {
     "name": {
-      "property": "celery-background-color",
+      "colorFamily": "celery",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "celery-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b908fb61-f581-4942-9d00-57a828a0660b",
@@ -685,9 +711,11 @@
   },
   {
     "name": {
-      "property": "celery-background-color",
+      "colorFamily": "celery",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "celery-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
@@ -697,9 +725,11 @@
   },
   {
     "name": {
-      "property": "celery-background-color",
+      "colorFamily": "celery",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "celery-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b908fb61-f581-4942-9d00-57a828a0660b",
@@ -754,8 +784,10 @@
   },
   {
     "name": {
-      "property": "celery-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "celery",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "celery-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
@@ -765,8 +797,10 @@
   },
   {
     "name": {
-      "property": "celery-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "celery",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "celery-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
@@ -776,8 +810,10 @@
   },
   {
     "name": {
-      "property": "celery-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "celery",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "celery-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
@@ -787,9 +823,11 @@
   },
   {
     "name": {
-      "property": "chartreuse-background-color",
+      "colorFamily": "chartreuse",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "chartreuse-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b72ad072-4768-463a-b951-00f1cbe4f657",
@@ -799,9 +837,11 @@
   },
   {
     "name": {
-      "property": "chartreuse-background-color",
+      "colorFamily": "chartreuse",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "chartreuse-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
@@ -811,9 +851,11 @@
   },
   {
     "name": {
-      "property": "chartreuse-background-color",
+      "colorFamily": "chartreuse",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "chartreuse-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b72ad072-4768-463a-b951-00f1cbe4f657",
@@ -868,8 +910,10 @@
   },
   {
     "name": {
-      "property": "chartreuse-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "chartreuse",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "chartreuse-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
@@ -879,8 +923,10 @@
   },
   {
     "name": {
-      "property": "chartreuse-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "chartreuse",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "chartreuse-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
@@ -890,8 +936,10 @@
   },
   {
     "name": {
-      "property": "chartreuse-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "chartreuse",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "chartreuse-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
@@ -901,9 +949,11 @@
   },
   {
     "name": {
-      "property": "cinnamon-background-color",
+      "colorFamily": "cinnamon",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "cinnamon-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -913,9 +963,11 @@
   },
   {
     "name": {
-      "property": "cinnamon-background-color",
+      "colorFamily": "cinnamon",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "cinnamon-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -925,9 +977,11 @@
   },
   {
     "name": {
-      "property": "cinnamon-background-color",
+      "colorFamily": "cinnamon",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "cinnamon-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -982,8 +1036,10 @@
   },
   {
     "name": {
-      "property": "cinnamon-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "cinnamon",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "cinnamon-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -993,8 +1049,10 @@
   },
   {
     "name": {
-      "property": "cinnamon-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "cinnamon",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "cinnamon-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -1004,8 +1062,10 @@
   },
   {
     "name": {
-      "property": "cinnamon-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "cinnamon",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "cinnamon-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -1015,9 +1075,11 @@
   },
   {
     "name": {
-      "property": "cyan-background-color",
+      "colorFamily": "cyan",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "cyan-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -1027,9 +1089,11 @@
   },
   {
     "name": {
-      "property": "cyan-background-color",
+      "colorFamily": "cyan",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "cyan-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
@@ -1039,9 +1103,11 @@
   },
   {
     "name": {
-      "property": "cyan-background-color",
+      "colorFamily": "cyan",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "cyan-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -1096,8 +1162,10 @@
   },
   {
     "name": {
-      "property": "cyan-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "cyan",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "cyan-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
@@ -1107,8 +1175,10 @@
   },
   {
     "name": {
-      "property": "cyan-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "cyan",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "cyan-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -1118,8 +1188,10 @@
   },
   {
     "name": {
-      "property": "cyan-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "cyan",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "cyan-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
@@ -1761,9 +1833,11 @@
   },
   {
     "name": {
-      "property": "fuchsia-background-color",
+      "colorFamily": "fuchsia",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "fuchsia-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -1773,9 +1847,11 @@
   },
   {
     "name": {
-      "property": "fuchsia-background-color",
+      "colorFamily": "fuchsia",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "fuchsia-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -1785,9 +1861,11 @@
   },
   {
     "name": {
-      "property": "fuchsia-background-color",
+      "colorFamily": "fuchsia",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "fuchsia-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -1842,8 +1920,10 @@
   },
   {
     "name": {
-      "property": "fuchsia-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "fuchsia",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "fuchsia-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -1853,8 +1933,10 @@
   },
   {
     "name": {
-      "property": "fuchsia-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "fuchsia",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "fuchsia-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -1864,8 +1946,10 @@
   },
   {
     "name": {
-      "property": "fuchsia-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "fuchsia",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "fuchsia-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -1875,9 +1959,11 @@
   },
   {
     "name": {
-      "property": "gray-background-color",
+      "colorFamily": "gray",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "gray-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -1887,9 +1973,11 @@
   },
   {
     "name": {
-      "property": "gray-background-color",
+      "colorFamily": "gray",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "gray-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -1899,9 +1987,11 @@
   },
   {
     "name": {
-      "property": "gray-background-color",
+      "colorFamily": "gray",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "gray-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -1956,8 +2046,10 @@
   },
   {
     "name": {
-      "property": "gray-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "gray",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "gray-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -1967,8 +2059,10 @@
   },
   {
     "name": {
-      "property": "gray-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "gray",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "gray-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
@@ -1978,8 +2072,10 @@
   },
   {
     "name": {
-      "property": "gray-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "gray",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "gray-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -1989,9 +2085,11 @@
   },
   {
     "name": {
-      "property": "green-background-color",
+      "colorFamily": "green",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "green-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
@@ -2001,9 +2099,11 @@
   },
   {
     "name": {
-      "property": "green-background-color",
+      "colorFamily": "green",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "green-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
@@ -2013,9 +2113,11 @@
   },
   {
     "name": {
-      "property": "green-background-color",
+      "colorFamily": "green",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "green-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
@@ -2070,8 +2172,10 @@
   },
   {
     "name": {
-      "property": "green-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "green",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "green-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
@@ -2081,8 +2185,10 @@
   },
   {
     "name": {
-      "property": "green-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "green",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "green-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
@@ -2092,8 +2198,10 @@
   },
   {
     "name": {
-      "property": "green-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "green",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "green-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
@@ -2103,9 +2211,11 @@
   },
   {
     "name": {
-      "property": "indigo-background-color",
+      "colorFamily": "indigo",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "indigo-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -2115,9 +2225,11 @@
   },
   {
     "name": {
-      "property": "indigo-background-color",
+      "colorFamily": "indigo",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "indigo-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -2127,9 +2239,11 @@
   },
   {
     "name": {
-      "property": "indigo-background-color",
+      "colorFamily": "indigo",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "indigo-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -2184,8 +2298,10 @@
   },
   {
     "name": {
-      "property": "indigo-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "indigo",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "indigo-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -2195,8 +2311,10 @@
   },
   {
     "name": {
-      "property": "indigo-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "indigo",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "indigo-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -2206,8 +2324,10 @@
   },
   {
     "name": {
-      "property": "indigo-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "indigo",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "indigo-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -2406,9 +2526,11 @@
   },
   {
     "name": {
-      "property": "magenta-background-color",
+      "colorFamily": "magenta",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "magenta-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -2418,9 +2540,11 @@
   },
   {
     "name": {
-      "property": "magenta-background-color",
+      "colorFamily": "magenta",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "magenta-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -2430,9 +2554,11 @@
   },
   {
     "name": {
-      "property": "magenta-background-color",
+      "colorFamily": "magenta",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "magenta-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -2487,8 +2613,10 @@
   },
   {
     "name": {
-      "property": "magenta-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "magenta",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "magenta-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -2498,8 +2626,10 @@
   },
   {
     "name": {
-      "property": "magenta-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "magenta",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "magenta-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -2509,8 +2639,10 @@
   },
   {
     "name": {
-      "property": "magenta-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "magenta",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "magenta-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -3335,9 +3467,11 @@
   },
   {
     "name": {
-      "property": "orange-background-color",
+      "colorFamily": "orange",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "orange-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
@@ -3347,9 +3481,11 @@
   },
   {
     "name": {
-      "property": "orange-background-color",
+      "colorFamily": "orange",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "orange-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -3359,9 +3495,11 @@
   },
   {
     "name": {
-      "property": "orange-background-color",
+      "colorFamily": "orange",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "orange-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
@@ -3416,8 +3554,10 @@
   },
   {
     "name": {
-      "property": "orange-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "orange",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "orange-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -3427,8 +3567,10 @@
   },
   {
     "name": {
-      "property": "orange-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "orange",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "orange-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -3438,8 +3580,10 @@
   },
   {
     "name": {
-      "property": "orange-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "orange",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "orange-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -3490,9 +3634,11 @@
   },
   {
     "name": {
-      "property": "pink-background-color",
+      "colorFamily": "pink",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "pink-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -3502,9 +3648,11 @@
   },
   {
     "name": {
-      "property": "pink-background-color",
+      "colorFamily": "pink",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "pink-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -3514,9 +3662,11 @@
   },
   {
     "name": {
-      "property": "pink-background-color",
+      "colorFamily": "pink",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "pink-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -3571,8 +3721,10 @@
   },
   {
     "name": {
-      "property": "pink-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "pink",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "pink-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -3582,8 +3734,10 @@
   },
   {
     "name": {
-      "property": "pink-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "pink",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "pink-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -3593,8 +3747,10 @@
   },
   {
     "name": {
-      "property": "pink-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "pink",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "pink-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -3793,9 +3949,11 @@
   },
   {
     "name": {
-      "property": "purple-background-color",
+      "colorFamily": "purple",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "purple-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -3805,9 +3963,11 @@
   },
   {
     "name": {
-      "property": "purple-background-color",
+      "colorFamily": "purple",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "purple-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -3817,9 +3977,11 @@
   },
   {
     "name": {
-      "property": "purple-background-color",
+      "colorFamily": "purple",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "purple-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -3874,8 +4036,10 @@
   },
   {
     "name": {
-      "property": "purple-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "purple",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "purple-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -3885,8 +4049,10 @@
   },
   {
     "name": {
-      "property": "purple-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "purple",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "purple-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -3896,8 +4062,10 @@
   },
   {
     "name": {
-      "property": "purple-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "purple",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "purple-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -3907,9 +4075,11 @@
   },
   {
     "name": {
-      "property": "red-background-color",
+      "colorFamily": "red",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "red-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -3919,9 +4089,11 @@
   },
   {
     "name": {
-      "property": "red-background-color",
+      "colorFamily": "red",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "red-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -3931,9 +4103,11 @@
   },
   {
     "name": {
-      "property": "red-background-color",
+      "colorFamily": "red",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "red-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -3988,8 +4162,10 @@
   },
   {
     "name": {
-      "property": "red-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "red",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "red-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -3999,8 +4175,10 @@
   },
   {
     "name": {
-      "property": "red-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "red",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "red-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
@@ -4010,8 +4188,10 @@
   },
   {
     "name": {
-      "property": "red-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "red",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "red-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -4021,9 +4201,11 @@
   },
   {
     "name": {
-      "property": "seafoam-background-color",
+      "colorFamily": "seafoam",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "seafoam-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
@@ -4033,9 +4215,11 @@
   },
   {
     "name": {
-      "property": "seafoam-background-color",
+      "colorFamily": "seafoam",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "seafoam-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
@@ -4045,9 +4229,11 @@
   },
   {
     "name": {
-      "property": "seafoam-background-color",
+      "colorFamily": "seafoam",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "seafoam-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
@@ -4102,8 +4288,10 @@
   },
   {
     "name": {
-      "property": "seafoam-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "seafoam",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "seafoam-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad52345b-0360-4819-9fe8-b6e07249810d",
@@ -4113,8 +4301,10 @@
   },
   {
     "name": {
-      "property": "seafoam-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "seafoam",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "seafoam-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
@@ -4124,8 +4314,10 @@
   },
   {
     "name": {
-      "property": "seafoam-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "seafoam",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "seafoam-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad52345b-0360-4819-9fe8-b6e07249810d",
@@ -4135,9 +4327,11 @@
   },
   {
     "name": {
-      "property": "silver-background-color",
+      "colorFamily": "silver",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "silver-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -4147,9 +4341,11 @@
   },
   {
     "name": {
-      "property": "silver-background-color",
+      "colorFamily": "silver",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "silver-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -4159,9 +4355,11 @@
   },
   {
     "name": {
-      "property": "silver-background-color",
+      "colorFamily": "silver",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "silver-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -4216,8 +4414,10 @@
   },
   {
     "name": {
-      "property": "silver-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "silver",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "silver-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -4227,8 +4427,10 @@
   },
   {
     "name": {
-      "property": "silver-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "silver",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "silver-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -4238,8 +4440,10 @@
   },
   {
     "name": {
-      "property": "silver-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "silver",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "silver-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -4341,9 +4545,11 @@
   },
   {
     "name": {
-      "property": "turquoise-background-color",
+      "colorFamily": "turquoise",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "turquoise-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -4353,9 +4559,11 @@
   },
   {
     "name": {
-      "property": "turquoise-background-color",
+      "colorFamily": "turquoise",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "turquoise-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -4365,9 +4573,11 @@
   },
   {
     "name": {
-      "property": "turquoise-background-color",
+      "colorFamily": "turquoise",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "turquoise-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -4422,8 +4632,10 @@
   },
   {
     "name": {
-      "property": "turquoise-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "turquoise",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "turquoise-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -4433,8 +4645,10 @@
   },
   {
     "name": {
-      "property": "turquoise-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "turquoise",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "turquoise-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -4444,8 +4658,10 @@
   },
   {
     "name": {
-      "property": "turquoise-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "turquoise",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "turquoise-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -4455,9 +4671,11 @@
   },
   {
     "name": {
-      "property": "yellow-background-color",
+      "colorFamily": "yellow",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "yellow-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -4467,9 +4685,11 @@
   },
   {
     "name": {
-      "property": "yellow-background-color",
+      "colorFamily": "yellow",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "yellow-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
@@ -4479,9 +4699,11 @@
   },
   {
     "name": {
-      "property": "yellow-background-color",
+      "colorFamily": "yellow",
+      "property": "background-color",
       "state": "default",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "yellow-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -4536,8 +4758,10 @@
   },
   {
     "name": {
-      "property": "yellow-visual-color",
-      "colorScheme": "light"
+      "colorFamily": "yellow",
+      "property": "visual-color",
+      "colorScheme": "light",
+      "legacyKey": "yellow-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
@@ -4547,8 +4771,10 @@
   },
   {
     "name": {
-      "property": "yellow-visual-color",
-      "colorScheme": "dark"
+      "colorFamily": "yellow",
+      "property": "visual-color",
+      "colorScheme": "dark",
+      "legacyKey": "yellow-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
@@ -4558,8 +4784,10 @@
   },
   {
     "name": {
-      "property": "yellow-visual-color",
-      "colorScheme": "wireframe"
+      "colorFamily": "yellow",
+      "property": "visual-color",
+      "colorScheme": "wireframe",
+      "legacyKey": "yellow-visual-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes 114 tokens in `color-aliases.tokens.json` whose `name.property`
fused a registry color family directly into the property string
(e.g. `property: "blue-background-color"`) instead of using the `colorFamily`
field, which the same file already uses correctly elsewhere (e.g.
`{colorFamily: "gray", variant: "subtle", property: "background-color"}`).

Each entry is re-authored to `colorFamily: "<family>"` + plain
`property: "background-color"` / `"visual-color"`, with a `legacyKey` pinned
per token so the serialized legacy output is unchanged — no `naming.rs`
serializer change required.

## Related Issue

Resolves beads issue `spectrum-design-data-dsi.5` (found while reviewing
dsi.4's decomposer-heuristic fix).

## Motivation and Context

These 114 tokens roundtripped correctly but were an authoring-consistency
gap: the family was jammed into `property` instead of using the existing
`colorFamily` field, and (having no `legacyKey`) they were invisible to the
residual analyzer that tracks legacy/cascade drift. Bulk re-authoring without
a plan risked breaking the roundtrip — the naive split (`colorFamily` +
plain `property`, no `legacyKey`) collides with the palette-ramp branch in
`naming.rs`, which drops `property` entirely whenever `colorFamily` is set
with no owner. Pinning `legacyKey` per token avoids that branch and any
serializer change altogether.

## How Has This Been Tested?

- `moon run sdk:build design-data:legacy-output`: regenerated
  `packages/tokens/src/*` — **zero diff** vs. pre-change output (byte-identical).
- `moon run design-data:roundtrip-verify`: `Roundtrip OK`.
- `moon run design-data:validate`: SPEC-043 warning count for
  `color-aliases.tokens.json` unchanged (18 before, 18 after) — no new warnings.
- `moon run :test`: full workspace test suite passes, except one pre-existing,
  unrelated `sdk-wasm:test` failure (`accent-background-color` resolution)
  confirmed present on `main` before this change (verified via `git stash`).

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
