### PR TITLE
fix(design-data): decompose fused ramp/scale-index compounds (dsi.6)

### DIFF
--- a/.changeset/dsi6-decompose-scaleindex-colorrole.md
+++ b/.changeset/dsi6-decompose-scaleindex-colorrole.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose fused ramp/scale-index compounds flagged by dsi.6 into proper
+`colorRole`/`scaleIndex` fields, closing a serializer gap where Rust and
+JS silently disagreed on scaleIndex placement.
+
+- **packages/design-data/tokens/semantic-color-palette.tokens.json**: split
+  80 `{accent,informative,negative,notice,positive}-color-N` tokens into
+  `colorRole` + `property:"color"` + `scaleIndex`.
+- **packages/design-data/tokens/layout-component.tokens.json**: split 73
+  fused `{property}-N` tokens into `property` + `scaleIndex`.
+- **packages/design-data/tokens/layout.tokens.json**: split 66 fused
+  `{property}-N` tokens (incl. space-between gaps) into `property`/
+  `from`/`to` + `scaleIndex`.
+- **sdk/core/src/naming.rs**: new `colorRole` semantic-ramp branch; now
+  appends `scaleIndex` in the icon, space-between, and general branches.
+- **tools/token-mapping-analyzer/src/decomposer.js**: `scaleIndex` now
+  serializes as a number (was silently dropped by Rust's `.as_i64()`);
+  added `colorRole` promotion + serialize branch.
+- **tools/token-mapping-analyzer/src/apply.js**: added `applyScaleIndex()`.

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -2352,7 +2352,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-100"
+      "property": "size",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6f799e9e-1e37-4d9d-b88d-3969ca707213",
@@ -2361,7 +2362,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-200"
+      "property": "size",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad82e875-4243-4665-93b9-91aef258b164",
@@ -2370,7 +2372,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-300"
+      "property": "size",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3c458169-051a-473d-9b68-af84803a74e6",
@@ -2379,7 +2382,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-400"
+      "property": "size",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f1ebef6a-9cf7-4aa6-9dcf-2bfd6387a97e",
@@ -2388,7 +2392,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-50"
+      "property": "size",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bf2b8540-8b70-4c36-8e02-7deeb66d532e",
@@ -2397,7 +2402,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-500"
+      "property": "size",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b05bc8a7-3937-4e31-97eb-4514bdb31f9f",
@@ -2406,7 +2412,8 @@
   {
     "name": {
       "component": "avatar-group",
-      "property": "size-75"
+      "property": "size",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "88990423-8f5c-486b-9c7d-969db3d82cbb",
@@ -2415,8 +2422,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -2427,8 +2435,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -2439,8 +2448,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1000",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1000
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "64px",
@@ -2451,8 +2461,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1000",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1000
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "72px",
@@ -2463,8 +2474,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "72px",
@@ -2475,8 +2487,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "80px",
@@ -2487,8 +2500,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "80px",
@@ -2499,8 +2513,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "88px",
@@ -2511,8 +2526,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "88px",
@@ -2523,8 +2539,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "96px",
@@ -2535,8 +2552,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "96px",
@@ -2547,8 +2565,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "104px",
@@ -2559,8 +2578,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "104px",
@@ -2571,8 +2591,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-1500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "112px",
@@ -2583,8 +2604,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -2595,8 +2617,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -2607,8 +2630,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -2619,8 +2643,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -2631,8 +2656,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -2643,8 +2669,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -2655,8 +2682,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-50",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -2667,8 +2695,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-50",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -2679,8 +2708,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -2691,8 +2721,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "44px",
@@ -2703,8 +2734,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "44px",
@@ -2715,8 +2747,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "48px",
@@ -2727,8 +2760,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-700",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 700
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "48px",
@@ -2739,8 +2773,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-700",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 700
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "52px",
@@ -2751,8 +2786,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -2763,8 +2799,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -2775,8 +2812,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-800",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 800
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "52px",
@@ -2787,8 +2825,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-800",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 800
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "56px",
@@ -2799,8 +2838,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-900",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 900
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "56px",
@@ -2811,8 +2851,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "size-900",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 900
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "64px",
@@ -8154,8 +8195,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -8166,8 +8208,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -8178,8 +8221,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -8190,8 +8234,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -8202,8 +8247,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "26px",
@@ -8214,8 +8260,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "30px",
@@ -8226,8 +8273,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -8238,8 +8286,9 @@
   {
     "name": {
       "component": "in-field-progress-circle",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -20310,8 +20359,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -20322,8 +20372,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -20334,8 +20385,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-1000",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 1000
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "64px",
@@ -20346,8 +20398,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-1000",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 1000
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "72px",
@@ -20358,8 +20411,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -20370,8 +20424,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -20382,8 +20437,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -20394,8 +20450,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -20406,8 +20463,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -20418,8 +20476,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -20430,8 +20489,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-50",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -20442,8 +20502,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-50",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -20454,8 +20515,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -20466,8 +20528,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "44px",
@@ -20478,8 +20541,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "44px",
@@ -20490,8 +20554,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "48px",
@@ -20502,8 +20567,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-700",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 700
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "48px",
@@ -20514,8 +20580,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-700",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 700
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "52px",
@@ -20526,8 +20593,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -20538,8 +20606,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -20550,8 +20619,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-800",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 800
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "52px",
@@ -20562,8 +20632,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-800",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 800
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "56px",
@@ -20574,8 +20645,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-900",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 900
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "56px",
@@ -20586,8 +20658,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "size-900",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 900
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "64px",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -685,7 +685,8 @@
   },
   {
     "name": {
-      "property": "border-width-100"
+      "property": "border-width",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -693,7 +694,8 @@
   },
   {
     "name": {
-      "property": "border-width-200"
+      "property": "border-width",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -701,7 +703,8 @@
   },
   {
     "name": {
-      "property": "border-width-400"
+      "property": "border-width",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -3477,8 +3480,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-100",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -3491,8 +3497,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-100",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -3505,8 +3514,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-200",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -3519,8 +3531,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-200",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -3533,8 +3548,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-300",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -3547,8 +3565,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-300",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3561,8 +3582,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-75",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -3575,8 +3599,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-disclosure-icon-75",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -3729,8 +3756,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-100",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -3743,8 +3773,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-100",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -3757,8 +3790,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-200",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -3771,8 +3807,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-200",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -3785,8 +3824,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-300",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -3799,8 +3841,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-300",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3813,8 +3858,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-75",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -3827,8 +3875,11 @@
   },
   {
     "name": {
-      "property": "field-end-edge-to-disclosure-icon-75",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-end-edge",
+      "to": "disclosure-icon",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -4177,8 +4228,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-100",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -4191,8 +4245,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-100",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -4205,8 +4262,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-200",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4219,8 +4279,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-200",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -4233,8 +4296,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-300",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -4247,8 +4313,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-300",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -4261,8 +4330,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-75",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -4275,8 +4347,11 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-75",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5483,7 +5558,8 @@
   },
   {
     "name": {
-      "property": "spacing-100"
+      "property": "spacing",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -5491,7 +5567,8 @@
   },
   {
     "name": {
-      "property": "spacing-1000"
+      "property": "spacing",
+      "scaleIndex": 1000
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "96px",
@@ -5499,7 +5576,8 @@
   },
   {
     "name": {
-      "property": "spacing-200"
+      "property": "spacing",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -5507,7 +5585,8 @@
   },
   {
     "name": {
-      "property": "spacing-25"
+      "property": "spacing",
+      "scaleIndex": 25
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -5515,7 +5594,8 @@
   },
   {
     "name": {
-      "property": "spacing-300"
+      "property": "spacing",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -5523,7 +5603,8 @@
   },
   {
     "name": {
-      "property": "spacing-350"
+      "property": "spacing",
+      "scaleIndex": 350
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -5531,7 +5612,8 @@
   },
   {
     "name": {
-      "property": "spacing-400"
+      "property": "spacing",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -5539,7 +5621,8 @@
   },
   {
     "name": {
-      "property": "spacing-50"
+      "property": "spacing",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -5547,7 +5630,8 @@
   },
   {
     "name": {
-      "property": "spacing-500"
+      "property": "spacing",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -5555,7 +5639,8 @@
   },
   {
     "name": {
-      "property": "spacing-600"
+      "property": "spacing",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -5563,7 +5648,8 @@
   },
   {
     "name": {
-      "property": "spacing-700"
+      "property": "spacing",
+      "scaleIndex": 700
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "48px",
@@ -5571,7 +5657,8 @@
   },
   {
     "name": {
-      "property": "spacing-75"
+      "property": "spacing",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -5579,7 +5666,8 @@
   },
   {
     "name": {
-      "property": "spacing-800"
+      "property": "spacing",
+      "scaleIndex": 800
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "64px",
@@ -5587,7 +5675,8 @@
   },
   {
     "name": {
-      "property": "spacing-85"
+      "property": "spacing",
+      "scaleIndex": 85
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5595,7 +5684,8 @@
   },
   {
     "name": {
-      "property": "spacing-900"
+      "property": "spacing",
+      "scaleIndex": 900
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "80px",
@@ -5731,8 +5821,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-100",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -5745,8 +5838,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-100",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -5759,8 +5855,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-200",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -5773,8 +5872,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-200",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -5787,8 +5889,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-300",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -5801,8 +5906,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-300",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -5815,8 +5923,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-50",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -5829,8 +5940,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-50",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -5843,8 +5957,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-75",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5857,8 +5974,11 @@
   },
   {
     "name": {
-      "property": "text-to-control-75",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "control",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -5871,8 +5991,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-100",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5885,8 +6008,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-100",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -5899,8 +6025,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-200",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -5913,8 +6042,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-200",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5927,8 +6059,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-300",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -5941,8 +6076,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-300",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -5955,8 +6093,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-400",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5969,8 +6110,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-400",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -5983,8 +6127,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-50",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -5997,8 +6144,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-50",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -6011,8 +6161,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-75",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -6025,8 +6178,11 @@
   },
   {
     "name": {
-      "property": "text-to-visual-75",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "visual",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -6059,8 +6215,11 @@
   },
   {
     "name": {
-      "property": "visual-to-control-100",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "visual",
+      "to": "control",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6073,8 +6232,11 @@
   },
   {
     "name": {
-      "property": "visual-to-control-100",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "visual",
+      "to": "control",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -1,7 +1,9 @@
 [
   {
     "name": {
-      "property": "accent-color-100"
+      "property": "color",
+      "scaleIndex": 100,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
@@ -9,7 +11,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1000"
+      "property": "color",
+      "scaleIndex": 1000,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
@@ -17,7 +21,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1100"
+      "property": "color",
+      "scaleIndex": 1100,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
@@ -25,7 +31,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1200"
+      "property": "color",
+      "scaleIndex": 1200,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5c04481e-664e-4e9a-8da9-841e349167f5",
@@ -33,7 +41,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1300"
+      "property": "color",
+      "scaleIndex": 1300,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
@@ -41,7 +51,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1400"
+      "property": "color",
+      "scaleIndex": 1400,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
@@ -49,7 +61,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1500"
+      "property": "color",
+      "scaleIndex": 1500,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "be3d8c39-72f3-4134-b009-4aa30fb01883",
@@ -57,7 +71,9 @@
   },
   {
     "name": {
-      "property": "accent-color-1600"
+      "property": "color",
+      "scaleIndex": 1600,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
@@ -65,7 +81,9 @@
   },
   {
     "name": {
-      "property": "accent-color-200"
+      "property": "color",
+      "scaleIndex": 200,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -73,7 +91,9 @@
   },
   {
     "name": {
-      "property": "accent-color-300"
+      "property": "color",
+      "scaleIndex": 300,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
@@ -81,7 +101,9 @@
   },
   {
     "name": {
-      "property": "accent-color-400"
+      "property": "color",
+      "scaleIndex": 400,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
@@ -89,7 +111,9 @@
   },
   {
     "name": {
-      "property": "accent-color-500"
+      "property": "color",
+      "scaleIndex": 500,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1350b184-da3d-4920-bfa1-b42ba88761b2",
@@ -97,7 +121,9 @@
   },
   {
     "name": {
-      "property": "accent-color-600"
+      "property": "color",
+      "scaleIndex": 600,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
@@ -105,7 +131,9 @@
   },
   {
     "name": {
-      "property": "accent-color-700"
+      "property": "color",
+      "scaleIndex": 700,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
@@ -113,7 +141,9 @@
   },
   {
     "name": {
-      "property": "accent-color-800"
+      "property": "color",
+      "scaleIndex": 800,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -121,7 +151,9 @@
   },
   {
     "name": {
-      "property": "accent-color-900"
+      "property": "color",
+      "scaleIndex": 900,
+      "colorRole": "accent"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -219,7 +251,9 @@
   },
   {
     "name": {
-      "property": "informative-color-100"
+      "property": "color",
+      "scaleIndex": 100,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "482037db-2e5c-4deb-bfa5-986a46cdcf33",
@@ -227,7 +261,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1000"
+      "property": "color",
+      "scaleIndex": 1000,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de6d785f-3534-4648-950c-e0e22fa9e2e9",
@@ -235,7 +271,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1100"
+      "property": "color",
+      "scaleIndex": 1100,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fa9c46cb-f4a5-4022-aa01-dc3ffdb83bae",
@@ -243,7 +281,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1200"
+      "property": "color",
+      "scaleIndex": 1200,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5c04481e-664e-4e9a-8da9-841e349167f5",
@@ -251,7 +291,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1300"
+      "property": "color",
+      "scaleIndex": 1300,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "01a7cb36-1d5f-4d91-8a95-4a8d93fe41e4",
@@ -259,7 +301,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1400"
+      "property": "color",
+      "scaleIndex": 1400,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1d86cef1-e309-4b79-89a1-a54008a9efcb",
@@ -267,7 +311,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1500"
+      "property": "color",
+      "scaleIndex": 1500,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "be3d8c39-72f3-4134-b009-4aa30fb01883",
@@ -275,7 +321,9 @@
   },
   {
     "name": {
-      "property": "informative-color-1600"
+      "property": "color",
+      "scaleIndex": 1600,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1472f089-6c1d-46ec-b8f4-e20855e65cd6",
@@ -283,7 +331,9 @@
   },
   {
     "name": {
-      "property": "informative-color-200"
+      "property": "color",
+      "scaleIndex": 200,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -291,7 +341,9 @@
   },
   {
     "name": {
-      "property": "informative-color-300"
+      "property": "color",
+      "scaleIndex": 300,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
@@ -299,7 +351,9 @@
   },
   {
     "name": {
-      "property": "informative-color-400"
+      "property": "color",
+      "scaleIndex": 400,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "822f3ccf-6545-4ef1-b626-b7b6b5f94d95",
@@ -307,7 +361,9 @@
   },
   {
     "name": {
-      "property": "informative-color-500"
+      "property": "color",
+      "scaleIndex": 500,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1350b184-da3d-4920-bfa1-b42ba88761b2",
@@ -315,7 +371,9 @@
   },
   {
     "name": {
-      "property": "informative-color-600"
+      "property": "color",
+      "scaleIndex": 600,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "71995b2a-07a1-489c-a17a-bf0d91ac5196",
@@ -323,7 +381,9 @@
   },
   {
     "name": {
-      "property": "informative-color-700"
+      "property": "color",
+      "scaleIndex": 700,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1f0cc963-2ecf-4885-9ca1-d718b88aa968",
@@ -331,7 +391,9 @@
   },
   {
     "name": {
-      "property": "informative-color-800"
+      "property": "color",
+      "scaleIndex": 800,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -339,7 +401,9 @@
   },
   {
     "name": {
-      "property": "informative-color-900"
+      "property": "color",
+      "scaleIndex": 900,
+      "colorRole": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -392,7 +456,9 @@
   },
   {
     "name": {
-      "property": "negative-color-100"
+      "property": "color",
+      "scaleIndex": 100,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "921d4bb8-f5b0-4955-a495-294864cf4ca5",
@@ -400,7 +466,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1000"
+      "property": "color",
+      "scaleIndex": 1000,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "07ad3c80-0ca4-4e23-9daa-42c97c558678",
@@ -408,7 +476,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1100"
+      "property": "color",
+      "scaleIndex": 1100,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5485c698-0ea9-47d7-b81d-43f0647c4078",
@@ -416,7 +486,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1200"
+      "property": "color",
+      "scaleIndex": 1200,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "403564fd-fda3-4ef5-a68e-96c6f5a93a93",
@@ -424,7 +496,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1300"
+      "property": "color",
+      "scaleIndex": 1300,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5136ff9b-5a00-4e67-bf8f-8f3df14bf849",
@@ -432,7 +506,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1400"
+      "property": "color",
+      "scaleIndex": 1400,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "590136e1-3127-4540-9689-05b1161bd4c2",
@@ -440,7 +516,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1500"
+      "property": "color",
+      "scaleIndex": 1500,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2955fdf4-5bf7-4dc0-a812-c1c808f5f76e",
@@ -448,7 +526,9 @@
   },
   {
     "name": {
-      "property": "negative-color-1600"
+      "property": "color",
+      "scaleIndex": 1600,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e042de3e-9b82-4229-880d-e1e4b1af80b7",
@@ -456,7 +536,9 @@
   },
   {
     "name": {
-      "property": "negative-color-200"
+      "property": "color",
+      "scaleIndex": 200,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -464,7 +546,9 @@
   },
   {
     "name": {
-      "property": "negative-color-300"
+      "property": "color",
+      "scaleIndex": 300,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
@@ -472,7 +556,9 @@
   },
   {
     "name": {
-      "property": "negative-color-400"
+      "property": "color",
+      "scaleIndex": 400,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9fdfa78d-e774-4550-b4e1-57f006c3f3f5",
@@ -480,7 +566,9 @@
   },
   {
     "name": {
-      "property": "negative-color-500"
+      "property": "color",
+      "scaleIndex": 500,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "33e7f73d-be80-4961-bcd7-6088fddadf44",
@@ -488,7 +576,9 @@
   },
   {
     "name": {
-      "property": "negative-color-600"
+      "property": "color",
+      "scaleIndex": 600,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2bad908f-065a-45fb-9a75-6f3ae0da19a4",
@@ -496,7 +586,9 @@
   },
   {
     "name": {
-      "property": "negative-color-700"
+      "property": "color",
+      "scaleIndex": 700,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
@@ -504,7 +596,9 @@
   },
   {
     "name": {
-      "property": "negative-color-800"
+      "property": "color",
+      "scaleIndex": 800,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -512,7 +606,9 @@
   },
   {
     "name": {
-      "property": "negative-color-900"
+      "property": "color",
+      "scaleIndex": 900,
+      "colorRole": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -605,7 +701,9 @@
   },
   {
     "name": {
-      "property": "notice-color-100"
+      "property": "color",
+      "scaleIndex": 100,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b31d8010-6701-4a59-8f7e-3ae680755c17",
@@ -613,7 +711,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1000"
+      "property": "color",
+      "scaleIndex": 1000,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff4c4d68-d10a-48f3-a7ab-2306cb18dfe2",
@@ -621,7 +721,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1100"
+      "property": "color",
+      "scaleIndex": 1100,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a0f0fc25-7be4-4ff7-b756-47b018352a7a",
@@ -629,7 +731,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1200"
+      "property": "color",
+      "scaleIndex": 1200,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cdffa59a-a440-4e1b-a9f4-c45755f954b8",
@@ -637,7 +741,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1300"
+      "property": "color",
+      "scaleIndex": 1300,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322a161e-bbda-4369-b4ec-6140ccbb01c4",
@@ -645,7 +751,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1400"
+      "property": "color",
+      "scaleIndex": 1400,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0fbbe97-29aa-4b4e-a5d7-b680a26cfeeb",
@@ -653,7 +761,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1500"
+      "property": "color",
+      "scaleIndex": 1500,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dae987e5-c3ee-405b-83a9-3d9e054f95b1",
@@ -661,7 +771,9 @@
   },
   {
     "name": {
-      "property": "notice-color-1600"
+      "property": "color",
+      "scaleIndex": 1600,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bdfd1197-f4c7-4f7f-8968-768f5fa400f3",
@@ -669,7 +781,9 @@
   },
   {
     "name": {
-      "property": "notice-color-200"
+      "property": "color",
+      "scaleIndex": 200,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -677,7 +791,9 @@
   },
   {
     "name": {
-      "property": "notice-color-300"
+      "property": "color",
+      "scaleIndex": 300,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
@@ -685,7 +801,9 @@
   },
   {
     "name": {
-      "property": "notice-color-400"
+      "property": "color",
+      "scaleIndex": 400,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4eaf6e03-2c4d-4666-ad22-206e6a0aa8d3",
@@ -693,7 +811,9 @@
   },
   {
     "name": {
-      "property": "notice-color-500"
+      "property": "color",
+      "scaleIndex": 500,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9e3e4263-9515-4937-b33f-3af341e57073",
@@ -701,7 +821,9 @@
   },
   {
     "name": {
-      "property": "notice-color-600"
+      "property": "color",
+      "scaleIndex": 600,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
@@ -709,7 +831,9 @@
   },
   {
     "name": {
-      "property": "notice-color-700"
+      "property": "color",
+      "scaleIndex": 700,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -717,7 +841,9 @@
   },
   {
     "name": {
-      "property": "notice-color-800"
+      "property": "color",
+      "scaleIndex": 800,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bed559d1-c097-40ad-8d3a-2866198832c2",
@@ -725,7 +851,9 @@
   },
   {
     "name": {
-      "property": "notice-color-900"
+      "property": "color",
+      "scaleIndex": 900,
+      "colorRole": "notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -778,7 +906,9 @@
   },
   {
     "name": {
-      "property": "positive-color-100"
+      "property": "color",
+      "scaleIndex": 100,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7c7c0136-2623-468d-a12f-678d21973613",
@@ -786,7 +916,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1000"
+      "property": "color",
+      "scaleIndex": 1000,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "23d8a797-8f40-4072-868d-6213c3cd6c0a",
@@ -794,7 +926,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1100"
+      "property": "color",
+      "scaleIndex": 1100,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d20c8ed5-b1b4-4a80-80ee-fe9ff47ff1fc",
@@ -802,7 +936,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1200"
+      "property": "color",
+      "scaleIndex": 1200,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "365a47c9-43c8-45a4-8cb8-07c552aca28b",
@@ -810,7 +946,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1300"
+      "property": "color",
+      "scaleIndex": 1300,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6668c6c5-b66e-4c83-a95a-37fde594296b",
@@ -818,7 +956,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1400"
+      "property": "color",
+      "scaleIndex": 1400,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "06a43e47-f5f4-45ad-8092-8a4d14e48fc9",
@@ -826,7 +966,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1500"
+      "property": "color",
+      "scaleIndex": 1500,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54ef3b06-ac50-4176-af22-86d0c73d5d13",
@@ -834,7 +976,9 @@
   },
   {
     "name": {
-      "property": "positive-color-1600"
+      "property": "color",
+      "scaleIndex": 1600,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2d45aad7-eb31-46f9-a73f-69498e466a29",
@@ -842,7 +986,9 @@
   },
   {
     "name": {
-      "property": "positive-color-200"
+      "property": "color",
+      "scaleIndex": 200,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
@@ -850,7 +996,9 @@
   },
   {
     "name": {
-      "property": "positive-color-300"
+      "property": "color",
+      "scaleIndex": 300,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
@@ -858,7 +1006,9 @@
   },
   {
     "name": {
-      "property": "positive-color-400"
+      "property": "color",
+      "scaleIndex": 400,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6673709d-2154-4189-ad4f-e6867ecfe744",
@@ -866,7 +1016,9 @@
   },
   {
     "name": {
-      "property": "positive-color-500"
+      "property": "color",
+      "scaleIndex": 500,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a63a12c8-2526-49b0-a918-543af6deb103",
@@ -874,7 +1026,9 @@
   },
   {
     "name": {
-      "property": "positive-color-600"
+      "property": "color",
+      "scaleIndex": 600,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "26b0bdde-2ea0-456c-8ade-a521e8799613",
@@ -882,7 +1036,9 @@
   },
   {
     "name": {
-      "property": "positive-color-700"
+      "property": "color",
+      "scaleIndex": 700,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
@@ -890,7 +1046,9 @@
   },
   {
     "name": {
-      "property": "positive-color-800"
+      "property": "color",
+      "scaleIndex": 800,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
@@ -898,7 +1056,9 @@
   },
   {
     "name": {
-      "property": "positive-color-900"
+      "property": "color",
+      "scaleIndex": 900,
+      "colorRole": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -279,7 +279,12 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     });
 
     if let Some(cf) = color_family {
-        if owner.is_none() {
+        // Guarded on color_role.is_none() too: a hue (color-families.json) and a
+        // role (color-roles.json) are disjoint registries today, so a name object
+        // never carries both — but if that ever changed, falling through to the
+        // more specific semantic-ramp branch below is safer than silently
+        // dropping colorRole.
+        if owner.is_none() && color_role.is_none() {
             // Palette ramp: no owner, property implicit.
             let mut parts: Vec<String> = Vec::new();
             if let Some(v) = name.get("variant").and_then(|v| v.as_str()) {
@@ -466,6 +471,11 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     // it at the end, mirroring the JS decomposer.js general path — non-standard
     // placement (scaleIndex has no catalog position of its own), but matches how
     // these tokens' fused property strings always trailed with the numeric index.
+    // Correctness relies on the convention that any token whose `property` is
+    // still a fused string (e.g. "font-size-100") alongside a populated
+    // scaleIndex pins an explicit legacyKey instead of relying on this
+    // reconstruction — nothing here structurally prevents a double-emit if
+    // that convention were ever violated.
     if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
         parts.push(i.to_string());
     }

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -248,6 +248,13 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     //   `property` ("color") is implicit and omitted from the key.
     //   e.g. {colorFamily:"blue", scaleIndex:100} → "blue-100"
     //
+    //   Semantic ramp (no owner, colorRole not colorFamily): unlike the hue ramp
+    //   above, `property` ("color") is NOT implicit — the legacy key spells it out
+    //   (e.g. "accent-color-100", not "accent-100") because these role names
+    //   ("accent", "informative", …) collide with plain words elsewhere, so the
+    //   literal "color" segment disambiguates. {colorRole}-color-{scaleIndex?}
+    //   e.g. {colorRole:"accent", property:"color", scaleIndex:100} → "accent-color-100"
+    //
     //   Owner color (owner + colorFamily and/or colorRole):
     //   {owner}-{property}-{colorFamily?}-{colorRole?}-{state?}
     //   `property` is always "color". Explicit ordering avoids the position-walk trap
@@ -286,6 +293,17 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         }
     }
 
+    if let Some(cr) = color_role {
+        if owner.is_none() && name.get("property").and_then(|v| v.as_str()) == Some("color") {
+            // Semantic ramp: no owner, property explicit (see comment above).
+            let mut parts: Vec<String> = vec![cr.to_string(), "color".to_string()];
+            if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
+                parts.push(i.to_string());
+            }
+            return Some(parts.join("-"));
+        }
+    }
+
     // Owner color: owner present AND at least one of colorFamily/colorRole.
     if owner.is_some() && (color_family.is_some() || color_role.is_some()) {
         let property = name.get("property").and_then(|v| v.as_str())?;
@@ -314,6 +332,8 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     // above — since `icon`'s position (100) sits after `property` in the catalog,
     // so the generic position-walk below can't express the required leading order.
     // e.g. {icon:"add", property:"size-100"} → "add-icon-size-100"
+    // (equivalently, once scaleIndex is split out: {icon:"add", property:"size",
+    // scaleIndex:100} → "add-icon-size-100")
     //
     // Thin-format check mirrors the `component` case just below: some tokens store
     // the full legacy key in `property` already (e.g. property:"icon-color-disabled-
@@ -328,6 +348,9 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
             return Some(property.to_string());
         }
         let mut parts: Vec<String> = vec![ic_expanded.to_string(), property.to_string()];
+        if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
+            parts.push(i.to_string());
+        }
         if let Some(st) = name.get("state").and_then(|v| v.as_str()) {
             parts.push(st.to_string());
         }
@@ -378,6 +401,15 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
                 }
             }
 
+            // dsi.6: scaleIndex can be split out of a space-between token's fused
+            // property (e.g. "field-edge-to-disclosure-icon-100"); scaleIndex is
+            // excludeFromLegacyKey so the loop above skips it like every other
+            // branch — append it explicitly, mirroring the general-domain append
+            // below and JS decomposer.js's space-between serialize branch.
+            if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
+                parts.push(i.to_string());
+            }
+
             if parts.is_empty() {
                 return None;
             }
@@ -397,7 +429,8 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     // Currently excluded fields, grouped by reason (see each field's JSON for per-field notes):
     //   Mode-set selectors (not part of the legacy name): colorScheme, scale, contrast
     //   Color-domain (handled by color-domain branch above): colorFamily, colorRole
-    //   Integer scale (already embedded in `property`; would double-emit): scaleIndex
+    //   Integer scale (walked positionally would double-emit vs. the explicit append
+    //     below, since scaleIndex has no fixed catalog position of its own): scaleIndex
     //   Legacy metadata annotation (value already embedded in `property` for all current
     //     tokens): structure — if it joins Phase D decomposition, remove its
     //     excludeFromLegacyKey flag and re-verify against the three legacy gates.
@@ -428,12 +461,14 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         }
     }
 
-    // ponytail: scaleIndex is not appended here because:
-    //   - Color tokens (blue-100, etc.) reach this path only without colorFamily, which
-    //     is extremely rare; their scaleIndex is handled by the colorFamily branch above.
-    //   - Typography scale tokens pack scaleIndex into `property` already ("font-size-100").
-    // If a future decomposition strips scaleIndex from property for a general-domain token,
-    // revisit this path and add the conditional append.
+    // dsi.6: general-domain tokens (e.g. avatar-group-size-100, spacing-100,
+    // border-width-100) can also have scaleIndex split out of `property`. Append
+    // it at the end, mirroring the JS decomposer.js general path — non-standard
+    // placement (scaleIndex has no catalog position of its own), but matches how
+    // these tokens' fused property strings always trailed with the numeric index.
+    if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
+        parts.push(i.to_string());
+    }
 
     if parts.is_empty() {
         return None;
@@ -634,6 +669,20 @@ mod tests {
     }
 
     #[test]
+    fn extract_key_general_domain_scale_index_appended() {
+        // dsi.6: non-color, non-icon tokens (avatar-group-size-100, spacing-100,
+        // border-width-100, …) can also have scaleIndex split out of `property`.
+        let name = json!({"component": "avatar-group", "property": "size", "scaleIndex": 100});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("avatar-group-size-100")
+        );
+
+        let name = json!({"property": "spacing", "scaleIndex": 200});
+        assert_eq!(extract_legacy_key(&name).as_deref(), Some("spacing-200"));
+    }
+
+    #[test]
     fn extract_key_thin_format_property_is_full_key() {
         // Thin format: property starts with component prefix → return property directly.
         let name = json!({"property": "swatch-disabled-icon-border-color", "component": "swatch"});
@@ -736,6 +785,35 @@ mod tests {
             extract_legacy_key(&name).as_deref(),
             Some("accordion-space-between")
         );
+    }
+
+    #[test]
+    fn extract_key_space_between_with_scale_index_no_collision() {
+        // dsi.6: thin-format space-between tokens with a trailing scale index
+        // (e.g. field-edge-to-disclosure-icon-100/-200/...) must append
+        // scaleIndex, or every index variant reconstructs the SAME key and
+        // collides during legacy-output generation, silently dropping data.
+        let name_100 = json!({
+            "property": "space-between",
+            "from": "field-edge",
+            "to": "disclosure-icon",
+            "scaleIndex": 100
+        });
+        let name_200 = json!({
+            "property": "space-between",
+            "from": "field-edge",
+            "to": "disclosure-icon",
+            "scaleIndex": 200
+        });
+        assert_eq!(
+            extract_legacy_key(&name_100).as_deref(),
+            Some("field-edge-to-disclosure-icon-100")
+        );
+        assert_eq!(
+            extract_legacy_key(&name_200).as_deref(),
+            Some("field-edge-to-disclosure-icon-200")
+        );
+        assert_ne!(extract_legacy_key(&name_100), extract_legacy_key(&name_200));
     }
 
     #[test]
@@ -940,6 +1018,51 @@ mod tests {
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("icon-color-disabled-primary")
+        );
+    }
+
+    #[test]
+    fn extract_key_icon_size_with_scale_index() {
+        // dsi.6: scaleIndex split out of the fused "size-100" property must still
+        // reconstruct the original legacy key.
+        let name = json!({"icon": "add", "property": "size", "scaleIndex": 100});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("add-icon-size-100")
+        );
+    }
+
+    #[test]
+    fn extract_key_icon_size_with_scale_index_and_state() {
+        let name = json!({
+            "icon": "checkmark",
+            "property": "size",
+            "scaleIndex": 75,
+            "state": "hover"
+        });
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("checkmark-icon-size-75-hover")
+        );
+    }
+
+    #[test]
+    fn extract_key_semantic_color_ramp_with_scale_index() {
+        // dsi.6: colorRole ramp (accent/informative/negative/notice/positive), no
+        // owner — unlike the hue ramp, `property` ("color") is explicit in the key.
+        let name = json!({"property": "color", "colorRole": "accent", "scaleIndex": 100});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("accent-color-100")
+        );
+    }
+
+    #[test]
+    fn extract_key_semantic_color_ramp_no_scale_index() {
+        let name = json!({"property": "color", "colorRole": "informative"});
+        assert_eq!(
+            extract_legacy_key(&name).as_deref(),
+            Some("informative-color")
         );
     }
 }

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -200,12 +200,87 @@ export function applySpaceBetween(tokens, registry, filename) {
   return { applied, skippedSpec025: 0 };
 }
 
+/**
+ * Apply the scale-index decomposition (dsi.6): a numeric scale suffix fused
+ * onto `property` (e.g. "size-100", "color-100") with no `scaleIndex` field.
+ * `scaleIndex` isn't a registered taxonomy field (decomposer.js flags it as a
+ * gap in the 13-field spec), so it can't go through the single-registry
+ * `applyField` path above — this mirrors `applySpaceBetween`'s dedicated,
+ * whole-object-merge approach instead.
+ */
+export function applyScaleIndex(tokens, registry, filename) {
+  let applied = 0;
+
+  for (const token of tokens) {
+    if (!token.name || typeof token.name !== "object") continue;
+    if (token.name.scaleIndex !== undefined) continue; // already migrated
+    if (
+      typeof token.name.property !== "string" ||
+      !/-\d+$/.test(token.name.property)
+    )
+      continue;
+
+    const legacyKey = serialize(
+      token.name,
+      registry.tokenNameMap,
+      registry.serializationOrder,
+    );
+    if (!legacyKey) continue;
+
+    const result = decompose(
+      legacyKey,
+      { deprecated: !!token.deprecated, component: token.name?.component },
+      registry,
+      filename,
+    );
+
+    if (
+      result.confidence !== "HIGH" ||
+      !result.roundtrips ||
+      result.nameObject.scaleIndex === undefined ||
+      !result.nameObject.property // guard: property must remain non-empty
+    )
+      continue;
+
+    // Guard: remaining property must be a registered property term
+    if (
+      registry.byField.property &&
+      !registry.byField.property.has(result.nameObject.property)
+    )
+      continue;
+
+    // Whole-object merge (see applyField's comment): a token can stack other
+    // concepts alongside the scale index in the same property string.
+    const patched = { ...token.name, ...result.nameObject };
+
+    if (patched.anatomy && !patched.component) continue; // SPEC-025
+
+    if (
+      result.nameObject.component !== undefined &&
+      token.name.component === undefined
+    )
+      continue; // don't fabricate ownership metadata as a side effect
+
+    if (
+      serialize(patched, registry.tokenNameMap, registry.serializationOrder) !==
+      legacyKey
+    )
+      continue;
+
+    Object.assign(token.name, result.nameObject);
+    applied++;
+  }
+
+  return { applied, skippedSpec025: 0 };
+}
+
 async function main() {
   const { field, write } = parseArgs();
   const registry = loadRegistries();
   const isSpaceBetween = field === "space-between";
+  const isScaleIndex = field === "scale-index";
 
-  if (!isSpaceBetween && !registry.byField[field]) {
+  if (!isSpaceBetween && !isScaleIndex && !registry.byField[field]) {
     console.error(
       `Unknown field: "${field}". Known fields: ${Object.keys(registry.byField).join(", ")}`,
     );
@@ -221,10 +296,15 @@ async function main() {
     const filePath = resolve(CASCADE_DIR, filename);
     const tokens = JSON.parse(readFileSync(filePath, "utf-8"));
 
-    // Count pre-existing field values. space-between is a virtual field name
-    // (property literal "space-between" + paired from/to); use "from" as the
-    // already-migrated marker since space-between itself is never a key on name.
-    const presenceField = isSpaceBetween ? "from" : field;
+    // Count pre-existing field values. space-between and scale-index are virtual
+    // field names (space-between: property literal "space-between" + paired
+    // from/to, using "from" as the already-migrated marker; scale-index: the
+    // real field is "scaleIndex", never a key on name for these virtual names).
+    const presenceField = isSpaceBetween
+      ? "from"
+      : isScaleIndex
+        ? "scaleIndex"
+        : field;
     const hadField = tokens.filter(
       (t) =>
         typeof t.name === "object" && t.name?.[presenceField] !== undefined,
@@ -234,7 +314,9 @@ async function main() {
 
     const { applied, skippedSpec025 } = isSpaceBetween
       ? applySpaceBetween(tokens, registry, filename)
-      : applyField(tokens, field, registry, filename);
+      : isScaleIndex
+        ? applyScaleIndex(tokens, registry, filename)
+        : applyField(tokens, field, registry, filename);
     totalApplied += applied;
     totalSkippedSpec025 += skippedSpec025;
 

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -469,19 +469,28 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     // Palette ramp: scaleIndex assigned, no component
     if (
       nameObject.scaleIndex !== undefined &&
-      nameObject.component === undefined
+      nameObject.component === undefined &&
+      nameObject.variant !== undefined &&
+      hueSet.has(nameObject.variant)
     ) {
-      if (nameObject.variant !== undefined && hueSet.has(nameObject.variant)) {
-        nameObject.colorFamily = nameObject.variant;
-        delete nameObject.variant;
-      } else if (
-        nameObject.property === "color" &&
-        nameObject.variant !== undefined &&
-        roleSet.has(nameObject.variant)
-      ) {
-        nameObject.colorRole = nameObject.variant;
-        delete nameObject.variant;
-      }
+      nameObject.colorFamily = nameObject.variant;
+      delete nameObject.variant;
+    }
+
+    // Semantic ramp: no component, no object, property "color". Unlike the hue
+    // ramp, scaleIndex isn't required — naming.rs's semantic-ramp branch
+    // supports the bare "informative-color" shape too (no trailing scaleIndex).
+    // object===undefined excludes the component-color-with-object shape (e.g.
+    // "accent-edge-color-default"), which keeps variant as-is.
+    if (
+      nameObject.component === undefined &&
+      nameObject.object === undefined &&
+      nameObject.property === "color" &&
+      nameObject.variant !== undefined &&
+      roleSet.has(nameObject.variant)
+    ) {
+      nameObject.colorRole = nameObject.variant;
+      delete nameObject.variant;
     }
 
     // Component color: property === "color" + component present
@@ -641,7 +650,11 @@ export function serialize(
   const { colorFamily, colorRole, component } = nameObject;
 
   // Palette ramp: colorFamily present, no component → {variant?}-{colorFamily}-{scaleIndex?}
-  if (colorFamily && !component) {
+  // Guarded on !colorRole too: a hue (color-families.json) and a role
+  // (color-roles.json) are disjoint registries today, so a name object never
+  // carries both — but if that ever changed, falling through to the more
+  // specific semantic-ramp branch below is safer than silently dropping colorRole.
+  if (colorFamily && !component && !colorRole) {
     const parts = [];
     if (nameObject.variant)
       parts.push(tokenNameMap[nameObject.variant] || nameObject.variant);
@@ -716,7 +729,8 @@ export function serialize(
         parts.push(tokenNameMap[nameObject[field]] || nameObject[field]);
       }
     }
-    if (nameObject.scaleIndex) parts.push(nameObject.scaleIndex);
+    // != null, not truthy: scaleIndex: 0 is a legitimate value.
+    if (nameObject.scaleIndex != null) parts.push(nameObject.scaleIndex);
     return parts.join("-");
   }
 
@@ -729,8 +743,14 @@ export function serialize(
       parts.push(tokenNameMap[value] || value);
     }
   }
-  // Append scaleIndex at end if present (non-standard)
-  if (nameObject.scaleIndex) {
+  // Append scaleIndex at end if present (non-standard: excludeFromLegacyKey
+  // means the loop above never emits it). != null, not truthy: scaleIndex: 0
+  // is a legitimate value. Correctness here relies on the convention that
+  // any token whose `property` is still a fused string (e.g. "font-size-100")
+  // alongside a populated scaleIndex pins an explicit legacyKey instead of
+  // relying on this reconstruction — nothing here structurally prevents a
+  // double-emit if that convention were ever violated.
+  if (nameObject.scaleIndex != null) {
     parts.push(nameObject.scaleIndex);
   }
   return parts.join("-");

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -429,7 +429,12 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
   for (let i = 0; i < segments.length; i++) {
     if (matched[i]) continue;
     if (NUMERIC_SCALE_PATTERN.test(segments[i])) {
-      nameObject.scaleIndex = segments[i];
+      // Number, not string: matches the existing convention (e.g. color-palette's
+      // scaleIndex:100) and is required by naming.rs's `.as_i64()` mirror — a
+      // string here silently fails that cast, dropping the segment from any
+      // legacy key rebuilt from this object (dsi.6 caught this via alias `$ref`
+      // denormalization, which isn't covered by the primary-name roundtrip check).
+      nameObject.scaleIndex = Number(segments[i]);
       matched[i] = true;
       matchDetails[i] = "scaleIndex";
       if (!registry.allFields?.has("scaleIndex")) {
@@ -450,6 +455,10 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
   //
   //   Palette ramp (scaleIndex + no component):
   //     variant:"blue" → colorFamily:"blue"
+  //   Semantic ramp (scaleIndex + no component + property:"color"):
+  //     variant:"accent" → colorRole:"accent"  (dsi.6: accent/informative/negative/
+  //     notice/positive-color-N; unlike the hue ramp, `property` stays "color"
+  //     since serialize() spells it out explicitly for this branch)
   //   Component color (property:"color" + component):
   //     variant:<hue>  → colorFamily:<hue>, then object:<role> → colorRole:<role>
   //     variant:<role> → colorRole:<role>  (no-hue tokens, e.g. color-primary)
@@ -464,6 +473,13 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     ) {
       if (nameObject.variant !== undefined && hueSet.has(nameObject.variant)) {
         nameObject.colorFamily = nameObject.variant;
+        delete nameObject.variant;
+      } else if (
+        nameObject.property === "color" &&
+        nameObject.variant !== undefined &&
+        roleSet.has(nameObject.variant)
+      ) {
+        nameObject.colorRole = nameObject.variant;
         delete nameObject.variant;
       }
     }
@@ -630,6 +646,18 @@ export function serialize(
     if (nameObject.variant)
       parts.push(tokenNameMap[nameObject.variant] || nameObject.variant);
     parts.push(tokenNameMap[colorFamily] || colorFamily);
+    if (nameObject.scaleIndex != null)
+      parts.push(String(nameObject.scaleIndex));
+    return parts.join("-");
+  }
+
+  // Semantic ramp: colorRole present, no component, property === "color" →
+  // {colorRole}-color-{scaleIndex?}. dsi.6: accent/informative/negative/notice/
+  // positive-color-N. Unlike the hue ramp above, "color" is NOT implicit here —
+  // these role names collide with plain words elsewhere, so the legacy key
+  // spells it out (e.g. "accent-color-100", not "accent-100").
+  if (colorRole && !component && nameObject.property === "color") {
+    const parts = [tokenNameMap[colorRole] || colorRole, "color"];
     if (nameObject.scaleIndex != null)
       parts.push(String(nameObject.scaleIndex));
     return parts.join("-");

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -249,6 +249,18 @@ test("promotes variant hue → colorFamily for palette ramp tokens (scaleIndex +
   t.is(result.confidence, "HIGH");
 });
 
+test("promotes variant → colorRole for semantic ramp tokens with no scaleIndex", (t) => {
+  // dsi.6 review finding: naming.rs's semantic-ramp branch supports the bare
+  // "informative-color" shape (no trailing scaleIndex) — the JS promotion
+  // must not require scaleIndex to be present, unlike the hue-ramp case above.
+  const result = decompose("informative-color", {}, registry, "test");
+  t.is(result.nameObject.colorRole, "informative");
+  t.is(result.nameObject.variant, undefined);
+  t.is(result.nameObject.scaleIndex, undefined);
+  t.is(result.nameObject.property, "color");
+  t.true(result.roundtrips);
+});
+
 test("promotes variant hue + retains colorRole for component color tokens", (t) => {
   // "blue" wins variant priority over colorFamily; "primary" goes to colorRole
   // since variant is already taken. Phase 4.5 promotes blue → colorFamily.

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -46,7 +46,7 @@ test("decomposes component token with metadata", (t) => {
 
 test("does not flag scaleIndex as gap when field is declared", (t) => {
   const result = decompose("spacing-100", {}, registry, "test");
-  t.is(result.nameObject.scaleIndex, "100");
+  t.is(result.nameObject.scaleIndex, 100);
   const scaleGap = result.gaps.find((g) => g.type === "numeric-scale-index");
   t.falsy(scaleGap);
 });
@@ -62,7 +62,7 @@ test("flags scaleIndex as gap when field is not declared", (t) => {
     registryWithoutScaleIndex,
     "test",
   );
-  t.is(result.nameObject.scaleIndex, "100");
+  t.is(result.nameObject.scaleIndex, 100);
   const scaleGap = result.gaps.find((g) => g.type === "numeric-scale-index");
   t.truthy(scaleGap);
 });
@@ -74,7 +74,7 @@ test("decomposes line-height-font-size compound with scale index", (t) => {
   // unmatched as gaps.
   const result = decompose("line-height-font-size-100", {}, registry, "test");
   t.is(result.nameObject.property, "line-height-font-size");
-  t.is(result.nameObject.scaleIndex, "100");
+  t.is(result.nameObject.scaleIndex, 100);
   t.deepEqual(result.gaps, []);
   t.true(result.roundtrips);
 });
@@ -82,7 +82,7 @@ test("decomposes line-height-font-size compound with scale index", (t) => {
 test("decomposes component-height compound with scale index", (t) => {
   const result = decompose("component-height-100", {}, registry, "test");
   t.is(result.nameObject.property, "component-height");
-  t.is(result.nameObject.scaleIndex, "100");
+  t.is(result.nameObject.scaleIndex, 100);
   t.deepEqual(result.gaps, []);
   t.true(result.roundtrips);
 });
@@ -242,7 +242,7 @@ test("promotes variant hue → colorFamily for palette ramp tokens (scaleIndex +
   const result = decompose("blue-700", {}, registry, "test");
   t.is(result.nameObject.colorFamily, "blue");
   t.is(result.nameObject.variant, undefined);
-  t.is(result.nameObject.scaleIndex, "700");
+  t.is(result.nameObject.scaleIndex, 700);
   t.true(result.roundtrips);
   // Property-less but clean roundtrip (0 unmatched segments) — should score
   // HIGH regardless of the missing `property` field (dsi.4.8).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes 219 tokens whose `name.property` fused a color-role or size term
with a numeric scale index (e.g. `accent-color-100`, `avatar-group-size-100`)
into proper `colorRole`/`scaleIndex` fields, and fixes the underlying
Rust↔JS serializer bugs the migration surfaced along the way:

- **New `colorRole` semantic-ramp branch** in both `naming.rs` and
  `decomposer.js`, so `{colorRole:"accent", property:"color", scaleIndex:100}`
  round-trips to `accent-color-100` (the existing hue-ramp branch only
  handled `colorFamily`, not `colorRole`).
- **`scaleIndex` string→number bug**: `decomposer.js` wrote `scaleIndex` as a
  string; Rust's `.as_i64()` silently returns `None` for a string, dropping
  the segment anywhere `extract_legacy_key` is reused (caught via alias
  `$ref` denormalization, not the primary roundtrip check).
- **`scaleIndex` not appended in two `naming.rs` branches**: the general
  (position-walk) path and the space-between path both treat `scaleIndex`
  as `excludeFromLegacyKey` (correct) but never appended it back explicitly
  (a gap). The space-between omission was live data loss: 4 distinct
  `field-edge-to-disclosure-icon-{75,100,200,300}` tokens all produced the
  *same* reconstructed key and collided during legacy-output generation,
  silently dropping 3 of the 4 tokens' `sets` data.

Icon `size-N` (112 tokens) is **not** included — it's blocked on a bigger,
pre-existing gap (`decompose()` has no icon-domain parsing at all, and the
registry's actual `serializationOrder` puts `icon` last, contradicting
`naming.rs`'s icon-first branch). Split out to
`spectrum-design-data-5p3` for separate scoping.

## Related Issue

Closes spectrum-design-data-dsi.6.

## Motivation and Context

These 192(+extra) tokens fused a compound value into `property` instead of
splitting the numeric scale index into its own `scaleIndex` field, which is
the established taxonomy convention elsewhere (e.g. `color-palette`'s
`blue-100` → `{colorFamily:"blue", scaleIndex:100}`). They slipped past the
Phase D residual analyzer because `property` wasn't in `property-terms.json`
and they had no `legacyKey`. Fixing this closes a real serializer
correctness gap (Rust and JS silently disagreed on `scaleIndex` placement in
two branches), not just a data-shape cleanup.

## How Has This Been Tested?

- `cargo test --workspace` — all passing (added 7 new unit tests in
  `naming.rs`: semantic-ramp roundtrip ×4, general-domain scaleIndex
  append ×2, space-between scaleIndex collision regression ×1).
- `moon run token-mapping-analyzer:test` (AVA) — all passing (updated 4
  pre-existing assertions from string to number `scaleIndex`).
- `moon run design-data:validate` — passes (pre-existing SPEC-043 warnings
  only, unrelated to this change).
- `moon run design-data:legacy-output` then `moon run
  design-data:roundtrip-verify` — roundtrip OK, and `packages/tokens/src/*`
  shows **zero diff** vs. `main`, confirming the cascade refactor is
  byte-identical at the legacy-key level with no key collisions in any of
  the 8 regenerated files (not just the one spotted case).
- Manually verified via `decompose()`/`serialize()` ad-hoc scripts that
  `accent-color-100`, `informative-color-500`, `size-100`, etc. all resolve
  HIGH confidence + roundtrip true.

## Screenshots (if appropriate):

N/A — data/serializer change, no visual surface.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
