### PR TITLE
fix(design-data): unify corner-radius property term, decompose medium residual (dsi.10)

### DIFF
--- a/.changeset/dsi10-corner-radius-registry-gap.md
+++ b/.changeset/dsi10-corner-radius-registry-gap.md
@@ -1,0 +1,19 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Register `corner-radius` as the canonical property term (unifying the
+previously-unregistered `corner-radius` and the single-use `border-radius`
+entry) and decompose the last fused `corner-radius-medium` residual (dsi.10).
+
+- **packages/design-data/registry/property-terms.json**: renamed the
+  `border-radius` term to `corner-radius` (label + id) to match actual
+  token usage; no more unregistered `corner-radius` property.
+- **packages/design-data/tokens/layout-component.tokens.json**: migrated
+  the one `border-radius` token to `property: corner-radius` (existing
+  pinned `legacyKey` keeps serialized output unchanged).
+- **packages/design-data/tokens/layout.tokens.json**: decomposed
+  `corner-radius-medium` + `state: default` into
+  `property: corner-radius`, `state: default`, `size: m`, matching its
+  `xl`/`l`/`s` siblings; verified byte-identical via
+  `design-data:roundtrip-verify`.

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -134,8 +134,8 @@
       "description": "Border or stroke thickness"
     },
     {
-      "id": "border-radius",
-      "label": "Border Radius",
+      "id": "corner-radius",
+      "label": "Corner Radius",
       "description": "Corner rounding radius"
     },
     {

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -8047,7 +8047,7 @@
       "anatomy": "fill",
       "qualifier": "stacked",
       "position": "inner",
-      "property": "border-radius",
+      "property": "corner-radius",
       "legacyKey": "in-field-button-fill-stacked-inner-border-rounding"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -2707,8 +2707,9 @@
   },
   {
     "name": {
-      "property": "corner-radius-medium",
-      "state": "default"
+      "property": "corner-radius",
+      "state": "default",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ada2ea1d-1728-411a-8aae-a198ce390a25",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1970,8 +1970,8 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "description": "Border or stroke thickness"
     },
     {
-      "id": "border-radius",
-      "label": "Border Radius",
+      "id": "corner-radius",
+      "label": "Corner Radius",
       "description": "Corner rounding radius"
     },
     {


### PR DESCRIPTION
## Description

Registers `corner-radius` as the canonical property term (unifying it with
the previously-registered, single-use `border-radius` entry) and decomposes
the last fused `corner-radius-medium` residual flagged by the untracked-fused-property
scan in `layout.tokens.json`.

- **packages/design-data/registry/property-terms.json**: renamed the
  `border-radius` term to `corner-radius` (label + id) to match actual token
  usage — `corner-radius` was used by many tokens but unregistered, while
  `border-radius` was registered but used by exactly one token.
- **packages/design-data/tokens/layout-component.tokens.json**: migrated the
  one `border-radius` token to `property: corner-radius` (its pinned
  `legacyKey` keeps serialized output unchanged).
- **packages/design-data/tokens/layout.tokens.json**: decomposed
  `corner-radius-medium` + `state: default` into `property: corner-radius`,
  `state: default`, `size: m`, matching its `xl`/`l`/`s` siblings.
- **sdk/core/src/registry_data.rs**: regenerated via `moon run sdk:codegen`.

The 11 `corner-radius-N` scale-ramp tokens (e.g. `corner-radius-100`,
`corner-radius-1000`) found alongside this residual are a different shape
(scale-index fusion, not a registry gap) and are split out to a follow-up
bead (`spectrum-design-data-a3z`) rather than bundled here.

## Related Issue

Closes bead `spectrum-design-data-dsi.10` (Phase D taxonomy triage,
`spectrum-design-data-dsi`).

## Motivation and Context

Part of the ongoing Phase D residual-triage sweep: `corner-radius` tokens
were tripping the untracked-fused-property scan because the term wasn't
registered, and one token still fused its size into the property string
instead of using the `size` field.

## How Has This Been Tested?

- `moon run token-mapping-analyzer:analyze` — no more `corner-radius-*`
  fused strings in the residual report, 0 FAIL.
- `moon run design-data:roundtrip-verify` — confirms byte-identical
  serialized output (no legacy names changed).
- `moon run design-data:validate` — passes (only pre-existing, unrelated
  warnings).
- `moon run sdk:test` — full Rust workspace suite passes.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset
  valid.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
