### PR TITLE
fix(design-data): validate SPEC-009 compound state values segment-by-segment

### DIFF
--- a/.changeset/boh-spec009-compound-state-segments.md
+++ b/.changeset/boh-spec009-compound-state-segments.md
@@ -1,0 +1,14 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+SPEC-009 now validates compound `state` values segment-by-segment instead of
+requiring the whole hyphenated string to match a literal registry entry,
+silencing 6 permanent-noise warnings from Proposal 005's compound-state
+convention (closes bead boh).
+
+- **sdk/core/src/validate/rules/spec009.rs**: for the `state` field, a value
+  that fails the whole-string registry lookup is now checked at every hyphen
+  boundary (`{mode-state}-{interaction-state}`), so multi-word interaction
+  states like `keyboard-focus` aren't mis-split; a value only warns if no
+  split has both halves in the registry.

--- a/sdk/core/src/validate/rules/spec009.rs
+++ b/sdk/core/src/validate/rules/spec009.rs
@@ -19,9 +19,27 @@
 //! in #941) and checked here like any other advisory field. Fields excluded from
 //! this check:
 //! - `colorScheme`, `scale`, `contrast` — mode-set fields, validated by SPEC-005/SPEC-008
+//!
+//! Per Proposal 005, `state` also accepts compound values (`{mode-state}-{interaction-state}`,
+//! e.g. `"selected-hover"`, `"selected-key-focus"`). A compound value that fails the
+//! whole-string registry lookup is checked segment-by-segment before warning.
+
+use std::collections::HashSet;
 
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
+
+/// Per Proposal 005, a compound state is `{mode-state}-{interaction-state}`.
+/// Since either segment (e.g. `keyboard-focus`) may itself contain a hyphen,
+/// try every hyphen boundary rather than assuming one fixed split point.
+/// Valid only if some split has both halves individually known to the registry.
+fn is_valid_compound_state(value: &str, registry_set: &HashSet<String>) -> bool {
+    value.match_indices('-').any(|(i, _)| {
+        let (mode_state, rest) = value.split_at(i);
+        let interaction_state = &rest[1..];
+        registry_set.contains(mode_state) && registry_set.contains(interaction_state)
+    })
+}
 
 pub struct Rule;
 
@@ -54,20 +72,26 @@ impl ValidationRule for Rule {
                     None => continue,
                 };
 
-                if !registry_set.contains(value) {
-                    diags.push(Diagnostic {
-                        file: record.file.clone(),
-                        token: Some(record.name.clone()),
-                        rule_id: Some("SPEC-009".into()),
-                        severity: Severity::Warning,
-                        message: format!(
-                            "name.{field} value \"{value}\" is not in the spectrum-design-data \
-                             registry/{field} vocabulary"
-                        ),
-                        instance_path: Some(format!("/name/{field}")),
-                        schema_path: None,
-                    });
+                if registry_set.contains(value) {
+                    continue;
                 }
+
+                if field == "state" && is_valid_compound_state(value, registry_set) {
+                    continue;
+                }
+
+                diags.push(Diagnostic {
+                    file: record.file.clone(),
+                    token: Some(record.name.clone()),
+                    rule_id: Some("SPEC-009".into()),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "name.{field} value \"{value}\" is not in the spectrum-design-data \
+                         registry/{field} vocabulary"
+                    ),
+                    instance_path: Some(format!("/name/{field}")),
+                    schema_path: None,
+                });
             }
         }
 
@@ -184,6 +208,41 @@ mod tests {
             json!({"name": {"property": "color", "colorScheme": "nonexistent"}, "value": "#fff"}),
         )]);
         assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
+    }
+
+    #[test]
+    fn compound_state_of_known_segments_no_warning() {
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "state": "selected-hover"}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
+    }
+
+    #[test]
+    fn compound_state_with_hyphenated_segment_no_warning() {
+        // "keyboard-focus" (aliased as "key-focus") is itself a single registry
+        // value, so "selected-key-focus" must split as selected + key-focus,
+        // not selected + key + focus.
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "state": "selected-key-focus"}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
+    }
+
+    #[test]
+    fn compound_state_with_unknown_segment_warns() {
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "state": "selected-nonexistent"}, "value": "#fff"}),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-009");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("selected-nonexistent"));
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

SPEC-009 (`name-field-enum-sync`) previously required a `state` value to
match a registry entry as a whole literal string. Proposal 005's
compound-state convention (`{mode-state}-{interaction-state}`, e.g.
`"selected-hover"`, `"focus-hover"`, `"selected-key-focus"`) introduced by
dsi.9 (#1255) produced 6 permanent advisory warnings on `main` because the
compound strings aren't literal registry entries.

This teaches SPEC-009 to fall back to segment-by-segment validation for the
`state` field: if the whole string doesn't match, it tries every hyphen
boundary and accepts the value if some split has both halves individually
known to the registry (including aliases). Splitting at every boundary
(rather than a fixed first-hyphen split) is required because interaction
states like `keyboard-focus` (aliased `key-focus`) themselves contain a
hyphen — e.g. `"selected-key-focus"` must split as `selected` + `key-focus`,
not `selected` + `key` + `focus`.

## Related Issue

Closes bead `spectrum-design-data-boh`.

## Motivation and Context

Advisory validation noise that will never resolve itself makes real
regressions harder to spot in `moon run design-data:validate` output. This
was explicitly called out as intentional follow-up work in
`docs/proposals/005-compound-states.md`.

## How Has This Been Tested?

- Added unit tests in `sdk/core/src/validate/rules/spec009.rs` covering: a
  simple two-segment compound (`selected-hover`), a compound whose second
  segment itself contains a hyphen (`selected-key-focus`), and a compound
  with a genuinely unknown segment (`selected-nonexistent`, still warns).
- `cargo test -p design-data-core`: 639 passed, 0 failed.
- `cargo clippy -p design-data-core -- -D warnings`: no issues.
- Ran `design-data validate ./tokens --exceptions-path
  ../tokens/naming-exceptions.json` before/after: total SPEC-009 warnings
  dropped from 1265 to 1259 (exactly the 6 compound-state warnings from
  dsi.9), while the unrelated `state:"filled"` warning is preserved
  (confirms the fix doesn't over-suppress genuinely unknown values).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
