### PR TITLE
fix(design-data): decompose corner-radius-N ramp into scaleIndex (a3z)

### DIFF
--- a/.changeset/a3z-decompose-corner-radius-scaleindex.md
+++ b/.changeset/a3z-decompose-corner-radius-scaleindex.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose fused `corner-radius-N` ramp into `property` + `scaleIndex` (a3z).
+
+- **packages/design-data/tokens/layout.tokens.json**: 11 `corner-radius-{0,75,100..800,1000}`
+  tokens migrated from fused `property: "corner-radius-N"` to `property: "corner-radius"`
+  plus numeric `scaleIndex`, following the dsi.6 recipe. Each token keeps its existing
+  dimension/multiplier token type; roundtrip verified unchanged.

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -2589,7 +2589,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-0"
+      "property": "corner-radius",
+      "scaleIndex": 0
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -2597,7 +2598,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-100"
+      "property": "corner-radius",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -2605,7 +2607,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-1000"
+      "property": "corner-radius",
+      "scaleIndex": 1000
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 0.5,
@@ -2613,7 +2616,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-200"
+      "property": "corner-radius",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -2621,7 +2625,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-300"
+      "property": "corner-radius",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -2629,7 +2634,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-400"
+      "property": "corner-radius",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -2637,7 +2643,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-500"
+      "property": "corner-radius",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -2645,7 +2652,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-600"
+      "property": "corner-radius",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -2653,7 +2661,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-700"
+      "property": "corner-radius",
+      "scaleIndex": 700
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2661,7 +2670,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-75"
+      "property": "corner-radius",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "3px",
@@ -2669,7 +2679,8 @@
   },
   {
     "name": {
-      "property": "corner-radius-800"
+      "property": "corner-radius",
+      "scaleIndex": 800
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes the fused `corner-radius-N` ramp in `packages/design-data/tokens/layout.tokens.json`
into `property: "corner-radius"` + numeric `scaleIndex`, following the dsi.6 recipe (bead
`spectrum-design-data-a3z`, split from `dsi.10`).

11 tokens affected: `corner-radius-{0,75,100,200,300,400,500,600,700,800,1000}`.

The bead carried a `human` label because the ramp looked heterogeneous: ten rungs are
`dimension` (px) values but `corner-radius-1000` is a bare unitless `0.5` multiplier. That
concern turned out to be a non-issue — each token already carries its own correct `$schema`
(`dimension.json` for the px rungs, `multiplier.json` for `corner-radius-1000`), and the
`scaleIndex` serialize/deserialize path in `naming.rs`/`decomposer.js` is a pure name-object
transform, fully decoupled from the token's `value`/`$schema`. So all 11 decompose uniformly
with no schema change and no special-casing.

## Related Issue

Closes bead `spectrum-design-data-a3z` (split from `dsi.10`).

## Motivation and Context

Fused `property-N` strings hide the ramp's scale index inside the property name instead of
using the dedicated `scaleIndex` field, making the ramp harder to query/reason about
programmatically and inconsistent with the sibling ramps already migrated under dsi.6
(accent-color-N, spacing, etc.).

## How Has This Been Tested?

- `moon run design-data:legacy-output` + `moon run design-data:roundtrip-verify` — zero diff,
  `Roundtrip OK: ../tokens/src`.
- `moon run sdk:test` (`cargo test --workspace`) — all green.
- `moon run token-mapping-analyzer:test` (decomposer.js suite, incl. scaleIndex-gap tests) —
  38 passed.
- `moon run design-data:validate` — no new warnings/errors (pre-existing unrelated SPEC-009
  warnings only).
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — 8/8 valid.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
