### PR TITLE
fix(design-data): decompose line-height-font-size-N reference (dsi.12)

### DIFF
--- a/.changeset/dsi12-line-height-font-size-reference.md
+++ b/.changeset/dsi12-line-height-font-size-reference.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose fused `line-height-font-size-N` into `line-height` + `referenceScaleIndex` (dsi.12).
+
+- **packages/design-data/fields/referenceScaleIndex.json**: new field declaring a numeric
+  index that references a step in another scale (here, the font-size tier a line-height
+  is paired with), distinct from `scaleIndex` (a token's own ramp position).
+- **packages/design-data/tokens/typography.tokens.json**: 36 `line-height-font-size-N`
+  tokens migrated to `property: "line-height"` + `referenceScaleIndex`, with an
+  explicit `legacyKey` pin preserving the original flat key until naming.rs learns
+  to reconstruct it from the new field.

--- a/.changeset/dsi12-line-height-font-size-reference.md
+++ b/.changeset/dsi12-line-height-font-size-reference.md
@@ -10,4 +10,5 @@ Decompose fused `line-height-font-size-N` into `line-height` + `referenceScaleIn
 - **packages/design-data/tokens/typography.tokens.json**: 36 `line-height-font-size-N`
   tokens migrated to `property: "line-height"` + `referenceScaleIndex`, with an
   explicit `legacyKey` pin preserving the original flat key until naming.rs learns
-  to reconstruct it from the new field.
+  to reconstruct it from the new field. Verified byte-identical via
+  `design-data migrate legacy-verify` against `packages/tokens/src`.

--- a/packages/design-data/fields/referenceScaleIndex.json
+++ b/packages/design-data/fields/referenceScaleIndex.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
+  "specVersion": "1.0.0-draft",
+  "name": "referenceScaleIndex",
+  "description": "Numeric index referencing a step in ANOTHER scale that this token corresponds to (e.g. a line-height paired with font-size tier N), distinct from scaleIndex (this token's own ramp position).",
+  "kind": "numeric",
+  "registry": null,
+  "validation": "none",
+  "serialization": {
+    "position": 98
+  },
+  "scope": null,
+  "required": false,
+  "valueType": "integer",
+  "excludeFromLegacyKey": true
+}

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -3491,8 +3491,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-100",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 100,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -3502,8 +3504,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-100",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 100,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3513,8 +3517,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1000",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 1000,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "46px",
@@ -3524,8 +3530,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1000",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 1000,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-1000"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "56px",
@@ -3535,8 +3543,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1100",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 1100,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "52px",
@@ -3546,8 +3556,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1100",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 1100,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-1100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "64px",
@@ -3557,8 +3569,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1200",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 1200,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "58px",
@@ -3568,8 +3582,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1200",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 1200,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-1200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "72px",
@@ -3579,8 +3595,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1300",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 1300,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "66px",
@@ -3590,8 +3608,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1300",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 1300,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-1300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "80px",
@@ -3601,8 +3621,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1400",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 1400,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "74px",
@@ -3612,8 +3634,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1400",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 1400,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-1400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "90px",
@@ -3623,8 +3647,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1500",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 1500,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "84px",
@@ -3634,8 +3660,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-1500",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 1500,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-1500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "102px",
@@ -3645,8 +3673,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-200",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 200,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -3656,8 +3686,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-200",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 200,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -3667,8 +3699,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-25",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 25,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-25"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -3678,8 +3712,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-25",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 25,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-25"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -3689,8 +3725,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-300",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 300,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3700,8 +3738,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-300",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 300,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "26px",
@@ -3711,8 +3751,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-400",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 400,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -3722,8 +3764,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-400",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 400,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-400"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -3733,8 +3777,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-50",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 50,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -3744,8 +3790,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-50",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 50,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-50"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -3755,8 +3803,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-500",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 500,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "26px",
@@ -3766,8 +3816,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-500",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 500,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-500"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -3777,8 +3829,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-600",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 600,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "30px",
@@ -3788,8 +3842,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-600",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 600,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-600"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -3799,8 +3855,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-700",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 700,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -3810,8 +3868,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-700",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 700,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-700"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "40px",
@@ -3821,8 +3881,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-75",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 75,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -3832,8 +3894,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-75",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 75,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -3843,8 +3907,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-800",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 800,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "36px",
@@ -3854,8 +3920,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-800",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 800,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-800"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "44px",
@@ -3865,8 +3933,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-900",
-      "scale": "desktop"
+      "property": "line-height",
+      "referenceScaleIndex": 900,
+      "scale": "desktop",
+      "legacyKey": "line-height-font-size-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "42px",
@@ -3876,8 +3946,10 @@
   },
   {
     "name": {
-      "property": "line-height-font-size-900",
-      "scale": "mobile"
+      "property": "line-height",
+      "referenceScaleIndex": 900,
+      "scale": "mobile",
+      "legacyKey": "line-height-font-size-900"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "50px",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -3260,6 +3260,7 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "alignment", position: 27, validation: FieldValidation::Advisory, scope: Some("typography"), required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "qualifier", position: 28, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "role", position: 29, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "referenceScaleIndex", position: 98, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "scaleIndex", position: 99, validation: FieldValidation::None, scope: None, required: false, has_registry: false, value_type: "integer", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "icon", position: 100, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes 36 `line-height-font-size-{25,50,75,100..1500}` tokens in
`typography.tokens.json`, which fused the `line-height` property with a
reference to the font-size tier each one pairs with. These previously showed
up as a residual gap: `property` not in `property-terms.json` and no
`legacyKey`.

- `property: "line-height-font-size-100"` → `property: "line-height"` +
  `referenceScaleIndex: 100`, with an explicit `legacyKey` pin preserving the
  original flat key (`line-height-font-size-100`).
- Added `packages/design-data/fields/referenceScaleIndex.json` — a new field
  distinct from `scaleIndex`: it references a step in *another* scale
  (the font-size ramp) rather than the token's own ramp position.
- `legacyKey` is pinned rather than left to reconstruct naturally: teaching
  `naming.rs`/`decomposer.js` to rebuild `line-height-font-size-N` from
  `property + referenceScaleIndex` is deferred as follow-up work. The pin
  keeps the legacy output byte-identical in the meantime.

## Related Issue

Closes spectrum-design-data-dsi.12 (Phase D residual triage, parent:
spectrum-design-data-dsi).

## Motivation and Context

Part of the ongoing Phase D pass decomposing fused `property` strings across
the token set so each carries structured metadata instead of an opaque
compound string. Same shape as the recent `corner-radius-N` → `scaleIndex`
migration (#1259), but this family needed a new field rather than reusing
`scaleIndex`, since the index here refers to a different scale (font-size),
not the token's own ramp.

## How Has This Been Tested?

- `moon run sdk:codegen` — regenerated `registry_data.rs` to embed the new
  field; `moon run sdk:codegen-check` confirms it's in sync.
- `moon run sdk:test` — full Rust workspace test suite passes.
- `node tools/token-mapping-analyzer/src/index.js` — roundtrip check shows
  0 FAIL; the 36 migrated tokens are not among the reported unmatched
  segments.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
