### PR TITLE
fix(design-data): add icon-domain recognition to decompose/serialize (5p3)

### DIFF
--- a/.changeset/5p3-decompose-icon-scaleindex.md
+++ b/.changeset/5p3-decompose-icon-scaleindex.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Add icon-domain recognition to decompose/serialize and migrate icon `size-N` tokens
+to `scaleIndex` (5p3, dsi.6 follow-up).
+
+- **tools/token-mapping-analyzer/src/registry-index.js**: index each term's `tokenName`
+  (e.g. "checkmark" → "checkmark-icon") as its own matchable segment set, not just a
+  serialization alias, so decompose can recognize the icon's expanded legacy form.
+- **tools/token-mapping-analyzer/src/decomposer.js**: `serialize()` gained an icon-owner
+  branch (mirrors `naming.rs`'s icon-first legacy key ordering); `decompose()` now accepts
+  metadata-provided `icon` (mirrors existing `component` handling) to disambiguate
+  tokenName/anatomy-term collisions of equal segment length (e.g. `link-out-icon`); added
+  `"icon"` to the stale `FALLBACK_SERIALIZATION_ORDER`.
+- **tools/token-mapping-analyzer/src/apply.js**, **index.js**: thread `token.name.icon`
+  metadata into `decompose()` calls.
+- **packages/design-data/tokens/layout-component.tokens.json**: 112 icon `size-N` tokens
+  migrated from fused `property: "size-N"` to `property: "size"` + numeric `scaleIndex`,
+  following the dsi.6 recipe; legacy-verify confirms byte-identical output.
+- **packages/design-data/tokens/layout.tokens.json**: 1 additional `space-between` token
+  picked up by the same full-cascade run.

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -1651,8 +1651,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -1664,8 +1665,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -1677,8 +1679,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -1690,8 +1693,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -1703,8 +1707,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -1716,8 +1721,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -1729,8 +1735,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-50",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -1742,8 +1749,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-50",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -1755,8 +1763,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -1768,8 +1777,9 @@
   {
     "name": {
       "icon": "add",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2112,8 +2122,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2125,8 +2136,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -2138,8 +2150,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -2151,8 +2164,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -2164,8 +2178,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -2177,8 +2192,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -2190,8 +2206,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -2203,8 +2220,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -2216,8 +2234,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -2229,8 +2248,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -2242,8 +2262,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -2255,8 +2276,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -2268,8 +2290,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2281,8 +2304,9 @@
   {
     "name": {
       "icon": "arrow",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -2294,8 +2318,9 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -2307,8 +2332,9 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2320,8 +2346,9 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2333,8 +2360,9 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -2346,8 +2374,9 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -2359,8 +2388,9 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -2372,7 +2402,8 @@
   {
     "name": {
       "icon": "asterisk",
-      "property": "size-75"
+      "property": "size",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -4697,8 +4728,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4710,8 +4742,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4723,8 +4756,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -4736,8 +4770,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4749,8 +4784,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4762,8 +4798,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -4775,8 +4812,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -4788,8 +4826,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -4801,8 +4840,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-50",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4814,8 +4854,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-50",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -4827,8 +4868,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -4840,8 +4882,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -4853,8 +4896,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -4866,8 +4910,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -4879,8 +4924,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4892,8 +4938,9 @@
   {
     "name": {
       "icon": "checkmark",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -4905,8 +4952,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4918,8 +4966,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4931,8 +4980,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -4944,8 +4994,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4957,8 +5008,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4970,8 +5022,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -4983,8 +5036,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -4996,8 +5050,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -5009,8 +5064,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-50",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5022,8 +5078,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-50",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -5035,8 +5092,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -5048,8 +5106,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -5061,8 +5120,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -5074,8 +5134,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -5087,8 +5148,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -5100,8 +5162,9 @@
   {
     "name": {
       "icon": "chevron",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6253,8 +6316,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6266,8 +6330,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6279,8 +6344,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6292,8 +6358,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6305,8 +6372,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6318,8 +6386,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6331,8 +6400,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6344,8 +6414,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6357,8 +6428,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6370,8 +6442,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6383,8 +6456,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6396,8 +6470,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -6409,8 +6484,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6422,8 +6498,9 @@
   {
     "name": {
       "icon": "cross",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6435,8 +6512,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6448,8 +6526,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6461,8 +6540,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6474,8 +6554,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6487,8 +6568,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6500,8 +6582,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6513,8 +6596,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6526,8 +6610,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -6539,8 +6624,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-50",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6552,8 +6638,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-50",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 50
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6565,8 +6652,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-500",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6578,8 +6666,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-500",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 500
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -6591,8 +6680,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-600",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -6604,8 +6694,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-600",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 600
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -6617,8 +6708,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -6630,8 +6722,9 @@
   {
     "name": {
       "icon": "dash",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6769,8 +6862,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6782,8 +6876,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6795,8 +6890,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6808,8 +6904,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6821,8 +6918,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6834,8 +6932,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6847,8 +6946,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6860,8 +6960,9 @@
   {
     "name": {
       "icon": "drag-handle",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -7537,7 +7638,8 @@
   {
     "name": {
       "icon": "gripper",
-      "property": "size-100"
+      "property": "size",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -8508,8 +8610,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-100",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -8521,8 +8624,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-100",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 100
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -8534,8 +8638,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-200",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -8547,8 +8652,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-200",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 200
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -8560,8 +8666,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-300",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -8573,8 +8680,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-300",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 300
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -8586,8 +8694,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-400",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -8599,8 +8708,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-400",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 400
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -8612,8 +8722,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-75",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -8625,8 +8736,9 @@
   {
     "name": {
       "icon": "link-out",
-      "property": "size-75",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "scaleIndex": 75
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -5258,7 +5258,10 @@
   },
   {
     "name": {
-      "property": "label-to-description-0"
+      "property": "space-between",
+      "from": "label",
+      "to": "description",
+      "scaleIndex": 0
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -70,7 +70,11 @@ export function applyField(tokens, field, registry, filename) {
 
     const result = decompose(
       legacyKey,
-      { deprecated: !!token.deprecated, component: token.name?.component },
+      {
+        deprecated: !!token.deprecated,
+        component: token.name?.component,
+        icon: token.name?.icon,
+      },
       registry,
       filename,
     );
@@ -165,7 +169,11 @@ export function applySpaceBetween(tokens, registry, filename) {
 
     const result = decompose(
       legacyKey,
-      { deprecated: !!token.deprecated, component: token.name?.component },
+      {
+        deprecated: !!token.deprecated,
+        component: token.name?.component,
+        icon: token.name?.icon,
+      },
       registry,
       filename,
     );
@@ -229,7 +237,11 @@ export function applyScaleIndex(tokens, registry, filename) {
 
     const result = decompose(
       legacyKey,
-      { deprecated: !!token.deprecated, component: token.name?.component },
+      {
+        deprecated: !!token.deprecated,
+        component: token.name?.component,
+        icon: token.name?.icon,
+      },
       registry,
       filename,
     );

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -27,6 +27,7 @@ const FALLBACK_SERIALIZATION_ORDER = [
   "shape",
   "state",
   "role",
+  "icon",
 ];
 
 /**
@@ -179,6 +180,30 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
       nameObject.component = tokenData.component;
       warnings.push(
         `component "${tokenData.component}" in metadata but not found in name segments`,
+      );
+    }
+  }
+
+  // Phase 1b: Use metadata-provided icon if available. Mirrors the component
+  // handling above — needed because an icon's expanded legacy form (e.g.
+  // "link-out" -> "link-out-icon") can be the same length as an unrelated
+  // anatomy term (anatomy-terms.json also declares "link-out-icon"), so
+  // Phase 3's length-then-priority tie-break would otherwise pick anatomy
+  // (icon isn't in fieldPriority) over the correct icon field.
+  if (tokenData.icon) {
+    const icExpanded = registry.tokenNameMap[tokenData.icon] || tokenData.icon;
+    const icSegments = icExpanded.split("-");
+    const icIndex = findSubsequence(segments, icSegments);
+    if (icIndex !== -1) {
+      nameObject.icon = tokenData.icon;
+      for (let i = icIndex; i < icIndex + icSegments.length; i++) {
+        matched[i] = true;
+        matchDetails[i] = "icon";
+      }
+    } else {
+      nameObject.icon = tokenData.icon;
+      warnings.push(
+        `icon "${tokenData.icon}" in metadata but not found in name segments`,
       );
     }
   }
@@ -731,6 +756,25 @@ export function serialize(
     }
     // != null, not truthy: scaleIndex: 0 is a legitimate value.
     if (nameObject.scaleIndex != null) parts.push(nameObject.scaleIndex);
+    return parts.join("-");
+  }
+
+  // Icon (non-color) domain: an icon-family token without colorFamily/colorRole
+  // (the ramp branches above didn't apply). `icon`'s catalog position sorts
+  // last, but the legacy key spells it first (e.g. "add-icon-size-100"), so
+  // the position-walk below can't express this — needs an explicit branch.
+  // Mirrors sdk/core/src/naming.rs's non-color icon branch — keep in sync.
+  if (nameObject.icon && !colorFamily && !colorRole && nameObject.property) {
+    const icExpanded = tokenNameMap[nameObject.icon] || nameObject.icon;
+    // Thin-format passthrough: property already spells "{icon}-...".
+    if (nameObject.property.startsWith(`${icExpanded}-`)) {
+      return nameObject.property;
+    }
+    const parts = [icExpanded, nameObject.property];
+    if (nameObject.scaleIndex != null)
+      parts.push(String(nameObject.scaleIndex));
+    if (nameObject.state)
+      parts.push(tokenNameMap[nameObject.state] || nameObject.state);
     return parts.join("-");
   }
 

--- a/tools/token-mapping-analyzer/src/index.js
+++ b/tools/token-mapping-analyzer/src/index.js
@@ -73,6 +73,7 @@ async function main() {
           deprecated: !!token.deprecated,
           private: !!token.private,
           component: token.name.component,
+          icon: token.name.icon,
         },
         registry,
         filename,

--- a/tools/token-mapping-analyzer/src/registry-index.js
+++ b/tools/token-mapping-analyzer/src/registry-index.js
@@ -72,9 +72,18 @@ export function loadRegistries() {
       const segments = entry.id.split("-");
       allTerms.push({ segments, field, id: entry.id });
 
-      // Track tokenName for legacy serialization
+      // Track tokenName for legacy serialization, and also index it for
+      // matching: some fields (e.g. icon) serialize to a longer legacy form
+      // ("checkmark" -> "checkmark-icon") that must be recognized as a whole
+      // during decompose, not split into its own segments (which can collide
+      // with unrelated single-segment terms in other registries).
       if (entry.tokenName) {
         tokenNameMap[entry.id] = entry.tokenName;
+        allTerms.push({
+          segments: entry.tokenName.split("-"),
+          field,
+          id: entry.id,
+        });
       }
 
       // Also index aliases for matching

--- a/tools/token-mapping-analyzer/test/apply.test.js
+++ b/tools/token-mapping-analyzer/test/apply.test.js
@@ -14,7 +14,11 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { loadRegistries } from "../src/registry-index.js";
 import { serialize } from "../src/decomposer.js";
-import { applyField, applySpaceBetween } from "../src/apply.js";
+import {
+  applyField,
+  applySpaceBetween,
+  applyScaleIndex,
+} from "../src/apply.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CASCADE_DIR = resolve(__dirname, "../../../packages/design-data/tokens");
@@ -288,6 +292,37 @@ test("applyField extracts co-occurring fields together to preserve the roundtrip
 // family:"serif" + emphasis:"emphasized"). Without a component field, applying
 // that merge violates SPEC-025 (anatomy requires component) even though the
 // *targeted* field was "family", not "anatomy". Regression test for that bug.
+test("applyScaleIndex migrates icon size-N tokens (dsi.6 icon follow-up, spectrum-design-data-5p3)", (t) => {
+  const registry = loadRegistries();
+  const tokens = [
+    // Plain icon owner.
+    { name: { icon: "add", property: "size-200", scale: "desktop" } },
+    // "link-out-icon" also exists as an anatomy term of the same length —
+    // this token exercises that collision (see decomposer.test.js).
+    { name: { icon: "link-out", property: "size-100", scale: "mobile" } },
+  ];
+
+  const { applied } = applyScaleIndex(
+    tokens,
+    registry,
+    "layout-component.tokens.json",
+  );
+
+  t.is(applied, 2);
+  t.deepEqual(tokens[0].name, {
+    icon: "add",
+    property: "size",
+    scale: "desktop",
+    scaleIndex: 200,
+  });
+  t.deepEqual(tokens[1].name, {
+    icon: "link-out",
+    property: "size",
+    scale: "mobile",
+    scaleIndex: 100,
+  });
+});
+
 test("applyField skips a merge that would introduce a SPEC-025 violation (anatomy without component)", (t) => {
   const registry = loadRegistries();
   const tokens = [

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -402,3 +402,50 @@ test("serialize() reconstructs the -to- connective for a space-between name", (t
   );
   t.is(legacyKey, "accordion-bottom-to-handle-extra-large-hover");
 });
+
+test("decomposes an icon size-N token and splits the scaleIndex (dsi.6 icon follow-up)", (t) => {
+  const result = decompose("add-icon-size-200", {}, registry, "test");
+  t.is(result.nameObject.icon, "add");
+  t.is(result.nameObject.property, "size");
+  t.is(result.nameObject.scaleIndex, 200);
+  t.is(result.confidence, "HIGH");
+  t.true(result.roundtrips);
+});
+
+test("serialize() reconstructs an icon size-N key with state", (t) => {
+  const legacyKey = serialize(
+    { icon: "checkmark", property: "size", scaleIndex: 75, state: "hover" },
+    registry.tokenNameMap,
+    registry.serializationOrder,
+  );
+  t.is(legacyKey, "checkmark-icon-size-75-hover");
+});
+
+// "link-out-icon" is also declared as an anatomy term (anatomy-terms.json), the
+// same length as the icon's expanded tokenName — without metadata, Phase 3's
+// length-then-priority tie-break would resolve it to `anatomy` (icon isn't in
+// fieldPriority) instead of `icon`. Passing tokenData.icon (mirrors component
+// metadata handling) disambiguates it before that tie-break runs.
+test("metadata-provided icon resolves an anatomy/icon tokenName collision (link-out-icon)", (t) => {
+  const withoutMetadata = decompose(
+    "link-out-icon-size-100",
+    {},
+    registry,
+    "test",
+  );
+  t.is(withoutMetadata.nameObject.anatomy, "link-out-icon");
+  t.is(withoutMetadata.nameObject.icon, undefined);
+
+  const withMetadata = decompose(
+    "link-out-icon-size-100",
+    { icon: "link-out" },
+    registry,
+    "test",
+  );
+  t.is(withMetadata.nameObject.icon, "link-out");
+  t.is(withMetadata.nameObject.anatomy, undefined);
+  t.is(withMetadata.nameObject.property, "size");
+  t.is(withMetadata.nameObject.scaleIndex, 100);
+  t.is(withMetadata.confidence, "HIGH");
+  t.true(withMetadata.roundtrips);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds icon-domain recognition to `decompose()`/`serialize()` in
`tools/token-mapping-analyzer`, unblocking the 112 icon `size-N` tokens in
`layout-component.tokens.json` that dsi.6 split off as unsafe to migrate.

Investigation showed the bead's original framing was partly wrong: neither
`naming.rs` (its icon-first legacy-key branch is deliberate and already
correct/tested) nor `applyScaleIndex()` (domain-agnostic; needed no change)
required fixes. The actual gaps were entirely in the JS decompose/serialize
mirror:

1. `registry-index.js` never indexed a term's `tokenName` (e.g. `"add"` →
   `"add-icon"`) as a matchable segment set — only as a serialization alias —
   so decompose couldn't recognize an icon's expanded legacy form at all.
2. `serialize()` had no icon-owner branch, so icon tokens either fell to the
   general path (wrong order) or were silently dropped by the stale
   `FALLBACK_SERIALIZATION_ORDER` (missing `"icon"`).
3. Once (1) was fixed, a subtler collision surfaced: `link-out-icon` is also
   a declared **anatomy** term of the same segment length, so the length-then-
   priority tie-break (icon isn't in `fieldPriority`) picked `anatomy` instead.
   Fixed by threading `token.name.icon` metadata into `decompose()`, mirroring
   the existing `component` metadata handling.

## Related Issue

Closes spectrum-design-data-5p3 (dsi.6 follow-up).

## Motivation and Context

dsi.6 introduced `applyScaleIndex()` to split a fused numeric suffix (e.g.
`size-200`) out of `property` into a numeric `scaleIndex`, and it's been
rolled out domain by domain. Icon tokens were the one domain that came back
0 applied — the safety guard correctly rejected all 112 rather than risk
corruption, but the underlying gap needed a real fix rather than another
guard.

## How Has This Been Tested?

- `pnpm ava` in `tools/token-mapping-analyzer`: 42/42 passing, including new
  cases for icon decompose/serialize round-trips and the anatomy/icon
  collision.
- `cargo test --workspace` (Rust): all passing, confirming `naming.rs` and
  the embedded registry data remain consistent — no Rust changes were needed.
- `design-data migrate legacy-verify packages/design-data/tokens --reference
  packages/tokens/src`: **Legacy output OK** — confirms the migration is
  byte-identical/representation-only.
- Dry-run and `--write` via `node tools/token-mapping-analyzer/src/apply.js
  --field scale-index`: exactly 112 tokens applied in
  `layout-component.tokens.json` (matching the bead's count) plus 1
  incidental `space-between` token in `layout.tokens.json` picked up by the
  same full-cascade run.
- Verified the `sdk-wasm:test` failure seen under `moon run :test` pre-exists
  on `main` (reproduced identically after stashing this branch's changes) —
  unrelated to this change.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
