### PR TITLE
fix(wasm): update stale parity test fixture after accent-* decompose

### DIFF
--- a/sdk/wasm/test/parity.test.js
+++ b/sdk/wasm/test/parity.test.js
@@ -74,12 +74,14 @@ test("Dataset.embedded() query returns results for known Spectrum tokens", (t) =
 
 test("Dataset.embedded() resolve returns a token for a known property", (t) => {
   const ds = wasm.Dataset.embedded();
-  // accent-background-color: a stable core Spectrum property present across all colorSchemes;
+  // background-color: a stable core Spectrum property present across all colorSchemes;
   // unlikely to be renamed or removed, making it a reliable fixture anchor.
-  const result = ds.resolve("accent-background-color", {
+  // (accent-background-color was decomposed into colorRole:"accent" +
+  // property:"background-color" by #1246 — resolve() matches name.property literally.)
+  const result = ds.resolve("background-color", {
     colorScheme: "light",
   });
-  t.truthy(result, "Expected a resolved token for accent-background-color");
+  t.truthy(result, "Expected a resolved token for background-color");
   t.is(typeof result.specificity, "number");
   t.truthy(result.token.raw);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the failing `sdk-wasm:test` case `Dataset.embedded() resolve returns a
token for a known property`, which fails identically on `main` today (verified
via a throwaway worktree) — it predates this change and isn't caused by any
in-flight PR.

`resolve_property` (`sdk/core/src/cascade.rs`) matches `name.property`
literally. The test passed `"accent-background-color"`, which was a valid
`property` value before #1246 decomposed it into `colorRole:"accent"` +
`property:"background-color"`. The test was never updated, so `resolve()`
has returned `undefined` ever since. Swapped the fixture to
`"background-color"`, which is still a stable, cross-`colorScheme` anchor.

## Related Issue

No tracked issue — small, self-contained test fixture fix discovered while
investigating an unrelated PR's pre-existing CI failure.

## Motivation and Context

`sdk-wasm:test` was red on every recent branch, masking any *real* wasm
regression a future change might introduce.

## How Has This Been Tested?

- `moon run sdk-wasm:test`: 60/60 passing (was 59/60).
- Confirmed the failure reproduces identically on `origin/main` before this
  fix, via `git worktree add`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
