### PR TITLE
fix(design-data): declare missing component anatomy/state values (7a5)

### DIFF
--- a/.changeset/7a5-component-anatomy-state-gaps.md
+++ b/.changeset/7a5-component-anatomy-state-gaps.md
@@ -1,0 +1,14 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Fix SPEC-020/SPEC-022 component anatomy/state gaps surfaced by strict
+`--components-path` validation (7a5).
+
+- **packages/design-data/components/tree-view.json**: declare the `default` state,
+  used by the `space-between` token but previously undeclared.
+- **packages/design-data/components/swatch.json**: declare the `slash` anatomy part,
+  used by 4 `thickness` tokens but previously undeclared.
+- **packages/design-data/components/stack-item.json**: new component file — 32 tokens
+  reference `component: "stack-item"` but no schema existed; declares its
+  `down`/`hover`/`key-focus` states.

--- a/packages/design-data/components/stack-item.json
+++ b/packages/design-data/components/stack-item.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/stack-item.json",
+  "specVersion": "1.0.0-draft",
+  "name": "stack-item",
+  "displayName": "Stack item",
+  "description": "A single row primitive used by list-like containers such as list-view and tree-view.",
+  "meta": {
+    "category": "containers",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "states": [
+    { "name": "down", "trigger": "interaction" },
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "key-focus", "trigger": "interaction" }
+  ],
+  "lifecycle": { "introduced": "1.0.0-draft" }
+}

--- a/packages/design-data/components/swatch.json
+++ b/packages/design-data/components/swatch.json
@@ -76,6 +76,12 @@
     "isSelected": { "type": "boolean", "default": false },
     "isDisabled": { "type": "boolean", "default": false }
   },
+  "anatomy": [
+    {
+      "name": "slash",
+      "description": "Diagonal slash indicating an empty or \"none\" swatch."
+    }
+  ],
   "states": [
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/tree-view.json
+++ b/packages/design-data/components/tree-view.json
@@ -172,6 +172,7 @@
     }
   ],
   "states": [
+    { "name": "default", "description": "Resting base state." },
     { "name": "hover", "trigger": "interaction" },
     { "name": "down", "trigger": "interaction" },
     { "name": "keyboard-focus", "trigger": "interaction" }

--- a/sdk/core/src/data_source/embedded.rs
+++ b/sdk/core/src/data_source/embedded.rs
@@ -401,8 +401,8 @@ mod tests {
             .collect();
         assert_eq!(
             components.len(),
-            81,
-            "expected 81 component schemas — update this count if you've added/removed \
+            82,
+            "expected 82 component schemas — update this count if you've added/removed \
              schemas from packages/design-data/components/"
         );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Strict validation (`design-data validate --components-path`, stricter than the CI-run
`moon run design-data:validate` which omits that flag) surfaces SPEC-020
(`component-anatomy-valid`) and SPEC-022 (`component-state-valid`) mismatches between
component JSON declarations and the structured `name.anatomy`/`name.state` fields
actually used by token data.

- **`tree-view.json`**: declares the `default` state, used by the `space-between` token
  but previously undeclared.
- **`swatch.json`**: declares the `slash` anatomy part, used by 4 `thickness` tokens but
  previously undeclared.
- **`stack-item.json`** (new file): 32 tokens reference `component: "stack-item"` but no
  component schema existed for it at all, so those tokens were entirely invisible to
  component-aware validation rules. Declares its `down`/`hover`/`key-focus` states.
- **`embedded.rs`**: bumps the hardcoded component-schema count assertion from 81 to 82
  to account for the new file.

Each declared value was verified against the actual token data (`jq` over
`packages/design-data/tokens/*.tokens.json`) and cross-checked against the
`anatomy-terms`/`states` registries before being added — not guessed from the original
bug report, which turned out to name values (`row`, `selected`, `icon`, `disabled`) that
only exist inside `property` strings, never in the structured fields these rules match.
`select-box.json` was left untouched: its tokens carry no structured anatomy/state values,
so there was nothing to fix there.

## Related Issue

Closes spectrum-design-data-7a5.

## Motivation and Context

Data-quality fix — not CI-blocking today (the `design-data:validate` moon task doesn't
pass `--components-path`, so these mismatches don't surface in CI; that gap is tracked
separately in spectrum-design-data-0jm). Fixing it keeps the component declarations honest
about which anatomy/state values are actually in use, and unblocks stricter validation runs
from reporting false noise on these four components.

## How Has This Been Tested?

- `moon run sdk:build` then ran
  `design-data validate ./packages/design-data/tokens --components-path ./packages/design-data/components --exceptions-path ./packages/tokens/naming-exceptions.json`
  — confirmed zero SPEC-020/SPEC-022 diagnostics remain for `tree-view`, `swatch`,
  `stack-item`, `select-box` (all four were previously producing the tree-view `default`
  error at minimum).
- `moon run sdk:codegen` / `sdk:codegen-check` — up to date.
- `moon run sdk:test` — full Rust workspace suite passes (657 tests), including the
  updated `materialize_components_count` assertion.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset lint-clean.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
