### PR TITLE
fix(sdk): resolve structured token names in SPEC-027

### DIFF
--- a/.changeset/soc-spec027-structured-name-resolution.md
+++ b/.changeset/soc-spec027-structured-name-resolution.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+SPEC-027 now resolves each token's legacy key via the shared `naming::extract_legacy_key`
+resolver instead of assuming a flat string `name`, eliminating ~2948 false-positive
+`tokenBindings` errors caused by the name-object migration (closes bead soc).
+
+- **sdk/core/src/validate/rules/spec027.rs**: `token_names` is built by resolving each
+  token's structured (or plain-string) `name` through `extract_legacy_key`, the same
+  resolver used by `legacy.rs` and the graph's `legacy_name_index`, so `tokenBindings[].token`
+  references match correctly regardless of name shape; added a regression test covering a
+  structured `name` object.

--- a/sdk/core/src/validate/rules/spec027.rs
+++ b/sdk/core/src/validate/rules/spec027.rs
@@ -30,12 +30,18 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
 
-        // Only string-named tokens are referenceable via tokenBindings.
-        let token_names: std::collections::HashSet<&str> = ctx
+        // Resolve each token's flat legacy key (handles both the plain-string
+        // escape hatch and structured `name` objects) — this is what
+        // tokenBindings[].token values match against.
+        let token_names: std::collections::HashSet<String> = ctx
             .graph
             .tokens
             .values()
-            .filter_map(|t| t.raw.get("name").and_then(|n| n.as_str()))
+            .filter_map(|t| {
+                t.raw
+                    .get("name")
+                    .and_then(crate::naming::extract_legacy_key)
+            })
             .collect();
 
         for comp in &ctx.graph.components {
@@ -155,6 +161,29 @@ mod tests {
     #[test]
     fn no_bindings_no_error() {
         let diags = run(vec![], json!({"name": "button"}));
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn structured_name_object_resolves() {
+        // Post name-object migration, tokens carry a structured `name` object
+        // rather than a flat string. tokenBindings must still resolve against
+        // the token's legacy key (pinned here via `legacyKey`).
+        let diags = run(
+            vec![json!({
+                "name": {
+                    "property": "height",
+                    "component": "select-box",
+                    "orientation": "vertical",
+                    "legacyKey": "select-box-vertical-height"
+                },
+                "value": "32px"
+            })],
+            json!({
+                "name": "select-box",
+                "tokenBindings": [{"token": "select-box-vertical-height", "slot": "default"}]
+            }),
+        );
         assert!(diags.is_empty());
     }
 }


### PR DESCRIPTION
## Description

SPEC-027 (`token-binding-token-exists`) built its set of valid token names by
matching `raw.get("name").and_then(|n| n.as_str())` — i.e. it assumed every
token's `name` field is a flat JSON string. Post the name-object migration,
all 4180 tokens in the corpus carry a structured `name` **object**, so this
match returned nothing for every token, and the rule fired a false positive
for virtually every `tokenBindings[].token` reference in the component
declarations (~2948 diagnostics in a strict `validate --components-path` run).

The fix resolves each token's flat legacy key via the existing
`naming::extract_legacy_key` resolver instead — the same resolver already
used by `legacy.rs` and the graph's `legacy_name_index` to bridge structured
`name` objects back to their flat legacy key. It transparently handles the
plain-string escape hatch too, so no existing behavior changes for
string-named tokens.

## Related Issue

Closes bead `spectrum-design-data-soc`.

## Motivation and Context

This bug was blocking a strict `validate --components-path` run from being
usable at all — nearly every component declaration failed SPEC-027, drowning
out any real signal. Discovered while fixing a separate bead (component
anatomy/state gaps, `7a5`).

## How Has This Been Tested?

- Added a regression test (`structured_name_object_resolves`) exercising a
  structured `name` object with a pinned `legacyKey`; existing 3 tests
  (string names, unknown token, no bindings) still pass unchanged.
- `cargo test --workspace`: 659+ tests, 0 failed.
- End-to-end: ran `design-data-cli validate` with `--components-path` and
  `--strict` before/after — SPEC-027 diagnostics dropped from ~2948 to 134.
  Spot-checked a sample of the remaining 134 (e.g.
  `field-top-to-disclosure-icon-75-compact`) and confirmed they reference
  tokens that genuinely don't exist anywhere in the corpus — real dangling
  `tokenBindings` references, not a resolver bug. Tracking those separately.
- Changeset added and verified with
  `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
