### PR TITLE
fix(design-data): load components in CI validate, restore SPEC-018/020/022 checks

### DIFF
--- a/.changeset/0jm-components-path-ci-gate.md
+++ b/.changeset/0jm-components-path-ci-gate.md
@@ -1,0 +1,18 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+`design-data:validate` now loads component JSON so component-aware SPEC rules
+actually run in CI instead of silently short-circuiting (closes bead 0jm).
+
+- **packages/design-data/moon.yml**: `validate` task now passes `--components-path
+  ./components --components-report-only`. Report-only until SPEC-027's remaining
+  decomposed-token backlog is resolved; SPEC-018/020/022 are already at 0.
+- **sdk/cli/src/main.rs**, **sdk/core/src/report.rs**: new `--components-report-only`
+  flag downgrading component-rule errors to warnings.
+- **sdk/core/src/validate/rules/spec027.rs**: fixed a 100%-false-failure bug —
+  tokenBindings were matched against tokens' string `name`, but cascade tokens use
+  object `name`; now also matches `name.legacyKey`.
+- **packages/design-data/components/*.json**: declared 16 previously-undeclared
+  components; added missing anatomy/state declarations across 13 components; fixed
+  combo-box's malformed state names.

--- a/.changeset/0jm-components-path-ci-gate.md
+++ b/.changeset/0jm-components-path-ci-gate.md
@@ -7,12 +7,10 @@ actually run in CI instead of silently short-circuiting (closes bead 0jm).
 
 - **packages/design-data/moon.yml**: `validate` task now passes `--components-path
   ./components --components-report-only`. Report-only until SPEC-027's remaining
-  decomposed-token backlog is resolved; SPEC-018/020/022 are already at 0.
+  ~134 genuinely-dangling `tokenBindings` are triaged; SPEC-018/020/022 are already
+  at 0.
 - **sdk/cli/src/main.rs**, **sdk/core/src/report.rs**: new `--components-report-only`
   flag downgrading component-rule errors to warnings.
-- **sdk/core/src/validate/rules/spec027.rs**: fixed a 100%-false-failure bug —
-  tokenBindings were matched against tokens' string `name`, but cascade tokens use
-  object `name`; now also matches `name.legacyKey`.
 - **packages/design-data/components/*.json**: declared 16 previously-undeclared
   components; added missing anatomy/state declarations across 13 components; fixed
   combo-box's malformed state names.

--- a/packages/design-data/components/action-bar.json
+++ b/packages/design-data/components/action-bar.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "guideline",
-      "content": "Action bar in Dark theme.\n\nAction bar is split into a separate component for each color theme — light and dark. Since each is set to either light or dark mode in Figma, they do not switch automatically like the rest of the UI when placed in frames that are set to \"auto\" mode.\n\nIn dark theme, the action bar also includes a 1px inner border to help it stand out against the background colors."
+      "content": "Action bar in Dark theme.\n\nAction bar is split into a separate component for each color theme \u2014 light and dark. Since each is set to either light or dark mode in Figma, they do not switch automatically like the rest of the UI when placed in frames that are set to \"auto\" mode.\n\nIn dark theme, the action bar also includes a 1px inner border to help it stand out against the background colors."
     },
     {
       "type": "guideline",
@@ -50,10 +50,15 @@
     {
       "type": "do-dont",
       "content": "Don't use quick actions",
-      "dont": "Instead of quick actions, use an action bar for both single and bulk selection patterns. An action bar is useful for when a user needs to perform actions on either a single or multiple items at the same time. It can be used on either a grid view or a table view.\n\nDon't use quick actions — a deprecated component — because it presents conflicting nested actions (for example, a whole asset card could open a detailed view). This makes targeting specific actions very difficult, especially on smaller screens or with the keyboard."
+      "dont": "Instead of quick actions, use an action bar for both single and bulk selection patterns. An action bar is useful for when a user needs to perform actions on either a single or multiple items at the same time. It can be used on either a grid view or a table view.\n\nDon't use quick actions \u2014 a deprecated component \u2014 because it presents conflicting nested actions (for example, a whole asset card could open a detailed view). This makes targeting specific actions very difficult, especially on smaller screens or with the keyboard."
     }
   ],
-  "options": { "isEmphasized": { "type": "boolean", "default": false } },
+  "options": {
+    "isEmphasized": {
+      "type": "boolean",
+      "default": false
+    }
+  },
   "anatomy": [
     {
       "name": "action-group-area",
@@ -62,13 +67,27 @@
     {
       "name": "item-counter",
       "description": "Badge showing a count of items or actions."
+    },
+    {
+      "name": "counter"
     }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "action-bar-height", "context": "Height" },
-    { "token": "action-bar-minimum-width", "context": "Width (minimum)" },
-    { "token": "corner-radius-medium-size-extra-large", "context": "Rounding" },
+    {
+      "token": "action-bar-height",
+      "context": "Height"
+    },
+    {
+      "token": "action-bar-minimum-width",
+      "context": "Width (minimum)"
+    },
+    {
+      "token": "corner-radius-medium-size-extra-large",
+      "context": "Rounding"
+    },
     {
       "token": "action-bar-top-to-content-area",
       "context": "Spacing (padding)"
@@ -93,24 +112,66 @@
       "token": "action-bar-close-button-to-counter",
       "context": "Spacing (counter)"
     },
-    { "token": "background-elevated-color", "context": "Background (default)" },
+    {
+      "token": "background-elevated-color",
+      "context": "Background (default)"
+    },
     {
       "token": "neutral-content-color-default",
       "context": "Background (emphasized)"
     },
-    { "token": "action-bar-border", "context": "Border" },
-    { "token": "drop-shadow-elevated-color", "context": "Drop shadow" },
-    { "token": "drop-shadow-elevated-x", "context": "Drop shadow" },
-    { "token": "drop-shadow-elevated-y", "context": "Drop shadow" },
-    { "token": "drop-shadow-elevated-blur", "context": "Drop shadow" },
-    { "token": "action-bar-counter-font-size", "context": "Counter" },
-    { "token": "line-height-100", "context": "Counter" },
-    { "token": "cjk-line-height-100", "context": "Counter" },
-    { "token": "accent-background-color-default", "context": "Background" },
-    { "token": "accent-background-color-hover", "context": "Background" },
-    { "token": "accent-background-color-down", "context": "Background" },
-    { "token": "accent-background-color-key-focus", "context": "Background" },
-    { "token": "white", "context": "Icon and Clear icon" },
+    {
+      "token": "action-bar-border",
+      "context": "Border"
+    },
+    {
+      "token": "drop-shadow-elevated-color",
+      "context": "Drop shadow"
+    },
+    {
+      "token": "drop-shadow-elevated-x",
+      "context": "Drop shadow"
+    },
+    {
+      "token": "drop-shadow-elevated-y",
+      "context": "Drop shadow"
+    },
+    {
+      "token": "drop-shadow-elevated-blur",
+      "context": "Drop shadow"
+    },
+    {
+      "token": "action-bar-counter-font-size",
+      "context": "Counter"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Counter"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Counter"
+    },
+    {
+      "token": "accent-background-color-default",
+      "context": "Background"
+    },
+    {
+      "token": "accent-background-color-hover",
+      "context": "Background"
+    },
+    {
+      "token": "accent-background-color-down",
+      "context": "Background"
+    },
+    {
+      "token": "accent-background-color-key-focus",
+      "context": "Background"
+    },
+    {
+      "token": "white",
+      "context": "Icon and Clear icon"
+    },
     {
       "token": "neutral-selected-background-color-default",
       "context": "Background"
@@ -127,7 +188,10 @@
       "token": "neutral-selected-background-color-key-focus",
       "context": "Background"
     },
-    { "token": "gray-25", "context": "Icon and Clear icon" },
+    {
+      "token": "gray-25",
+      "context": "Icon and Clear icon"
+    },
     {
       "token": "neutral-content-color-hover",
       "context": "Control (selected, non emphasized)"
@@ -160,7 +224,10 @@
       "token": "neutral-subdued-content-color-default",
       "context": "Step text"
     },
-    { "token": "neutral-subdued-content-color-hover", "context": "Step text" },
+    {
+      "token": "neutral-subdued-content-color-hover",
+      "context": "Step text"
+    },
     {
       "token": "neutral-subdued-content-color-key-focus",
       "context": "Step text"
@@ -177,15 +244,28 @@
       "token": "neutral-subdued-background-color-key-focus",
       "context": "Step visual"
     },
-    { "token": "neutral-background-color-default", "context": "Step visual" },
-    { "token": "neutral-background-color-key-focus", "context": "Step visual" },
-    { "token": "neutral-visual-color", "context": "Step visual" }
+    {
+      "token": "neutral-background-color-default",
+      "context": "Step visual"
+    },
+    {
+      "token": "neutral-background-color-key-focus",
+      "context": "Step visual"
+    },
+    {
+      "token": "neutral-visual-color",
+      "context": "Step visual"
+    }
   ],
   "accessibility": {
     "intents": ["trigger"],
     "focusable": false,
     "wcag": [
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/action-bar.json
+++ b/packages/design-data/components/action-bar.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "guideline",
-      "content": "Action bar in Dark theme.\n\nAction bar is split into a separate component for each color theme \u2014 light and dark. Since each is set to either light or dark mode in Figma, they do not switch automatically like the rest of the UI when placed in frames that are set to \"auto\" mode.\n\nIn dark theme, the action bar also includes a 1px inner border to help it stand out against the background colors."
+      "content": "Action bar in Dark theme.\n\nAction bar is split into a separate component for each color theme — light and dark. Since each is set to either light or dark mode in Figma, they do not switch automatically like the rest of the UI when placed in frames that are set to \"auto\" mode.\n\nIn dark theme, the action bar also includes a 1px inner border to help it stand out against the background colors."
     },
     {
       "type": "guideline",
@@ -50,15 +50,10 @@
     {
       "type": "do-dont",
       "content": "Don't use quick actions",
-      "dont": "Instead of quick actions, use an action bar for both single and bulk selection patterns. An action bar is useful for when a user needs to perform actions on either a single or multiple items at the same time. It can be used on either a grid view or a table view.\n\nDon't use quick actions \u2014 a deprecated component \u2014 because it presents conflicting nested actions (for example, a whole asset card could open a detailed view). This makes targeting specific actions very difficult, especially on smaller screens or with the keyboard."
+      "dont": "Instead of quick actions, use an action bar for both single and bulk selection patterns. An action bar is useful for when a user needs to perform actions on either a single or multiple items at the same time. It can be used on either a grid view or a table view.\n\nDon't use quick actions — a deprecated component — because it presents conflicting nested actions (for example, a whole asset card could open a detailed view). This makes targeting specific actions very difficult, especially on smaller screens or with the keyboard."
     }
   ],
-  "options": {
-    "isEmphasized": {
-      "type": "boolean",
-      "default": false
-    }
-  },
+  "options": { "isEmphasized": { "type": "boolean", "default": false } },
   "anatomy": [
     {
       "name": "action-group-area",
@@ -68,26 +63,13 @@
       "name": "item-counter",
       "description": "Badge showing a count of items or actions."
     },
-    {
-      "name": "counter"
-    }
+    { "name": "counter" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "action-bar-height",
-      "context": "Height"
-    },
-    {
-      "token": "action-bar-minimum-width",
-      "context": "Width (minimum)"
-    },
-    {
-      "token": "corner-radius-medium-size-extra-large",
-      "context": "Rounding"
-    },
+    { "token": "action-bar-height", "context": "Height" },
+    { "token": "action-bar-minimum-width", "context": "Width (minimum)" },
+    { "token": "corner-radius-medium-size-extra-large", "context": "Rounding" },
     {
       "token": "action-bar-top-to-content-area",
       "context": "Spacing (padding)"
@@ -112,66 +94,24 @@
       "token": "action-bar-close-button-to-counter",
       "context": "Spacing (counter)"
     },
-    {
-      "token": "background-elevated-color",
-      "context": "Background (default)"
-    },
+    { "token": "background-elevated-color", "context": "Background (default)" },
     {
       "token": "neutral-content-color-default",
       "context": "Background (emphasized)"
     },
-    {
-      "token": "action-bar-border",
-      "context": "Border"
-    },
-    {
-      "token": "drop-shadow-elevated-color",
-      "context": "Drop shadow"
-    },
-    {
-      "token": "drop-shadow-elevated-x",
-      "context": "Drop shadow"
-    },
-    {
-      "token": "drop-shadow-elevated-y",
-      "context": "Drop shadow"
-    },
-    {
-      "token": "drop-shadow-elevated-blur",
-      "context": "Drop shadow"
-    },
-    {
-      "token": "action-bar-counter-font-size",
-      "context": "Counter"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Counter"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Counter"
-    },
-    {
-      "token": "accent-background-color-default",
-      "context": "Background"
-    },
-    {
-      "token": "accent-background-color-hover",
-      "context": "Background"
-    },
-    {
-      "token": "accent-background-color-down",
-      "context": "Background"
-    },
-    {
-      "token": "accent-background-color-key-focus",
-      "context": "Background"
-    },
-    {
-      "token": "white",
-      "context": "Icon and Clear icon"
-    },
+    { "token": "action-bar-border", "context": "Border" },
+    { "token": "drop-shadow-elevated-color", "context": "Drop shadow" },
+    { "token": "drop-shadow-elevated-x", "context": "Drop shadow" },
+    { "token": "drop-shadow-elevated-y", "context": "Drop shadow" },
+    { "token": "drop-shadow-elevated-blur", "context": "Drop shadow" },
+    { "token": "action-bar-counter-font-size", "context": "Counter" },
+    { "token": "line-height-100", "context": "Counter" },
+    { "token": "cjk-line-height-100", "context": "Counter" },
+    { "token": "accent-background-color-default", "context": "Background" },
+    { "token": "accent-background-color-hover", "context": "Background" },
+    { "token": "accent-background-color-down", "context": "Background" },
+    { "token": "accent-background-color-key-focus", "context": "Background" },
+    { "token": "white", "context": "Icon and Clear icon" },
     {
       "token": "neutral-selected-background-color-default",
       "context": "Background"
@@ -188,10 +128,7 @@
       "token": "neutral-selected-background-color-key-focus",
       "context": "Background"
     },
-    {
-      "token": "gray-25",
-      "context": "Icon and Clear icon"
-    },
+    { "token": "gray-25", "context": "Icon and Clear icon" },
     {
       "token": "neutral-content-color-hover",
       "context": "Control (selected, non emphasized)"
@@ -224,10 +161,7 @@
       "token": "neutral-subdued-content-color-default",
       "context": "Step text"
     },
-    {
-      "token": "neutral-subdued-content-color-hover",
-      "context": "Step text"
-    },
+    { "token": "neutral-subdued-content-color-hover", "context": "Step text" },
     {
       "token": "neutral-subdued-content-color-key-focus",
       "context": "Step text"
@@ -244,28 +178,15 @@
       "token": "neutral-subdued-background-color-key-focus",
       "context": "Step visual"
     },
-    {
-      "token": "neutral-background-color-default",
-      "context": "Step visual"
-    },
-    {
-      "token": "neutral-background-color-key-focus",
-      "context": "Step visual"
-    },
-    {
-      "token": "neutral-visual-color",
-      "context": "Step visual"
-    }
+    { "token": "neutral-background-color-default", "context": "Step visual" },
+    { "token": "neutral-background-color-key-focus", "context": "Step visual" },
+    { "token": "neutral-visual-color", "context": "Step visual" }
   ],
   "accessibility": {
     "intents": ["trigger"],
     "focusable": false,
     "wcag": [
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/avatar.json
+++ b/packages/design-data/components/avatar.json
@@ -28,7 +28,7 @@
     },
     {
       "type": "guideline",
-      "content": "An avatar has multiple visual styles, depending on the user preference. These show up as branded gradient images, initials of the user\u2019s name, as well as any image that a user uploads. For users who do not have Adobe accounts, they will default to the guest avatar."
+      "content": "An avatar has multiple visual styles, depending on the user preference. These show up as branded gradient images, initials of the user’s name, as well as any image that a user uploads. For users who do not have Adobe accounts, they will default to the guest avatar."
     },
     {
       "type": "guideline",
@@ -36,7 +36,7 @@
     },
     {
       "type": "guideline",
-      "content": "An avatar group displays a set of related avatars together. It\u2019s typically used to represent a collection of people or entities."
+      "content": "An avatar group displays a set of related avatars together. It’s typically used to represent a collection of people or entities."
     },
     {
       "type": "guideline",
@@ -44,7 +44,7 @@
     },
     {
       "type": "guideline",
-      "content": "The initials avatar is designed to work with latin characters only and supports 1 or 2 characters that are programmatically identified by the first name and last name in a user\u2019s account settings. For users with non-latin characters, their default avatar should be the gradient image style."
+      "content": "The initials avatar is designed to work with latin characters only and supports 1 or 2 characters that are programmatically identified by the first name and last name in a user’s account settings. For users with non-latin characters, their default avatar should be the gradient image style."
     },
     {
       "type": "guideline",
@@ -56,237 +56,78 @@
       "type": "number",
       "default": 500,
       "values": [
-        {
-          "value": 50
-        },
-        {
-          "value": 75
-        },
-        {
-          "value": 100
-        },
-        {
-          "value": 200
-        },
-        {
-          "value": 300
-        },
-        {
-          "value": 400
-        },
-        {
-          "value": 500
-        },
-        {
-          "value": 600
-        },
-        {
-          "value": 700
-        },
-        {
-          "value": 800
-        },
-        {
-          "value": 900
-        },
-        {
-          "value": 1000
-        },
-        {
-          "value": 1100
-        },
-        {
-          "value": 1200
-        },
-        {
-          "value": 1300
-        },
-        {
-          "value": 1400
-        },
-        {
-          "value": 1500
-        }
+        { "value": 50 },
+        { "value": 75 },
+        { "value": 100 },
+        { "value": 200 },
+        { "value": 300 },
+        { "value": 400 },
+        { "value": 500 },
+        { "value": 600 },
+        { "value": 700 },
+        { "value": 800 },
+        { "value": 900 },
+        { "value": 1000 },
+        { "value": 1100 },
+        { "value": 1200 },
+        { "value": 1300 },
+        { "value": 1400 },
+        { "value": 1500 }
       ]
     },
     "image": {
       "type": "string",
       "default": "user image",
       "values": [
-        {
-          "value": "user image"
-        },
-        {
-          "value": "gradient image"
-        },
-        {
-          "value": "gradient"
-        },
-        {
-          "value": "guest image"
-        },
-        {
-          "value": "initials"
-        }
+        { "value": "user image" },
+        { "value": "gradient image" },
+        { "value": "gradient" },
+        { "value": "guest image" },
+        { "value": "initials" }
       ]
     },
-    "isDisabled": {
-      "type": "boolean",
-      "default": false
-    },
-    "showStroke": {
-      "type": "boolean",
-      "default": false
-    }
+    "isDisabled": { "type": "boolean", "default": false },
+    "showStroke": { "type": "boolean", "default": false }
   },
   "states": [
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    },
-    {
-      "name": "disabled",
-      "trigger": "prop"
-    }
+    { "name": "down", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" },
+    { "name": "disabled", "trigger": "prop" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "avatar-size-50",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-75",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-100",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-200",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-300",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-400",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-500",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-600",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-700",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-800",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-900",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-1000",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-1100",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-1200",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-1300",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-1400",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-size-1500",
-      "context": "Size"
-    },
-    {
-      "token": "avatar-border-thickness",
-      "context": "Border"
-    },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "focus-indicator-gap",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "avatar-gradient-stop-1",
-      "context": "0% "
-    },
-    {
-      "token": "static-[color]-400",
-      "context": "0% "
-    },
-    {
-      "token": "avatar-gradient-stop-2",
-      "context": "66% "
-    },
-    {
-      "token": "static-[color]-600",
-      "context": "66% "
-    },
-    {
-      "token": "avatar-gradient-stop-3",
-      "context": "100% "
-    },
-    {
-      "token": "static-[color]-800",
-      "context": "100% "
-    },
-    {
-      "token": "gradient-angle",
-      "context": "Top-left to bottom-right"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Text (List view item)"
-    },
-    {
-      "token": "extra-bold-font-weight",
-      "context": "Text (List view item)"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Text (List view item)"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Text (List view item)"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Text (List view item)"
-    }
+    { "token": "avatar-size-50", "context": "Size" },
+    { "token": "avatar-size-75", "context": "Size" },
+    { "token": "avatar-size-100", "context": "Size" },
+    { "token": "avatar-size-200", "context": "Size" },
+    { "token": "avatar-size-300", "context": "Size" },
+    { "token": "avatar-size-400", "context": "Size" },
+    { "token": "avatar-size-500", "context": "Size" },
+    { "token": "avatar-size-600", "context": "Size" },
+    { "token": "avatar-size-700", "context": "Size" },
+    { "token": "avatar-size-800", "context": "Size" },
+    { "token": "avatar-size-900", "context": "Size" },
+    { "token": "avatar-size-1000", "context": "Size" },
+    { "token": "avatar-size-1100", "context": "Size" },
+    { "token": "avatar-size-1200", "context": "Size" },
+    { "token": "avatar-size-1300", "context": "Size" },
+    { "token": "avatar-size-1400", "context": "Size" },
+    { "token": "avatar-size-1500", "context": "Size" },
+    { "token": "avatar-border-thickness", "context": "Border" },
+    { "token": "focus-indicator-thickness", "context": "Focus indicator" },
+    { "token": "focus-indicator-gap", "context": "Focus indicator" },
+    { "token": "avatar-gradient-stop-1", "context": "0% " },
+    { "token": "static-[color]-400", "context": "0% " },
+    { "token": "avatar-gradient-stop-2", "context": "66% " },
+    { "token": "static-[color]-600", "context": "66% " },
+    { "token": "avatar-gradient-stop-3", "context": "100% " },
+    { "token": "static-[color]-800", "context": "100% " },
+    { "token": "gradient-angle", "context": "Top-left to bottom-right" },
+    { "token": "default-font-family", "context": "Text (List view item)" },
+    { "token": "extra-bold-font-weight", "context": "Text (List view item)" },
+    { "token": "default-font-style", "context": "Text (List view item)" },
+    { "token": "font-size-100", "context": "Text (List view item)" },
+    { "token": "line-height-100", "context": "Text (List view item)" }
   ],
-  "accessibility": {
-    "focusable": false
-  }
+  "accessibility": { "focusable": false }
 }

--- a/packages/design-data/components/avatar.json
+++ b/packages/design-data/components/avatar.json
@@ -28,7 +28,7 @@
     },
     {
       "type": "guideline",
-      "content": "An avatar has multiple visual styles, depending on the user preference. These show up as branded gradient images, initials of the user’s name, as well as any image that a user uploads. For users who do not have Adobe accounts, they will default to the guest avatar."
+      "content": "An avatar has multiple visual styles, depending on the user preference. These show up as branded gradient images, initials of the user\u2019s name, as well as any image that a user uploads. For users who do not have Adobe accounts, they will default to the guest avatar."
     },
     {
       "type": "guideline",
@@ -36,7 +36,7 @@
     },
     {
       "type": "guideline",
-      "content": "An avatar group displays a set of related avatars together. It’s typically used to represent a collection of people or entities."
+      "content": "An avatar group displays a set of related avatars together. It\u2019s typically used to represent a collection of people or entities."
     },
     {
       "type": "guideline",
@@ -44,7 +44,7 @@
     },
     {
       "type": "guideline",
-      "content": "The initials avatar is designed to work with latin characters only and supports 1 or 2 characters that are programmatically identified by the first name and last name in a user’s account settings. For users with non-latin characters, their default avatar should be the gradient image style."
+      "content": "The initials avatar is designed to work with latin characters only and supports 1 or 2 characters that are programmatically identified by the first name and last name in a user\u2019s account settings. For users with non-latin characters, their default avatar should be the gradient image style."
     },
     {
       "type": "guideline",
@@ -56,77 +56,237 @@
       "type": "number",
       "default": 500,
       "values": [
-        { "value": 50 },
-        { "value": 75 },
-        { "value": 100 },
-        { "value": 200 },
-        { "value": 300 },
-        { "value": 400 },
-        { "value": 500 },
-        { "value": 600 },
-        { "value": 700 },
-        { "value": 800 },
-        { "value": 900 },
-        { "value": 1000 },
-        { "value": 1100 },
-        { "value": 1200 },
-        { "value": 1300 },
-        { "value": 1400 },
-        { "value": 1500 }
+        {
+          "value": 50
+        },
+        {
+          "value": 75
+        },
+        {
+          "value": 100
+        },
+        {
+          "value": 200
+        },
+        {
+          "value": 300
+        },
+        {
+          "value": 400
+        },
+        {
+          "value": 500
+        },
+        {
+          "value": 600
+        },
+        {
+          "value": 700
+        },
+        {
+          "value": 800
+        },
+        {
+          "value": 900
+        },
+        {
+          "value": 1000
+        },
+        {
+          "value": 1100
+        },
+        {
+          "value": 1200
+        },
+        {
+          "value": 1300
+        },
+        {
+          "value": 1400
+        },
+        {
+          "value": 1500
+        }
       ]
     },
     "image": {
       "type": "string",
       "default": "user image",
       "values": [
-        { "value": "user image" },
-        { "value": "gradient image" },
-        { "value": "gradient" },
-        { "value": "guest image" },
-        { "value": "initials" }
+        {
+          "value": "user image"
+        },
+        {
+          "value": "gradient image"
+        },
+        {
+          "value": "gradient"
+        },
+        {
+          "value": "guest image"
+        },
+        {
+          "value": "initials"
+        }
       ]
     },
-    "isDisabled": { "type": "boolean", "default": false },
-    "showStroke": { "type": "boolean", "default": false }
+    "isDisabled": {
+      "type": "boolean",
+      "default": false
+    },
+    "showStroke": {
+      "type": "boolean",
+      "default": false
+    }
   },
   "states": [
-    { "name": "down", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    },
+    {
+      "name": "disabled",
+      "trigger": "prop"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "avatar-size-50", "context": "Size" },
-    { "token": "avatar-size-75", "context": "Size" },
-    { "token": "avatar-size-100", "context": "Size" },
-    { "token": "avatar-size-200", "context": "Size" },
-    { "token": "avatar-size-300", "context": "Size" },
-    { "token": "avatar-size-400", "context": "Size" },
-    { "token": "avatar-size-500", "context": "Size" },
-    { "token": "avatar-size-600", "context": "Size" },
-    { "token": "avatar-size-700", "context": "Size" },
-    { "token": "avatar-size-800", "context": "Size" },
-    { "token": "avatar-size-900", "context": "Size" },
-    { "token": "avatar-size-1000", "context": "Size" },
-    { "token": "avatar-size-1100", "context": "Size" },
-    { "token": "avatar-size-1200", "context": "Size" },
-    { "token": "avatar-size-1300", "context": "Size" },
-    { "token": "avatar-size-1400", "context": "Size" },
-    { "token": "avatar-size-1500", "context": "Size" },
-    { "token": "avatar-border-thickness", "context": "Border" },
-    { "token": "focus-indicator-thickness", "context": "Focus indicator" },
-    { "token": "focus-indicator-gap", "context": "Focus indicator" },
-    { "token": "avatar-gradient-stop-1", "context": "0% " },
-    { "token": "static-[color]-400", "context": "0% " },
-    { "token": "avatar-gradient-stop-2", "context": "66% " },
-    { "token": "static-[color]-600", "context": "66% " },
-    { "token": "avatar-gradient-stop-3", "context": "100% " },
-    { "token": "static-[color]-800", "context": "100% " },
-    { "token": "gradient-angle", "context": "Top-left to bottom-right" },
-    { "token": "default-font-family", "context": "Text (List view item)" },
-    { "token": "extra-bold-font-weight", "context": "Text (List view item)" },
-    { "token": "default-font-style", "context": "Text (List view item)" },
-    { "token": "font-size-100", "context": "Text (List view item)" },
-    { "token": "line-height-100", "context": "Text (List view item)" }
+    {
+      "token": "avatar-size-50",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-75",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-100",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-200",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-300",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-400",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-500",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-600",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-700",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-800",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-900",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-1000",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-1100",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-1200",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-1300",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-1400",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-size-1500",
+      "context": "Size"
+    },
+    {
+      "token": "avatar-border-thickness",
+      "context": "Border"
+    },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "focus-indicator-gap",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "avatar-gradient-stop-1",
+      "context": "0% "
+    },
+    {
+      "token": "static-[color]-400",
+      "context": "0% "
+    },
+    {
+      "token": "avatar-gradient-stop-2",
+      "context": "66% "
+    },
+    {
+      "token": "static-[color]-600",
+      "context": "66% "
+    },
+    {
+      "token": "avatar-gradient-stop-3",
+      "context": "100% "
+    },
+    {
+      "token": "static-[color]-800",
+      "context": "100% "
+    },
+    {
+      "token": "gradient-angle",
+      "context": "Top-left to bottom-right"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Text (List view item)"
+    },
+    {
+      "token": "extra-bold-font-weight",
+      "context": "Text (List view item)"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Text (List view item)"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Text (List view item)"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Text (List view item)"
+    }
   ],
-  "accessibility": { "focusable": false }
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data/components/bar-panel.json
+++ b/packages/design-data/components/bar-panel.json
@@ -9,12 +9,6 @@
     "category": "containers",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "anatomy": [
-    {
-      "name": "gripper"
-    }
-  ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "anatomy": [{ "name": "gripper" }],
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/bar-panel.json
+++ b/packages/design-data/components/bar-panel.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/bar-panel.json",
+  "specVersion": "1.0.0-draft",
+  "name": "bar-panel",
+  "displayName": "Bar panel",
+  "description": "A panel anchored to an edge, exposing a draggable gripper for resizing.",
+  "meta": {
+    "category": "containers",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "anatomy": [
+    {
+      "name": "gripper"
+    }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/card-horizontal.json
+++ b/packages/design-data/components/card-horizontal.json
@@ -9,12 +9,6 @@
     "category": "containers",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "states": [
-    {
-      "name": "default"
-    }
-  ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "states": [{ "name": "default" }],
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/card-horizontal.json
+++ b/packages/design-data/components/card-horizontal.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/card-horizontal.json",
+  "specVersion": "1.0.0-draft",
+  "name": "card-horizontal",
+  "displayName": "Horizontal card",
+  "description": "A card variant laid out horizontally, pairing a preview with content side by side.",
+  "meta": {
+    "category": "containers",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "states": [
+    {
+      "name": "default"
+    }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/card.json
+++ b/packages/design-data/components/card.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/card.json",
+  "specVersion": "1.0.0-draft",
+  "name": "card",
+  "displayName": "Card",
+  "description": "A single card surface used to group related content and actions; the base of the cards family (cards.json documents the group).",
+  "meta": {
+    "category": "containers",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "anatomy": [
+    {
+      "name": "selection"
+    },
+    {
+      "name": "well"
+    }
+  ],
+  "states": [
+    {
+      "name": "default"
+    }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/card.json
+++ b/packages/design-data/components/card.json
@@ -9,20 +9,7 @@
     "category": "containers",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "anatomy": [
-    {
-      "name": "selection"
-    },
-    {
-      "name": "well"
-    }
-  ],
-  "states": [
-    {
-      "name": "default"
-    }
-  ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "anatomy": [{ "name": "selection" }, { "name": "well" }],
+  "states": [{ "name": "default" }],
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/coach-mark.json
+++ b/packages/design-data/components/coach-mark.json
@@ -48,11 +48,11 @@
     },
     {
       "type": "guideline",
-      "content": "The “Previous” button should always be a quiet secondary button."
+      "content": "The \u201cPrevious\u201d button should always be a quiet secondary button."
     },
     {
       "type": "guideline",
-      "content": "The “Skip tour” and “Restart tour” options should only be available within the more actions menu."
+      "content": "The \u201cSkip tour\u201d and \u201cRestart tour\u201d options should only be available within the more actions menu."
     },
     {
       "type": "guideline",
@@ -64,11 +64,11 @@
     },
     {
       "type": "guideline",
-      "content": "The primary action should be brief and consistent. Use \"OK\" for a single coach mark. Within a tour, use “Next” for all but the last step, and “Finish” for the last step. Don’t use different primary action names for every step in a tour."
+      "content": "The primary action should be brief and consistent. Use \"OK\" for a single coach mark. Within a tour, use \u201cNext\u201d for all but the last step, and \u201cFinish\u201d for the last step. Don\u2019t use different primary action names for every step in a tour."
     },
     {
       "type": "guideline",
-      "content": "When a part of the tour is dependent on a user taking an action, it’s okay to put the primary button in the disabled state as long as the user has a way to exit the tour. For a one-off coach mark, this means the primary button should remain as a route to dismiss. In a tour, it’s recommended to have the more actions menu present."
+      "content": "When a part of the tour is dependent on a user taking an action, it\u2019s okay to put the primary button in the disabled state as long as the user has a way to exit the tour. For a one-off coach mark, this means the primary button should remain as a route to dismiss. In a tour, it\u2019s recommended to have the more actions menu present."
     },
     {
       "type": "guideline",
@@ -76,8 +76,12 @@
     }
   ],
   "options": {
-    "title": { "type": "string" },
-    "description": { "type": "string" },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
     "hideImage": {
       "type": "boolean",
       "default": false,
@@ -115,13 +119,36 @@
     {
       "name": "pagination-text",
       "description": "Text indicating step position (e.g. '2 of 5')."
+    },
+    {
+      "name": "body"
+    },
+    {
+      "name": "media"
+    },
+    {
+      "name": "pagination"
+    },
+    {
+      "name": "title"
     }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "coach-mark-width", "context": "Width" },
-    { "token": "coach-mark-minimum-width", "context": "Width" },
-    { "token": "coach-mark-maximum-width", "context": "Width" },
+    {
+      "token": "coach-mark-width",
+      "context": "Width"
+    },
+    {
+      "token": "coach-mark-minimum-width",
+      "context": "Width"
+    },
+    {
+      "token": "coach-mark-maximum-width",
+      "context": "Width"
+    },
     {
       "token": "coach-mark-edge-to-content",
       "context": "Spacing (top/bottom/start/end edge to text)"
@@ -138,34 +165,89 @@
       "token": "coach-mark-pagination-text-to-bottom-edge",
       "context": "Spacing (pagination to bottom)"
     },
-    { "token": "coach-mark-media-minimum-height", "context": "Media (16:9)" },
-    { "token": "coach-mark-media-height", "context": "Media (4:3)" },
-    { "token": "spacing-100", "context": "Spacing (action button to menu)" },
-    { "token": "title-sans-serif-font-family", "context": "Title" },
-    { "token": "title-sans-serif-font-weight", "context": "Title" },
-    { "token": "title-serif-font-style", "context": "Title" },
-    { "token": "coach-mark-title-font-size", "context": "Title" },
-    { "token": "title-line-height", "context": "Title" },
-    { "token": "body-sans-serif-font-family", "context": "Body" },
-    { "token": "body-sans-serif-font-weight", "context": "Body" },
-    { "token": "body-serif-font-style", "context": "Body" },
-    { "token": "coach-mark-body-font-size", "context": "Body" },
-    { "token": "line-height-200", "context": "Body" },
-    { "token": "medium-font-weight", "context": "Pagination" },
+    {
+      "token": "coach-mark-media-minimum-height",
+      "context": "Media (16:9)"
+    },
+    {
+      "token": "coach-mark-media-height",
+      "context": "Media (4:3)"
+    },
+    {
+      "token": "spacing-100",
+      "context": "Spacing (action button to menu)"
+    },
+    {
+      "token": "title-sans-serif-font-family",
+      "context": "Title"
+    },
+    {
+      "token": "title-sans-serif-font-weight",
+      "context": "Title"
+    },
+    {
+      "token": "title-serif-font-style",
+      "context": "Title"
+    },
+    {
+      "token": "coach-mark-title-font-size",
+      "context": "Title"
+    },
+    {
+      "token": "title-line-height",
+      "context": "Title"
+    },
+    {
+      "token": "body-sans-serif-font-family",
+      "context": "Body"
+    },
+    {
+      "token": "body-sans-serif-font-weight",
+      "context": "Body"
+    },
+    {
+      "token": "body-serif-font-style",
+      "context": "Body"
+    },
+    {
+      "token": "coach-mark-body-font-size",
+      "context": "Body"
+    },
+    {
+      "token": "line-height-200",
+      "context": "Body"
+    },
+    {
+      "token": "medium-font-weight",
+      "context": "Pagination"
+    },
     {
       "token": "coach-mark-pagination-body-font-size",
       "context": "Pagination"
     },
-    { "token": "heading-color", "context": "Color" },
-    { "token": "body-color", "context": "Color" },
-    { "token": "coach-mark-pagination-color", "context": "Color" }
+    {
+      "token": "heading-color",
+      "context": "Color"
+    },
+    {
+      "token": "body-color",
+      "context": "Color"
+    },
+    {
+      "token": "coach-mark-pagination-color",
+      "context": "Color"
+    }
   ],
   "accessibility": {
     "intents": ["dismiss"],
     "focusable": true,
     "keyboardIntents": ["dismiss"],
     "wcag": [
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/coach-mark.json
+++ b/packages/design-data/components/coach-mark.json
@@ -48,11 +48,11 @@
     },
     {
       "type": "guideline",
-      "content": "The \u201cPrevious\u201d button should always be a quiet secondary button."
+      "content": "The “Previous” button should always be a quiet secondary button."
     },
     {
       "type": "guideline",
-      "content": "The \u201cSkip tour\u201d and \u201cRestart tour\u201d options should only be available within the more actions menu."
+      "content": "The “Skip tour” and “Restart tour” options should only be available within the more actions menu."
     },
     {
       "type": "guideline",
@@ -64,11 +64,11 @@
     },
     {
       "type": "guideline",
-      "content": "The primary action should be brief and consistent. Use \"OK\" for a single coach mark. Within a tour, use \u201cNext\u201d for all but the last step, and \u201cFinish\u201d for the last step. Don\u2019t use different primary action names for every step in a tour."
+      "content": "The primary action should be brief and consistent. Use \"OK\" for a single coach mark. Within a tour, use “Next” for all but the last step, and “Finish” for the last step. Don’t use different primary action names for every step in a tour."
     },
     {
       "type": "guideline",
-      "content": "When a part of the tour is dependent on a user taking an action, it\u2019s okay to put the primary button in the disabled state as long as the user has a way to exit the tour. For a one-off coach mark, this means the primary button should remain as a route to dismiss. In a tour, it\u2019s recommended to have the more actions menu present."
+      "content": "When a part of the tour is dependent on a user taking an action, it’s okay to put the primary button in the disabled state as long as the user has a way to exit the tour. For a one-off coach mark, this means the primary button should remain as a route to dismiss. In a tour, it’s recommended to have the more actions menu present."
     },
     {
       "type": "guideline",
@@ -76,12 +76,8 @@
     }
   ],
   "options": {
-    "title": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
     "hideImage": {
       "type": "boolean",
       "default": false,
@@ -120,35 +116,16 @@
       "name": "pagination-text",
       "description": "Text indicating step position (e.g. '2 of 5')."
     },
-    {
-      "name": "body"
-    },
-    {
-      "name": "media"
-    },
-    {
-      "name": "pagination"
-    },
-    {
-      "name": "title"
-    }
+    { "name": "body" },
+    { "name": "media" },
+    { "name": "pagination" },
+    { "name": "title" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "coach-mark-width",
-      "context": "Width"
-    },
-    {
-      "token": "coach-mark-minimum-width",
-      "context": "Width"
-    },
-    {
-      "token": "coach-mark-maximum-width",
-      "context": "Width"
-    },
+    { "token": "coach-mark-width", "context": "Width" },
+    { "token": "coach-mark-minimum-width", "context": "Width" },
+    { "token": "coach-mark-maximum-width", "context": "Width" },
     {
       "token": "coach-mark-edge-to-content",
       "context": "Spacing (top/bottom/start/end edge to text)"
@@ -165,89 +142,34 @@
       "token": "coach-mark-pagination-text-to-bottom-edge",
       "context": "Spacing (pagination to bottom)"
     },
-    {
-      "token": "coach-mark-media-minimum-height",
-      "context": "Media (16:9)"
-    },
-    {
-      "token": "coach-mark-media-height",
-      "context": "Media (4:3)"
-    },
-    {
-      "token": "spacing-100",
-      "context": "Spacing (action button to menu)"
-    },
-    {
-      "token": "title-sans-serif-font-family",
-      "context": "Title"
-    },
-    {
-      "token": "title-sans-serif-font-weight",
-      "context": "Title"
-    },
-    {
-      "token": "title-serif-font-style",
-      "context": "Title"
-    },
-    {
-      "token": "coach-mark-title-font-size",
-      "context": "Title"
-    },
-    {
-      "token": "title-line-height",
-      "context": "Title"
-    },
-    {
-      "token": "body-sans-serif-font-family",
-      "context": "Body"
-    },
-    {
-      "token": "body-sans-serif-font-weight",
-      "context": "Body"
-    },
-    {
-      "token": "body-serif-font-style",
-      "context": "Body"
-    },
-    {
-      "token": "coach-mark-body-font-size",
-      "context": "Body"
-    },
-    {
-      "token": "line-height-200",
-      "context": "Body"
-    },
-    {
-      "token": "medium-font-weight",
-      "context": "Pagination"
-    },
+    { "token": "coach-mark-media-minimum-height", "context": "Media (16:9)" },
+    { "token": "coach-mark-media-height", "context": "Media (4:3)" },
+    { "token": "spacing-100", "context": "Spacing (action button to menu)" },
+    { "token": "title-sans-serif-font-family", "context": "Title" },
+    { "token": "title-sans-serif-font-weight", "context": "Title" },
+    { "token": "title-serif-font-style", "context": "Title" },
+    { "token": "coach-mark-title-font-size", "context": "Title" },
+    { "token": "title-line-height", "context": "Title" },
+    { "token": "body-sans-serif-font-family", "context": "Body" },
+    { "token": "body-sans-serif-font-weight", "context": "Body" },
+    { "token": "body-serif-font-style", "context": "Body" },
+    { "token": "coach-mark-body-font-size", "context": "Body" },
+    { "token": "line-height-200", "context": "Body" },
+    { "token": "medium-font-weight", "context": "Pagination" },
     {
       "token": "coach-mark-pagination-body-font-size",
       "context": "Pagination"
     },
-    {
-      "token": "heading-color",
-      "context": "Color"
-    },
-    {
-      "token": "body-color",
-      "context": "Color"
-    },
-    {
-      "token": "coach-mark-pagination-color",
-      "context": "Color"
-    }
+    { "token": "heading-color", "context": "Color" },
+    { "token": "body-color", "context": "Color" },
+    { "token": "coach-mark-pagination-color", "context": "Color" }
   ],
   "accessibility": {
     "intents": ["dismiss"],
     "focusable": true,
     "keyboardIntents": ["dismiss"],
     "wcag": [
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/collection-card.json
+++ b/packages/design-data/components/collection-card.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/collection-card.json",
+  "specVersion": "1.0.0-draft",
+  "name": "collection-card",
+  "displayName": "Collection card",
+  "description": "A card variant representing a collection of items rather than a single asset.",
+  "meta": {
+    "category": "containers",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/collection-card.json
+++ b/packages/design-data/components/collection-card.json
@@ -9,7 +9,5 @@
     "category": "containers",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/color-control.json
+++ b/packages/design-data/components/color-control.json
@@ -9,12 +9,6 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "anatomy": [
-    {
-      "name": "track"
-    }
-  ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "anatomy": [{ "name": "track" }],
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/color-control.json
+++ b/packages/design-data/components/color-control.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/color-control.json",
+  "specVersion": "1.0.0-draft",
+  "name": "color-control",
+  "displayName": "Color control",
+  "description": "Shared interactive control (slider/area) underlying color-picker components.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "anatomy": [
+    {
+      "name": "track"
+    }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/combo-box.json
+++ b/packages/design-data/components/combo-box.json
@@ -213,10 +213,26 @@
     "errorMessage": { "type": "string" }
   },
   "states": [
-    { "name": "hover-(text-area)", "trigger": "prop" },
-    { "name": "hover-(button-area)", "trigger": "prop" },
-    { "name": "focus-+-hover", "trigger": "prop" },
-    { "name": "focus-+-not-hover", "trigger": "prop" },
+    {
+      "name": "hover-text-area",
+      "trigger": "prop",
+      "description": "Hover scoped to the text-entry anatomy part, distinct from hover over the field button."
+    },
+    {
+      "name": "hover-button-area",
+      "trigger": "prop",
+      "description": "Hover scoped to the field button anatomy part, distinct from hover over the text-entry area."
+    },
+    {
+      "name": "focus-hover",
+      "trigger": "prop",
+      "description": "Combined focus and hover, when the field is focused and the pointer is also over it."
+    },
+    {
+      "name": "focus-not-hover",
+      "trigger": "prop",
+      "description": "Focus without hover, when the field is focused but the pointer is not over it."
+    },
     { "name": "keyboard-focus", "trigger": "interaction" }
   ],
   "lifecycle": { "introduced": "1.0.0-draft" },

--- a/packages/design-data/components/date-field.json
+++ b/packages/design-data/components/date-field.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/date-field.json",
+  "specVersion": "1.0.0-draft",
+  "name": "date-field",
+  "displayName": "Date field",
+  "description": "A field for entering a date value.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/date-field.json
+++ b/packages/design-data/components/date-field.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/double-calendar.json
+++ b/packages/design-data/components/double-calendar.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/double-calendar.json
+++ b/packages/design-data/components/double-calendar.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/double-calendar.json",
+  "specVersion": "1.0.0-draft",
+  "name": "double-calendar",
+  "displayName": "Double calendar",
+  "description": "A date-picker calendar variant displaying two consecutive months.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/field.json
+++ b/packages/design-data/components/field.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/field.json",
+  "specVersion": "1.0.0-draft",
+  "name": "field",
+  "displayName": "Field",
+  "description": "Shared layout primitive underlying labeled form fields (text field, picker, etc.).",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/field.json
+++ b/packages/design-data/components/field.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/floating-action-button.json
+++ b/packages/design-data/components/floating-action-button.json
@@ -9,7 +9,5 @@
     "category": "actions",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/floating-action-button.json
+++ b/packages/design-data/components/floating-action-button.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/floating-action-button.json",
+  "specVersion": "1.0.0-draft",
+  "name": "floating-action-button",
+  "displayName": "Floating action button",
+  "description": "A circular button that floats above content to surface a primary action.",
+  "meta": {
+    "category": "actions",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/form-item.json
+++ b/packages/design-data/components/form-item.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/form-item.json
+++ b/packages/design-data/components/form-item.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/form-item.json",
+  "specVersion": "1.0.0-draft",
+  "name": "form-item",
+  "displayName": "Form item",
+  "description": "Layout wrapper pairing a form field with its label and helper text.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/in-field-button.json
+++ b/packages/design-data/components/in-field-button.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/in-field-button.json",
+  "specVersion": "1.0.0-draft",
+  "name": "in-field-button",
+  "displayName": "In-field button",
+  "description": "A button embedded inside a field's input area, such as a clear or disclosure action.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "anatomy": [
+    {
+      "name": "fill"
+    }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/in-field-button.json
+++ b/packages/design-data/components/in-field-button.json
@@ -9,12 +9,6 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "anatomy": [
-    {
-      "name": "fill"
-    }
-  ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "anatomy": [{ "name": "fill" }],
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/menu.json
+++ b/packages/design-data/components/menu.json
@@ -16,11 +16,11 @@
     },
     {
       "type": "guideline",
-      "content": "A disabled menu item indicates that an option exists but isn’t available in the current context. This helps preserve layout consistency and signals that the action might be available later."
+      "content": "A disabled menu item indicates that an option exists but isn\u2019t available in the current context. This helps preserve layout consistency and signals that the action might be available later."
     },
     {
       "type": "guideline",
-      "content": "An unavailable menu item signals that an option exists but isn’t accessible in the current scenario. This helps ensure the label remains visible and provides context about why the option is unavailable, or directions for how to make it available."
+      "content": "An unavailable menu item signals that an option exists but isn\u2019t accessible in the current scenario. This helps ensure the label remains visible and provides context about why the option is unavailable, or directions for how to make it available."
     },
     {
       "type": "guideline",
@@ -64,7 +64,7 @@
     },
     {
       "type": "guideline",
-      "content": "Menu items can include icons, but only when they add meaningful context — not just for decoration. Use icons when they have a strong, recognizable association with the label (like tool switching in a toolbar)."
+      "content": "Menu items can include icons, but only when they add meaningful context \u2014 not just for decoration. Use icons when they have a strong, recognizable association with the label (like tool switching in a toolbar)."
     },
     {
       "type": "guideline",
@@ -92,15 +92,15 @@
     },
     {
       "type": "guideline",
-      "content": "When a menu is shown in a tray, selecting a parent item with a submenu replaces the tray’s content with the submenu. A back button labeled with the parent item’s title appears at the top of the tray to let users return to the previous menu level."
+      "content": "When a menu is shown in a tray, selecting a parent item with a submenu replaces the tray\u2019s content with the submenu. A back button labeled with the parent item\u2019s title appears at the top of the tray to let users return to the previous menu level."
     },
     {
       "type": "guideline",
-      "content": "A menu item can be navigated using a keyboard. The keyboard focus state takes the menu item’s visual hover state and adds a focus ring around the item."
+      "content": "A menu item can be navigated using a keyboard. The keyboard focus state takes the menu item\u2019s visual hover state and adds a focus ring around the item."
     },
     {
       "type": "guideline",
-      "content": "When a menu item’s label or description are too long for the available horizontal space, they wrap to form another line."
+      "content": "When a menu item\u2019s label or description are too long for the available horizontal space, they wrap to form another line."
     },
     {
       "type": "guideline",
@@ -116,51 +116,96 @@
     },
     {
       "type": "guideline",
-      "content": "Following Adobe’s UX writing style, write menu items in sentence case unless they contain words that are branded terms."
+      "content": "Following Adobe\u2019s UX writing style, write menu items in sentence case unless they contain words that are branded terms."
     },
     {
       "type": "guideline",
-      "content": "Don’t end a menu command with an ellipsis (…) unless it requires additional input to complete the action, typically in a dialog."
+      "content": "Don\u2019t end a menu command with an ellipsis (\u2026) unless it requires additional input to complete the action, typically in a dialog."
     }
   ],
   "options": {
     "container": {
       "type": "string",
-      "values": [{ "value": "popover" }, { "value": "tray" }]
+      "values": [
+        {
+          "value": "popover"
+        },
+        {
+          "value": "tray"
+        }
+      ]
     },
-    "label": { "type": "string" },
+    "label": {
+      "type": "string"
+    },
     "icon": {
       "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/types/workflow-icon.json",
       "description": "Icon must be present if the label is not defined."
     },
-    "description": { "type": "string" },
-    "value": { "type": "string" },
+    "description": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    },
     "size": {
       "type": "string",
       "default": "m",
       "values": [
-        { "value": "s" },
-        { "value": "m" },
-        { "value": "l" },
-        { "value": "xl" }
+        {
+          "value": "s"
+        },
+        {
+          "value": "m"
+        },
+        {
+          "value": "l"
+        },
+        {
+          "value": "xl"
+        }
       ]
     },
     "selectionMode": {
       "type": "string",
       "values": [
-        { "value": "single" },
-        { "value": "multiple" },
-        { "value": "no selection" }
+        {
+          "value": "single"
+        },
+        {
+          "value": "multiple"
+        },
+        {
+          "value": "no selection"
+        }
       ]
     },
     "selectionStyle": {
       "type": "string",
-      "values": [{ "value": "checkbox" }, { "value": "switch" }]
+      "values": [
+        {
+          "value": "checkbox"
+        },
+        {
+          "value": "switch"
+        }
+      ]
     },
-    "sectionHeader": { "type": "string" },
-    "isCollapsible": { "type": "boolean", "default": false },
-    "isUnavailable": { "type": "boolean", "default": false },
-    "isDisabled": { "type": "boolean", "default": false }
+    "sectionHeader": {
+      "type": "string"
+    },
+    "isCollapsible": {
+      "type": "boolean",
+      "default": false
+    },
+    "isUnavailable": {
+      "type": "boolean",
+      "default": false
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "default": false
+    }
   },
   "anatomy": [
     {
@@ -182,13 +227,22 @@
         "link-out-icon"
       ]
     },
-    { "name": "icon", "description": "Leading icon of a menu item." },
-    { "name": "label", "description": "Primary label text of a menu item." },
+    {
+      "name": "icon",
+      "description": "Leading icon of a menu item."
+    },
+    {
+      "name": "label",
+      "description": "Primary label text of a menu item."
+    },
     {
       "name": "description",
       "description": "Secondary descriptive text of a menu item."
     },
-    { "name": "value", "description": "Current value display of a menu item." },
+    {
+      "name": "value",
+      "description": "Current value display of a menu item."
+    },
     {
       "name": "switch",
       "description": "Switch control for a menu item with switch selection style."
@@ -197,7 +251,10 @@
       "name": "checkbox",
       "description": "Checkbox control for a menu item with checkbox selection style."
     },
-    { "name": "thumbnail", "description": "Thumbnail image of a menu item." },
+    {
+      "name": "thumbnail",
+      "description": "Thumbnail image of a menu item."
+    },
     {
       "name": "drill-in-chevron",
       "description": "Chevron indicating a menu item opens a sub-menu."
@@ -208,20 +265,50 @@
     }
   ],
   "states": [
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "down", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    },
+    {
+      "name": "default"
+    },
+    {
+      "name": "disabled",
+      "trigger": "prop"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
     {
       "token": "popover-submenu-to-menu-item-position",
       "context": "Sub-menu alignment with menu item"
     },
-    { "token": "component-height-75", "context": "Minimum height" },
-    { "token": "component-height-100", "context": "Minimum height" },
-    { "token": "component-height-200", "context": "Minimum height" },
-    { "token": "component-height-300", "context": "Minimum height" },
+    {
+      "token": "component-height-75",
+      "context": "Minimum height"
+    },
+    {
+      "token": "component-height-100",
+      "context": "Minimum height"
+    },
+    {
+      "token": "component-height-200",
+      "context": "Minimum height"
+    },
+    {
+      "token": "component-height-300",
+      "context": "Minimum height"
+    },
     {
       "token": "component-size-difference-down",
       "context": "Component size (down)"
@@ -234,18 +321,42 @@
       "token": "component-size-minimum-perspective-down",
       "context": "Component size (down)"
     },
-    { "token": "corner-radius-400", "context": "Rounding" },
-    { "token": "corner-radius-500", "context": "Rounding" },
-    { "token": "corner-radius-600", "context": "Rounding" },
-    { "token": "corner-radius-700", "context": "Rounding" },
+    {
+      "token": "corner-radius-400",
+      "context": "Rounding"
+    },
+    {
+      "token": "corner-radius-500",
+      "context": "Rounding"
+    },
+    {
+      "token": "corner-radius-600",
+      "context": "Rounding"
+    },
+    {
+      "token": "corner-radius-700",
+      "context": "Rounding"
+    },
     {
       "token": "menu-item-section-divider-height",
       "context": "Height (section divider)"
     },
-    { "token": "text-to-visual-75", "context": "Spacing (icon to label)" },
-    { "token": "text-to-visual-100", "context": "Spacing (icon to label)" },
-    { "token": "text-to-visual-200", "context": "Spacing (icon to label)" },
-    { "token": "text-to-visual-300", "context": "Spacing (icon to label)" },
+    {
+      "token": "text-to-visual-75",
+      "context": "Spacing (icon to label)"
+    },
+    {
+      "token": "text-to-visual-100",
+      "context": "Spacing (icon to label)"
+    },
+    {
+      "token": "text-to-visual-200",
+      "context": "Spacing (icon to label)"
+    },
+    {
+      "token": "text-to-visual-300",
+      "context": "Spacing (icon to label)"
+    },
     {
       "token": "component-top-to-workflow-icon-75",
       "context": "Spacing (top edge to icon)"
@@ -262,7 +373,10 @@
       "token": "component-top-to-workflow-icon-300",
       "context": "Spacing (top edge to icon)"
     },
-    { "token": "menu-item-to-items", "context": "Spacing (item to item)" },
+    {
+      "token": "menu-item-to-items",
+      "context": "Spacing (item to item)"
+    },
     {
       "token": "component-edge-to-text-75",
       "context": "Spacing (start/end edges to content)"
@@ -431,12 +545,30 @@
       "token": "menu-item-top-to-disclosure-icon-extra-large",
       "context": "Spacing (top edge to disclosure icon)"
     },
-    { "token": "focus-indicator-thickness", "context": "Focus indicator" },
-    { "token": "focus-indicator-gap", "context": "Focus indicator" },
-    { "token": "workflow-icon-size-75", "context": "Icon (menu item)" },
-    { "token": "workflow-icon-size-100", "context": "Icon (menu item)" },
-    { "token": "workflow-icon-size-200", "context": "Icon (menu item)" },
-    { "token": "workflow-icon-size-300", "context": "Icon (menu item)" },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "focus-indicator-gap",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "workflow-icon-size-75",
+      "context": "Icon (menu item)"
+    },
+    {
+      "token": "workflow-icon-size-100",
+      "context": "Icon (menu item)"
+    },
+    {
+      "token": "workflow-icon-size-200",
+      "context": "Icon (menu item)"
+    },
+    {
+      "token": "workflow-icon-size-300",
+      "context": "Icon (menu item)"
+    },
     {
       "token": "checkmark-icon-size-75",
       "context": "Icon (single selection, selected menu item)"
@@ -481,24 +613,66 @@
       "token": "link-out-icon-size-200",
       "context": "Icon (external link action, menu item)"
     },
-    { "token": "thumbnail-size-500", "context": "Thumbnail" },
-    { "token": "thumbnail-size-700", "context": "Thumbnail" },
-    { "token": "thumbnail-size-800", "context": "Thumbnail" },
-    { "token": "thumbnail-size-900", "context": "Thumbnail" },
-    { "token": "menu-item-background-color-default", "context": "Background" },
-    { "token": "menu-item-background-color-hover", "context": "Background" },
-    { "token": "menu-item-background-color-down", "context": "Background" },
+    {
+      "token": "thumbnail-size-500",
+      "context": "Thumbnail"
+    },
+    {
+      "token": "thumbnail-size-700",
+      "context": "Thumbnail"
+    },
+    {
+      "token": "thumbnail-size-800",
+      "context": "Thumbnail"
+    },
+    {
+      "token": "thumbnail-size-900",
+      "context": "Thumbnail"
+    },
+    {
+      "token": "menu-item-background-color-default",
+      "context": "Background"
+    },
+    {
+      "token": "menu-item-background-color-hover",
+      "context": "Background"
+    },
+    {
+      "token": "menu-item-background-color-down",
+      "context": "Background"
+    },
     {
       "token": "menu-item-background-color-key-focus",
       "context": "Background"
     },
-    { "token": "menu-item-background-color-disabled", "context": "Background" },
-    { "token": "menu-item-background-opacity", "context": "Background" },
-    { "token": "neutral-content-color-default", "context": "Label and icon" },
-    { "token": "neutral-content-color-hover", "context": "Label and icon" },
-    { "token": "neutral-content-color-down", "context": "Label and icon" },
-    { "token": "neutral-content-color-key-focus", "context": "Label and icon" },
-    { "token": "disabled-content-color", "context": "Label and icon" },
+    {
+      "token": "menu-item-background-color-disabled",
+      "context": "Background"
+    },
+    {
+      "token": "menu-item-background-opacity",
+      "context": "Background"
+    },
+    {
+      "token": "neutral-content-color-default",
+      "context": "Label and icon"
+    },
+    {
+      "token": "neutral-content-color-hover",
+      "context": "Label and icon"
+    },
+    {
+      "token": "neutral-content-color-down",
+      "context": "Label and icon"
+    },
+    {
+      "token": "neutral-content-color-key-focus",
+      "context": "Label and icon"
+    },
+    {
+      "token": "disabled-content-color",
+      "context": "Label and icon"
+    },
     {
       "token": "neutral-subdued-content-color-default",
       "context": "Description"
@@ -507,25 +681,70 @@
       "token": "neutral-subdued-content-color-hover",
       "context": "Description"
     },
-    { "token": "neutral-subdued-content-color-down", "context": "Description" },
+    {
+      "token": "neutral-subdued-content-color-down",
+      "context": "Description"
+    },
     {
       "token": "neutral-subdued-content-color-key-focus",
       "context": "Description"
     },
-    { "token": "accent-content-color-default", "context": "Checkmark icon" },
-    { "token": "accent-content-color-hover", "context": "Checkmark icon" },
-    { "token": "accent-content-color-down", "context": "Checkmark icon" },
-    { "token": "accent-content-color-key-focus", "context": "Checkmark icon" },
-    { "token": "focus-indicator-color", "context": "Focus indicator" },
-    { "token": "default-font-family", "context": "Section header title" },
-    { "token": "bold-font-weight", "context": "Section header title" },
-    { "token": "default-font-style", "context": "Section header title" },
-    { "token": "font-size-75", "context": "Section header title" },
-    { "token": "font-size-100", "context": "Section header title" },
-    { "token": "font-size-200", "context": "Section header title" },
-    { "token": "font-size-300", "context": "Section header title" },
-    { "token": "line-height-100", "context": "Section header title" },
-    { "token": "cjk-line-height-100", "context": "Section header title" },
+    {
+      "token": "accent-content-color-default",
+      "context": "Checkmark icon"
+    },
+    {
+      "token": "accent-content-color-hover",
+      "context": "Checkmark icon"
+    },
+    {
+      "token": "accent-content-color-down",
+      "context": "Checkmark icon"
+    },
+    {
+      "token": "accent-content-color-key-focus",
+      "context": "Checkmark icon"
+    },
+    {
+      "token": "focus-indicator-color",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Section header title"
+    },
+    {
+      "token": "bold-font-weight",
+      "context": "Section header title"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Section header title"
+    },
+    {
+      "token": "font-size-75",
+      "context": "Section header title"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Section header title"
+    },
+    {
+      "token": "font-size-200",
+      "context": "Section header title"
+    },
+    {
+      "token": "font-size-300",
+      "context": "Section header title"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Section header title"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Section header title"
+    },
     {
       "token": "regular-font-weight",
       "context": "Descriptions (section header and item)"
@@ -541,8 +760,16 @@
     "focusable": false,
     "keyboardIntents": ["navigate-options", "activate", "dismiss"],
     "wcag": [
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/menu.json
+++ b/packages/design-data/components/menu.json
@@ -16,11 +16,11 @@
     },
     {
       "type": "guideline",
-      "content": "A disabled menu item indicates that an option exists but isn\u2019t available in the current context. This helps preserve layout consistency and signals that the action might be available later."
+      "content": "A disabled menu item indicates that an option exists but isn’t available in the current context. This helps preserve layout consistency and signals that the action might be available later."
     },
     {
       "type": "guideline",
-      "content": "An unavailable menu item signals that an option exists but isn\u2019t accessible in the current scenario. This helps ensure the label remains visible and provides context about why the option is unavailable, or directions for how to make it available."
+      "content": "An unavailable menu item signals that an option exists but isn’t accessible in the current scenario. This helps ensure the label remains visible and provides context about why the option is unavailable, or directions for how to make it available."
     },
     {
       "type": "guideline",
@@ -64,7 +64,7 @@
     },
     {
       "type": "guideline",
-      "content": "Menu items can include icons, but only when they add meaningful context \u2014 not just for decoration. Use icons when they have a strong, recognizable association with the label (like tool switching in a toolbar)."
+      "content": "Menu items can include icons, but only when they add meaningful context — not just for decoration. Use icons when they have a strong, recognizable association with the label (like tool switching in a toolbar)."
     },
     {
       "type": "guideline",
@@ -92,15 +92,15 @@
     },
     {
       "type": "guideline",
-      "content": "When a menu is shown in a tray, selecting a parent item with a submenu replaces the tray\u2019s content with the submenu. A back button labeled with the parent item\u2019s title appears at the top of the tray to let users return to the previous menu level."
+      "content": "When a menu is shown in a tray, selecting a parent item with a submenu replaces the tray’s content with the submenu. A back button labeled with the parent item’s title appears at the top of the tray to let users return to the previous menu level."
     },
     {
       "type": "guideline",
-      "content": "A menu item can be navigated using a keyboard. The keyboard focus state takes the menu item\u2019s visual hover state and adds a focus ring around the item."
+      "content": "A menu item can be navigated using a keyboard. The keyboard focus state takes the menu item’s visual hover state and adds a focus ring around the item."
     },
     {
       "type": "guideline",
-      "content": "When a menu item\u2019s label or description are too long for the available horizontal space, they wrap to form another line."
+      "content": "When a menu item’s label or description are too long for the available horizontal space, they wrap to form another line."
     },
     {
       "type": "guideline",
@@ -116,96 +116,51 @@
     },
     {
       "type": "guideline",
-      "content": "Following Adobe\u2019s UX writing style, write menu items in sentence case unless they contain words that are branded terms."
+      "content": "Following Adobe’s UX writing style, write menu items in sentence case unless they contain words that are branded terms."
     },
     {
       "type": "guideline",
-      "content": "Don\u2019t end a menu command with an ellipsis (\u2026) unless it requires additional input to complete the action, typically in a dialog."
+      "content": "Don’t end a menu command with an ellipsis (…) unless it requires additional input to complete the action, typically in a dialog."
     }
   ],
   "options": {
     "container": {
       "type": "string",
-      "values": [
-        {
-          "value": "popover"
-        },
-        {
-          "value": "tray"
-        }
-      ]
+      "values": [{ "value": "popover" }, { "value": "tray" }]
     },
-    "label": {
-      "type": "string"
-    },
+    "label": { "type": "string" },
     "icon": {
       "$ref": "https://opensource.adobe.com/spectrum-design-data/schemas/types/workflow-icon.json",
       "description": "Icon must be present if the label is not defined."
     },
-    "description": {
-      "type": "string"
-    },
-    "value": {
-      "type": "string"
-    },
+    "description": { "type": "string" },
+    "value": { "type": "string" },
     "size": {
       "type": "string",
       "default": "m",
       "values": [
-        {
-          "value": "s"
-        },
-        {
-          "value": "m"
-        },
-        {
-          "value": "l"
-        },
-        {
-          "value": "xl"
-        }
+        { "value": "s" },
+        { "value": "m" },
+        { "value": "l" },
+        { "value": "xl" }
       ]
     },
     "selectionMode": {
       "type": "string",
       "values": [
-        {
-          "value": "single"
-        },
-        {
-          "value": "multiple"
-        },
-        {
-          "value": "no selection"
-        }
+        { "value": "single" },
+        { "value": "multiple" },
+        { "value": "no selection" }
       ]
     },
     "selectionStyle": {
       "type": "string",
-      "values": [
-        {
-          "value": "checkbox"
-        },
-        {
-          "value": "switch"
-        }
-      ]
+      "values": [{ "value": "checkbox" }, { "value": "switch" }]
     },
-    "sectionHeader": {
-      "type": "string"
-    },
-    "isCollapsible": {
-      "type": "boolean",
-      "default": false
-    },
-    "isUnavailable": {
-      "type": "boolean",
-      "default": false
-    },
-    "isDisabled": {
-      "type": "boolean",
-      "default": false
-    }
+    "sectionHeader": { "type": "string" },
+    "isCollapsible": { "type": "boolean", "default": false },
+    "isUnavailable": { "type": "boolean", "default": false },
+    "isDisabled": { "type": "boolean", "default": false }
   },
   "anatomy": [
     {
@@ -227,22 +182,13 @@
         "link-out-icon"
       ]
     },
-    {
-      "name": "icon",
-      "description": "Leading icon of a menu item."
-    },
-    {
-      "name": "label",
-      "description": "Primary label text of a menu item."
-    },
+    { "name": "icon", "description": "Leading icon of a menu item." },
+    { "name": "label", "description": "Primary label text of a menu item." },
     {
       "name": "description",
       "description": "Secondary descriptive text of a menu item."
     },
-    {
-      "name": "value",
-      "description": "Current value display of a menu item."
-    },
+    { "name": "value", "description": "Current value display of a menu item." },
     {
       "name": "switch",
       "description": "Switch control for a menu item with switch selection style."
@@ -251,10 +197,7 @@
       "name": "checkbox",
       "description": "Checkbox control for a menu item with checkbox selection style."
     },
-    {
-      "name": "thumbnail",
-      "description": "Thumbnail image of a menu item."
-    },
+    { "name": "thumbnail", "description": "Thumbnail image of a menu item." },
     {
       "name": "drill-in-chevron",
       "description": "Chevron indicating a menu item opens a sub-menu."
@@ -265,50 +208,22 @@
     }
   ],
   "states": [
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    },
-    {
-      "name": "default"
-    },
-    {
-      "name": "disabled",
-      "trigger": "prop"
-    }
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "down", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" },
+    { "name": "default", "trigger": "prop" },
+    { "name": "disabled", "trigger": "prop" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     {
       "token": "popover-submenu-to-menu-item-position",
       "context": "Sub-menu alignment with menu item"
     },
-    {
-      "token": "component-height-75",
-      "context": "Minimum height"
-    },
-    {
-      "token": "component-height-100",
-      "context": "Minimum height"
-    },
-    {
-      "token": "component-height-200",
-      "context": "Minimum height"
-    },
-    {
-      "token": "component-height-300",
-      "context": "Minimum height"
-    },
+    { "token": "component-height-75", "context": "Minimum height" },
+    { "token": "component-height-100", "context": "Minimum height" },
+    { "token": "component-height-200", "context": "Minimum height" },
+    { "token": "component-height-300", "context": "Minimum height" },
     {
       "token": "component-size-difference-down",
       "context": "Component size (down)"
@@ -321,42 +236,18 @@
       "token": "component-size-minimum-perspective-down",
       "context": "Component size (down)"
     },
-    {
-      "token": "corner-radius-400",
-      "context": "Rounding"
-    },
-    {
-      "token": "corner-radius-500",
-      "context": "Rounding"
-    },
-    {
-      "token": "corner-radius-600",
-      "context": "Rounding"
-    },
-    {
-      "token": "corner-radius-700",
-      "context": "Rounding"
-    },
+    { "token": "corner-radius-400", "context": "Rounding" },
+    { "token": "corner-radius-500", "context": "Rounding" },
+    { "token": "corner-radius-600", "context": "Rounding" },
+    { "token": "corner-radius-700", "context": "Rounding" },
     {
       "token": "menu-item-section-divider-height",
       "context": "Height (section divider)"
     },
-    {
-      "token": "text-to-visual-75",
-      "context": "Spacing (icon to label)"
-    },
-    {
-      "token": "text-to-visual-100",
-      "context": "Spacing (icon to label)"
-    },
-    {
-      "token": "text-to-visual-200",
-      "context": "Spacing (icon to label)"
-    },
-    {
-      "token": "text-to-visual-300",
-      "context": "Spacing (icon to label)"
-    },
+    { "token": "text-to-visual-75", "context": "Spacing (icon to label)" },
+    { "token": "text-to-visual-100", "context": "Spacing (icon to label)" },
+    { "token": "text-to-visual-200", "context": "Spacing (icon to label)" },
+    { "token": "text-to-visual-300", "context": "Spacing (icon to label)" },
     {
       "token": "component-top-to-workflow-icon-75",
       "context": "Spacing (top edge to icon)"
@@ -373,10 +264,7 @@
       "token": "component-top-to-workflow-icon-300",
       "context": "Spacing (top edge to icon)"
     },
-    {
-      "token": "menu-item-to-items",
-      "context": "Spacing (item to item)"
-    },
+    { "token": "menu-item-to-items", "context": "Spacing (item to item)" },
     {
       "token": "component-edge-to-text-75",
       "context": "Spacing (start/end edges to content)"
@@ -545,30 +433,12 @@
       "token": "menu-item-top-to-disclosure-icon-extra-large",
       "context": "Spacing (top edge to disclosure icon)"
     },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "focus-indicator-gap",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "workflow-icon-size-75",
-      "context": "Icon (menu item)"
-    },
-    {
-      "token": "workflow-icon-size-100",
-      "context": "Icon (menu item)"
-    },
-    {
-      "token": "workflow-icon-size-200",
-      "context": "Icon (menu item)"
-    },
-    {
-      "token": "workflow-icon-size-300",
-      "context": "Icon (menu item)"
-    },
+    { "token": "focus-indicator-thickness", "context": "Focus indicator" },
+    { "token": "focus-indicator-gap", "context": "Focus indicator" },
+    { "token": "workflow-icon-size-75", "context": "Icon (menu item)" },
+    { "token": "workflow-icon-size-100", "context": "Icon (menu item)" },
+    { "token": "workflow-icon-size-200", "context": "Icon (menu item)" },
+    { "token": "workflow-icon-size-300", "context": "Icon (menu item)" },
     {
       "token": "checkmark-icon-size-75",
       "context": "Icon (single selection, selected menu item)"
@@ -613,66 +483,24 @@
       "token": "link-out-icon-size-200",
       "context": "Icon (external link action, menu item)"
     },
-    {
-      "token": "thumbnail-size-500",
-      "context": "Thumbnail"
-    },
-    {
-      "token": "thumbnail-size-700",
-      "context": "Thumbnail"
-    },
-    {
-      "token": "thumbnail-size-800",
-      "context": "Thumbnail"
-    },
-    {
-      "token": "thumbnail-size-900",
-      "context": "Thumbnail"
-    },
-    {
-      "token": "menu-item-background-color-default",
-      "context": "Background"
-    },
-    {
-      "token": "menu-item-background-color-hover",
-      "context": "Background"
-    },
-    {
-      "token": "menu-item-background-color-down",
-      "context": "Background"
-    },
+    { "token": "thumbnail-size-500", "context": "Thumbnail" },
+    { "token": "thumbnail-size-700", "context": "Thumbnail" },
+    { "token": "thumbnail-size-800", "context": "Thumbnail" },
+    { "token": "thumbnail-size-900", "context": "Thumbnail" },
+    { "token": "menu-item-background-color-default", "context": "Background" },
+    { "token": "menu-item-background-color-hover", "context": "Background" },
+    { "token": "menu-item-background-color-down", "context": "Background" },
     {
       "token": "menu-item-background-color-key-focus",
       "context": "Background"
     },
-    {
-      "token": "menu-item-background-color-disabled",
-      "context": "Background"
-    },
-    {
-      "token": "menu-item-background-opacity",
-      "context": "Background"
-    },
-    {
-      "token": "neutral-content-color-default",
-      "context": "Label and icon"
-    },
-    {
-      "token": "neutral-content-color-hover",
-      "context": "Label and icon"
-    },
-    {
-      "token": "neutral-content-color-down",
-      "context": "Label and icon"
-    },
-    {
-      "token": "neutral-content-color-key-focus",
-      "context": "Label and icon"
-    },
-    {
-      "token": "disabled-content-color",
-      "context": "Label and icon"
-    },
+    { "token": "menu-item-background-color-disabled", "context": "Background" },
+    { "token": "menu-item-background-opacity", "context": "Background" },
+    { "token": "neutral-content-color-default", "context": "Label and icon" },
+    { "token": "neutral-content-color-hover", "context": "Label and icon" },
+    { "token": "neutral-content-color-down", "context": "Label and icon" },
+    { "token": "neutral-content-color-key-focus", "context": "Label and icon" },
+    { "token": "disabled-content-color", "context": "Label and icon" },
     {
       "token": "neutral-subdued-content-color-default",
       "context": "Description"
@@ -681,70 +509,25 @@
       "token": "neutral-subdued-content-color-hover",
       "context": "Description"
     },
-    {
-      "token": "neutral-subdued-content-color-down",
-      "context": "Description"
-    },
+    { "token": "neutral-subdued-content-color-down", "context": "Description" },
     {
       "token": "neutral-subdued-content-color-key-focus",
       "context": "Description"
     },
-    {
-      "token": "accent-content-color-default",
-      "context": "Checkmark icon"
-    },
-    {
-      "token": "accent-content-color-hover",
-      "context": "Checkmark icon"
-    },
-    {
-      "token": "accent-content-color-down",
-      "context": "Checkmark icon"
-    },
-    {
-      "token": "accent-content-color-key-focus",
-      "context": "Checkmark icon"
-    },
-    {
-      "token": "focus-indicator-color",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Section header title"
-    },
-    {
-      "token": "bold-font-weight",
-      "context": "Section header title"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Section header title"
-    },
-    {
-      "token": "font-size-75",
-      "context": "Section header title"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Section header title"
-    },
-    {
-      "token": "font-size-200",
-      "context": "Section header title"
-    },
-    {
-      "token": "font-size-300",
-      "context": "Section header title"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Section header title"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Section header title"
-    },
+    { "token": "accent-content-color-default", "context": "Checkmark icon" },
+    { "token": "accent-content-color-hover", "context": "Checkmark icon" },
+    { "token": "accent-content-color-down", "context": "Checkmark icon" },
+    { "token": "accent-content-color-key-focus", "context": "Checkmark icon" },
+    { "token": "focus-indicator-color", "context": "Focus indicator" },
+    { "token": "default-font-family", "context": "Section header title" },
+    { "token": "bold-font-weight", "context": "Section header title" },
+    { "token": "default-font-style", "context": "Section header title" },
+    { "token": "font-size-75", "context": "Section header title" },
+    { "token": "font-size-100", "context": "Section header title" },
+    { "token": "font-size-200", "context": "Section header title" },
+    { "token": "font-size-300", "context": "Section header title" },
+    { "token": "line-height-100", "context": "Section header title" },
+    { "token": "cjk-line-height-100", "context": "Section header title" },
     {
       "token": "regular-font-weight",
       "context": "Descriptions (section header and item)"
@@ -760,16 +543,8 @@
     "focusable": false,
     "keyboardIntents": ["navigate-options", "activate", "dismiss"],
     "wcag": [
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/segmented-text-field.json
+++ b/packages/design-data/components/segmented-text-field.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/segmented-text-field.json",
+  "specVersion": "1.0.0-draft",
+  "name": "segmented-text-field",
+  "displayName": "Segmented text field",
+  "description": "A text field split into discrete segments, such as for structured input.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/segmented-text-field.json
+++ b/packages/design-data/components/segmented-text-field.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/select-box.json
+++ b/packages/design-data/components/select-box.json
@@ -56,7 +56,7 @@
     },
     {
       "type": "guideline",
-      "content": "A select box group can be navigated using a keyboard. The keyboard focus state takes the button’s visual hover state and adds a blue ring to the button in focus."
+      "content": "A select box group can be navigated using a keyboard. The keyboard focus state takes the button\u2019s visual hover state and adds a blue ring to the button in focus."
     },
     {
       "type": "guideline",
@@ -76,25 +76,48 @@
     },
     {
       "type": "guideline",
-      "content": "Select boxes use a checkbox to indicate both single- and multi-selection. Don’t use radio buttons for single-selection."
+      "content": "Select boxes use a checkbox to indicate both single- and multi-selection. Don\u2019t use radio buttons for single-selection."
     },
     {
       "type": "guideline",
-      "content": "Some cases may make more sense for the user to select one or a few options in a group of select boxes, but if the use case doesn’t make sense to be checking a selection, showCheckbox can be false and the highlight style can be used instead. There is no visual differentiation between single- and multi-select behaviors when checkboxes are not present."
+      "content": "Some cases may make more sense for the user to select one or a few options in a group of select boxes, but if the use case doesn\u2019t make sense to be checking a selection, showCheckbox can be false and the highlight style can be used instead. There is no visual differentiation between single- and multi-select behaviors when checkboxes are not present."
     }
   ],
   "options": {
-    "label": { "type": "string" },
+    "label": {
+      "type": "string"
+    },
     "orientation": {
       "type": "string",
       "default": "vertical",
-      "values": [{ "value": "horizontal" }, { "value": "vertical" }]
+      "values": [
+        {
+          "value": "horizontal"
+        },
+        {
+          "value": "vertical"
+        }
+      ]
     },
-    "body": { "type": "string" },
-    "isSelected": { "type": "boolean", "default": false },
-    "hideIllustration": { "type": "boolean", "default": false },
-    "showCheckbox": { "type": "boolean", "default": false },
-    "isDisabled": { "type": "boolean", "default": false },
+    "body": {
+      "type": "string"
+    },
+    "isSelected": {
+      "type": "boolean",
+      "default": false
+    },
+    "hideIllustration": {
+      "type": "boolean",
+      "default": false
+    },
+    "showCheckbox": {
+      "type": "boolean",
+      "default": false
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "default": false
+    },
     "multiple": {
       "type": "boolean",
       "default": false,
@@ -102,11 +125,26 @@
     }
   },
   "states": [
-    { "name": "down", "trigger": "interaction" },
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected",
+      "trigger": "interaction"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
     {
       "token": "select-box-vertical-height",
@@ -152,61 +190,162 @@
       "token": "select-box-horizontal-illustration-to-label",
       "context": "Spacing (illustration to label, horizontal)"
     },
-    { "token": "border-width-200", "context": "Border (Selected)" },
-    { "token": "component-size-difference-down", "context": "Down state" },
-    { "token": "component-size-width-ratio-down", "context": "Down state" },
+    {
+      "token": "border-width-200",
+      "context": "Border (Selected)"
+    },
+    {
+      "token": "component-size-difference-down",
+      "context": "Down state"
+    },
+    {
+      "token": "component-size-width-ratio-down",
+      "context": "Down state"
+    },
     {
       "token": "component-size-minimum-perspective-down",
       "context": "Down state"
     },
-    { "token": "focus-indicator-thickness", "context": "Border (Selected)" },
-    { "token": "corner-radius-700", "context": "Border radius" },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Border (Selected)"
+    },
+    {
+      "token": "corner-radius-700",
+      "context": "Border radius"
+    },
     {
       "token": "select-box-edge-to-checkbox",
       "context": "Spacing (top/side edge to checkbox)"
     },
-    { "token": "default-font-family", "context": "Text (vertical)" },
-    { "token": "regular-font-weight", "context": "Text (vertical)" },
-    { "token": "default-font-style", "context": "Text (vertical)" },
-    { "token": "font-size-100", "context": "Text (vertical)" },
-    { "token": "line-height-100", "context": "Text (vertical)" },
-    { "token": "cjk-line-height-100", "context": "Text (vertical)" },
-    { "token": "bold-font-weight", "context": "Text (horizontal)" },
-    { "token": "background-layer-2-color", "context": "Background" },
+    {
+      "token": "default-font-family",
+      "context": "Text (vertical)"
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Text (vertical)"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Text (vertical)"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Text (vertical)"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Text (vertical)"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Text (vertical)"
+    },
+    {
+      "token": "bold-font-weight",
+      "context": "Text (horizontal)"
+    },
+    {
+      "token": "background-layer-2-color",
+      "context": "Background"
+    },
     {
       "token": "neutral-content-color-default",
       "context": "Illustration color"
     },
-    { "token": "neutral-content-color-hover", "context": "Illustration color" },
-    { "token": "netural-content-color-focus", "context": "Illustration color" },
+    {
+      "token": "neutral-content-color-hover",
+      "context": "Illustration color"
+    },
+    {
+      "token": "netural-content-color-focus",
+      "context": "Illustration color"
+    },
     {
       "token": "select-box-selected-border-color",
       "context": "Border (selected)"
     },
-    { "token": "gray-900", "context": "Border (selected)" },
-    { "token": "focus-indicator-color", "context": "Border (focus)" },
-    { "token": "disabled-content-color", "context": "Disabled" },
-    { "token": "disabled-background-color", "context": "Disabled" },
-    { "token": "drop-shadow-emphasized-default-x", "context": "Default" },
-    { "token": "drop-shadow-emphasized-default-y", "context": "Default" },
-    { "token": "drop-shadow-emphasized-default-blur", "context": "Default" },
-    { "token": "drop-shadow-emphasized-default-color", "context": "Default" },
-    { "token": "drop-shadow-emphasized-hover-x", "context": "Hover" },
-    { "token": "drop-shadow-emphasized-hover-y", "context": "Hover" },
-    { "token": "drop-shadow-emphasized-hover-blur", "context": "Hover" },
-    { "token": "drop-shadow-emphasized-hover-color", "context": "Hover" },
-    { "token": "drop-shadow-elevated-x", "context": "Focus" },
-    { "token": "drop-shadow-elevated-y", "context": "Focus" },
-    { "token": "drop-shadow-elevated-blur", "context": "Focus" },
-    { "token": "drop-shadow-elevated-color", "context": "Focus" }
+    {
+      "token": "gray-900",
+      "context": "Border (selected)"
+    },
+    {
+      "token": "focus-indicator-color",
+      "context": "Border (focus)"
+    },
+    {
+      "token": "disabled-content-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "disabled-background-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-x",
+      "context": "Default"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-y",
+      "context": "Default"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-blur",
+      "context": "Default"
+    },
+    {
+      "token": "drop-shadow-emphasized-default-color",
+      "context": "Default"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-x",
+      "context": "Hover"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-y",
+      "context": "Hover"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-blur",
+      "context": "Hover"
+    },
+    {
+      "token": "drop-shadow-emphasized-hover-color",
+      "context": "Hover"
+    },
+    {
+      "token": "drop-shadow-elevated-x",
+      "context": "Focus"
+    },
+    {
+      "token": "drop-shadow-elevated-y",
+      "context": "Focus"
+    },
+    {
+      "token": "drop-shadow-elevated-blur",
+      "context": "Focus"
+    },
+    {
+      "token": "drop-shadow-elevated-color",
+      "context": "Focus"
+    }
   ],
   "accessibility": {
     "intents": ["select"],
     "focusable": true,
     "keyboardIntents": ["activate"],
     "wcag": [
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/select-box.json
+++ b/packages/design-data/components/select-box.json
@@ -56,7 +56,7 @@
     },
     {
       "type": "guideline",
-      "content": "A select box group can be navigated using a keyboard. The keyboard focus state takes the button\u2019s visual hover state and adds a blue ring to the button in focus."
+      "content": "A select box group can be navigated using a keyboard. The keyboard focus state takes the button’s visual hover state and adds a blue ring to the button in focus."
     },
     {
       "type": "guideline",
@@ -76,48 +76,25 @@
     },
     {
       "type": "guideline",
-      "content": "Select boxes use a checkbox to indicate both single- and multi-selection. Don\u2019t use radio buttons for single-selection."
+      "content": "Select boxes use a checkbox to indicate both single- and multi-selection. Don’t use radio buttons for single-selection."
     },
     {
       "type": "guideline",
-      "content": "Some cases may make more sense for the user to select one or a few options in a group of select boxes, but if the use case doesn\u2019t make sense to be checking a selection, showCheckbox can be false and the highlight style can be used instead. There is no visual differentiation between single- and multi-select behaviors when checkboxes are not present."
+      "content": "Some cases may make more sense for the user to select one or a few options in a group of select boxes, but if the use case doesn’t make sense to be checking a selection, showCheckbox can be false and the highlight style can be used instead. There is no visual differentiation between single- and multi-select behaviors when checkboxes are not present."
     }
   ],
   "options": {
-    "label": {
-      "type": "string"
-    },
+    "label": { "type": "string" },
     "orientation": {
       "type": "string",
       "default": "vertical",
-      "values": [
-        {
-          "value": "horizontal"
-        },
-        {
-          "value": "vertical"
-        }
-      ]
+      "values": [{ "value": "horizontal" }, { "value": "vertical" }]
     },
-    "body": {
-      "type": "string"
-    },
-    "isSelected": {
-      "type": "boolean",
-      "default": false
-    },
-    "hideIllustration": {
-      "type": "boolean",
-      "default": false
-    },
-    "showCheckbox": {
-      "type": "boolean",
-      "default": false
-    },
-    "isDisabled": {
-      "type": "boolean",
-      "default": false
-    },
+    "body": { "type": "string" },
+    "isSelected": { "type": "boolean", "default": false },
+    "hideIllustration": { "type": "boolean", "default": false },
+    "showCheckbox": { "type": "boolean", "default": false },
+    "isDisabled": { "type": "boolean", "default": false },
     "multiple": {
       "type": "boolean",
       "default": false,
@@ -125,26 +102,12 @@
     }
   },
   "states": [
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected",
-      "trigger": "interaction"
-    }
+    { "name": "down", "trigger": "interaction" },
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" },
+    { "name": "selected", "trigger": "interaction" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     {
       "token": "select-box-vertical-height",
@@ -190,162 +153,61 @@
       "token": "select-box-horizontal-illustration-to-label",
       "context": "Spacing (illustration to label, horizontal)"
     },
-    {
-      "token": "border-width-200",
-      "context": "Border (Selected)"
-    },
-    {
-      "token": "component-size-difference-down",
-      "context": "Down state"
-    },
-    {
-      "token": "component-size-width-ratio-down",
-      "context": "Down state"
-    },
+    { "token": "border-width-200", "context": "Border (Selected)" },
+    { "token": "component-size-difference-down", "context": "Down state" },
+    { "token": "component-size-width-ratio-down", "context": "Down state" },
     {
       "token": "component-size-minimum-perspective-down",
       "context": "Down state"
     },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Border (Selected)"
-    },
-    {
-      "token": "corner-radius-700",
-      "context": "Border radius"
-    },
+    { "token": "focus-indicator-thickness", "context": "Border (Selected)" },
+    { "token": "corner-radius-700", "context": "Border radius" },
     {
       "token": "select-box-edge-to-checkbox",
       "context": "Spacing (top/side edge to checkbox)"
     },
-    {
-      "token": "default-font-family",
-      "context": "Text (vertical)"
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Text (vertical)"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Text (vertical)"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Text (vertical)"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Text (vertical)"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Text (vertical)"
-    },
-    {
-      "token": "bold-font-weight",
-      "context": "Text (horizontal)"
-    },
-    {
-      "token": "background-layer-2-color",
-      "context": "Background"
-    },
+    { "token": "default-font-family", "context": "Text (vertical)" },
+    { "token": "regular-font-weight", "context": "Text (vertical)" },
+    { "token": "default-font-style", "context": "Text (vertical)" },
+    { "token": "font-size-100", "context": "Text (vertical)" },
+    { "token": "line-height-100", "context": "Text (vertical)" },
+    { "token": "cjk-line-height-100", "context": "Text (vertical)" },
+    { "token": "bold-font-weight", "context": "Text (horizontal)" },
+    { "token": "background-layer-2-color", "context": "Background" },
     {
       "token": "neutral-content-color-default",
       "context": "Illustration color"
     },
-    {
-      "token": "neutral-content-color-hover",
-      "context": "Illustration color"
-    },
-    {
-      "token": "netural-content-color-focus",
-      "context": "Illustration color"
-    },
+    { "token": "neutral-content-color-hover", "context": "Illustration color" },
+    { "token": "netural-content-color-focus", "context": "Illustration color" },
     {
       "token": "select-box-selected-border-color",
       "context": "Border (selected)"
     },
-    {
-      "token": "gray-900",
-      "context": "Border (selected)"
-    },
-    {
-      "token": "focus-indicator-color",
-      "context": "Border (focus)"
-    },
-    {
-      "token": "disabled-content-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "disabled-background-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "drop-shadow-emphasized-default-x",
-      "context": "Default"
-    },
-    {
-      "token": "drop-shadow-emphasized-default-y",
-      "context": "Default"
-    },
-    {
-      "token": "drop-shadow-emphasized-default-blur",
-      "context": "Default"
-    },
-    {
-      "token": "drop-shadow-emphasized-default-color",
-      "context": "Default"
-    },
-    {
-      "token": "drop-shadow-emphasized-hover-x",
-      "context": "Hover"
-    },
-    {
-      "token": "drop-shadow-emphasized-hover-y",
-      "context": "Hover"
-    },
-    {
-      "token": "drop-shadow-emphasized-hover-blur",
-      "context": "Hover"
-    },
-    {
-      "token": "drop-shadow-emphasized-hover-color",
-      "context": "Hover"
-    },
-    {
-      "token": "drop-shadow-elevated-x",
-      "context": "Focus"
-    },
-    {
-      "token": "drop-shadow-elevated-y",
-      "context": "Focus"
-    },
-    {
-      "token": "drop-shadow-elevated-blur",
-      "context": "Focus"
-    },
-    {
-      "token": "drop-shadow-elevated-color",
-      "context": "Focus"
-    }
+    { "token": "gray-900", "context": "Border (selected)" },
+    { "token": "focus-indicator-color", "context": "Border (focus)" },
+    { "token": "disabled-content-color", "context": "Disabled" },
+    { "token": "disabled-background-color", "context": "Disabled" },
+    { "token": "drop-shadow-emphasized-default-x", "context": "Default" },
+    { "token": "drop-shadow-emphasized-default-y", "context": "Default" },
+    { "token": "drop-shadow-emphasized-default-blur", "context": "Default" },
+    { "token": "drop-shadow-emphasized-default-color", "context": "Default" },
+    { "token": "drop-shadow-emphasized-hover-x", "context": "Hover" },
+    { "token": "drop-shadow-emphasized-hover-y", "context": "Hover" },
+    { "token": "drop-shadow-emphasized-hover-blur", "context": "Hover" },
+    { "token": "drop-shadow-emphasized-hover-color", "context": "Hover" },
+    { "token": "drop-shadow-elevated-x", "context": "Focus" },
+    { "token": "drop-shadow-elevated-y", "context": "Focus" },
+    { "token": "drop-shadow-elevated-blur", "context": "Focus" },
+    { "token": "drop-shadow-elevated-color", "context": "Focus" }
   ],
   "accessibility": {
     "intents": ["select"],
     "focusable": true,
     "keyboardIntents": ["activate"],
     "wcag": [
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/side-navigation.json
+++ b/packages/design-data/components/side-navigation.json
@@ -40,7 +40,7 @@
     },
     {
       "type": "guideline",
-      "content": "The width of the side navigation is flexible, so choose a width that works with the navigation items in your experience. Make the width generous enough so that it doesn\u2019t feel too condensed. Doing this will ensure that users won't confuse the side navigation with buttons or other controls."
+      "content": "The width of the side navigation is flexible, so choose a width that works with the navigation items in your experience. Make the width generous enough so that it doesn’t feel too condensed. Doing this will ensure that users won't confuse the side navigation with buttons or other controls."
     },
     {
       "type": "guideline",
@@ -48,7 +48,7 @@
     },
     {
       "type": "guideline",
-      "content": "Make sure the width is generous enough so that it doesn\u2019t feel too condensed. This ensures it doesn\u2019t get confused with buttons or other controls."
+      "content": "Make sure the width is generous enough so that it doesn’t feel too condensed. This ensures it doesn’t get confused with buttons or other controls."
     },
     {
       "type": "guideline",
@@ -127,15 +127,9 @@
       "default": "single",
       "description": "How selection is handled for items.",
       "values": [
-        {
-          "value": "none"
-        },
-        {
-          "value": "single"
-        },
-        {
-          "value": "multiple"
-        }
+        { "value": "none" },
+        { "value": "single" },
+        { "value": "multiple" }
       ]
     }
   },
@@ -144,44 +138,19 @@
       "name": "trailing-accessory-area",
       "description": "Trailing area for accessory content such as counts or actions."
     },
-    {
-      "name": "indicator"
-    }
+    { "name": "indicator" }
   ],
   "states": [
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    }
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "down", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "component-height-100",
-      "context": "Minimum height"
-    },
-    {
-      "token": "side-navigation-width",
-      "context": "Width (default)"
-    },
-    {
-      "token": "side-navigation-minimum-width",
-      "context": "Width (minimum)"
-    },
-    {
-      "token": "side-navigation-maximum-width",
-      "context": "Width (maximum)"
-    },
+    { "token": "component-height-100", "context": "Minimum height" },
+    { "token": "side-navigation-width", "context": "Width (default)" },
+    { "token": "side-navigation-minimum-width", "context": "Width (minimum)" },
+    { "token": "side-navigation-maximum-width", "context": "Width (maximum)" },
     {
       "token": "component-size-difference-down",
       "context": "Component size (down)"
@@ -206,14 +175,8 @@
       "token": "side-navigation-indicator-to-content",
       "context": "Spacing (indicator to content)"
     },
-    {
-      "token": "workflow-icon-size-100",
-      "context": "Icon"
-    },
-    {
-      "token": "text-to-visual-100",
-      "context": "Spacing (icon to label)"
-    },
+    { "token": "workflow-icon-size-100", "context": "Icon" },
+    { "token": "text-to-visual-100", "context": "Spacing (icon to label)" },
     {
       "token": "component-edge-to-text-100",
       "context": "Spacing (single-level, start/end to content)"
@@ -278,10 +241,7 @@
       "token": "side-navigation-header-to-item",
       "context": "Spacing (vertically between side-nav item and side-nav title)"
     },
-    {
-      "token": "component-top-to-workflow-icon-100",
-      "context": "Layout"
-    },
+    { "token": "component-top-to-workflow-icon-100", "context": "Layout" },
     {
       "token": "component-padding-vertical-100",
       "context": "Spacing (top edge to label)"
@@ -290,22 +250,10 @@
       "token": "side-navigation-bottom-to-text",
       "context": "Spacing (label wrapping)"
     },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "focus-indicator-gap",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "gray-400",
-      "context": "Side navigation indicator "
-    },
-    {
-      "token": "gray-800",
-      "context": "Side navigation indicator "
-    },
+    { "token": "focus-indicator-thickness", "context": "Focus indicator" },
+    { "token": "focus-indicator-gap", "context": "Focus indicator" },
+    { "token": "gray-400", "context": "Side navigation indicator " },
+    { "token": "gray-800", "context": "Side navigation indicator " },
     {
       "token": "neutral-subdued-content-color-default",
       "context": "Navigation item label and icon"
@@ -338,70 +286,32 @@
       "token": "neutral-content-color-key-focus",
       "context": "Navigation item label and icon (selected)"
     },
-    {
-      "token": "gray-600",
-      "context": "Side navigation title"
-    },
+    { "token": "gray-600", "context": "Side navigation title" },
     {
       "token": "disabled-content-color",
       "context": "Label and icon (disabled)"
     },
-    {
-      "token": "focus-indicator-color",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Text  "
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Text  "
-    },
-    {
-      "token": "default-font-style",
-      "context": "Text  "
-    },
-    {
-      "token": "font-size-100",
-      "context": "Text  "
-    },
-    {
-      "token": "line-height-100",
-      "context": "Text  "
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Text  "
-    },
-    {
-      "token": "bold-font-weight",
-      "context": "Text (selected)"
-    },
+    { "token": "focus-indicator-color", "context": "Focus indicator" },
+    { "token": "default-font-family", "context": "Text  " },
+    { "token": "regular-font-weight", "context": "Text  " },
+    { "token": "default-font-style", "context": "Text  " },
+    { "token": "font-size-100", "context": "Text  " },
+    { "token": "line-height-100", "context": "Text  " },
+    { "token": "cjk-line-height-100", "context": "Text  " },
+    { "token": "bold-font-weight", "context": "Text (selected)" },
     {
       "token": "medium-font-weight",
       "context": "Text (Side navigation title)"
     },
-    {
-      "token": "font-size-75",
-      "context": "Text (Side navigation title)"
-    }
+    { "token": "font-size-75", "context": "Text (Side navigation title)" }
   ],
   "accessibility": {
     "intents": ["navigate"],
     "focusable": true,
     "keyboardIntents": ["navigate-items", "activate"],
     "wcag": [
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/side-navigation.json
+++ b/packages/design-data/components/side-navigation.json
@@ -40,7 +40,7 @@
     },
     {
       "type": "guideline",
-      "content": "The width of the side navigation is flexible, so choose a width that works with the navigation items in your experience. Make the width generous enough so that it doesn’t feel too condensed. Doing this will ensure that users won't confuse the side navigation with buttons or other controls."
+      "content": "The width of the side navigation is flexible, so choose a width that works with the navigation items in your experience. Make the width generous enough so that it doesn\u2019t feel too condensed. Doing this will ensure that users won't confuse the side navigation with buttons or other controls."
     },
     {
       "type": "guideline",
@@ -48,7 +48,7 @@
     },
     {
       "type": "guideline",
-      "content": "Make sure the width is generous enough so that it doesn’t feel too condensed. This ensures it doesn’t get confused with buttons or other controls."
+      "content": "Make sure the width is generous enough so that it doesn\u2019t feel too condensed. This ensures it doesn\u2019t get confused with buttons or other controls."
     },
     {
       "type": "guideline",
@@ -127,9 +127,15 @@
       "default": "single",
       "description": "How selection is handled for items.",
       "values": [
-        { "value": "none" },
-        { "value": "single" },
-        { "value": "multiple" }
+        {
+          "value": "none"
+        },
+        {
+          "value": "single"
+        },
+        {
+          "value": "multiple"
+        }
       ]
     }
   },
@@ -137,19 +143,45 @@
     {
       "name": "trailing-accessory-area",
       "description": "Trailing area for accessory content such as counts or actions."
+    },
+    {
+      "name": "indicator"
     }
   ],
   "states": [
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "down", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "component-height-100", "context": "Minimum height" },
-    { "token": "side-navigation-width", "context": "Width (default)" },
-    { "token": "side-navigation-minimum-width", "context": "Width (minimum)" },
-    { "token": "side-navigation-maximum-width", "context": "Width (maximum)" },
+    {
+      "token": "component-height-100",
+      "context": "Minimum height"
+    },
+    {
+      "token": "side-navigation-width",
+      "context": "Width (default)"
+    },
+    {
+      "token": "side-navigation-minimum-width",
+      "context": "Width (minimum)"
+    },
+    {
+      "token": "side-navigation-maximum-width",
+      "context": "Width (maximum)"
+    },
     {
       "token": "component-size-difference-down",
       "context": "Component size (down)"
@@ -174,8 +206,14 @@
       "token": "side-navigation-indicator-to-content",
       "context": "Spacing (indicator to content)"
     },
-    { "token": "workflow-icon-size-100", "context": "Icon" },
-    { "token": "text-to-visual-100", "context": "Spacing (icon to label)" },
+    {
+      "token": "workflow-icon-size-100",
+      "context": "Icon"
+    },
+    {
+      "token": "text-to-visual-100",
+      "context": "Spacing (icon to label)"
+    },
     {
       "token": "component-edge-to-text-100",
       "context": "Spacing (single-level, start/end to content)"
@@ -240,7 +278,10 @@
       "token": "side-navigation-header-to-item",
       "context": "Spacing (vertically between side-nav item and side-nav title)"
     },
-    { "token": "component-top-to-workflow-icon-100", "context": "Layout" },
+    {
+      "token": "component-top-to-workflow-icon-100",
+      "context": "Layout"
+    },
     {
       "token": "component-padding-vertical-100",
       "context": "Spacing (top edge to label)"
@@ -249,10 +290,22 @@
       "token": "side-navigation-bottom-to-text",
       "context": "Spacing (label wrapping)"
     },
-    { "token": "focus-indicator-thickness", "context": "Focus indicator" },
-    { "token": "focus-indicator-gap", "context": "Focus indicator" },
-    { "token": "gray-400", "context": "Side navigation indicator " },
-    { "token": "gray-800", "context": "Side navigation indicator " },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "focus-indicator-gap",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "gray-400",
+      "context": "Side navigation indicator "
+    },
+    {
+      "token": "gray-800",
+      "context": "Side navigation indicator "
+    },
     {
       "token": "neutral-subdued-content-color-default",
       "context": "Navigation item label and icon"
@@ -285,32 +338,70 @@
       "token": "neutral-content-color-key-focus",
       "context": "Navigation item label and icon (selected)"
     },
-    { "token": "gray-600", "context": "Side navigation title" },
+    {
+      "token": "gray-600",
+      "context": "Side navigation title"
+    },
     {
       "token": "disabled-content-color",
       "context": "Label and icon (disabled)"
     },
-    { "token": "focus-indicator-color", "context": "Focus indicator" },
-    { "token": "default-font-family", "context": "Text  " },
-    { "token": "regular-font-weight", "context": "Text  " },
-    { "token": "default-font-style", "context": "Text  " },
-    { "token": "font-size-100", "context": "Text  " },
-    { "token": "line-height-100", "context": "Text  " },
-    { "token": "cjk-line-height-100", "context": "Text  " },
-    { "token": "bold-font-weight", "context": "Text (selected)" },
+    {
+      "token": "focus-indicator-color",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Text  "
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Text  "
+    },
+    {
+      "token": "default-font-style",
+      "context": "Text  "
+    },
+    {
+      "token": "font-size-100",
+      "context": "Text  "
+    },
+    {
+      "token": "line-height-100",
+      "context": "Text  "
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Text  "
+    },
+    {
+      "token": "bold-font-weight",
+      "context": "Text (selected)"
+    },
     {
       "token": "medium-font-weight",
       "context": "Text (Side navigation title)"
     },
-    { "token": "font-size-75", "context": "Text (Side navigation title)" }
+    {
+      "token": "font-size-75",
+      "context": "Text (Side navigation title)"
+    }
   ],
   "accessibility": {
     "intents": ["navigate"],
     "focusable": true,
     "keyboardIntents": ["navigate-items", "activate"],
     "wcag": [
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/single-calendar.json
+++ b/packages/design-data/components/single-calendar.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/single-calendar.json",
+  "specVersion": "1.0.0-draft",
+  "name": "single-calendar",
+  "displayName": "Single calendar",
+  "description": "A date-picker calendar variant displaying a single month.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/single-calendar.json
+++ b/packages/design-data/components/single-calendar.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/slider.json
+++ b/packages/design-data/components/slider.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "guideline",
-      "content": "Sliders select a value along a continuous range. They’re ideal when upper and lower limits are fixed. Use when approximate or fast selection is more important than precision."
+      "content": "Sliders select a value along a continuous range. They\u2019re ideal when upper and lower limits are fixed. Use when approximate or fast selection is more important than precision."
     },
     {
       "type": "guideline",
@@ -24,7 +24,7 @@
     },
     {
       "type": "guideline",
-      "content": "The value is the number selected within the slider’s range, from the min value to max value."
+      "content": "The value is the number selected within the slider\u2019s range, from the min value to max value."
     },
     {
       "type": "guideline",
@@ -40,7 +40,7 @@
     },
     {
       "type": "guideline",
-      "content": "Sometimes a value needs to be formatted for localization or for clearer communication such as currencies or percentages. Formatting can involve rounding, mathematical transformations, number formatting, or displaying a prefix or suffix, such as “+/-” or “px.”"
+      "content": "Sometimes a value needs to be formatted for localization or for clearer communication such as currencies or percentages. Formatting can involve rounding, mathematical transformations, number formatting, or displaying a prefix or suffix, such as \u201c+/-\u201d or \u201cpx.\u201d"
     },
     {
       "type": "guideline",
@@ -72,11 +72,11 @@
     },
     {
       "type": "guideline",
-      "content": "A slider can be navigated using a keyboard. The keyboard focus state takes the slider’s visual hover state and adds a blue ring to the slider handle in focus."
+      "content": "A slider can be navigated using a keyboard. The keyboard focus state takes the slider\u2019s visual hover state and adds a blue ring to the slider handle in focus."
     },
     {
       "type": "guideline",
-      "content": "A slider representing multiple non-identical values appears as indeterminate, with an en dash (–) in place of the value. The handle position corresponds to the first selected value."
+      "content": "A slider representing multiple non-identical values appears as indeterminate, with an en dash (\u2013) in place of the value. The handle position corresponds to the first selected value."
     },
     {
       "type": "guideline",
@@ -92,11 +92,11 @@
     },
     {
       "type": "guideline",
-      "content": "In addition to dragging the handle, sliders can offer other ways to change the value, known as “hot text.” Users can click the value text and drag up or down, or scroll up or down while hovering over the value text."
+      "content": "In addition to dragging the handle, sliders can offer other ways to change the value, known as \u201chot text.\u201d Users can click the value text and drag up or down, or scroll up or down while hovering over the value text."
     },
     {
       "type": "guideline",
-      "content": "Slider values can include a unit when it adds context, such as “%” or “px.” When the value is shown within a text field, the unit disappears on focus."
+      "content": "Slider values can include a unit when it adds context, such as \u201c%\u201d or \u201cpx.\u201d When the value is shown within a text field, the unit disappears on focus."
     },
     {
       "type": "guideline",
@@ -104,21 +104,42 @@
     }
   ],
   "options": {
-    "label": { "type": "string" },
+    "label": {
+      "type": "string"
+    },
     "labelPosition": {
       "type": "string",
       "default": "top",
-      "values": [{ "value": "top" }, { "value": "side" }]
+      "values": [
+        {
+          "value": "top"
+        },
+        {
+          "value": "side"
+        }
+      ]
     },
-    "value": { "type": "number", "description": "from minValue to maxValue" },
-    "minValue": { "type": "number", "default": 0 },
-    "maxValue": { "type": "number", "default": 100 },
+    "value": {
+      "type": "number",
+      "description": "from minValue to maxValue"
+    },
+    "minValue": {
+      "type": "number",
+      "default": 0
+    },
+    "maxValue": {
+      "type": "number",
+      "default": 100
+    },
     "isRange": {
       "type": "boolean",
       "default": false,
       "description": "If true, the slider will allow selection of a range of values by displaying two handles."
     },
-    "step": { "type": "number", "default": 1 },
+    "step": {
+      "type": "number",
+      "default": 1
+    },
     "valueFormat": {
       "type": "string",
       "description": "This will vary depending on implementation."
@@ -126,31 +147,84 @@
     "progressionScale": {
       "type": "string",
       "default": "linear",
-      "values": [{ "value": "linear" }, { "value": "log" }]
+      "values": [
+        {
+          "value": "linear"
+        },
+        {
+          "value": "log"
+        }
+      ]
     },
-    "width": { "type": "number" },
-    "hasFill": { "type": "boolean", "default": false },
-    "fillStart": { "type": "number", "default": 0 },
-    "hasGradient": { "type": "boolean", "default": false },
-    "isEditable": { "type": "boolean", "default": false },
-    "isDisabled": { "type": "boolean", "default": false }
+    "width": {
+      "type": "number"
+    },
+    "hasFill": {
+      "type": "boolean",
+      "default": false
+    },
+    "fillStart": {
+      "type": "number",
+      "default": 0
+    },
+    "hasGradient": {
+      "type": "boolean",
+      "default": false
+    },
+    "isEditable": {
+      "type": "boolean",
+      "default": false
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "default": false
+    }
   },
   "anatomy": [
     {
       "name": "text-field",
       "description": "Editable numeric value field."
+    },
+    {
+      "name": "handle"
+    },
+    {
+      "name": "track"
+    },
+    {
+      "name": "control"
     }
   ],
   "states": [
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "down", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "field-default-width-small", "context": "Width (default)" },
-    { "token": "field-default-width-medium", "context": "Width (default)" },
-    { "token": "field-default-width-large", "context": "Width (default)" },
+    {
+      "token": "field-default-width-small",
+      "context": "Width (default)"
+    },
+    {
+      "token": "field-default-width-medium",
+      "context": "Width (default)"
+    },
+    {
+      "token": "field-default-width-large",
+      "context": "Width (default)"
+    },
     {
       "token": "field-default-width-extra-large",
       "context": "Width (default)"
@@ -167,16 +241,46 @@
       "token": "component-size-minimum-perspective-down",
       "context": "Component size (down)"
     },
-    { "token": "slider-track-height-medium", "context": "Track (height)" },
-    { "token": "slider-track-height-large", "context": "Track (height)" },
-    { "token": "component-height-75", "context": "Height (slider control) " },
-    { "token": "component-height-100", "context": "Height (slider control) " },
-    { "token": "component-height-200", "context": "Height (slider control) " },
-    { "token": "component-height-300", "context": "Height (slider control) " },
-    { "token": "slider-handle-small", "context": "Handle (size)" },
-    { "token": "slider-handle-medium", "context": "Handle (size)" },
-    { "token": "slider-handle-large", "context": "Handle (size)" },
-    { "token": "slider-handle-extra-large", "context": "Handle (size)" },
+    {
+      "token": "slider-track-height-medium",
+      "context": "Track (height)"
+    },
+    {
+      "token": "slider-track-height-large",
+      "context": "Track (height)"
+    },
+    {
+      "token": "component-height-75",
+      "context": "Height (slider control) "
+    },
+    {
+      "token": "component-height-100",
+      "context": "Height (slider control) "
+    },
+    {
+      "token": "component-height-200",
+      "context": "Height (slider control) "
+    },
+    {
+      "token": "component-height-300",
+      "context": "Height (slider control) "
+    },
+    {
+      "token": "slider-handle-small",
+      "context": "Handle (size)"
+    },
+    {
+      "token": "slider-handle-medium",
+      "context": "Handle (size)"
+    },
+    {
+      "token": "slider-handle-large",
+      "context": "Handle (size)"
+    },
+    {
+      "token": "slider-handle-extra-large",
+      "context": "Handle (size)"
+    },
     {
       "token": "slider-precision-handle-height-small",
       "context": "Handle (size)"
@@ -193,10 +297,22 @@
       "token": "slider-precision-handle-height-extra-large",
       "context": "Handle (size)"
     },
-    { "token": "slider-precision-handle-width", "context": "Handle (size)" },
-    { "token": "border-width-200", "context": "Handle (border)" },
-    { "token": "focus-indicator-thickness", "context": "Focus ring" },
-    { "token": "focus-indicator-gap", "context": "Focus ring" },
+    {
+      "token": "slider-precision-handle-width",
+      "context": "Handle (size)"
+    },
+    {
+      "token": "border-width-200",
+      "context": "Handle (border)"
+    },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Focus ring"
+    },
+    {
+      "token": "focus-indicator-gap",
+      "context": "Focus ring"
+    },
     {
       "token": "component-top-to-text-75",
       "context": "Spacing (top/bottom edge to label)"
@@ -293,26 +409,86 @@
       "token": "slider-control-to-text-field-extra-large",
       "context": "Spacing (slider to field)"
     },
-    { "token": "neutral-subdued-content-color-default", "context": "Value" },
-    { "token": "alias-track-default", "context": "Track" },
-    { "token": "gray-700", "context": "Track" },
-    { "token": "accent-content-color-default", "context": "Track" },
-    { "token": "gray-800", "context": "Handle" },
-    { "token": "gray-900", "context": "Handle" },
-    { "token": "gray-25", "context": "Handle" },
-    { "token": "focus-indicator-color", "context": "Focus ring" },
-    { "token": "disabled-content-color", "context": "Disabled" },
-    { "token": "disabled-background-color", "context": "Disabled" },
-    { "token": "disabled-border-color", "context": "Disabled" },
-    { "token": "default-font-family", "context": "Label" },
-    { "token": "regular-font-weight", "context": "Label" },
-    { "token": "default-font-style", "context": "Label" },
-    { "token": "font-size-75", "context": "Label" },
-    { "token": "font-size-100", "context": "Label" },
-    { "token": "font-size-200", "context": "Label" },
-    { "token": "font-size-300", "context": "Label" },
-    { "token": "line-height-100", "context": "Label" },
-    { "token": "cjk-line-height-100", "context": "Label" }
+    {
+      "token": "neutral-subdued-content-color-default",
+      "context": "Value"
+    },
+    {
+      "token": "alias-track-default",
+      "context": "Track"
+    },
+    {
+      "token": "gray-700",
+      "context": "Track"
+    },
+    {
+      "token": "accent-content-color-default",
+      "context": "Track"
+    },
+    {
+      "token": "gray-800",
+      "context": "Handle"
+    },
+    {
+      "token": "gray-900",
+      "context": "Handle"
+    },
+    {
+      "token": "gray-25",
+      "context": "Handle"
+    },
+    {
+      "token": "focus-indicator-color",
+      "context": "Focus ring"
+    },
+    {
+      "token": "disabled-content-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "disabled-background-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "disabled-border-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Label"
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Label"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-75",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-200",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-300",
+      "context": "Label"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Label"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Label"
+    }
   ],
   "accessibility": {
     "role": "slider",
@@ -320,9 +496,21 @@
     "focusable": true,
     "keyboardIntents": ["increment", "decrement"],
     "wcag": [
-      { "criterion": "1.3.1", "level": "A", "title": "Info and Relationships" },
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/slider.json
+++ b/packages/design-data/components/slider.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "guideline",
-      "content": "Sliders select a value along a continuous range. They\u2019re ideal when upper and lower limits are fixed. Use when approximate or fast selection is more important than precision."
+      "content": "Sliders select a value along a continuous range. They’re ideal when upper and lower limits are fixed. Use when approximate or fast selection is more important than precision."
     },
     {
       "type": "guideline",
@@ -24,7 +24,7 @@
     },
     {
       "type": "guideline",
-      "content": "The value is the number selected within the slider\u2019s range, from the min value to max value."
+      "content": "The value is the number selected within the slider’s range, from the min value to max value."
     },
     {
       "type": "guideline",
@@ -40,7 +40,7 @@
     },
     {
       "type": "guideline",
-      "content": "Sometimes a value needs to be formatted for localization or for clearer communication such as currencies or percentages. Formatting can involve rounding, mathematical transformations, number formatting, or displaying a prefix or suffix, such as \u201c+/-\u201d or \u201cpx.\u201d"
+      "content": "Sometimes a value needs to be formatted for localization or for clearer communication such as currencies or percentages. Formatting can involve rounding, mathematical transformations, number formatting, or displaying a prefix or suffix, such as “+/-” or “px.”"
     },
     {
       "type": "guideline",
@@ -72,11 +72,11 @@
     },
     {
       "type": "guideline",
-      "content": "A slider can be navigated using a keyboard. The keyboard focus state takes the slider\u2019s visual hover state and adds a blue ring to the slider handle in focus."
+      "content": "A slider can be navigated using a keyboard. The keyboard focus state takes the slider’s visual hover state and adds a blue ring to the slider handle in focus."
     },
     {
       "type": "guideline",
-      "content": "A slider representing multiple non-identical values appears as indeterminate, with an en dash (\u2013) in place of the value. The handle position corresponds to the first selected value."
+      "content": "A slider representing multiple non-identical values appears as indeterminate, with an en dash (–) in place of the value. The handle position corresponds to the first selected value."
     },
     {
       "type": "guideline",
@@ -92,11 +92,11 @@
     },
     {
       "type": "guideline",
-      "content": "In addition to dragging the handle, sliders can offer other ways to change the value, known as \u201chot text.\u201d Users can click the value text and drag up or down, or scroll up or down while hovering over the value text."
+      "content": "In addition to dragging the handle, sliders can offer other ways to change the value, known as “hot text.” Users can click the value text and drag up or down, or scroll up or down while hovering over the value text."
     },
     {
       "type": "guideline",
-      "content": "Slider values can include a unit when it adds context, such as \u201c%\u201d or \u201cpx.\u201d When the value is shown within a text field, the unit disappears on focus."
+      "content": "Slider values can include a unit when it adds context, such as “%” or “px.” When the value is shown within a text field, the unit disappears on focus."
     },
     {
       "type": "guideline",
@@ -104,42 +104,21 @@
     }
   ],
   "options": {
-    "label": {
-      "type": "string"
-    },
+    "label": { "type": "string" },
     "labelPosition": {
       "type": "string",
       "default": "top",
-      "values": [
-        {
-          "value": "top"
-        },
-        {
-          "value": "side"
-        }
-      ]
+      "values": [{ "value": "top" }, { "value": "side" }]
     },
-    "value": {
-      "type": "number",
-      "description": "from minValue to maxValue"
-    },
-    "minValue": {
-      "type": "number",
-      "default": 0
-    },
-    "maxValue": {
-      "type": "number",
-      "default": 100
-    },
+    "value": { "type": "number", "description": "from minValue to maxValue" },
+    "minValue": { "type": "number", "default": 0 },
+    "maxValue": { "type": "number", "default": 100 },
     "isRange": {
       "type": "boolean",
       "default": false,
       "description": "If true, the slider will allow selection of a range of values by displaying two handles."
     },
-    "step": {
-      "type": "number",
-      "default": 1
-    },
+    "step": { "type": "number", "default": 1 },
     "valueFormat": {
       "type": "string",
       "description": "This will vary depending on implementation."
@@ -147,84 +126,34 @@
     "progressionScale": {
       "type": "string",
       "default": "linear",
-      "values": [
-        {
-          "value": "linear"
-        },
-        {
-          "value": "log"
-        }
-      ]
+      "values": [{ "value": "linear" }, { "value": "log" }]
     },
-    "width": {
-      "type": "number"
-    },
-    "hasFill": {
-      "type": "boolean",
-      "default": false
-    },
-    "fillStart": {
-      "type": "number",
-      "default": 0
-    },
-    "hasGradient": {
-      "type": "boolean",
-      "default": false
-    },
-    "isEditable": {
-      "type": "boolean",
-      "default": false
-    },
-    "isDisabled": {
-      "type": "boolean",
-      "default": false
-    }
+    "width": { "type": "number" },
+    "hasFill": { "type": "boolean", "default": false },
+    "fillStart": { "type": "number", "default": 0 },
+    "hasGradient": { "type": "boolean", "default": false },
+    "isEditable": { "type": "boolean", "default": false },
+    "isDisabled": { "type": "boolean", "default": false }
   },
   "anatomy": [
     {
       "name": "text-field",
       "description": "Editable numeric value field."
     },
-    {
-      "name": "handle"
-    },
-    {
-      "name": "track"
-    },
-    {
-      "name": "control"
-    }
+    { "name": "handle" },
+    { "name": "track" },
+    { "name": "control" }
   ],
   "states": [
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    }
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "down", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "field-default-width-small",
-      "context": "Width (default)"
-    },
-    {
-      "token": "field-default-width-medium",
-      "context": "Width (default)"
-    },
-    {
-      "token": "field-default-width-large",
-      "context": "Width (default)"
-    },
+    { "token": "field-default-width-small", "context": "Width (default)" },
+    { "token": "field-default-width-medium", "context": "Width (default)" },
+    { "token": "field-default-width-large", "context": "Width (default)" },
     {
       "token": "field-default-width-extra-large",
       "context": "Width (default)"
@@ -241,46 +170,16 @@
       "token": "component-size-minimum-perspective-down",
       "context": "Component size (down)"
     },
-    {
-      "token": "slider-track-height-medium",
-      "context": "Track (height)"
-    },
-    {
-      "token": "slider-track-height-large",
-      "context": "Track (height)"
-    },
-    {
-      "token": "component-height-75",
-      "context": "Height (slider control) "
-    },
-    {
-      "token": "component-height-100",
-      "context": "Height (slider control) "
-    },
-    {
-      "token": "component-height-200",
-      "context": "Height (slider control) "
-    },
-    {
-      "token": "component-height-300",
-      "context": "Height (slider control) "
-    },
-    {
-      "token": "slider-handle-small",
-      "context": "Handle (size)"
-    },
-    {
-      "token": "slider-handle-medium",
-      "context": "Handle (size)"
-    },
-    {
-      "token": "slider-handle-large",
-      "context": "Handle (size)"
-    },
-    {
-      "token": "slider-handle-extra-large",
-      "context": "Handle (size)"
-    },
+    { "token": "slider-track-height-medium", "context": "Track (height)" },
+    { "token": "slider-track-height-large", "context": "Track (height)" },
+    { "token": "component-height-75", "context": "Height (slider control) " },
+    { "token": "component-height-100", "context": "Height (slider control) " },
+    { "token": "component-height-200", "context": "Height (slider control) " },
+    { "token": "component-height-300", "context": "Height (slider control) " },
+    { "token": "slider-handle-small", "context": "Handle (size)" },
+    { "token": "slider-handle-medium", "context": "Handle (size)" },
+    { "token": "slider-handle-large", "context": "Handle (size)" },
+    { "token": "slider-handle-extra-large", "context": "Handle (size)" },
     {
       "token": "slider-precision-handle-height-small",
       "context": "Handle (size)"
@@ -297,22 +196,10 @@
       "token": "slider-precision-handle-height-extra-large",
       "context": "Handle (size)"
     },
-    {
-      "token": "slider-precision-handle-width",
-      "context": "Handle (size)"
-    },
-    {
-      "token": "border-width-200",
-      "context": "Handle (border)"
-    },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Focus ring"
-    },
-    {
-      "token": "focus-indicator-gap",
-      "context": "Focus ring"
-    },
+    { "token": "slider-precision-handle-width", "context": "Handle (size)" },
+    { "token": "border-width-200", "context": "Handle (border)" },
+    { "token": "focus-indicator-thickness", "context": "Focus ring" },
+    { "token": "focus-indicator-gap", "context": "Focus ring" },
     {
       "token": "component-top-to-text-75",
       "context": "Spacing (top/bottom edge to label)"
@@ -409,86 +296,26 @@
       "token": "slider-control-to-text-field-extra-large",
       "context": "Spacing (slider to field)"
     },
-    {
-      "token": "neutral-subdued-content-color-default",
-      "context": "Value"
-    },
-    {
-      "token": "alias-track-default",
-      "context": "Track"
-    },
-    {
-      "token": "gray-700",
-      "context": "Track"
-    },
-    {
-      "token": "accent-content-color-default",
-      "context": "Track"
-    },
-    {
-      "token": "gray-800",
-      "context": "Handle"
-    },
-    {
-      "token": "gray-900",
-      "context": "Handle"
-    },
-    {
-      "token": "gray-25",
-      "context": "Handle"
-    },
-    {
-      "token": "focus-indicator-color",
-      "context": "Focus ring"
-    },
-    {
-      "token": "disabled-content-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "disabled-background-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "disabled-border-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Label"
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Label"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-75",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-200",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-300",
-      "context": "Label"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Label"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Label"
-    }
+    { "token": "neutral-subdued-content-color-default", "context": "Value" },
+    { "token": "alias-track-default", "context": "Track" },
+    { "token": "gray-700", "context": "Track" },
+    { "token": "accent-content-color-default", "context": "Track" },
+    { "token": "gray-800", "context": "Handle" },
+    { "token": "gray-900", "context": "Handle" },
+    { "token": "gray-25", "context": "Handle" },
+    { "token": "focus-indicator-color", "context": "Focus ring" },
+    { "token": "disabled-content-color", "context": "Disabled" },
+    { "token": "disabled-background-color", "context": "Disabled" },
+    { "token": "disabled-border-color", "context": "Disabled" },
+    { "token": "default-font-family", "context": "Label" },
+    { "token": "regular-font-weight", "context": "Label" },
+    { "token": "default-font-style", "context": "Label" },
+    { "token": "font-size-75", "context": "Label" },
+    { "token": "font-size-100", "context": "Label" },
+    { "token": "font-size-200", "context": "Label" },
+    { "token": "font-size-300", "context": "Label" },
+    { "token": "line-height-100", "context": "Label" },
+    { "token": "cjk-line-height-100", "context": "Label" }
   ],
   "accessibility": {
     "role": "slider",
@@ -496,21 +323,9 @@
     "focusable": true,
     "keyboardIntents": ["increment", "decrement"],
     "wcag": [
-      {
-        "criterion": "1.3.1",
-        "level": "A",
-        "title": "Info and Relationships"
-      },
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "1.3.1", "level": "A", "title": "Info and Relationships" },
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/stack-item.json
+++ b/packages/design-data/components/stack-item.json
@@ -10,40 +10,14 @@
     "documentationUrl": "https://spectrum.adobe.com/"
   },
   "states": [
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "key-focus",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected-default",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected-down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected-hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected-keyboard-focus",
-      "trigger": "interaction"
-    }
+    { "name": "down", "trigger": "interaction" },
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "key-focus", "trigger": "interaction" },
+    { "name": "selected", "trigger": "interaction" },
+    { "name": "selected-default", "trigger": "interaction" },
+    { "name": "selected-down", "trigger": "interaction" },
+    { "name": "selected-hover", "trigger": "interaction" },
+    { "name": "selected-keyboard-focus", "trigger": "interaction" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/stack-item.json
+++ b/packages/design-data/components/stack-item.json
@@ -10,9 +10,40 @@
     "documentationUrl": "https://spectrum.adobe.com/"
   },
   "states": [
-    { "name": "down", "trigger": "interaction" },
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "key-focus", "trigger": "interaction" }
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "key-focus",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected-default",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected-down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected-hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected-keyboard-focus",
+      "trigger": "interaction"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" }
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
 }

--- a/packages/design-data/components/status-light.json
+++ b/packages/design-data/components/status-light.json
@@ -48,44 +48,100 @@
     }
   ],
   "options": {
-    "label": { "type": "string" },
+    "label": {
+      "type": "string"
+    },
     "variant": {
       "type": "string",
       "default": "informative",
       "values": [
-        { "value": "informative" },
-        { "value": "neutral" },
-        { "value": "positive" },
-        { "value": "notice" },
-        { "value": "negative" },
-        { "value": "indigo" },
-        { "value": "celery" },
-        { "value": "chartreuse" },
-        { "value": "yellow" },
-        { "value": "magenta" },
-        { "value": "fuchsia" },
-        { "value": "purple" },
-        { "value": "seafoam" },
-        { "value": "pink" },
-        { "value": "turquoise" },
-        { "value": "cinnamon" },
-        { "value": "brown" },
-        { "value": "silver" },
-        { "value": "gray" },
-        { "value": "red" },
-        { "value": "orange" },
-        { "value": "green" },
-        { "value": "cyan" }
+        {
+          "value": "informative"
+        },
+        {
+          "value": "neutral"
+        },
+        {
+          "value": "positive"
+        },
+        {
+          "value": "notice"
+        },
+        {
+          "value": "negative"
+        },
+        {
+          "value": "indigo"
+        },
+        {
+          "value": "celery"
+        },
+        {
+          "value": "chartreuse"
+        },
+        {
+          "value": "yellow"
+        },
+        {
+          "value": "magenta"
+        },
+        {
+          "value": "fuchsia"
+        },
+        {
+          "value": "purple"
+        },
+        {
+          "value": "seafoam"
+        },
+        {
+          "value": "pink"
+        },
+        {
+          "value": "turquoise"
+        },
+        {
+          "value": "cinnamon"
+        },
+        {
+          "value": "brown"
+        },
+        {
+          "value": "silver"
+        },
+        {
+          "value": "gray"
+        },
+        {
+          "value": "red"
+        },
+        {
+          "value": "orange"
+        },
+        {
+          "value": "green"
+        },
+        {
+          "value": "cyan"
+        }
       ]
     },
     "size": {
       "type": "string",
       "default": "m",
       "values": [
-        { "value": "s" },
-        { "value": "m" },
-        { "value": "l" },
-        { "value": "xl" }
+        {
+          "value": "s"
+        },
+        {
+          "value": "m"
+        },
+        {
+          "value": "l"
+        },
+        {
+          "value": "xl"
+        }
       ]
     }
   },
@@ -105,18 +161,47 @@
     {
       "name": "visual-300",
       "description": "Severity dot, 300 size variant."
+    },
+    {
+      "name": "dot"
     }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "component-height-75", "context": "Height" },
-    { "token": "component-height-100", "context": "Height" },
-    { "token": "component-height-200", "context": "Height" },
-    { "token": "component-height-300", "context": "Height" },
-    { "token": "status-light-dot-size-small", "context": "Dot size" },
-    { "token": "status-light-dot-size-medium", "context": "Dot size" },
-    { "token": "status-light-dot-size-large", "context": "Dot size" },
-    { "token": "status-light-dot-extra-large", "context": "Dot size" },
+    {
+      "token": "component-height-75",
+      "context": "Height"
+    },
+    {
+      "token": "component-height-100",
+      "context": "Height"
+    },
+    {
+      "token": "component-height-200",
+      "context": "Height"
+    },
+    {
+      "token": "component-height-300",
+      "context": "Height"
+    },
+    {
+      "token": "status-light-dot-size-small",
+      "context": "Dot size"
+    },
+    {
+      "token": "status-light-dot-size-medium",
+      "context": "Dot size"
+    },
+    {
+      "token": "status-light-dot-size-large",
+      "context": "Dot size"
+    },
+    {
+      "token": "status-light-dot-extra-large",
+      "context": "Dot size"
+    },
     {
       "token": "status-light-text-to-visual-75",
       "context": "Spacing (dot to label) "
@@ -181,36 +266,128 @@
       "token": "component-bottom-to-text-300",
       "context": "Spacing (top/bottom edge to label)"
     },
-    { "token": "default-font-family", "context": "Label" },
-    { "token": "regular-font-weight", "context": "Label" },
-    { "token": "default-font-style", "context": "Label" },
-    { "token": "font-size-75", "context": "Label" },
-    { "token": "font-size-100", "context": "Label" },
-    { "token": "font-size-200", "context": "Label" },
-    { "token": "font-size-300", "context": "Label" },
-    { "token": "line-height-100", "context": "Label" },
-    { "token": "cjk-line-height-100", "context": "Label" },
-    { "token": "informative-visual-color", "context": "Semantic (Dot) " },
-    { "token": "neutral-visual-color", "context": "Semantic (Dot) " },
-    { "token": "positive-visual-color", "context": "Semantic (Dot) " },
-    { "token": "notice-visual-color", "context": "Semantic (Dot) " },
-    { "token": "negative-visual-color", "context": "Semantic (Dot) " },
-    { "token": "celery-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "chartreuse-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "cyan-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "fuchsia-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "purple-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "magenta-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "indigo-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "seafoam-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "yellow-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "pink-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "turquoise-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "cinnamon-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "brown-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "silver-visual-color", "context": "Non-semantic (Dot)  " },
-    { "token": "gray-600", "context": "Label" },
-    { "token": "neutral-content-color-default", "context": "Label" }
+    {
+      "token": "default-font-family",
+      "context": "Label"
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Label"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-75",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-200",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-300",
+      "context": "Label"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Label"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Label"
+    },
+    {
+      "token": "informative-visual-color",
+      "context": "Semantic (Dot) "
+    },
+    {
+      "token": "neutral-visual-color",
+      "context": "Semantic (Dot) "
+    },
+    {
+      "token": "positive-visual-color",
+      "context": "Semantic (Dot) "
+    },
+    {
+      "token": "notice-visual-color",
+      "context": "Semantic (Dot) "
+    },
+    {
+      "token": "negative-visual-color",
+      "context": "Semantic (Dot) "
+    },
+    {
+      "token": "celery-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "chartreuse-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "cyan-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "fuchsia-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "purple-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "magenta-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "indigo-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "seafoam-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "yellow-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "pink-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "turquoise-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "cinnamon-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "brown-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "silver-visual-color",
+      "context": "Non-semantic (Dot)  "
+    },
+    {
+      "token": "gray-600",
+      "context": "Label"
+    },
+    {
+      "token": "neutral-content-color-default",
+      "context": "Label"
+    }
   ],
-  "accessibility": { "focusable": false }
+  "accessibility": {
+    "focusable": false
+  }
 }

--- a/packages/design-data/components/status-light.json
+++ b/packages/design-data/components/status-light.json
@@ -48,100 +48,44 @@
     }
   ],
   "options": {
-    "label": {
-      "type": "string"
-    },
+    "label": { "type": "string" },
     "variant": {
       "type": "string",
       "default": "informative",
       "values": [
-        {
-          "value": "informative"
-        },
-        {
-          "value": "neutral"
-        },
-        {
-          "value": "positive"
-        },
-        {
-          "value": "notice"
-        },
-        {
-          "value": "negative"
-        },
-        {
-          "value": "indigo"
-        },
-        {
-          "value": "celery"
-        },
-        {
-          "value": "chartreuse"
-        },
-        {
-          "value": "yellow"
-        },
-        {
-          "value": "magenta"
-        },
-        {
-          "value": "fuchsia"
-        },
-        {
-          "value": "purple"
-        },
-        {
-          "value": "seafoam"
-        },
-        {
-          "value": "pink"
-        },
-        {
-          "value": "turquoise"
-        },
-        {
-          "value": "cinnamon"
-        },
-        {
-          "value": "brown"
-        },
-        {
-          "value": "silver"
-        },
-        {
-          "value": "gray"
-        },
-        {
-          "value": "red"
-        },
-        {
-          "value": "orange"
-        },
-        {
-          "value": "green"
-        },
-        {
-          "value": "cyan"
-        }
+        { "value": "informative" },
+        { "value": "neutral" },
+        { "value": "positive" },
+        { "value": "notice" },
+        { "value": "negative" },
+        { "value": "indigo" },
+        { "value": "celery" },
+        { "value": "chartreuse" },
+        { "value": "yellow" },
+        { "value": "magenta" },
+        { "value": "fuchsia" },
+        { "value": "purple" },
+        { "value": "seafoam" },
+        { "value": "pink" },
+        { "value": "turquoise" },
+        { "value": "cinnamon" },
+        { "value": "brown" },
+        { "value": "silver" },
+        { "value": "gray" },
+        { "value": "red" },
+        { "value": "orange" },
+        { "value": "green" },
+        { "value": "cyan" }
       ]
     },
     "size": {
       "type": "string",
       "default": "m",
       "values": [
-        {
-          "value": "s"
-        },
-        {
-          "value": "m"
-        },
-        {
-          "value": "l"
-        },
-        {
-          "value": "xl"
-        }
+        { "value": "s" },
+        { "value": "m" },
+        { "value": "l" },
+        { "value": "xl" }
       ]
     }
   },
@@ -162,46 +106,18 @@
       "name": "visual-300",
       "description": "Severity dot, 300 size variant."
     },
-    {
-      "name": "dot"
-    }
+    { "name": "dot" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "component-height-75",
-      "context": "Height"
-    },
-    {
-      "token": "component-height-100",
-      "context": "Height"
-    },
-    {
-      "token": "component-height-200",
-      "context": "Height"
-    },
-    {
-      "token": "component-height-300",
-      "context": "Height"
-    },
-    {
-      "token": "status-light-dot-size-small",
-      "context": "Dot size"
-    },
-    {
-      "token": "status-light-dot-size-medium",
-      "context": "Dot size"
-    },
-    {
-      "token": "status-light-dot-size-large",
-      "context": "Dot size"
-    },
-    {
-      "token": "status-light-dot-extra-large",
-      "context": "Dot size"
-    },
+    { "token": "component-height-75", "context": "Height" },
+    { "token": "component-height-100", "context": "Height" },
+    { "token": "component-height-200", "context": "Height" },
+    { "token": "component-height-300", "context": "Height" },
+    { "token": "status-light-dot-size-small", "context": "Dot size" },
+    { "token": "status-light-dot-size-medium", "context": "Dot size" },
+    { "token": "status-light-dot-size-large", "context": "Dot size" },
+    { "token": "status-light-dot-extra-large", "context": "Dot size" },
     {
       "token": "status-light-text-to-visual-75",
       "context": "Spacing (dot to label) "
@@ -266,128 +182,36 @@
       "token": "component-bottom-to-text-300",
       "context": "Spacing (top/bottom edge to label)"
     },
-    {
-      "token": "default-font-family",
-      "context": "Label"
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Label"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-75",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-200",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-300",
-      "context": "Label"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Label"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Label"
-    },
-    {
-      "token": "informative-visual-color",
-      "context": "Semantic (Dot) "
-    },
-    {
-      "token": "neutral-visual-color",
-      "context": "Semantic (Dot) "
-    },
-    {
-      "token": "positive-visual-color",
-      "context": "Semantic (Dot) "
-    },
-    {
-      "token": "notice-visual-color",
-      "context": "Semantic (Dot) "
-    },
-    {
-      "token": "negative-visual-color",
-      "context": "Semantic (Dot) "
-    },
-    {
-      "token": "celery-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "chartreuse-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "cyan-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "fuchsia-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "purple-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "magenta-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "indigo-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "seafoam-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "yellow-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "pink-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "turquoise-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "cinnamon-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "brown-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "silver-visual-color",
-      "context": "Non-semantic (Dot)  "
-    },
-    {
-      "token": "gray-600",
-      "context": "Label"
-    },
-    {
-      "token": "neutral-content-color-default",
-      "context": "Label"
-    }
+    { "token": "default-font-family", "context": "Label" },
+    { "token": "regular-font-weight", "context": "Label" },
+    { "token": "default-font-style", "context": "Label" },
+    { "token": "font-size-75", "context": "Label" },
+    { "token": "font-size-100", "context": "Label" },
+    { "token": "font-size-200", "context": "Label" },
+    { "token": "font-size-300", "context": "Label" },
+    { "token": "line-height-100", "context": "Label" },
+    { "token": "cjk-line-height-100", "context": "Label" },
+    { "token": "informative-visual-color", "context": "Semantic (Dot) " },
+    { "token": "neutral-visual-color", "context": "Semantic (Dot) " },
+    { "token": "positive-visual-color", "context": "Semantic (Dot) " },
+    { "token": "notice-visual-color", "context": "Semantic (Dot) " },
+    { "token": "negative-visual-color", "context": "Semantic (Dot) " },
+    { "token": "celery-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "chartreuse-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "cyan-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "fuchsia-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "purple-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "magenta-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "indigo-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "seafoam-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "yellow-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "pink-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "turquoise-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "cinnamon-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "brown-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "silver-visual-color", "context": "Non-semantic (Dot)  " },
+    { "token": "gray-600", "context": "Label" },
+    { "token": "neutral-content-color-default", "context": "Label" }
   ],
-  "accessibility": {
-    "focusable": false
-  }
+  "accessibility": { "focusable": false }
 }

--- a/packages/design-data/components/steplist.json
+++ b/packages/design-data/components/steplist.json
@@ -28,11 +28,11 @@
     },
     {
       "type": "guideline",
-      "content": "By default, steplists are horizontal and should be used for wider layouts or panels to keep the user’s focus moving from left to right. Vertical steplists should be used for more narrow layouts or panels to accommodate more steps without crowding."
+      "content": "By default, steplists are horizontal and should be used for wider layouts or panels to keep the user\u2019s focus moving from left to right. Vertical steplists should be used for more narrow layouts or panels to accommodate more steps without crowding."
     },
     {
       "type": "guideline",
-      "content": "Users can’t click on incomplete steps. The steplist follows a linear flow, requiring completion of the previous step before moving to the next."
+      "content": "Users can\u2019t click on incomplete steps. The steplist follows a linear flow, requiring completion of the previous step before moving to the next."
     },
     {
       "type": "guideline",
@@ -40,7 +40,7 @@
     },
     {
       "type": "guideline",
-      "content": "When a step’s label is long for the available horizontal space, it wraps to form another line."
+      "content": "When a step\u2019s label is long for the available horizontal space, it wraps to form another line."
     },
     {
       "type": "guideline",
@@ -51,7 +51,14 @@
     "orientation": {
       "type": "string",
       "default": "horizontal",
-      "values": [{ "value": "horizontal" }, { "value": "vertical" }]
+      "values": [
+        {
+          "value": "horizontal"
+        },
+        {
+          "value": "vertical"
+        }
+      ]
     },
     "items": {
       "type": "array",
@@ -92,9 +99,14 @@
     {
       "name": "track-size",
       "description": "The connecting track between steps."
+    },
+    {
+      "name": "track"
     }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
     {
       "token": "steplist-step-default-width-small",
@@ -144,16 +156,46 @@
       "token": "steplist-step-to-track-size-extra-large",
       "context": "Spacing (step to track)"
     },
-    { "token": "steplist-bottom-to-text", "context": "Text adjustment" },
-    { "token": "border-width-200", "context": "Visual border" },
-    { "token": "text-to-visual-75", "context": "Spacing (text to visual)" },
-    { "token": "text-to-visual-100", "context": "Spacing (text to visual)" },
-    { "token": "text-to-visual-200", "context": "Spacing (text to visual)" },
-    { "token": "text-to-visual-300", "context": "Spacing (text to visual)" },
-    { "token": "steplist-visual-size-small", "context": "Visual size" },
-    { "token": "steplist-visual-size-medium", "context": "Visual size" },
-    { "token": "steplist-visual-size-large", "context": "Visual size" },
-    { "token": "steplist-visual-size-extra-large", "context": "Visual size" },
+    {
+      "token": "steplist-bottom-to-text",
+      "context": "Text adjustment"
+    },
+    {
+      "token": "border-width-200",
+      "context": "Visual border"
+    },
+    {
+      "token": "text-to-visual-75",
+      "context": "Spacing (text to visual)"
+    },
+    {
+      "token": "text-to-visual-100",
+      "context": "Spacing (text to visual)"
+    },
+    {
+      "token": "text-to-visual-200",
+      "context": "Spacing (text to visual)"
+    },
+    {
+      "token": "text-to-visual-300",
+      "context": "Spacing (text to visual)"
+    },
+    {
+      "token": "steplist-visual-size-small",
+      "context": "Visual size"
+    },
+    {
+      "token": "steplist-visual-size-medium",
+      "context": "Visual size"
+    },
+    {
+      "token": "steplist-visual-size-large",
+      "context": "Visual size"
+    },
+    {
+      "token": "steplist-visual-size-extra-large",
+      "context": "Visual size"
+    },
     {
       "token": "steplist-track-thickness-thickness",
       "context": "Steplist track thickness"
@@ -162,15 +204,30 @@
       "token": "neutral-subdued-content-color-default",
       "context": "Step text"
     },
-    { "token": "neutral-subdued-content-color-hover", "context": "Step text" },
+    {
+      "token": "neutral-subdued-content-color-hover",
+      "context": "Step text"
+    },
     {
       "token": "neutral-subdued-content-color-key-focus",
       "context": "Step text"
     },
-    { "token": "neutral-content-color-default", "context": "Step text" },
-    { "token": "neutral-content-color-key-focus", "context": "Step text" },
-    { "token": "accent-content-color-default", "context": "Step text" },
-    { "token": "accent-content-color-key-focus", "context": "Step text" },
+    {
+      "token": "neutral-content-color-default",
+      "context": "Step text"
+    },
+    {
+      "token": "neutral-content-color-key-focus",
+      "context": "Step text"
+    },
+    {
+      "token": "accent-content-color-default",
+      "context": "Step text"
+    },
+    {
+      "token": "accent-content-color-key-focus",
+      "context": "Step text"
+    },
     {
       "token": "neutral-subdued-background-color-default",
       "context": "Step visual"
@@ -183,34 +240,102 @@
       "token": "neutral-subdued-background-color-key-focus",
       "context": "Step visual"
     },
-    { "token": "neutral-background-color-default", "context": "Step visual" },
-    { "token": "neutral-background-color-key-focus", "context": "Step visual" },
-    { "token": "neutral-visual-color", "context": "Step visual" },
-    { "token": "accent-background-color-default", "context": "Step visual" },
-    { "token": "accent-background-color-key-focus", "context": "Step visual" },
-    { "token": "accent-background-color-hover", "context": "Step visual" },
-    { "token": "gray-25", "context": "Step visual text" },
-    { "token": "white", "context": "Step visual text" },
-    { "token": "accent-visual-color", "context": "Steplist track" },
-    { "token": "disabled-content-color", "context": "Disabled" },
-    { "token": "disabled-background-color", "context": "Disabled" },
-    { "token": "default-font-family", "context": "Label" },
-    { "token": "regular-font-weight", "context": "Label" },
-    { "token": "default-font-style", "context": "Label" },
-    { "token": "font-size-75", "context": "Label" },
-    { "token": "font-size-100", "context": "Label" },
-    { "token": "font-size-200", "context": "Label" },
-    { "token": "font-size-300", "context": "Label" },
-    { "token": "line-height-100", "context": "Label" },
-    { "token": "cjk-line-height-100", "context": "Label" }
+    {
+      "token": "neutral-background-color-default",
+      "context": "Step visual"
+    },
+    {
+      "token": "neutral-background-color-key-focus",
+      "context": "Step visual"
+    },
+    {
+      "token": "neutral-visual-color",
+      "context": "Step visual"
+    },
+    {
+      "token": "accent-background-color-default",
+      "context": "Step visual"
+    },
+    {
+      "token": "accent-background-color-key-focus",
+      "context": "Step visual"
+    },
+    {
+      "token": "accent-background-color-hover",
+      "context": "Step visual"
+    },
+    {
+      "token": "gray-25",
+      "context": "Step visual text"
+    },
+    {
+      "token": "white",
+      "context": "Step visual text"
+    },
+    {
+      "token": "accent-visual-color",
+      "context": "Steplist track"
+    },
+    {
+      "token": "disabled-content-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "disabled-background-color",
+      "context": "Disabled"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Label"
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Label"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-75",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-200",
+      "context": "Label"
+    },
+    {
+      "token": "font-size-300",
+      "context": "Label"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Label"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Label"
+    }
   ],
   "accessibility": {
     "intents": ["navigate"],
     "focusable": true,
     "keyboardIntents": ["navigate-items", "activate"],
     "wcag": [
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/steplist.json
+++ b/packages/design-data/components/steplist.json
@@ -28,11 +28,11 @@
     },
     {
       "type": "guideline",
-      "content": "By default, steplists are horizontal and should be used for wider layouts or panels to keep the user\u2019s focus moving from left to right. Vertical steplists should be used for more narrow layouts or panels to accommodate more steps without crowding."
+      "content": "By default, steplists are horizontal and should be used for wider layouts or panels to keep the user’s focus moving from left to right. Vertical steplists should be used for more narrow layouts or panels to accommodate more steps without crowding."
     },
     {
       "type": "guideline",
-      "content": "Users can\u2019t click on incomplete steps. The steplist follows a linear flow, requiring completion of the previous step before moving to the next."
+      "content": "Users can’t click on incomplete steps. The steplist follows a linear flow, requiring completion of the previous step before moving to the next."
     },
     {
       "type": "guideline",
@@ -40,7 +40,7 @@
     },
     {
       "type": "guideline",
-      "content": "When a step\u2019s label is long for the available horizontal space, it wraps to form another line."
+      "content": "When a step’s label is long for the available horizontal space, it wraps to form another line."
     },
     {
       "type": "guideline",
@@ -51,14 +51,7 @@
     "orientation": {
       "type": "string",
       "default": "horizontal",
-      "values": [
-        {
-          "value": "horizontal"
-        },
-        {
-          "value": "vertical"
-        }
-      ]
+      "values": [{ "value": "horizontal" }, { "value": "vertical" }]
     },
     "items": {
       "type": "array",
@@ -100,13 +93,9 @@
       "name": "track-size",
       "description": "The connecting track between steps."
     },
-    {
-      "name": "track"
-    }
+    { "name": "track" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
     {
       "token": "steplist-step-default-width-small",
@@ -156,46 +145,16 @@
       "token": "steplist-step-to-track-size-extra-large",
       "context": "Spacing (step to track)"
     },
-    {
-      "token": "steplist-bottom-to-text",
-      "context": "Text adjustment"
-    },
-    {
-      "token": "border-width-200",
-      "context": "Visual border"
-    },
-    {
-      "token": "text-to-visual-75",
-      "context": "Spacing (text to visual)"
-    },
-    {
-      "token": "text-to-visual-100",
-      "context": "Spacing (text to visual)"
-    },
-    {
-      "token": "text-to-visual-200",
-      "context": "Spacing (text to visual)"
-    },
-    {
-      "token": "text-to-visual-300",
-      "context": "Spacing (text to visual)"
-    },
-    {
-      "token": "steplist-visual-size-small",
-      "context": "Visual size"
-    },
-    {
-      "token": "steplist-visual-size-medium",
-      "context": "Visual size"
-    },
-    {
-      "token": "steplist-visual-size-large",
-      "context": "Visual size"
-    },
-    {
-      "token": "steplist-visual-size-extra-large",
-      "context": "Visual size"
-    },
+    { "token": "steplist-bottom-to-text", "context": "Text adjustment" },
+    { "token": "border-width-200", "context": "Visual border" },
+    { "token": "text-to-visual-75", "context": "Spacing (text to visual)" },
+    { "token": "text-to-visual-100", "context": "Spacing (text to visual)" },
+    { "token": "text-to-visual-200", "context": "Spacing (text to visual)" },
+    { "token": "text-to-visual-300", "context": "Spacing (text to visual)" },
+    { "token": "steplist-visual-size-small", "context": "Visual size" },
+    { "token": "steplist-visual-size-medium", "context": "Visual size" },
+    { "token": "steplist-visual-size-large", "context": "Visual size" },
+    { "token": "steplist-visual-size-extra-large", "context": "Visual size" },
     {
       "token": "steplist-track-thickness-thickness",
       "context": "Steplist track thickness"
@@ -204,30 +163,15 @@
       "token": "neutral-subdued-content-color-default",
       "context": "Step text"
     },
-    {
-      "token": "neutral-subdued-content-color-hover",
-      "context": "Step text"
-    },
+    { "token": "neutral-subdued-content-color-hover", "context": "Step text" },
     {
       "token": "neutral-subdued-content-color-key-focus",
       "context": "Step text"
     },
-    {
-      "token": "neutral-content-color-default",
-      "context": "Step text"
-    },
-    {
-      "token": "neutral-content-color-key-focus",
-      "context": "Step text"
-    },
-    {
-      "token": "accent-content-color-default",
-      "context": "Step text"
-    },
-    {
-      "token": "accent-content-color-key-focus",
-      "context": "Step text"
-    },
+    { "token": "neutral-content-color-default", "context": "Step text" },
+    { "token": "neutral-content-color-key-focus", "context": "Step text" },
+    { "token": "accent-content-color-default", "context": "Step text" },
+    { "token": "accent-content-color-key-focus", "context": "Step text" },
     {
       "token": "neutral-subdued-background-color-default",
       "context": "Step visual"
@@ -240,102 +184,34 @@
       "token": "neutral-subdued-background-color-key-focus",
       "context": "Step visual"
     },
-    {
-      "token": "neutral-background-color-default",
-      "context": "Step visual"
-    },
-    {
-      "token": "neutral-background-color-key-focus",
-      "context": "Step visual"
-    },
-    {
-      "token": "neutral-visual-color",
-      "context": "Step visual"
-    },
-    {
-      "token": "accent-background-color-default",
-      "context": "Step visual"
-    },
-    {
-      "token": "accent-background-color-key-focus",
-      "context": "Step visual"
-    },
-    {
-      "token": "accent-background-color-hover",
-      "context": "Step visual"
-    },
-    {
-      "token": "gray-25",
-      "context": "Step visual text"
-    },
-    {
-      "token": "white",
-      "context": "Step visual text"
-    },
-    {
-      "token": "accent-visual-color",
-      "context": "Steplist track"
-    },
-    {
-      "token": "disabled-content-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "disabled-background-color",
-      "context": "Disabled"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Label"
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Label"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-75",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-200",
-      "context": "Label"
-    },
-    {
-      "token": "font-size-300",
-      "context": "Label"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Label"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Label"
-    }
+    { "token": "neutral-background-color-default", "context": "Step visual" },
+    { "token": "neutral-background-color-key-focus", "context": "Step visual" },
+    { "token": "neutral-visual-color", "context": "Step visual" },
+    { "token": "accent-background-color-default", "context": "Step visual" },
+    { "token": "accent-background-color-key-focus", "context": "Step visual" },
+    { "token": "accent-background-color-hover", "context": "Step visual" },
+    { "token": "gray-25", "context": "Step visual text" },
+    { "token": "white", "context": "Step visual text" },
+    { "token": "accent-visual-color", "context": "Steplist track" },
+    { "token": "disabled-content-color", "context": "Disabled" },
+    { "token": "disabled-background-color", "context": "Disabled" },
+    { "token": "default-font-family", "context": "Label" },
+    { "token": "regular-font-weight", "context": "Label" },
+    { "token": "default-font-style", "context": "Label" },
+    { "token": "font-size-75", "context": "Label" },
+    { "token": "font-size-100", "context": "Label" },
+    { "token": "font-size-200", "context": "Label" },
+    { "token": "font-size-300", "context": "Label" },
+    { "token": "line-height-100", "context": "Label" },
+    { "token": "cjk-line-height-100", "context": "Label" }
   ],
   "accessibility": {
     "intents": ["navigate"],
     "focusable": true,
     "keyboardIntents": ["navigate-items", "activate"],
     "wcag": [
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/swatch.json
+++ b/packages/design-data/components/swatch.json
@@ -4,7 +4,7 @@
   "specVersion": "1.0.0-draft",
   "name": "swatch",
   "displayName": "Swatch",
-  "description": "A swatch shows a small sample of a fill \u2014 such as a color, gradient, texture, or material \u2014 that is intended to be applied to an object.",
+  "description": "A swatch shows a small sample of a fill — such as a color, gradient, texture, or material — that is intended to be applied to an object.",
   "meta": {
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/page/swatch/"
@@ -12,7 +12,7 @@
   "documentBlocks": [
     {
       "type": "purpose",
-      "content": "A swatch shows a small sample of a fill \u2014 such as a color, gradient, texture, or material \u2014 that is intended to be applied to an object."
+      "content": "A swatch shows a small sample of a fill — such as a color, gradient, texture, or material — that is intended to be applied to an object."
     },
     {
       "type": "guideline",
@@ -24,7 +24,7 @@
     },
     {
       "type": "guideline",
-      "content": "By default, swatches have partial rounding. There are 3 options for a swatch\u2019s rounding: none, partial rounding, and full rounding."
+      "content": "By default, swatches have partial rounding. There are 3 options for a swatch’s rounding: none, partial rounding, and full rounding."
     },
     {
       "type": "guideline",
@@ -52,136 +52,63 @@
       "type": "string",
       "default": "m",
       "values": [
-        {
-          "value": "xs"
-        },
-        {
-          "value": "s"
-        },
-        {
-          "value": "m"
-        },
-        {
-          "value": "l"
-        }
+        { "value": "xs" },
+        { "value": "s" },
+        { "value": "m" },
+        { "value": "l" }
       ]
     },
     "shape": {
       "type": "string",
       "default": "square",
-      "values": [
-        {
-          "value": "square"
-        },
-        {
-          "value": "rectangle"
-        }
-      ]
+      "values": [{ "value": "square" }, { "value": "rectangle" }]
     },
     "cornerRounding": {
       "type": "string",
       "default": "none",
       "description": "Determines the corner radius of the swatch. Partial refers to corner-radius-75.",
       "values": [
-        {
-          "value": "none"
-        },
-        {
-          "value": "partial"
-        },
-        {
-          "value": "full"
-        }
+        { "value": "none" },
+        { "value": "partial" },
+        { "value": "full" }
       ]
     },
-    "isSelected": {
-      "type": "boolean",
-      "default": false
-    },
-    "isDisabled": {
-      "type": "boolean",
-      "default": false
-    }
+    "isSelected": { "type": "boolean", "default": false },
+    "isDisabled": { "type": "boolean", "default": false }
   },
   "anatomy": [
     {
       "name": "slash",
       "description": "Diagonal slash indicating an empty or \"none\" swatch."
     },
-    {
-      "name": "icon"
-    }
+    { "name": "icon" }
   ],
   "states": [
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    },
-    {
-      "name": "disabled",
-      "trigger": "prop"
-    }
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "down", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" },
+    { "name": "disabled", "trigger": "prop" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "swatch-size-extra-small",
-      "context": "Size (square)"
-    },
-    {
-      "token": "swatch-size-small",
-      "context": "Size (square)"
-    },
-    {
-      "token": "swatch-size-medium",
-      "context": "Size (square)"
-    },
-    {
-      "token": "swatch-size-large",
-      "context": "Size (square)"
-    },
+    { "token": "swatch-size-extra-small", "context": "Size (square)" },
+    { "token": "swatch-size-small", "context": "Size (square)" },
+    { "token": "swatch-size-medium", "context": "Size (square)" },
+    { "token": "swatch-size-large", "context": "Size (square)" },
     {
       "token": "swatch-rectangle-width-multiplier",
       "context": "Width (rectangle)"
     },
-    {
-      "token": "corner-radius-75",
-      "context": "Rounding"
-    },
-    {
-      "token": "border-width-100",
-      "context": "Border"
-    },
+    { "token": "corner-radius-75", "context": "Rounding" },
+    { "token": "border-width-100", "context": "Border" },
     {
       "token": "border-width-200",
       "context": "Border and inner border (selected)"
     },
-    {
-      "token": "workflow-icon-size-50",
-      "context": "Disabled icon asset"
-    },
-    {
-      "token": "workflow-icon-size-75",
-      "context": "Disabled icon asset"
-    },
-    {
-      "token": "workflow-icon-size-100",
-      "context": "Disabled icon asset"
-    },
-    {
-      "token": "workflow-icon-size-200",
-      "context": "Disabled icon asset"
-    },
+    { "token": "workflow-icon-size-50", "context": "Disabled icon asset" },
+    { "token": "workflow-icon-size-75", "context": "Disabled icon asset" },
+    { "token": "workflow-icon-size-100", "context": "Disabled icon asset" },
+    { "token": "workflow-icon-size-200", "context": "Disabled icon asset" },
     {
       "token": "swatch-slash-thickness-extra-small",
       "context": "Slash thickness (empty)"
@@ -198,34 +125,13 @@
       "token": "swatch-slash-thickness-large",
       "context": "Slash thickness (empty)"
     },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Focus ring"
-    },
-    {
-      "token": "focus-indicator-gap",
-      "context": "Focus ring"
-    },
-    {
-      "token": "spacing-75",
-      "context": "Spacing (Tooltip to Swatch)"
-    },
-    {
-      "token": "swatch-border-color",
-      "context": "Border"
-    },
-    {
-      "token": "swatch-border-opacity",
-      "context": "Border"
-    },
-    {
-      "token": "gray-1000",
-      "context": "Border and inner border (selected)"
-    },
-    {
-      "token": "gray-25",
-      "context": "Border and inner border (selected)"
-    },
+    { "token": "focus-indicator-thickness", "context": "Focus ring" },
+    { "token": "focus-indicator-gap", "context": "Focus ring" },
+    { "token": "spacing-75", "context": "Spacing (Tooltip to Swatch)" },
+    { "token": "swatch-border-color", "context": "Border" },
+    { "token": "swatch-border-opacity", "context": "Border" },
+    { "token": "gray-1000", "context": "Border and inner border (selected)" },
+    { "token": "gray-25", "context": "Border and inner border (selected)" },
     {
       "token": "swatch-disabled-icon-border-color",
       "context": "Disabled icon"
@@ -234,54 +140,22 @@
       "token": "swatch-disabled-icon-border-opacity",
       "context": "Disabled icon"
     },
-    {
-      "token": "white",
-      "context": "Disabled icon"
-    },
-    {
-      "token": "negative-visual-color",
-      "context": "Slash"
-    },
-    {
-      "token": "neutral-content-color-default",
-      "context": "Dash UI icon"
-    },
-    {
-      "token": "gray-100",
-      "context": "Add \u201cbutton\u201d background"
-    },
-    {
-      "token": "gray-200",
-      "context": "Add \u201cbutton\u201d background"
-    },
-    {
-      "token": "focus-indicator-color",
-      "context": "Focus ring"
-    },
-    {
-      "token": "spacing-50",
-      "context": "Spacing (compact)"
-    },
-    {
-      "token": "spacing-100",
-      "context": "Spacing (spacious)"
-    }
+    { "token": "white", "context": "Disabled icon" },
+    { "token": "negative-visual-color", "context": "Slash" },
+    { "token": "neutral-content-color-default", "context": "Dash UI icon" },
+    { "token": "gray-100", "context": "Add “button” background" },
+    { "token": "gray-200", "context": "Add “button” background" },
+    { "token": "focus-indicator-color", "context": "Focus ring" },
+    { "token": "spacing-50", "context": "Spacing (compact)" },
+    { "token": "spacing-100", "context": "Spacing (spacious)" }
   ],
   "accessibility": {
     "intents": ["choose"],
     "focusable": true,
     "keyboardIntents": ["activate"],
     "wcag": [
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/swatch.json
+++ b/packages/design-data/components/swatch.json
@@ -4,7 +4,7 @@
   "specVersion": "1.0.0-draft",
   "name": "swatch",
   "displayName": "Swatch",
-  "description": "A swatch shows a small sample of a fill — such as a color, gradient, texture, or material — that is intended to be applied to an object.",
+  "description": "A swatch shows a small sample of a fill \u2014 such as a color, gradient, texture, or material \u2014 that is intended to be applied to an object.",
   "meta": {
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/page/swatch/"
@@ -12,7 +12,7 @@
   "documentBlocks": [
     {
       "type": "purpose",
-      "content": "A swatch shows a small sample of a fill — such as a color, gradient, texture, or material — that is intended to be applied to an object."
+      "content": "A swatch shows a small sample of a fill \u2014 such as a color, gradient, texture, or material \u2014 that is intended to be applied to an object."
     },
     {
       "type": "guideline",
@@ -24,7 +24,7 @@
     },
     {
       "type": "guideline",
-      "content": "By default, swatches have partial rounding. There are 3 options for a swatch’s rounding: none, partial rounding, and full rounding."
+      "content": "By default, swatches have partial rounding. There are 3 options for a swatch\u2019s rounding: none, partial rounding, and full rounding."
     },
     {
       "type": "guideline",
@@ -52,61 +52,136 @@
       "type": "string",
       "default": "m",
       "values": [
-        { "value": "xs" },
-        { "value": "s" },
-        { "value": "m" },
-        { "value": "l" }
+        {
+          "value": "xs"
+        },
+        {
+          "value": "s"
+        },
+        {
+          "value": "m"
+        },
+        {
+          "value": "l"
+        }
       ]
     },
     "shape": {
       "type": "string",
       "default": "square",
-      "values": [{ "value": "square" }, { "value": "rectangle" }]
+      "values": [
+        {
+          "value": "square"
+        },
+        {
+          "value": "rectangle"
+        }
+      ]
     },
     "cornerRounding": {
       "type": "string",
       "default": "none",
       "description": "Determines the corner radius of the swatch. Partial refers to corner-radius-75.",
       "values": [
-        { "value": "none" },
-        { "value": "partial" },
-        { "value": "full" }
+        {
+          "value": "none"
+        },
+        {
+          "value": "partial"
+        },
+        {
+          "value": "full"
+        }
       ]
     },
-    "isSelected": { "type": "boolean", "default": false },
-    "isDisabled": { "type": "boolean", "default": false }
+    "isSelected": {
+      "type": "boolean",
+      "default": false
+    },
+    "isDisabled": {
+      "type": "boolean",
+      "default": false
+    }
   },
   "anatomy": [
     {
       "name": "slash",
       "description": "Diagonal slash indicating an empty or \"none\" swatch."
+    },
+    {
+      "name": "icon"
     }
   ],
   "states": [
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "down", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    },
+    {
+      "name": "disabled",
+      "trigger": "prop"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "swatch-size-extra-small", "context": "Size (square)" },
-    { "token": "swatch-size-small", "context": "Size (square)" },
-    { "token": "swatch-size-medium", "context": "Size (square)" },
-    { "token": "swatch-size-large", "context": "Size (square)" },
+    {
+      "token": "swatch-size-extra-small",
+      "context": "Size (square)"
+    },
+    {
+      "token": "swatch-size-small",
+      "context": "Size (square)"
+    },
+    {
+      "token": "swatch-size-medium",
+      "context": "Size (square)"
+    },
+    {
+      "token": "swatch-size-large",
+      "context": "Size (square)"
+    },
     {
       "token": "swatch-rectangle-width-multiplier",
       "context": "Width (rectangle)"
     },
-    { "token": "corner-radius-75", "context": "Rounding" },
-    { "token": "border-width-100", "context": "Border" },
+    {
+      "token": "corner-radius-75",
+      "context": "Rounding"
+    },
+    {
+      "token": "border-width-100",
+      "context": "Border"
+    },
     {
       "token": "border-width-200",
       "context": "Border and inner border (selected)"
     },
-    { "token": "workflow-icon-size-50", "context": "Disabled icon asset" },
-    { "token": "workflow-icon-size-75", "context": "Disabled icon asset" },
-    { "token": "workflow-icon-size-100", "context": "Disabled icon asset" },
-    { "token": "workflow-icon-size-200", "context": "Disabled icon asset" },
+    {
+      "token": "workflow-icon-size-50",
+      "context": "Disabled icon asset"
+    },
+    {
+      "token": "workflow-icon-size-75",
+      "context": "Disabled icon asset"
+    },
+    {
+      "token": "workflow-icon-size-100",
+      "context": "Disabled icon asset"
+    },
+    {
+      "token": "workflow-icon-size-200",
+      "context": "Disabled icon asset"
+    },
     {
       "token": "swatch-slash-thickness-extra-small",
       "context": "Slash thickness (empty)"
@@ -123,13 +198,34 @@
       "token": "swatch-slash-thickness-large",
       "context": "Slash thickness (empty)"
     },
-    { "token": "focus-indicator-thickness", "context": "Focus ring" },
-    { "token": "focus-indicator-gap", "context": "Focus ring" },
-    { "token": "spacing-75", "context": "Spacing (Tooltip to Swatch)" },
-    { "token": "swatch-border-color", "context": "Border" },
-    { "token": "swatch-border-opacity", "context": "Border" },
-    { "token": "gray-1000", "context": "Border and inner border (selected)" },
-    { "token": "gray-25", "context": "Border and inner border (selected)" },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Focus ring"
+    },
+    {
+      "token": "focus-indicator-gap",
+      "context": "Focus ring"
+    },
+    {
+      "token": "spacing-75",
+      "context": "Spacing (Tooltip to Swatch)"
+    },
+    {
+      "token": "swatch-border-color",
+      "context": "Border"
+    },
+    {
+      "token": "swatch-border-opacity",
+      "context": "Border"
+    },
+    {
+      "token": "gray-1000",
+      "context": "Border and inner border (selected)"
+    },
+    {
+      "token": "gray-25",
+      "context": "Border and inner border (selected)"
+    },
     {
       "token": "swatch-disabled-icon-border-color",
       "context": "Disabled icon"
@@ -138,22 +234,54 @@
       "token": "swatch-disabled-icon-border-opacity",
       "context": "Disabled icon"
     },
-    { "token": "white", "context": "Disabled icon" },
-    { "token": "negative-visual-color", "context": "Slash" },
-    { "token": "neutral-content-color-default", "context": "Dash UI icon" },
-    { "token": "gray-100", "context": "Add “button” background" },
-    { "token": "gray-200", "context": "Add “button” background" },
-    { "token": "focus-indicator-color", "context": "Focus ring" },
-    { "token": "spacing-50", "context": "Spacing (compact)" },
-    { "token": "spacing-100", "context": "Spacing (spacious)" }
+    {
+      "token": "white",
+      "context": "Disabled icon"
+    },
+    {
+      "token": "negative-visual-color",
+      "context": "Slash"
+    },
+    {
+      "token": "neutral-content-color-default",
+      "context": "Dash UI icon"
+    },
+    {
+      "token": "gray-100",
+      "context": "Add \u201cbutton\u201d background"
+    },
+    {
+      "token": "gray-200",
+      "context": "Add \u201cbutton\u201d background"
+    },
+    {
+      "token": "focus-indicator-color",
+      "context": "Focus ring"
+    },
+    {
+      "token": "spacing-50",
+      "context": "Spacing (compact)"
+    },
+    {
+      "token": "spacing-100",
+      "context": "Spacing (spacious)"
+    }
   ],
   "accessibility": {
     "intents": ["choose"],
     "focusable": true,
     "keyboardIntents": ["activate"],
     "wcag": [
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/table.json
+++ b/packages/design-data/components/table.json
@@ -22,28 +22,37 @@
       "type": "guideline",
       "content": "Tables come in three sizes: small, medium, and large. Size affects the overall scale, including font size and spacing. Medium is the default. Use large for high-visibility tables or when readability is critical. Use small in constrained spaces or when the table is secondary to other content."
     },
-    { "type": "guideline", "content": "If true, the table header is hidden." },
+    {
+      "type": "guideline",
+      "content": "If true, the table header is hidden."
+    },
     {
       "type": "guideline",
       "content": "Configuration for the table header row."
     },
     {
       "type": "guideline",
-      "content": "Tables come in three densities: compact, regular, and spacious. Density controls vertical spacing while keeping font sizes consistent—compact rows have tighter padding, spacious rows have more breathing room. Regular is the default for most use cases. Use compact when fitting more data in a limited viewport is critical (e.g., dashboards, data-heavy admin panels). Use spacious when scannability and visual comfort are priorities (e.g., transaction histories, settings tables with minimal data)."
+      "content": "Tables come in three densities: compact, regular, and spacious. Density controls vertical spacing while keeping font sizes consistent\u2014compact rows have tighter padding, spacious rows have more breathing room. Regular is the default for most use cases. Use compact when fitting more data in a limited viewport is critical (e.g., dashboards, data-heavy admin panels). Use spacious when scannability and visual comfort are priorities (e.g., transaction histories, settings tables with minimal data)."
     },
     {
       "type": "guideline",
       "content": "Use a standard table when a table is the main focus of an experience. Quiet tables are for when a table is meant to be supplementary, subtle, or lightweight."
     },
-    { "type": "guideline", "content": "If true, table columns can be sorted." },
+    {
+      "type": "guideline",
+      "content": "If true, table columns can be sorted."
+    },
     {
       "type": "guideline",
       "content": "An array of column definitions for the table."
     },
-    { "type": "guideline", "content": "An array of row data for the table." },
     {
       "type": "guideline",
-      "content": "Column dividers help organize table content and aid users in parsing related data. You can apply dividers selectively to group related columns—for example, separating user information from action columns, or grouping metadata fields together. Use dividers sparingly to avoid visual clutter."
+      "content": "An array of row data for the table."
+    },
+    {
+      "type": "guideline",
+      "content": "Column dividers help organize table content and aid users in parsing related data. You can apply dividers selectively to group related columns\u2014for example, separating user information from action columns, or grouping metadata fields together. Use dividers sparingly to avoid visual clutter."
     },
     {
       "type": "guideline",
@@ -79,7 +88,7 @@
     },
     {
       "type": "guideline",
-      "content": "When there are gaps in the data, use an en dash (–) to represent null or not applicable (N/A) values."
+      "content": "When there are gaps in the data, use an en dash (\u2013) to represent null or not applicable (N/A) values."
     }
   ],
   "options": {
@@ -87,7 +96,17 @@
       "type": "string",
       "default": "m",
       "description": "Controls the density of table rows.",
-      "values": [{ "value": "s" }, { "value": "m" }, { "value": "l" }]
+      "values": [
+        {
+          "value": "s"
+        },
+        {
+          "value": "m"
+        },
+        {
+          "value": "l"
+        }
+      ]
     },
     "hideHeader": {
       "type": "boolean",
@@ -116,9 +135,15 @@
       "type": "string",
       "default": "regular",
       "values": [
-        { "value": "compact" },
-        { "value": "regular" },
-        { "value": "spacious" }
+        {
+          "value": "compact"
+        },
+        {
+          "value": "regular"
+        },
+        {
+          "value": "spacious"
+        }
       ]
     },
     "isQuiet": {
@@ -210,16 +235,27 @@
     {
       "name": "header-row-checkbox",
       "description": "Select-all checkbox within the column header row."
+    },
+    {
+      "name": "section-header"
     }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "chevron-100", "context": "Header icons" },
+    {
+      "token": "chevron-100",
+      "context": "Header icons"
+    },
     {
       "token": "corner-radius-medium-size-extra-small",
       "context": "Note: desktop 6px, mobile 6px;"
     },
-    { "token": "component-height-100", "context": "Column header row height" },
+    {
+      "token": "component-height-100",
+      "context": "Column header row height"
+    },
     {
       "token": "table-column-header-row-top-to-text-medium",
       "context": "Spacing (column header row top/bottom to text)"
@@ -312,13 +348,22 @@
       "token": "accent-content-color-selected",
       "context": "Selection indicator"
     },
-    { "token": "border-width-100", "context": "Note: 1px;" },
+    {
+      "token": "border-width-100",
+      "context": "Note: 1px;"
+    },
     {
       "token": "corner-radius-small-default",
       "context": "Focus indicator (cell)"
     },
-    { "token": "side-focus-indicator", "context": "Focus indicator (row)" },
-    { "token": "body-color", "context": "Column header and row (text)" },
+    {
+      "token": "side-focus-indicator",
+      "context": "Focus indicator (row)"
+    },
+    {
+      "token": "body-color",
+      "context": "Column header and row (text)"
+    },
     {
       "token": "neutral-subdued-content-color-default",
       "context": "Row: not selected"
@@ -363,9 +408,18 @@
       "token": "gray-75",
       "context": "Column header and row (background, border and divider)"
     },
-    { "token": "gray-200", "context": "Summary row (background)" },
-    { "token": "gray-100", "context": "Row (disabled)" },
-    { "token": "gray-400", "context": "Row (disabled)" },
+    {
+      "token": "gray-200",
+      "context": "Summary row (background)"
+    },
+    {
+      "token": "gray-100",
+      "context": "Row (disabled)"
+    },
+    {
+      "token": "gray-400",
+      "context": "Row (disabled)"
+    },
     {
       "token": "stack-item-background-color-hover",
       "context": "Row (not selected, hover)"
@@ -398,14 +452,38 @@
       "token": "table-selected-row-background-opacity-highlight-hover",
       "context": "Selected row background (highlight selection, hover)"
     },
-    { "token": "focus-indicator-color", "context": "Focus indicator (cell)" },
-    { "token": "default-font-family", "context": "Column header and row" },
-    { "token": "bold-font-weight", "context": "Column header and row" },
-    { "token": "default-font-style", "context": "Column header and row" },
-    { "token": "font-size-100", "context": "Column header and row" },
-    { "token": "line-height-100", "context": "Column header and row" },
-    { "token": "cjk-line-height-100", "context": "Column header and row" },
-    { "token": "regular-font-weight", "context": "Column header and row" },
+    {
+      "token": "focus-indicator-color",
+      "context": "Focus indicator (cell)"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Column header and row"
+    },
+    {
+      "token": "bold-font-weight",
+      "context": "Column header and row"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Column header and row"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Column header and row"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Column header and row"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Column header and row"
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Column header and row"
+    },
     {
       "token": "table-row-hover-color;",
       "context": "S1 Row (not selected, hover)"
@@ -441,9 +519,21 @@
     "focusable": true,
     "keyboardIntents": ["navigate-items", "activate", "select-all"],
     "wcag": [
-      { "criterion": "1.3.1", "level": "A", "title": "Info and Relationships" },
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "1.3.1",
+        "level": "A",
+        "title": "Info and Relationships"
+      },
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/table.json
+++ b/packages/design-data/components/table.json
@@ -22,37 +22,28 @@
       "type": "guideline",
       "content": "Tables come in three sizes: small, medium, and large. Size affects the overall scale, including font size and spacing. Medium is the default. Use large for high-visibility tables or when readability is critical. Use small in constrained spaces or when the table is secondary to other content."
     },
-    {
-      "type": "guideline",
-      "content": "If true, the table header is hidden."
-    },
+    { "type": "guideline", "content": "If true, the table header is hidden." },
     {
       "type": "guideline",
       "content": "Configuration for the table header row."
     },
     {
       "type": "guideline",
-      "content": "Tables come in three densities: compact, regular, and spacious. Density controls vertical spacing while keeping font sizes consistent\u2014compact rows have tighter padding, spacious rows have more breathing room. Regular is the default for most use cases. Use compact when fitting more data in a limited viewport is critical (e.g., dashboards, data-heavy admin panels). Use spacious when scannability and visual comfort are priorities (e.g., transaction histories, settings tables with minimal data)."
+      "content": "Tables come in three densities: compact, regular, and spacious. Density controls vertical spacing while keeping font sizes consistent—compact rows have tighter padding, spacious rows have more breathing room. Regular is the default for most use cases. Use compact when fitting more data in a limited viewport is critical (e.g., dashboards, data-heavy admin panels). Use spacious when scannability and visual comfort are priorities (e.g., transaction histories, settings tables with minimal data)."
     },
     {
       "type": "guideline",
       "content": "Use a standard table when a table is the main focus of an experience. Quiet tables are for when a table is meant to be supplementary, subtle, or lightweight."
     },
-    {
-      "type": "guideline",
-      "content": "If true, table columns can be sorted."
-    },
+    { "type": "guideline", "content": "If true, table columns can be sorted." },
     {
       "type": "guideline",
       "content": "An array of column definitions for the table."
     },
+    { "type": "guideline", "content": "An array of row data for the table." },
     {
       "type": "guideline",
-      "content": "An array of row data for the table."
-    },
-    {
-      "type": "guideline",
-      "content": "Column dividers help organize table content and aid users in parsing related data. You can apply dividers selectively to group related columns\u2014for example, separating user information from action columns, or grouping metadata fields together. Use dividers sparingly to avoid visual clutter."
+      "content": "Column dividers help organize table content and aid users in parsing related data. You can apply dividers selectively to group related columns—for example, separating user information from action columns, or grouping metadata fields together. Use dividers sparingly to avoid visual clutter."
     },
     {
       "type": "guideline",
@@ -88,7 +79,7 @@
     },
     {
       "type": "guideline",
-      "content": "When there are gaps in the data, use an en dash (\u2013) to represent null or not applicable (N/A) values."
+      "content": "When there are gaps in the data, use an en dash (–) to represent null or not applicable (N/A) values."
     }
   ],
   "options": {
@@ -96,17 +87,7 @@
       "type": "string",
       "default": "m",
       "description": "Controls the density of table rows.",
-      "values": [
-        {
-          "value": "s"
-        },
-        {
-          "value": "m"
-        },
-        {
-          "value": "l"
-        }
-      ]
+      "values": [{ "value": "s" }, { "value": "m" }, { "value": "l" }]
     },
     "hideHeader": {
       "type": "boolean",
@@ -135,15 +116,9 @@
       "type": "string",
       "default": "regular",
       "values": [
-        {
-          "value": "compact"
-        },
-        {
-          "value": "regular"
-        },
-        {
-          "value": "spacious"
-        }
+        { "value": "compact" },
+        { "value": "regular" },
+        { "value": "spacious" }
       ]
     },
     "isQuiet": {
@@ -236,26 +211,16 @@
       "name": "header-row-checkbox",
       "description": "Select-all checkbox within the column header row."
     },
-    {
-      "name": "section-header"
-    }
+    { "name": "section-header" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "chevron-100",
-      "context": "Header icons"
-    },
+    { "token": "chevron-100", "context": "Header icons" },
     {
       "token": "corner-radius-medium-size-extra-small",
       "context": "Note: desktop 6px, mobile 6px;"
     },
-    {
-      "token": "component-height-100",
-      "context": "Column header row height"
-    },
+    { "token": "component-height-100", "context": "Column header row height" },
     {
       "token": "table-column-header-row-top-to-text-medium",
       "context": "Spacing (column header row top/bottom to text)"
@@ -348,22 +313,13 @@
       "token": "accent-content-color-selected",
       "context": "Selection indicator"
     },
-    {
-      "token": "border-width-100",
-      "context": "Note: 1px;"
-    },
+    { "token": "border-width-100", "context": "Note: 1px;" },
     {
       "token": "corner-radius-small-default",
       "context": "Focus indicator (cell)"
     },
-    {
-      "token": "side-focus-indicator",
-      "context": "Focus indicator (row)"
-    },
-    {
-      "token": "body-color",
-      "context": "Column header and row (text)"
-    },
+    { "token": "side-focus-indicator", "context": "Focus indicator (row)" },
+    { "token": "body-color", "context": "Column header and row (text)" },
     {
       "token": "neutral-subdued-content-color-default",
       "context": "Row: not selected"
@@ -408,18 +364,9 @@
       "token": "gray-75",
       "context": "Column header and row (background, border and divider)"
     },
-    {
-      "token": "gray-200",
-      "context": "Summary row (background)"
-    },
-    {
-      "token": "gray-100",
-      "context": "Row (disabled)"
-    },
-    {
-      "token": "gray-400",
-      "context": "Row (disabled)"
-    },
+    { "token": "gray-200", "context": "Summary row (background)" },
+    { "token": "gray-100", "context": "Row (disabled)" },
+    { "token": "gray-400", "context": "Row (disabled)" },
     {
       "token": "stack-item-background-color-hover",
       "context": "Row (not selected, hover)"
@@ -452,38 +399,14 @@
       "token": "table-selected-row-background-opacity-highlight-hover",
       "context": "Selected row background (highlight selection, hover)"
     },
-    {
-      "token": "focus-indicator-color",
-      "context": "Focus indicator (cell)"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Column header and row"
-    },
-    {
-      "token": "bold-font-weight",
-      "context": "Column header and row"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Column header and row"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Column header and row"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Column header and row"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Column header and row"
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Column header and row"
-    },
+    { "token": "focus-indicator-color", "context": "Focus indicator (cell)" },
+    { "token": "default-font-family", "context": "Column header and row" },
+    { "token": "bold-font-weight", "context": "Column header and row" },
+    { "token": "default-font-style", "context": "Column header and row" },
+    { "token": "font-size-100", "context": "Column header and row" },
+    { "token": "line-height-100", "context": "Column header and row" },
+    { "token": "cjk-line-height-100", "context": "Column header and row" },
+    { "token": "regular-font-weight", "context": "Column header and row" },
     {
       "token": "table-row-hover-color;",
       "context": "S1 Row (not selected, hover)"
@@ -519,21 +442,9 @@
     "focusable": true,
     "keyboardIntents": ["navigate-items", "activate", "select-all"],
     "wcag": [
-      {
-        "criterion": "1.3.1",
-        "level": "A",
-        "title": "Info and Relationships"
-      },
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "1.3.1", "level": "A", "title": "Info and Relationships" },
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/time-field.json
+++ b/packages/design-data/components/time-field.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/time-field.json",
+  "specVersion": "1.0.0-draft",
+  "name": "time-field",
+  "displayName": "Time field",
+  "description": "A field for entering a time value.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/time-field.json
+++ b/packages/design-data/components/time-field.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/tree-view.json
+++ b/packages/design-data/components/tree-view.json
@@ -72,11 +72,11 @@
     },
     {
       "type": "guideline",
-      "content": "The root (topmost) level of the hierarchy does not always need to be shown or displayed as a tree view item. If the root provides no useful context, hide it or replace it with a section header. In cases such as mixed tree views, the root can serve as a “Back” button."
+      "content": "The root (topmost) level of the hierarchy does not always need to be shown or displayed as a tree view item. If the root provides no useful context, hide it or replace it with a section header. In cases such as mixed tree views, the root can serve as a \u201cBack\u201d button."
     },
     {
       "type": "guideline",
-      "content": "In some cases, users may need to view different hierarchies depending on context. To support this, let users drill into a tree view item to display a different variation of the tree view within the same panel. Use a navigation controller with a “Back” button to let users return to the previous view."
+      "content": "In some cases, users may need to view different hierarchies depending on context. To support this, let users drill into a tree view item to display a different variation of the tree view within the same panel. Use a navigation controller with a \u201cBack\u201d button to let users return to the previous view."
     },
     {
       "type": "guideline",
@@ -104,7 +104,7 @@
     },
     {
       "type": "guideline",
-      "content": "When tree views are very large, use a progress circle or a “Show more” control to reveal additional parts when contextually relevant. These loading patterns can apply to the entire tree view or to nested items."
+      "content": "When tree views are very large, use a progress circle or a \u201cShow more\u201d control to reveal additional parts when contextually relevant. These loading patterns can apply to the entire tree view or to nested items."
     },
     {
       "type": "guideline",
@@ -120,7 +120,7 @@
     },
     {
       "type": "guideline",
-      "content": "Any action for modifying the hierarchy should be offered as an explicit control and, if needed, as a keyboard shortcut — but never as a shortcut alone."
+      "content": "Any action for modifying the hierarchy should be offered as an explicit control and, if needed, as a keyboard shortcut \u2014 but never as a shortcut alone."
     },
     {
       "type": "guideline",
@@ -132,7 +132,7 @@
     },
     {
       "type": "guideline",
-      "content": "When you need to provide selection controls within a hierarchy, use a checkbox component instead of the tree view item’s label. This should not correspond to selecting specific content and works best for cases like categorized filtering."
+      "content": "When you need to provide selection controls within a hierarchy, use a checkbox component instead of the tree view item\u2019s label. This should not correspond to selecting specific content and works best for cases like categorized filtering."
     }
   ],
   "options": {
@@ -140,49 +140,128 @@
       "type": "string",
       "default": "m",
       "values": [
-        { "value": "s" },
-        { "value": "m" },
-        { "value": "l" },
-        { "value": "xl" }
+        {
+          "value": "s"
+        },
+        {
+          "value": "m"
+        },
+        {
+          "value": "l"
+        },
+        {
+          "value": "xl"
+        }
       ]
     },
-    "isDetached": { "type": "boolean", "default": false },
-    "isEmphasized": { "type": "boolean", "default": false },
-    "showDragIcon": { "type": "boolean", "default": false },
+    "isDetached": {
+      "type": "boolean",
+      "default": false
+    },
+    "isEmphasized": {
+      "type": "boolean",
+      "default": false
+    },
+    "showDragIcon": {
+      "type": "boolean",
+      "default": false
+    },
     "selectionMode": {
       "type": "string",
       "default": "multiple",
-      "values": [{ "value": "single" }, { "value": "multiple" }]
+      "values": [
+        {
+          "value": "single"
+        },
+        {
+          "value": "multiple"
+        }
+      ]
     },
     "selectionStyle": {
       "type": "string",
       "default": "checkbox",
-      "values": [{ "value": "checkbox" }, { "value": "highlight" }]
+      "values": [
+        {
+          "value": "checkbox"
+        },
+        {
+          "value": "highlight"
+        }
+      ]
     },
     "selectionBehavior": {
       "type": "string",
       "default": "toggle",
-      "values": [{ "value": "toggle" }, { "value": "replace" }]
+      "values": [
+        {
+          "value": "toggle"
+        },
+        {
+          "value": "replace"
+        }
+      ]
     }
   },
   "anatomy": [
     {
       "name": "action-area",
       "description": "Trailing area containing item actions."
+    },
+    {
+      "name": "row"
     }
   ],
   "states": [
-    { "name": "default", "description": "Resting base state." },
-    { "name": "hover", "trigger": "interaction" },
-    { "name": "down", "trigger": "interaction" },
-    { "name": "keyboard-focus", "trigger": "interaction" }
+    {
+      "name": "default",
+      "description": "Resting base state."
+    },
+    {
+      "name": "hover",
+      "trigger": "interaction"
+    },
+    {
+      "name": "down",
+      "trigger": "interaction"
+    },
+    {
+      "name": "keyboard-focus",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected-default",
+      "trigger": "interaction"
+    },
+    {
+      "name": "selected-hover",
+      "trigger": "interaction"
+    }
   ],
-  "lifecycle": { "introduced": "1.0.0-draft" },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  },
   "tokenBindings": [
-    { "token": "workflow-icon-size-100", "context": "Icon" },
-    { "token": "tree-view-minimum-height", "context": "Height (minimum)" },
-    { "token": "tree-view-minimum-width", "context": "Width (minimum)" },
-    { "token": "corner-radius-medium-default", "context": "Rounding" },
+    {
+      "token": "workflow-icon-size-100",
+      "context": "Icon"
+    },
+    {
+      "token": "tree-view-minimum-height",
+      "context": "Height (minimum)"
+    },
+    {
+      "token": "tree-view-minimum-width",
+      "context": "Width (minimum)"
+    },
+    {
+      "token": "corner-radius-medium-default",
+      "context": "Rounding"
+    },
     {
       "token": "tree-view-disclosure-indicator-height",
       "context": "Spacing (disclosure indicator)"
@@ -223,7 +302,10 @@
       "token": "tree-view-level-increment",
       "context": "Spacing (indentation)"
     },
-    { "token": "vertical-align-items", "context": "Spacing (vertical)" },
+    {
+      "token": "vertical-align-items",
+      "context": "Spacing (vertical)"
+    },
     {
       "token": "stack-item-minimum-padding-vertical",
       "context": "Spacing (vertical)"
@@ -232,9 +314,18 @@
       "token": "border-width-100",
       "context": "Border width (selected, highlight)"
     },
-    { "token": "focus-indicator-thickness", "context": "Focus " },
-    { "token": "focus-indicator-gap", "context": "Focus (drag handle)" },
-    { "token": "component-height-200", "context": "Height" },
+    {
+      "token": "focus-indicator-thickness",
+      "context": "Focus "
+    },
+    {
+      "token": "focus-indicator-gap",
+      "context": "Focus (drag handle)"
+    },
+    {
+      "token": "component-height-200",
+      "context": "Height"
+    },
     {
       "token": "stack-item-minimum-vertical-padding",
       "context": "Spacing (vertical)"
@@ -347,24 +438,78 @@
       "token": "disabled-content-color",
       "context": "Label and icon (disabled)"
     },
-    { "token": "focus-indicator-color", "context": "Focus indicator" },
-    { "token": "title-content-color", "context": "Label and icon" },
-    { "token": "default-font-family", "context": "Text (tree view item)" },
-    { "token": "regular-font-weight", "context": "Text (tree view item)" },
-    { "token": "default-font-style", "context": "Text (tree view item)" },
-    { "token": "font-size-100", "context": "Text (tree view item)" },
-    { "token": "line-height-100", "context": "Text (tree view item)" },
-    { "token": "cjk-line-height-100", "context": "Text (tree view item)" },
-    { "token": "bold-font-weight", "context": "Text (tree view title)" },
-    { "token": "thumbnail-size-75", "context": "Size" },
-    { "token": "thumbnail-size-300", "context": "Size" },
-    { "token": "thumbnail-size-1000", "context": "Size" },
-    { "token": "thumbnail-corner-radius", "context": "Rounding (default)" },
-    { "token": "spacing-75", "context": "Opacity checkerboard (layer)" },
-    { "token": "corner-radius-0", "context": "Rounding (layer)" },
-    { "token": "thumbnail-border-color", "context": "Border (default)" },
-    { "token": "thumbnail-border-opacity", "context": "Border (default)" },
-    { "token": "gray-500", "context": "Border (layer)" },
+    {
+      "token": "focus-indicator-color",
+      "context": "Focus indicator"
+    },
+    {
+      "token": "title-content-color",
+      "context": "Label and icon"
+    },
+    {
+      "token": "default-font-family",
+      "context": "Text (tree view item)"
+    },
+    {
+      "token": "regular-font-weight",
+      "context": "Text (tree view item)"
+    },
+    {
+      "token": "default-font-style",
+      "context": "Text (tree view item)"
+    },
+    {
+      "token": "font-size-100",
+      "context": "Text (tree view item)"
+    },
+    {
+      "token": "line-height-100",
+      "context": "Text (tree view item)"
+    },
+    {
+      "token": "cjk-line-height-100",
+      "context": "Text (tree view item)"
+    },
+    {
+      "token": "bold-font-weight",
+      "context": "Text (tree view title)"
+    },
+    {
+      "token": "thumbnail-size-75",
+      "context": "Size"
+    },
+    {
+      "token": "thumbnail-size-300",
+      "context": "Size"
+    },
+    {
+      "token": "thumbnail-size-1000",
+      "context": "Size"
+    },
+    {
+      "token": "thumbnail-corner-radius",
+      "context": "Rounding (default)"
+    },
+    {
+      "token": "spacing-75",
+      "context": "Opacity checkerboard (layer)"
+    },
+    {
+      "token": "corner-radius-0",
+      "context": "Rounding (layer)"
+    },
+    {
+      "token": "thumbnail-border-color",
+      "context": "Border (default)"
+    },
+    {
+      "token": "thumbnail-border-opacity",
+      "context": "Border (default)"
+    },
+    {
+      "token": "gray-500",
+      "context": "Border (layer)"
+    },
     {
       "token": "opacity-checkerboard-square-light",
       "context": "Checkerboard colors "
@@ -373,7 +518,10 @@
       "token": "opacity-checkerboard-square-dark",
       "context": "Checkerboard colors "
     },
-    { "token": "thumbnail-opacity-disabled", "context": "Disabled" }
+    {
+      "token": "thumbnail-opacity-disabled",
+      "context": "Disabled"
+    }
   ],
   "accessibility": {
     "role": "tree",
@@ -381,8 +529,16 @@
     "focusable": true,
     "keyboardIntents": ["navigate-items", "expand", "collapse", "activate"],
     "wcag": [
-      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
-      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
+      {
+        "criterion": "2.1.1",
+        "level": "A",
+        "title": "Keyboard"
+      },
+      {
+        "criterion": "4.1.2",
+        "level": "A",
+        "title": "Name, Role, Value"
+      }
     ]
   }
 }

--- a/packages/design-data/components/tree-view.json
+++ b/packages/design-data/components/tree-view.json
@@ -72,11 +72,11 @@
     },
     {
       "type": "guideline",
-      "content": "The root (topmost) level of the hierarchy does not always need to be shown or displayed as a tree view item. If the root provides no useful context, hide it or replace it with a section header. In cases such as mixed tree views, the root can serve as a \u201cBack\u201d button."
+      "content": "The root (topmost) level of the hierarchy does not always need to be shown or displayed as a tree view item. If the root provides no useful context, hide it or replace it with a section header. In cases such as mixed tree views, the root can serve as a “Back” button."
     },
     {
       "type": "guideline",
-      "content": "In some cases, users may need to view different hierarchies depending on context. To support this, let users drill into a tree view item to display a different variation of the tree view within the same panel. Use a navigation controller with a \u201cBack\u201d button to let users return to the previous view."
+      "content": "In some cases, users may need to view different hierarchies depending on context. To support this, let users drill into a tree view item to display a different variation of the tree view within the same panel. Use a navigation controller with a “Back” button to let users return to the previous view."
     },
     {
       "type": "guideline",
@@ -104,7 +104,7 @@
     },
     {
       "type": "guideline",
-      "content": "When tree views are very large, use a progress circle or a \u201cShow more\u201d control to reveal additional parts when contextually relevant. These loading patterns can apply to the entire tree view or to nested items."
+      "content": "When tree views are very large, use a progress circle or a “Show more” control to reveal additional parts when contextually relevant. These loading patterns can apply to the entire tree view or to nested items."
     },
     {
       "type": "guideline",
@@ -120,7 +120,7 @@
     },
     {
       "type": "guideline",
-      "content": "Any action for modifying the hierarchy should be offered as an explicit control and, if needed, as a keyboard shortcut \u2014 but never as a shortcut alone."
+      "content": "Any action for modifying the hierarchy should be offered as an explicit control and, if needed, as a keyboard shortcut — but never as a shortcut alone."
     },
     {
       "type": "guideline",
@@ -132,7 +132,7 @@
     },
     {
       "type": "guideline",
-      "content": "When you need to provide selection controls within a hierarchy, use a checkbox component instead of the tree view item\u2019s label. This should not correspond to selecting specific content and works best for cases like categorized filtering."
+      "content": "When you need to provide selection controls within a hierarchy, use a checkbox component instead of the tree view item’s label. This should not correspond to selecting specific content and works best for cases like categorized filtering."
     }
   ],
   "options": {
@@ -140,67 +140,29 @@
       "type": "string",
       "default": "m",
       "values": [
-        {
-          "value": "s"
-        },
-        {
-          "value": "m"
-        },
-        {
-          "value": "l"
-        },
-        {
-          "value": "xl"
-        }
+        { "value": "s" },
+        { "value": "m" },
+        { "value": "l" },
+        { "value": "xl" }
       ]
     },
-    "isDetached": {
-      "type": "boolean",
-      "default": false
-    },
-    "isEmphasized": {
-      "type": "boolean",
-      "default": false
-    },
-    "showDragIcon": {
-      "type": "boolean",
-      "default": false
-    },
+    "isDetached": { "type": "boolean", "default": false },
+    "isEmphasized": { "type": "boolean", "default": false },
+    "showDragIcon": { "type": "boolean", "default": false },
     "selectionMode": {
       "type": "string",
       "default": "multiple",
-      "values": [
-        {
-          "value": "single"
-        },
-        {
-          "value": "multiple"
-        }
-      ]
+      "values": [{ "value": "single" }, { "value": "multiple" }]
     },
     "selectionStyle": {
       "type": "string",
       "default": "checkbox",
-      "values": [
-        {
-          "value": "checkbox"
-        },
-        {
-          "value": "highlight"
-        }
-      ]
+      "values": [{ "value": "checkbox" }, { "value": "highlight" }]
     },
     "selectionBehavior": {
       "type": "string",
       "default": "toggle",
-      "values": [
-        {
-          "value": "toggle"
-        },
-        {
-          "value": "replace"
-        }
-      ]
+      "values": [{ "value": "toggle" }, { "value": "replace" }]
     }
   },
   "anatomy": [
@@ -208,60 +170,23 @@
       "name": "action-area",
       "description": "Trailing area containing item actions."
     },
-    {
-      "name": "row"
-    }
+    { "name": "row" }
   ],
   "states": [
-    {
-      "name": "default",
-      "description": "Resting base state."
-    },
-    {
-      "name": "hover",
-      "trigger": "interaction"
-    },
-    {
-      "name": "down",
-      "trigger": "interaction"
-    },
-    {
-      "name": "keyboard-focus",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected-default",
-      "trigger": "interaction"
-    },
-    {
-      "name": "selected-hover",
-      "trigger": "interaction"
-    }
+    { "name": "default", "description": "Resting base state." },
+    { "name": "hover", "trigger": "interaction" },
+    { "name": "down", "trigger": "interaction" },
+    { "name": "keyboard-focus", "trigger": "interaction" },
+    { "name": "selected", "trigger": "interaction" },
+    { "name": "selected-default", "trigger": "interaction" },
+    { "name": "selected-hover", "trigger": "interaction" }
   ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  },
+  "lifecycle": { "introduced": "1.0.0-draft" },
   "tokenBindings": [
-    {
-      "token": "workflow-icon-size-100",
-      "context": "Icon"
-    },
-    {
-      "token": "tree-view-minimum-height",
-      "context": "Height (minimum)"
-    },
-    {
-      "token": "tree-view-minimum-width",
-      "context": "Width (minimum)"
-    },
-    {
-      "token": "corner-radius-medium-default",
-      "context": "Rounding"
-    },
+    { "token": "workflow-icon-size-100", "context": "Icon" },
+    { "token": "tree-view-minimum-height", "context": "Height (minimum)" },
+    { "token": "tree-view-minimum-width", "context": "Width (minimum)" },
+    { "token": "corner-radius-medium-default", "context": "Rounding" },
     {
       "token": "tree-view-disclosure-indicator-height",
       "context": "Spacing (disclosure indicator)"
@@ -302,10 +227,7 @@
       "token": "tree-view-level-increment",
       "context": "Spacing (indentation)"
     },
-    {
-      "token": "vertical-align-items",
-      "context": "Spacing (vertical)"
-    },
+    { "token": "vertical-align-items", "context": "Spacing (vertical)" },
     {
       "token": "stack-item-minimum-padding-vertical",
       "context": "Spacing (vertical)"
@@ -314,18 +236,9 @@
       "token": "border-width-100",
       "context": "Border width (selected, highlight)"
     },
-    {
-      "token": "focus-indicator-thickness",
-      "context": "Focus "
-    },
-    {
-      "token": "focus-indicator-gap",
-      "context": "Focus (drag handle)"
-    },
-    {
-      "token": "component-height-200",
-      "context": "Height"
-    },
+    { "token": "focus-indicator-thickness", "context": "Focus " },
+    { "token": "focus-indicator-gap", "context": "Focus (drag handle)" },
+    { "token": "component-height-200", "context": "Height" },
     {
       "token": "stack-item-minimum-vertical-padding",
       "context": "Spacing (vertical)"
@@ -438,78 +351,24 @@
       "token": "disabled-content-color",
       "context": "Label and icon (disabled)"
     },
-    {
-      "token": "focus-indicator-color",
-      "context": "Focus indicator"
-    },
-    {
-      "token": "title-content-color",
-      "context": "Label and icon"
-    },
-    {
-      "token": "default-font-family",
-      "context": "Text (tree view item)"
-    },
-    {
-      "token": "regular-font-weight",
-      "context": "Text (tree view item)"
-    },
-    {
-      "token": "default-font-style",
-      "context": "Text (tree view item)"
-    },
-    {
-      "token": "font-size-100",
-      "context": "Text (tree view item)"
-    },
-    {
-      "token": "line-height-100",
-      "context": "Text (tree view item)"
-    },
-    {
-      "token": "cjk-line-height-100",
-      "context": "Text (tree view item)"
-    },
-    {
-      "token": "bold-font-weight",
-      "context": "Text (tree view title)"
-    },
-    {
-      "token": "thumbnail-size-75",
-      "context": "Size"
-    },
-    {
-      "token": "thumbnail-size-300",
-      "context": "Size"
-    },
-    {
-      "token": "thumbnail-size-1000",
-      "context": "Size"
-    },
-    {
-      "token": "thumbnail-corner-radius",
-      "context": "Rounding (default)"
-    },
-    {
-      "token": "spacing-75",
-      "context": "Opacity checkerboard (layer)"
-    },
-    {
-      "token": "corner-radius-0",
-      "context": "Rounding (layer)"
-    },
-    {
-      "token": "thumbnail-border-color",
-      "context": "Border (default)"
-    },
-    {
-      "token": "thumbnail-border-opacity",
-      "context": "Border (default)"
-    },
-    {
-      "token": "gray-500",
-      "context": "Border (layer)"
-    },
+    { "token": "focus-indicator-color", "context": "Focus indicator" },
+    { "token": "title-content-color", "context": "Label and icon" },
+    { "token": "default-font-family", "context": "Text (tree view item)" },
+    { "token": "regular-font-weight", "context": "Text (tree view item)" },
+    { "token": "default-font-style", "context": "Text (tree view item)" },
+    { "token": "font-size-100", "context": "Text (tree view item)" },
+    { "token": "line-height-100", "context": "Text (tree view item)" },
+    { "token": "cjk-line-height-100", "context": "Text (tree view item)" },
+    { "token": "bold-font-weight", "context": "Text (tree view title)" },
+    { "token": "thumbnail-size-75", "context": "Size" },
+    { "token": "thumbnail-size-300", "context": "Size" },
+    { "token": "thumbnail-size-1000", "context": "Size" },
+    { "token": "thumbnail-corner-radius", "context": "Rounding (default)" },
+    { "token": "spacing-75", "context": "Opacity checkerboard (layer)" },
+    { "token": "corner-radius-0", "context": "Rounding (layer)" },
+    { "token": "thumbnail-border-color", "context": "Border (default)" },
+    { "token": "thumbnail-border-opacity", "context": "Border (default)" },
+    { "token": "gray-500", "context": "Border (layer)" },
     {
       "token": "opacity-checkerboard-square-light",
       "context": "Checkerboard colors "
@@ -518,10 +377,7 @@
       "token": "opacity-checkerboard-square-dark",
       "context": "Checkerboard colors "
     },
-    {
-      "token": "thumbnail-opacity-disabled",
-      "context": "Disabled"
-    }
+    { "token": "thumbnail-opacity-disabled", "context": "Disabled" }
   ],
   "accessibility": {
     "role": "tree",
@@ -529,16 +385,8 @@
     "focusable": true,
     "keyboardIntents": ["navigate-items", "expand", "collapse", "activate"],
     "wcag": [
-      {
-        "criterion": "2.1.1",
-        "level": "A",
-        "title": "Keyboard"
-      },
-      {
-        "criterion": "4.1.2",
-        "level": "A",
-        "title": "Name, Role, Value"
-      }
+      { "criterion": "2.1.1", "level": "A", "title": "Keyboard" },
+      { "criterion": "4.1.2", "level": "A", "title": "Name, Role, Value" }
     ]
   }
 }

--- a/packages/design-data/components/triple-calendar.json
+++ b/packages/design-data/components/triple-calendar.json
@@ -9,7 +9,5 @@
     "category": "inputs",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/triple-calendar.json
+++ b/packages/design-data/components/triple-calendar.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/triple-calendar.json",
+  "specVersion": "1.0.0-draft",
+  "name": "triple-calendar",
+  "displayName": "Triple calendar",
+  "description": "A date-picker calendar variant displaying three consecutive months.",
+  "meta": {
+    "category": "inputs",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/components/user-card.json
+++ b/packages/design-data/components/user-card.json
@@ -9,12 +9,6 @@
     "category": "containers",
     "documentationUrl": "https://spectrum.adobe.com/"
   },
-  "anatomy": [
-    {
-      "name": "title"
-    }
-  ],
-  "lifecycle": {
-    "introduced": "1.0.0-draft"
-  }
+  "anatomy": [{ "name": "title" }],
+  "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/user-card.json
+++ b/packages/design-data/components/user-card.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/component.schema.json",
+  "$id": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/components/user-card.json",
+  "specVersion": "1.0.0-draft",
+  "name": "user-card",
+  "displayName": "User card",
+  "description": "A card variant surfacing a user's identity (avatar, name) alongside supporting content.",
+  "meta": {
+    "category": "containers",
+    "documentationUrl": "https://spectrum.adobe.com/"
+  },
+  "anatomy": [
+    {
+      "name": "title"
+    }
+  ],
+  "lifecycle": {
+    "introduced": "1.0.0-draft"
+  }
+}

--- a/packages/design-data/moon.yml
+++ b/packages/design-data/moon.yml
@@ -100,7 +100,7 @@ tasks:
   # instead of silently no-op'ing (see bead spectrum-design-data-0jm).
   # --components-report-only downgrades their findings to warnings: SPEC-018/
   # 020/022 are clean (downgrade is a no-op for them), but SPEC-027 still has
-  # a real backlog of ~1887 dangling tokenBindings against scale-decomposed
+  # a real backlog of ~134 dangling tokenBindings against scale-decomposed
   # tokens with no flat legacyKey -- a data-model question tracked in bead
   # spectrum-design-data-vpk, not yet safe to make blocking. Remove this flag
   # once that bead resolves and the count reaches 0.

--- a/packages/design-data/moon.yml
+++ b/packages/design-data/moon.yml
@@ -94,11 +94,24 @@ tasks:
   # components, mode-sets, and registry.
   # Note: `validate` uses --exceptions-path; `migrate convert` uses --exceptions.
   # These are different subcommands with different flag names.
+  #
+  # --components-path loads packages/design-data/components/*.json so
+  # component-aware rules (SPEC-018/020/022/026/027/031/035/040) actually run
+  # instead of silently no-op'ing (see bead spectrum-design-data-0jm).
+  # --components-report-only downgrades their findings to warnings: SPEC-018/
+  # 020/022 are clean (downgrade is a no-op for them), but SPEC-027 still has
+  # a real backlog of ~1887 dangling tokenBindings against scale-decomposed
+  # tokens with no flat legacyKey -- a data-model question tracked in bead
+  # spectrum-design-data-vpk, not yet safe to make blocking. Remove this flag
+  # once that bead resolves and the count reaches 0.
   validate:
     command: ../../sdk/target/debug/design-data
     args:
       - validate
       - ./tokens
+      - --components-path
+      - ./components
+      - --components-report-only
       - --exceptions-path
       - ../tokens/naming-exceptions.json
     toolchain: "system"
@@ -108,6 +121,7 @@ tasks:
       - ~:validate-registry
     inputs:
       - "@globs(tokens)"
+      - "@globs(catalogs)"
       - "/packages/tokens/naming-exceptions.json"
 
   # Regenerate packages/tokens/src/ from the cascade source of truth.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -121,6 +121,11 @@ enum Commands {
         /// Directory containing sidecar name maps (mirrors tokens/src layout); merges name objects at ingest
         #[arg(long, value_name = "DIR")]
         names_dir: Option<PathBuf>,
+        /// Downgrade component-aware rule errors (SPEC-018/020/022/026/027/031/035/040) to
+        /// warnings so `--components-path` can be loaded without failing on a pre-existing
+        /// backlog. Transitional flag for burn-down; see bead spectrum-design-data-0jm.
+        #[arg(long)]
+        components_report_only: bool,
         /// Treat warnings as errors
         #[arg(long)]
         strict: bool,
@@ -575,6 +580,7 @@ struct ValidateOpts {
     mode_sets_path: Option<PathBuf>,
     components_path: Option<PathBuf>,
     names_dir: Option<PathBuf>,
+    components_report_only: bool,
     strict: bool,
 }
 
@@ -604,7 +610,7 @@ fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
     let dims_dir = resolved.mode_sets;
     let comps_dir = resolved.components;
 
-    let report = validate::validate_all_with_options_and_names(
+    let mut report = validate::validate_all_with_options_and_names(
         path,
         &registry,
         &exceptions,
@@ -614,6 +620,14 @@ fn run_validate(path: &Path, opts: ValidateOpts) -> miette::Result<ExitCode> {
     )
     .into_diagnostic()
     .wrap_err("validation failed")?;
+
+    if opts.components_report_only {
+        let ids: std::collections::HashSet<&str> = validate::rules::COMPONENT_RULE_IDS
+            .iter()
+            .copied()
+            .collect();
+        report.downgrade_rules(&ids);
+    }
 
     match opts.format {
         OutputFormat::Json => {
@@ -1620,6 +1634,7 @@ fn main() -> ExitCode {
             mode_sets_path,
             components_path,
             names_dir,
+            components_report_only,
             strict,
         } => {
             let target = path.unwrap_or_else(|| PathBuf::from("."));
@@ -1632,6 +1647,7 @@ fn main() -> ExitCode {
                     mode_sets_path,
                     components_path,
                     names_dir,
+                    components_report_only,
                     strict,
                 },
             )

--- a/sdk/core/src/data_source/embedded.rs
+++ b/sdk/core/src/data_source/embedded.rs
@@ -401,8 +401,8 @@ mod tests {
             .collect();
         assert_eq!(
             components.len(),
-            82,
-            "expected 82 component schemas — update this count if you've added/removed \
+            98,
+            "expected 98 component schemas — update this count if you've added/removed \
              schemas from packages/design-data/components/"
         );
     }

--- a/sdk/core/src/report.rs
+++ b/sdk/core/src/report.rs
@@ -73,4 +73,20 @@ impl ValidationReport {
     pub fn failed(&self, strict: bool) -> bool {
         !self.errors.is_empty() || (strict && !self.warnings.is_empty())
     }
+
+    /// Downgrade errors whose `rule_id` is in `ids` to warnings, and recompute
+    /// `valid`. Used for report-only rollout of a rule set (e.g. component-aware
+    /// rules) so violations still print without failing CI.
+    pub fn downgrade_rules(&mut self, ids: &std::collections::HashSet<&str>) {
+        let (keep, mut downgrade): (Vec<_>, Vec<_>) = self
+            .errors
+            .drain(..)
+            .partition(|d| !matches!(&d.rule_id, Some(id) if ids.contains(id.as_str())));
+        self.errors = keep;
+        for d in &mut downgrade {
+            d.severity = Severity::Warning;
+        }
+        self.warnings.extend(downgrade);
+        self.recompute_valid();
+    }
 }

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -110,6 +110,14 @@ fn embedded_registry() -> &'static RegistryData {
     RegistryData::embedded()
 }
 
+/// Rules that only produce findings when `--components-path` is loaded (they
+/// short-circuit to a no-op otherwise). Used to downgrade component-rule errors
+/// to warnings under `--components-report-only` during backlog burn-down; see
+/// `ValidationReport::downgrade_rules` and bead spectrum-design-data-0jm.
+pub const COMPONENT_RULE_IDS: &[&str] = &[
+    "SPEC-018", "SPEC-020", "SPEC-022", "SPEC-026", "SPEC-027", "SPEC-031", "SPEC-035", "SPEC-040",
+];
+
 /// All default catalog rules. See packages/design-data-spec/rules/rules.yaml for the full catalog.
 pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
     vec![

--- a/sdk/core/src/validate/rules/spec027.rs
+++ b/sdk/core/src/validate/rules/spec027.rs
@@ -30,12 +30,19 @@ impl ValidationRule for Rule {
     fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
         let mut out = Vec::new();
 
-        // Only string-named tokens are referenceable via tokenBindings.
+        // tokenBindings reference the legacy flat token name. Post cascade-migration,
+        // every token's `name` is an object (not a string) and carries that flat name
+        // under `name.legacyKey` — match against that instead of a plain string `name`,
+        // which no token has anymore. See bead spectrum-design-data-vpk.
         let token_names: std::collections::HashSet<&str> = ctx
             .graph
             .tokens
             .values()
-            .filter_map(|t| t.raw.get("name").and_then(|n| n.as_str()))
+            .filter_map(|t| {
+                let name = t.raw.get("name")?;
+                name.as_str()
+                    .or_else(|| name.get("legacyKey").and_then(|v| v.as_str()))
+            })
             .collect();
 
         for comp in &ctx.graph.components {
@@ -129,6 +136,23 @@ mod tests {
     fn known_token_no_error() {
         let diags = run(
             vec![json!({"name": "button-background-color", "value": "#fff"})],
+            json!({
+                "name": "button",
+                "tokenBindings": [{"token": "button-background-color", "slot": "default"}]
+            }),
+        );
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn known_token_via_legacy_key_no_error() {
+        // Cascade tokens have an object `name` with a nested `legacyKey`, not a
+        // string `name` -- this is the shape every real token has post-migration.
+        let diags = run(
+            vec![json!({
+                "name": {"component": "button", "property": "background-color", "legacyKey": "button-background-color"},
+                "value": "#fff"
+            })],
             json!({
                 "name": "button",
                 "tokenBindings": [{"token": "button-background-color", "slot": "default"}]


### PR DESCRIPTION
## Description

CI's `design-data:validate` moon task never passed `--components-path`, so every component-aware SPEC rule (SPEC-018/020/022/026/027/031/035/040) silently short-circuited (`comp_map.get() -> None -> continue`) and CI was blind to a whole class of bugs. This PR wires components into CI validation and burns down the resulting backlog.

- **`sdk/cli/src/main.rs`, `sdk/core/src/report.rs`**: new `--components-report-only` flag + `ValidationReport::downgrade_rules`, downgrading component-rule errors to warnings so CI can load components without failing on backlog.
- **`sdk/core/src/validate/rules/spec027.rs`**: fixed a 100%-false-failure bug — `tokenBindings` were matched against tokens' string `name` field, but every cascade token's `name` is now an object; the rule now also matches `name.legacyKey`.
- **`packages/design-data/components/*.json`**: declared 16 previously-undeclared components (card, card-horizontal, collection-card, user-card, in-field-button, field, bar-panel, form-item, floating-action-button, triple-calendar, time-field, single-calendar, segmented-text-field, double-calendar, date-field, color-control); added missing anatomy/state declarations across 13 components (slider, coach-mark, table, status-light, side-navigation, steplist, action-bar, menu, avatar, tree-view, swatch, stack-item, select-box); fixed combo-box's malformed custom state names.
- **`packages/design-data/moon.yml`**: `validate` task now runs with `--components-path ./components --components-report-only`.

**Result:** SPEC-018 and SPEC-020/022 are fully clean (0 errors). SPEC-027 has a residual backlog of ~1887 dangling `tokenBindings` — these turned out to be a genuine data-model gap (scale-decomposed tokens have no `legacyKey` to bind against), not simple stale references, so I deliberately did not mass-fabricate a fix. That backlog stays visible as CI warnings via `--components-report-only` and is tracked as follow-up work (bead `spectrum-design-data-vpk`) rather than blocking this PR.

## Related Issue

Closes bead `spectrum-design-data-0jm`. Related beads closed in this PR: `3c4`, `5d7`, `25z`, `742`.

## Motivation and Context

Component-aware validation rules have been silently no-op'ing in CI since `--components-path` was never passed to the `validate` task, meaning bugs like malformed anatomy/state declarations and dangling `tokenBindings` could land undetected.

## How Has This Been Tested?

- `cargo test --manifest-path sdk/Cargo.toml -p design-data-core -p design-data-cli` — all pass (added a new unit test for the SPEC-027 `legacyKey` fix, and updated the embedded-components-count fixture from 82 → 98).
- `cargo clippy --manifest-path sdk/Cargo.toml --workspace -- -D warnings` — clean.
- `moon run design-data:validate` — exits 0 with components loaded; SPEC-018/020/022 confirmed at 0 via direct binary runs with `--components-path` (no report-only).
- `moon run sdk:test` — all pass.
- Changeset added (`minor`, validation-behavior change) and linted with `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
