### PR TITLE
fix(sdk): make design-data-wasm publishable, fix broken 0.4.0 packaging

### DIFF
--- a/.changeset/wasm-fix-consumer-republish.md
+++ b/.changeset/wasm-fix-consumer-republish.md
@@ -1,17 +1,21 @@
 ---
+"@adobe/design-data-wasm": patch
 "@adobe/design-data-agent-mcp": patch
 "@adobe/design-data": patch
 ---
 
-Republished against `@adobe/design-data-wasm@0.4.1`, which fixes a packaging bug
-where the npm tarball omitted the nested `pkg/node/package.json` and
-`pkg/web/package.json` files. Without them, Node's ESM/CJS module-type
-resolution incorrectly inherited `"type": "module"` from the wasm package root,
-causing every real consumer's `import("@adobe/design-data-wasm")` to crash with
-`ENOENT: no such file or directory, open './design_data_wasm_bg.wasm'`. The
-previously published `0.4.0` is permanently broken and unusable.
+Fixes a packaging bug where the `@adobe/design-data-wasm` npm tarball omitted
+the nested `pkg/node/package.json` and `pkg/web/package.json` files. Without
+them, Node's ESM/CJS module-type resolution incorrectly inherited
+`"type": "module"` from the wasm package root, causing every real consumer's
+`import("@adobe/design-data-wasm")` to crash with `ENOENT: no such file or
+directory, open './design_data_wasm_bg.wasm'`. The previously published
+`0.4.0` is permanently broken and unusable — this releases a fixed version and
+republishes the two dependents against it.
 
-- **@adobe/design-data-agent-mcp**: bump `@adobe/design-data-wasm` dependency to
-  the fixed `0.4.1`.
-- **@adobe/design-data**: bump `@adobe/design-data-wasm` dependency to the fixed
-  `0.4.1`.
+- **@adobe/design-data-wasm**: fix the `files` allowlist to include the
+  per-target `package.json` manifests.
+- **@adobe/design-data-agent-mcp**: bump `@adobe/design-data-wasm` dependency
+  to the fixed version.
+- **@adobe/design-data**: bump `@adobe/design-data-wasm` dependency to the
+  fixed version.

--- a/.changeset/wasm-fix-consumer-republish.md
+++ b/.changeset/wasm-fix-consumer-republish.md
@@ -1,0 +1,17 @@
+---
+"@adobe/design-data-agent-mcp": patch
+"@adobe/design-data": patch
+---
+
+Republished against `@adobe/design-data-wasm@0.4.1`, which fixes a packaging bug
+where the npm tarball omitted the nested `pkg/node/package.json` and
+`pkg/web/package.json` files. Without them, Node's ESM/CJS module-type
+resolution incorrectly inherited `"type": "module"` from the wasm package root,
+causing every real consumer's `import("@adobe/design-data-wasm")` to crash with
+`ENOENT: no such file or directory, open './design_data_wasm_bg.wasm'`. The
+previously published `0.4.0` is permanently broken and unusable.
+
+- **@adobe/design-data-agent-mcp**: bump `@adobe/design-data-wasm` dependency to
+  the fixed `0.4.1`.
+- **@adobe/design-data**: bump `@adobe/design-data-wasm` dependency to the fixed
+  `0.4.1`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,32 @@ jobs:
           node tasks/buildSpectrumTokens.js
           node tasks/buildManifest.js
 
+      # design-data-wasm's pkg/** build output is gitignored (rebuilt from
+      # source) but is required by `files` in sdk/wasm/package.json — without
+      # this, `changeset publish` would try to publish an empty package.
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.88.0"
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "sdk -> sdk/target"
+          key: wasm
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Set up moonrepo
+        uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: true
+
+      - name: Build wasm package
+        run: moon run sdk-wasm:build
+
       - name: Publish packages
         id: cs
         uses: GarthDB/changesets-action@v1.6.8

--- a/.gitignore
+++ b/.gitignore
@@ -120,9 +120,6 @@ dist
 # Rust (design-data SDK workspace)
 sdk/target/
 
-# wasm-pack generated output — rebuilt by `moon run sdk-wasm:build`
-sdk/wasm/pkg/
-
 # design-data derived embedded-database cache (rebuildable from canonical JSON,
 # never authoritative). Includes the OS cache dir contents and any locally built
 # cache assets emitted by `design-data cache-build`.

--- a/sdk/wasm/.gitignore
+++ b/sdk/wasm/.gitignore
@@ -1,0 +1,2 @@
+# wasm-pack generated output — rebuilt by `moon run sdk-wasm:build`.
+pkg/

--- a/sdk/wasm/moon.yml
+++ b/sdk/wasm/moon.yml
@@ -65,8 +65,18 @@ tasks:
     outputs:
       - "pkg/node/design_data_wasm.js"
       - "pkg/node/design_data_wasm.d.ts"
+      - "pkg/node/design_data_wasm_bg.wasm"
+      - "pkg/node/design_data_wasm_bg.wasm.d.ts"
+      - "pkg/node/package.json"
+      - "pkg/node/README.md"
+      - "pkg/node/LICENSE"
       - "pkg/web/design_data_wasm.js"
       - "pkg/web/design_data_wasm.d.ts"
+      - "pkg/web/design_data_wasm_bg.wasm"
+      - "pkg/web/design_data_wasm_bg.wasm.d.ts"
+      - "pkg/web/package.json"
+      - "pkg/web/README.md"
+      - "pkg/web/LICENSE"
     deps:
       - sdk:codegen-check
       - cache-build

--- a/sdk/wasm/package.json
+++ b/sdk/wasm/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@adobe/design-data-wasm",
-  "version": "0.4.0",
-  "private": true,
+  "version": "0.4.1",
   "description": "WebAssembly bindings for design-data-core — query, validate, resolve, diff, and registry helpers for Spectrum design tokens",
   "type": "module",
   "main": "./pkg/node/design_data_wasm.js",
@@ -19,10 +18,12 @@
     "pkg/node/design_data_wasm_bg.wasm",
     "pkg/node/design_data_wasm.d.ts",
     "pkg/node/design_data_wasm_bg.wasm.d.ts",
+    "pkg/node/package.json",
     "pkg/web/design_data_wasm.js",
     "pkg/web/design_data_wasm_bg.wasm",
     "pkg/web/design_data_wasm.d.ts",
     "pkg/web/design_data_wasm_bg.wasm.d.ts",
+    "pkg/web/package.json",
     "README.md"
   ],
   "keywords": [
@@ -34,6 +35,11 @@
   ],
   "engines": {
     "node": ">=20.12.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/sdk/wasm/scripts/build.mjs
+++ b/sdk/wasm/scripts/build.mjs
@@ -22,7 +22,8 @@
 
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
+import { rmSync } from 'node:fs';
 
 const cwd = dirname(fileURLToPath(import.meta.url + '/..'));
 
@@ -33,6 +34,12 @@ function build(target, outDir) {
     ['build', '--target', target, '--out-dir', outDir, '--', '--features', 'embedded'],
     { cwd, stdio: 'inherit' },
   );
+
+  // wasm-pack always drops a `.gitignore` (containing `*`) into outDir. npm's
+  // packlist honors that even though it's not a git-tracked file, silently
+  // dropping the wasm binary from `npm publish`/`npm pack`. Remove it so the
+  // built package is always publish-ready.
+  rmSync(join(cwd, outDir, '.gitignore'), { force: true });
 }
 
 build('nodejs', 'pkg/node');


### PR DESCRIPTION
## Description

`@adobe/design-data-wasm` was `private: true`, so it was never published even
though two public packages (`@adobe/design-data-agent-mcp`, `@adobe/design-data`)
declare a hard runtime dependency on it, pinned at the exact version `0.4.0`.
This 404'd installs for every external consumer (reported by Deanna Smith).

A manual one-time `0.4.0` publish + npm trusted-publishing (OIDC) setup was
already done outside CI to establish the package name on npm (OIDC can't be
configured for a name that doesn't exist yet). A real end-to-end smoke test
(fresh `npm install` + `import()`) then revealed the published tarball was
still broken: it was missing the nested `pkg/node/package.json` and
`pkg/web/package.json` files, so Node's module-type resolution misread the
CommonJS wasm-pack loader as ESM and crashed on import for every real
consumer. Since npm versions are immutable, `0.4.0` can't be fixed in place.

This PR fixes the packaging bug and, since OIDC is now configured, includes
`@adobe/design-data-wasm` itself in the changeset — no further manual publish
needed. That also required finishing the CI side (previously deferred as
"Stage 2"): the release job's Publish step had no Rust/wasm build step, so it
would have tried to publish an empty package for `design-data-wasm`. Added a
wasm build step (Rust toolchain + `moon run sdk-wasm:build`) before publish,
mirroring the existing `build-binaries` job's Rust setup.

This is also the first real test of the full changesets → OIDC release
pipeline for this package.

## Related Issue

Fixes the packaging bug behind Deanna Smith's report that Claude Code / the
design-data-agent-mcp package couldn't access `@adobe/design-data-wasm`.

## Motivation and Context

Unblocks `@adobe/design-data-agent-mcp` and `@adobe/design-data` as installable,
working npm packages for external consumers, and validates the wasm package's
CI/OIDC release path end-to-end.

## How Has This Been Tested?

- Fresh `moon run sdk-wasm:build --force`, then real (non-dry-run) `npm pack`
  in `sdk/wasm` — confirmed both `pkg/node/package.json` and
  `pkg/web/package.json` are present in the tarball (15 files total, up from
  13).
- Installed that actual `.tgz` into an independent clean scratch directory via
  `npm i <tarball>`, then ran `node -e "import('@adobe/design-data-wasm')..."`
  — module loaded successfully and `Dataset.embedded().query` resolved as a
  function.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.
- Verified a simulated moon cache-restore (`rm -rf pkg && moon run
  sdk-wasm:build` without `--force`) now restores the complete `pkg/`
  directory including `.wasm` binaries, matching the corrected `moon.yml`
  `outputs` list.
- The new `release.yml` wasm-build step has not yet been run in CI — this PR
  merge (via the Version Packages PR it generates) is the first real
  end-to-end test of it.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
