### PR TITLE
fix(design-data,ci): fix component documentationUrls and wasm-pack release install

### DIFF
--- a/.changeset/fix-component-documentation-urls.md
+++ b/.changeset/fix-component-documentation-urls.md
@@ -1,0 +1,9 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Fix placeholder documentationUrls on 17 new components (fixes Deploy Docs).
+
+- **packages/design-data/components/**: set per-component documentationUrl
+  (page/<name>/) on the 17 components added in #1266 so component slugs are
+  unique and match filename stems.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,9 +252,11 @@ jobs:
           workspaces: "sdk -> sdk/target"
           key: wasm
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
-
+      # wasm-pack is pinned in .prototools and installed by setup-toolchain
+      # below (prebuilt binary — matches ci.yml/deploy-docs.yml). Building it
+      # from source via `cargo install` instead pulls wasm-pack's own
+      # Cargo.lock, whose transitive deps can require a newer rustc than the
+      # 1.88.0 pinned above.
       - name: Set up moonrepo
         uses: moonrepo/setup-toolchain@v0
         with:

--- a/packages/design-data/components/bar-panel.json
+++ b/packages/design-data/components/bar-panel.json
@@ -7,7 +7,7 @@
   "description": "A panel anchored to an edge, exposing a draggable gripper for resizing.",
   "meta": {
     "category": "containers",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/bar-panel/"
   },
   "anatomy": [{ "name": "gripper" }],
   "lifecycle": { "introduced": "1.0.0-draft" }

--- a/packages/design-data/components/card-horizontal.json
+++ b/packages/design-data/components/card-horizontal.json
@@ -7,7 +7,7 @@
   "description": "A card variant laid out horizontally, pairing a preview with content side by side.",
   "meta": {
     "category": "containers",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/card-horizontal/"
   },
   "states": [{ "name": "default" }],
   "lifecycle": { "introduced": "1.0.0-draft" }

--- a/packages/design-data/components/card.json
+++ b/packages/design-data/components/card.json
@@ -7,7 +7,7 @@
   "description": "A single card surface used to group related content and actions; the base of the cards family (cards.json documents the group).",
   "meta": {
     "category": "containers",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/card/"
   },
   "anatomy": [{ "name": "selection" }, { "name": "well" }],
   "states": [{ "name": "default" }],

--- a/packages/design-data/components/collection-card.json
+++ b/packages/design-data/components/collection-card.json
@@ -7,7 +7,7 @@
   "description": "A card variant representing a collection of items rather than a single asset.",
   "meta": {
     "category": "containers",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/collection-card/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/color-control.json
+++ b/packages/design-data/components/color-control.json
@@ -7,7 +7,7 @@
   "description": "Shared interactive control (slider/area) underlying color-picker components.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/color-control/"
   },
   "anatomy": [{ "name": "track" }],
   "lifecycle": { "introduced": "1.0.0-draft" }

--- a/packages/design-data/components/date-field.json
+++ b/packages/design-data/components/date-field.json
@@ -7,7 +7,7 @@
   "description": "A field for entering a date value.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/date-field/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/double-calendar.json
+++ b/packages/design-data/components/double-calendar.json
@@ -7,7 +7,7 @@
   "description": "A date-picker calendar variant displaying two consecutive months.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/double-calendar/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/field.json
+++ b/packages/design-data/components/field.json
@@ -7,7 +7,7 @@
   "description": "Shared layout primitive underlying labeled form fields (text field, picker, etc.).",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/field/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/floating-action-button.json
+++ b/packages/design-data/components/floating-action-button.json
@@ -7,7 +7,7 @@
   "description": "A circular button that floats above content to surface a primary action.",
   "meta": {
     "category": "actions",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/floating-action-button/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/form-item.json
+++ b/packages/design-data/components/form-item.json
@@ -7,7 +7,7 @@
   "description": "Layout wrapper pairing a form field with its label and helper text.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/form-item/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/in-field-button.json
+++ b/packages/design-data/components/in-field-button.json
@@ -7,7 +7,7 @@
   "description": "A button embedded inside a field's input area, such as a clear or disclosure action.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/in-field-button/"
   },
   "anatomy": [{ "name": "fill" }],
   "lifecycle": { "introduced": "1.0.0-draft" }

--- a/packages/design-data/components/segmented-text-field.json
+++ b/packages/design-data/components/segmented-text-field.json
@@ -7,7 +7,7 @@
   "description": "A text field split into discrete segments, such as for structured input.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/segmented-text-field/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/single-calendar.json
+++ b/packages/design-data/components/single-calendar.json
@@ -7,7 +7,7 @@
   "description": "A date-picker calendar variant displaying a single month.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/single-calendar/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/stack-item.json
+++ b/packages/design-data/components/stack-item.json
@@ -7,7 +7,7 @@
   "description": "A single row primitive used by list-like containers such as list-view and tree-view.",
   "meta": {
     "category": "containers",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/stack-item/"
   },
   "states": [
     { "name": "down", "trigger": "interaction" },

--- a/packages/design-data/components/time-field.json
+++ b/packages/design-data/components/time-field.json
@@ -7,7 +7,7 @@
   "description": "A field for entering a time value.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/time-field/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/triple-calendar.json
+++ b/packages/design-data/components/triple-calendar.json
@@ -7,7 +7,7 @@
   "description": "A date-picker calendar variant displaying three consecutive months.",
   "meta": {
     "category": "inputs",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/triple-calendar/"
   },
   "lifecycle": { "introduced": "1.0.0-draft" }
 }

--- a/packages/design-data/components/user-card.json
+++ b/packages/design-data/components/user-card.json
@@ -7,7 +7,7 @@
   "description": "A card variant surfacing a user's identity (avatar, name) alongside supporting content.",
   "meta": {
     "category": "containers",
-    "documentationUrl": "https://spectrum.adobe.com/"
+    "documentationUrl": "https://spectrum.adobe.com/page/user-card/"
   },
   "anatomy": [{ "name": "title" }],
   "lifecycle": { "introduced": "1.0.0-draft" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two unrelated pre-existing CI failures, fixed together since both were surfaced
by #1271's merge:

1. **Deploy Docs** — 17 component JSON files added in #1266 had a placeholder
   `meta.documentationUrl` of `"https://spectrum.adobe.com/"` (no page path).
   This sets each one to `https://spectrum.adobe.com/page/<component-name>/`,
   matching the convention used by every other component file.
2. **Publish to npm ("Publish npm" job)** — the release workflow's
   `cargo install wasm-pack --locked` step now fails to compile
   ([run](https://github.com/adobe/spectrum-design-data/actions/runs/29772649420/job/88454629111)):
   wasm-pack 0.15.0's bundled lockfile pulls in `cargo-platform 0.3.3`, which
   requires a newer rustc than the `1.88.0` pinned in that job. Fixed by
   dropping the `cargo install` step and relying on `moonrepo/setup-toolchain`
   (already used for this in `ci.yml`/`deploy-docs.yml`), which installs the
   `.prototools`-pinned wasm-pack as a prebuilt binary — no compilation needed.

## Related Issue

Fixes Deploy Docs, which has been failing on `main` since e0c0411f (2026-07-19,
#1266), and fixes the wasm-pack install step in the release workflow's
"Publish to npm" job. Both are pre-existing, unrelated to the wasm packaging
fix in #1271 itself — that merge just triggered the next (also-failing) runs.

## Motivation and Context

`component-schemas`'s `getSlugFromDocumentationUrl` derives each component's
slug from the last non-empty path segment of `documentationUrl`. With a bare
`"https://spectrum.adobe.com/"`, that segment is `spectrum.adobe.com` for every
affected file, so all 17 collapsed to the same slug. This broke:

- `getAllSlugs should return all component slugs` — "All slugs should be unique"
- `getAllSlugs should return all component slugs sorted` — invariant that URL
  slug must equal filename stem

`component-schemas:test` is a dependency of `markdown-generator:generate`,
which Deploy Docs runs — so the whole pipeline failed.

Note: a few of the fixed components (S2 primitives like `bar-panel`,
`stack-item`, `collection-card`, `user-card`) may not have a live
`spectrum.adobe.com/page/…` page yet, so those URLs are currently aspirational
rather than live. The fix restores the unique-slug/filename-stem invariant;
whoever owns those components can correct the URL later if the real published
path differs.

## How Has This Been Tested?

- `moon run component-schemas:test` — 25/25 passing (previously 2 failing:
  unique-slugs and sorted).
- Added and linted a changeset for the documentationUrl fix:
  `node tools/changeset-linter/src/cli.js check --fail-on-warnings`
- Workflow YAML change verified by inspection (no local runner to execute
  the release job); the fix makes the "Publish npm" job's wasm-pack install
  match the already-working pattern in `ci.yml`/`deploy-docs.yml`. Will
  confirm green on the next real release run.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
