### PR TITLE
fix(ci): isolate wasm build from npm publish job to fix OIDC ENEEDAUTH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,18 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 #     creates or updates the "Version Packages" PR. On the version-PR merge it
 #     does nothing (no pending changesets) and exposes hasChangesets=false.
 #
-#   Phase 2 — `build-binaries` + `release`  (version-PR merge only)
-#     Both jobs gate on hasChangesets==false.
+#   Phase 2 — `build-binaries` + `build-wasm` + `release`  (version-PR merge only)
+#     All three jobs gate on hasChangesets==false.
 #     `build-binaries` additionally gates on `cliReleaseNeeded==true` — it only
 #     runs when sdk/cli/Cargo.toml carries a version not yet tagged as a GitHub
 #     Release. This avoids 4 expensive matrix builds on npm-only releases where
 #     the CLI version is unchanged. The `changesets` job detects this by checking
 #     for an existing `design-data-cli@<version>` git tag.
+#     `build-wasm` builds design-data-wasm's pkg/** output (gitignored, rebuilt
+#     from source) on moon/proto and uploads it as an artifact. This runs in its
+#     own job — not inline in `release` — because proto's toolchain shims put a
+#     non-OIDC-capable npm/pnpm on PATH, which breaks npm trusted publishing
+#     (see `release` job below).
 #     `release` publishes npm packages via changeset publish (OIDC), then
 #     downloads the built artifacts and attaches them to the GitHub Release
 #     tagged by the design-data-cli Cargo.toml version. Only an actual binary
@@ -105,6 +110,58 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
   # ── Phase 2a: build — runs only when CLI version is not yet released ────────
+  # Builds design-data-wasm's pkg/** (gitignored, rebuilt from source) via
+  # moon/proto in its own job — isolated from `release` below, whose npm
+  # trusted-publishing (OIDC) step needs the *real* global npm, not proto's
+  # shim. See the `release` job's "Download wasm package build" step.
+  build-wasm:
+    name: Build wasm package
+    needs: changesets
+    if: needs.changesets.outputs.hasChangesets == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.88.0"
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "sdk -> sdk/target"
+          key: wasm
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.17.0"
+
+      - run: npm install -g pnpm@10.17.1
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/cache-pnpm-store
+
+      - run: pnpm install --frozen-lockfile
+
+      # wasm-pack is pinned in .prototools and installed by setup-toolchain
+      # below (prebuilt binary — matches ci.yml/deploy-docs.yml).
+      - name: Set up moonrepo
+        uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: true
+
+      - name: Build wasm package
+        run: moon run sdk-wasm:build
+
+      - name: Upload wasm package build
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg-build
+          path: sdk/wasm/pkg
+          retention-days: 1
+
   build-binaries:
     name: Build binary (${{ matrix.platform }})
     needs: changesets
@@ -200,14 +257,16 @@ jobs:
   # ── Phase 2b: publish ───────────────────────────────────────────────────────
   release:
     name: Publish to npm
-    needs: [changesets, build-binaries]
+    needs: [changesets, build-binaries, build-wasm]
     # Runs on any version-PR merge. Only blocks on an actual binary build
     # failure: 'skipped' (nothing to compile) and 'success' both proceed,
-    # while 'failure' aborts the publish.
+    # while 'failure' aborts the publish. build-wasm must succeed — its
+    # output is required to publish design-data-wasm.
     if: |
       !cancelled() &&
       needs.changesets.outputs.hasChangesets == 'false' &&
-      needs.build-binaries.result != 'failure'
+      needs.build-binaries.result != 'failure' &&
+      needs.build-wasm.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -240,30 +299,15 @@ jobs:
       # design-data-wasm's pkg/** build output is gitignored (rebuilt from
       # source) but is required by `files` in sdk/wasm/package.json — without
       # this, `changeset publish` would try to publish an empty package.
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # Built in the separate `build-wasm` job (not inline here) and
+      # downloaded as an artifact: that job's moon/proto toolchain setup puts
+      # a non-OIDC-capable npm/pnpm shim on PATH, which breaks the npm
+      # trusted-publishing step below if it runs in this job.
+      - name: Download wasm package build
+        uses: actions/download-artifact@v4
         with:
-          toolchain: "1.88.0"
-          targets: wasm32-unknown-unknown
-
-      - name: Cache Cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "sdk -> sdk/target"
-          key: wasm
-
-      # wasm-pack is pinned in .prototools and installed by setup-toolchain
-      # below (prebuilt binary — matches ci.yml/deploy-docs.yml). Building it
-      # from source via `cargo install` instead pulls wasm-pack's own
-      # Cargo.lock, whose transitive deps can require a newer rustc than the
-      # 1.88.0 pinned above.
-      - name: Set up moonrepo
-        uses: moonrepo/setup-toolchain@v0
-        with:
-          auto-install: true
-
-      - name: Build wasm package
-        run: moon run sdk-wasm:build
+          name: wasm-pkg-build
+          path: sdk/wasm/pkg
 
       - name: Publish packages
         id: cs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Release workflow's "Publish to npm" job has been failing every publish
with `ENEEDAUTH` since PR #1271
([run](https://github.com/adobe/spectrum-design-data/actions/runs/29774136591/job/88461608676)),
even after re-running. All 9 packages that had a pending version failed
identically:

`@adobe/design-data`, `@adobe/spectrum-design-data`,
`@adobe/spectrum-component-api-schemas`, `@adobe/design-system-registry`,
`@adobe/design-data-wasm`, `@adobe/spectrum-component-diff-generator`,
`@adobe/design-data-agent-mcp`, `@adobe/design-data-mcp`,
`@adobe/spectrum-design-data-mcp`.

**Root cause**: not an npm/OIDC config problem — the trusted-publisher config
on npmjs.org was verified correct for two of the affected packages (owner
`adobe`, repo `spectrum-design-data`, workflow `release.yml`, no environment).
It's a regression: PR #1271 added wasm-build steps (including
`moonrepo/setup-toolchain@v0`) directly inside the "Publish to npm" job, ahead
of the npm publish step. That puts proto's toolchain shims on `PATH`, so
`pnpm release` resolves to `/home/runner/.proto/shims/*` instead of the real
global npm from `actions/setup-node` — and **proto's npm shim doesn't perform
npm's native OIDC token exchange**, so every publish falls back to
`ENEEDAUTH`.

This exact class of bug was already solved once in this repo: PRs #689/#690
deliberately stripped proto out of the publish job specifically to make OIDC
trusted publishing work. #1271 reintroduced it via the inline wasm build.

## Fix

Move the wasm build into its own `build-wasm` job (keeps moon/proto there,
where it's needed), upload `sdk/wasm/pkg/**` as an artifact
(`wasm-pkg-build`), and have the `release` job download that artifact instead
of building wasm inline. This mirrors the existing `build-binaries` →
artifact → `release` pattern already used for the CLI binaries. The publish
job is proto-free again, matching the last known-good publish
(`46af9961`/run `29692454863`, ~1 day before this regression).

## Related Issue

Closes spectrum-design-data-22u (bd). Blocks every npm publish since #1271
merged.

## Motivation and Context

Without this fix, no package can publish to npm — every release run fails at
the `Publish packages` step regardless of retries.

## How Has This Been Tested?

- YAML validated (`ruby -ryaml`).
- Verified the artifact-name change (`wasm-pkg-build`, not
  `design-data-wasm-pkg`) avoids colliding with the later
  `Download binary artifacts` step's `pattern: design-data-*`, which would
  otherwise re-download the wasm artifact into the wrong place.
- Can't fully exercise OIDC locally — will confirm on the next real release
  run (`Publish packages` should log `Using npm OIDC trusted publishing` and
  publish all 9 pending packages without `ENEEDAUTH`).

## Screenshots (if appropriate):

N/A — CI workflow change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (CI workflow — verified by inspection; will confirm on next real release run.)
- [ ] All new and existing tests passed. (N/A — no unit tests for this workflow file.)
