### PR TITLE
fix(design-data): remove 3 duplicate/typo'd tokenBindings in cards.json

### DIFF
--- a/.changeset/fix-cards-duplicate-tokenbindings.md
+++ b/.changeset/fix-cards-duplicate-tokenbindings.md
@@ -1,0 +1,10 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Remove 3 duplicate/typo'd tokenBindings on cards (SPEC-027 dangling-binding triage).
+
+- **packages/design-data/components/cards.json**: removed
+  `card-edge-to-content-{compact,default,spacious}-extra-medium` bindings — exact
+  duplicates of the existing `-medium` bindings with an invalid `-extra-` scale step
+  that doesn't exist in the token set.

--- a/packages/design-data/components/cards.json
+++ b/packages/design-data/components/cards.json
@@ -290,18 +290,6 @@
     { "token": "spacing-100", "context": "Spacing (header to footer)" },
     { "token": "card-header-to-footer", "context": "Spacing (text to visual)" },
     {
-      "token": "card-edge-to-content-compact-extra-medium",
-      "context": "Spacing (top/side/bottom edge to content, medium)"
-    },
-    {
-      "token": "card-edge-to-content-default-extra-medium",
-      "context": "Spacing (top/side/bottom edge to content, medium)"
-    },
-    {
-      "token": "card-edge-to-content-spacious-extra-medium",
-      "context": "Spacing (top/side/bottom edge to content, medium)"
-    },
-    {
       "token": "user-card-minimum-height-small",
       "context": "Height (minimum), default variant"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes 3 duplicate/typo'd `tokenBindings` entries in `packages/design-data/components/cards.json`, part of the ongoing SPEC-027 (`token-binding-token-exists`) dangling-tokenBindings triage (bead `vpk`).

`cards.json` had three bindings referencing `card-edge-to-content-{compact,default,spacious}-extra-medium` — a scale step (`extra-medium`) that doesn't exist anywhere in the token set — each duplicating an existing, correct `card-edge-to-content-{compact,default,spacious}-medium` binding with identical context. Removed the duplicate/invalid copies; the correct bindings remain untouched.

## Related Issue

Beads `vpk` (SPEC-027 triage) / `vpk.1` (design-owner sign-off for the remainder). No linked GitHub issue.

## Motivation and Context

SPEC-027 flags `tokenBindings[].token` values that don't resolve to a declared token. This triage has progressively cut the count (1887 → 134 → 50 via prior fixes); these 3 were the only ones in the current batch of 50 with an unambiguous, mechanical fix (exact duplicates). The remaining 47 have no safe unambiguous fix — fuzzy string matching produces wrong guesses (e.g. `default-font-size` → `default-font-style`) — so they're escalated for design-owner sign-off via `vpk.1` rather than guessed at here.

## How Has This Been Tested?

- `moon run sdk:build` then `design-data validate ./tokens --components-path ./components --exceptions-path ../tokens/naming-exceptions.json`: SPEC-027 count dropped from 50 to 47, no new errors introduced.
- `moon run design-data:validate` (the CI task, with `--components-report-only`): passes, 47 SPEC-027 warnings (matches expected remainder).
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings`: passes.

## Screenshots (if appropriate):

N/A — token metadata only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (data-only fix; verified via the existing `validate` task, no new test file needed)
- [x] All new and existing tests passed.
