### PR TITLE
fix(design-data): structure fused icon/space-between compounds in layout tokens

### DIFF
--- a/.changeset/dsi8-icon-space-between-fusions.md
+++ b/.changeset/dsi8-icon-space-between-fusions.md
@@ -1,0 +1,20 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Structured fused `-to-` spacing tokens in `layout.tokens.json` into the `name`
+object (bead spectrum-design-data-dsi.8). Published legacy names are
+unaffected since each migrated token's `legacyKey` pins the flat output name.
+
+- **packages/design-data/registry/icon-terms.json**: registered `alert` and
+  `validation` icon ids so icon-family space-between endpoints resolve.
+- **packages/design-data/tokens/layout.tokens.json**: 48 tokens migrated to
+  `{property:"space-between", from, to, icon?}` shape; 29 idiosyncratic
+  tokens hand-authored with a pinned `legacyKey`; additional `structure`,
+  `size`, `variant`, `qualifier` fields extracted where safe.
+- **packages/design-data/tokens/layout-component.tokens.json**: 41 tokens
+  migrated to the `space-between` shape (fix applies corpus-wide, not just
+  this bead's file).
+- **packages/design-data/tokens/color-aliases.tokens.json**: `variant`
+  extracted from fused property strings (e.g. `informative`, `negative`)
+  on keyboard-focus color-scheme tokens.

--- a/packages/design-data/registry/icon-terms.json
+++ b/packages/design-data/registry/icon-terms.json
@@ -85,6 +85,20 @@
       "description": "Gripper glyph",
       "tokenName": "gripper-icon",
       "usedIn": ["tokens"]
+    },
+    {
+      "id": "alert",
+      "label": "Alert Icon",
+      "description": "Alert/error glyph",
+      "tokenName": "alert-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "validation",
+      "label": "Validation Icon",
+      "description": "Field validation-state glyph",
+      "tokenName": "validation-icon",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -2484,10 +2484,11 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "light",
-      "legacyKey": "informative-background-color-key-focus"
+      "legacyKey": "informative-background-color-key-focus",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2497,10 +2498,11 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "dark",
-      "legacyKey": "informative-background-color-key-focus"
+      "legacyKey": "informative-background-color-key-focus",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2510,10 +2512,11 @@
   },
   {
     "name": {
-      "property": "informative-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "wireframe",
-      "legacyKey": "informative-background-color-key-focus"
+      "legacyKey": "informative-background-color-key-focus",
+      "variant": "informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2805,10 +2808,11 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "light",
-      "legacyKey": "negative-background-color-key-focus"
+      "legacyKey": "negative-background-color-key-focus",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2818,10 +2822,11 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "dark",
-      "legacyKey": "negative-background-color-key-focus"
+      "legacyKey": "negative-background-color-key-focus",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2831,10 +2836,11 @@
   },
   {
     "name": {
-      "property": "negative-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "wireframe",
-      "legacyKey": "negative-background-color-key-focus"
+      "legacyKey": "negative-background-color-key-focus",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2895,9 +2901,10 @@
   },
   {
     "name": {
-      "property": "negative-border-color",
+      "property": "border-color",
       "state": "keyboard-focus",
-      "legacyKey": "negative-border-color-key-focus"
+      "legacyKey": "negative-border-color-key-focus",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2938,9 +2945,10 @@
   },
   {
     "name": {
-      "property": "negative-content-color",
+      "property": "content-color",
       "state": "keyboard-focus",
-      "legacyKey": "negative-content-color-key-focus"
+      "legacyKey": "negative-content-color-key-focus",
+      "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -3017,9 +3025,10 @@
   },
   {
     "name": {
-      "property": "neutral-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
-      "legacyKey": "neutral-background-color-key-focus"
+      "legacyKey": "neutral-background-color-key-focus",
+      "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3126,9 +3135,10 @@
   },
   {
     "name": {
-      "property": "neutral-content-color",
+      "property": "content-color",
       "state": "keyboard-focus",
-      "legacyKey": "neutral-content-color-key-focus"
+      "legacyKey": "neutral-content-color-key-focus",
+      "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3957,10 +3967,11 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "light",
-      "legacyKey": "positive-background-color-key-focus"
+      "legacyKey": "positive-background-color-key-focus",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3970,10 +3981,11 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "dark",
-      "legacyKey": "positive-background-color-key-focus"
+      "legacyKey": "positive-background-color-key-focus",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -3983,10 +3995,11 @@
   },
   {
     "name": {
-      "property": "positive-background-color",
+      "property": "background-color",
       "state": "keyboard-focus",
       "colorScheme": "wireframe",
-      "legacyKey": "positive-background-color-key-focus"
+      "legacyKey": "positive-background-color-key-focus",
+      "variant": "positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -3208,8 +3208,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "bottom-to-text-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "bottom",
+      "to": "text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -3223,8 +3226,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "bottom-to-text-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "bottom",
+      "to": "text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -3272,8 +3278,9 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "height-multiline",
-      "scale": "desktop"
+      "property": "height",
+      "scale": "desktop",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "72px",
@@ -3284,8 +3291,9 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "height-multiline",
-      "scale": "mobile"
+      "property": "height",
+      "scale": "mobile",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "90px",
@@ -3296,7 +3304,10 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "separator-icon-to-bottom-text-multiline"
+      "property": "space-between",
+      "from": "separator-icon",
+      "to": "bottom-text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c5749cb5-6950-4aef-80f0-8445451370a7",
@@ -3306,8 +3317,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "separator-to-bottom-text-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "separator",
+      "to": "bottom-text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -3321,8 +3335,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "separator-to-bottom-text-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "separator",
+      "to": "bottom-text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3425,8 +3442,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "start-edge-to-text-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "start-edge",
+      "to": "text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -3440,8 +3460,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "start-edge-to-text-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "start-edge",
+      "to": "text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -3540,8 +3563,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "text-to-separator-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "separator",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -3555,8 +3581,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "text-to-separator-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "separator",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -3639,8 +3668,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-separator-icon-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "top",
+      "to": "separator-icon",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5b042e52-ddce-4e17-84c0-faf86049a945",
@@ -3652,8 +3684,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-separator-icon-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "top",
+      "to": "separator-icon",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "56dd2fd0-c7a3-4f2c-bda9-8e6ba6d99e6c",
@@ -3737,8 +3772,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-separator-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "top",
+      "to": "separator",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -3752,8 +3790,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-separator-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "top",
+      "to": "separator",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -3792,8 +3833,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-text-multiline",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "top",
+      "to": "text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -3807,8 +3851,11 @@
   {
     "name": {
       "component": "breadcrumbs",
-      "property": "top-to-text-multiline",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "top",
+      "to": "text",
+      "qualifier": "multiline"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -3915,9 +3962,10 @@
   },
   {
     "name": {
-      "property": "card-default-width-extra-large",
+      "property": "default-width",
       "component": "card",
-      "legacyKey": "card-default-width-extra-large"
+      "legacyKey": "card-default-width-extra-large",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "400px",
@@ -3925,9 +3973,10 @@
   },
   {
     "name": {
-      "property": "card-default-width-extra-small",
+      "property": "default-width",
       "component": "card",
-      "legacyKey": "card-default-width-extra-small"
+      "legacyKey": "card-default-width-extra-small",
+      "size": "xs"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "120px",
@@ -3935,9 +3984,10 @@
   },
   {
     "name": {
-      "property": "card-default-width-large",
+      "property": "default-width",
       "component": "card",
-      "legacyKey": "card-default-width-large"
+      "legacyKey": "card-default-width-large",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "320px",
@@ -3945,9 +3995,10 @@
   },
   {
     "name": {
-      "property": "card-default-width-medium",
+      "property": "default-width",
       "component": "card",
-      "legacyKey": "card-default-width-medium"
+      "legacyKey": "card-default-width-medium",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "240px",
@@ -3955,9 +4006,10 @@
   },
   {
     "name": {
-      "property": "card-default-width-small",
+      "property": "default-width",
       "component": "card",
-      "legacyKey": "card-default-width-small"
+      "legacyKey": "card-default-width-small",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "180px",
@@ -13867,7 +13919,10 @@
   {
     "name": {
       "component": "standard-panel",
-      "property": "edge-to-close-button-regular"
+      "property": "space-between",
+      "from": "edge",
+      "to": "close-button",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -13937,7 +13992,10 @@
   {
     "name": {
       "component": "standard-panel",
-      "property": "top-to-close-button-regular"
+      "property": "space-between",
+      "from": "top",
+      "to": "close-button",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -14337,9 +14395,11 @@
   },
   {
     "name": {
-      "property": "steplist-step-default-width-extra-large",
+      "property": "default-width",
       "component": "steplist",
-      "legacyKey": "steplist-step-default-width-extra-large"
+      "legacyKey": "steplist-step-default-width-extra-large",
+      "size": "xl",
+      "anatomy": "step"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "78px",
@@ -14347,9 +14407,11 @@
   },
   {
     "name": {
-      "property": "steplist-step-default-width-large",
+      "property": "default-width",
       "component": "steplist",
-      "legacyKey": "steplist-step-default-width-large"
+      "legacyKey": "steplist-step-default-width-large",
+      "anatomy": "step",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "70px",
@@ -14357,9 +14419,11 @@
   },
   {
     "name": {
-      "property": "steplist-step-default-width-medium",
+      "property": "default-width",
       "component": "steplist",
-      "legacyKey": "steplist-step-default-width-medium"
+      "legacyKey": "steplist-step-default-width-medium",
+      "anatomy": "step",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "54px",
@@ -14367,9 +14431,11 @@
   },
   {
     "name": {
-      "property": "steplist-step-default-width-small",
+      "property": "default-width",
       "component": "steplist",
-      "legacyKey": "steplist-step-default-width-small"
+      "legacyKey": "steplist-step-default-width-small",
+      "anatomy": "step",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "46px",
@@ -17257,9 +17323,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-extra-large-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-bottom-to-text-extra-large-regular"
+      "legacyKey": "table-row-bottom-to-text-extra-large-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "xl",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8b969d35-01ab-419f-b391-484aad88fd41",
@@ -17273,9 +17343,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-extra-large-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-bottom-to-text-extra-large-regular"
+      "legacyKey": "table-row-bottom-to-text-extra-large-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "xl",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f25c6bfd-0a0d-4fd1-ab7b-9cd1d13053e1",
@@ -17379,9 +17453,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-large-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-bottom-to-text-large-regular"
+      "legacyKey": "table-row-bottom-to-text-large-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f14b75f3-cb07-48b3-8543-34d80747ff36",
@@ -17395,9 +17473,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-large-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-bottom-to-text-large-regular"
+      "legacyKey": "table-row-bottom-to-text-large-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0de2f0a5-b32a-4f7b-b46c-1a6c25abc1ec",
@@ -17501,9 +17583,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-medium-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-bottom-to-text-medium-regular"
+      "legacyKey": "table-row-bottom-to-text-medium-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f14087ac-db72-43df-a8fa-9c9b03c6a1c9",
@@ -17517,9 +17603,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-medium-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-bottom-to-text-medium-regular"
+      "legacyKey": "table-row-bottom-to-text-medium-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6ff9a81f-a2f8-4966-a48b-c8561aa4f833",
@@ -17623,9 +17713,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-small-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-bottom-to-text-small-regular"
+      "legacyKey": "table-row-bottom-to-text-small-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "56b58d2a-01dd-488b-b6e9-ff49555602b4",
@@ -17639,9 +17733,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-bottom-to-text-small-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-bottom-to-text-small-regular"
+      "legacyKey": "table-row-bottom-to-text-small-regular",
+      "from": "row-bottom",
+      "to": "text",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d6100789-7076-403a-b878-7bb204093c52",
@@ -17767,9 +17865,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-extra-large-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-checkbox-to-top-extra-large-regular"
+      "legacyKey": "table-row-checkbox-to-top-extra-large-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "xl",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "acd6ad6b-bab0-40fb-afbe-5df7eea7efb3",
@@ -17783,9 +17885,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-extra-large-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-checkbox-to-top-extra-large-regular"
+      "legacyKey": "table-row-checkbox-to-top-extra-large-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "xl",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fb02243f-0490-4eb2-aac2-fa364c6eab59",
@@ -17911,9 +18017,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-large-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-checkbox-to-top-large-regular"
+      "legacyKey": "table-row-checkbox-to-top-large-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8c2b073-495b-402b-b1dc-2337b0e42f37",
@@ -17927,9 +18037,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-large-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-checkbox-to-top-large-regular"
+      "legacyKey": "table-row-checkbox-to-top-large-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a0fa4e03-c1de-400d-8629-0ae9ffb9b9d8",
@@ -18055,9 +18169,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-medium-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-checkbox-to-top-medium-regular"
+      "legacyKey": "table-row-checkbox-to-top-medium-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "be965b15-08f8-43be-9953-52151d8c7670",
@@ -18071,9 +18189,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-medium-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-checkbox-to-top-medium-regular"
+      "legacyKey": "table-row-checkbox-to-top-medium-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ae09505-d43f-4e2c-b8a6-014ccfef5c10",
@@ -18199,9 +18321,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-small-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-checkbox-to-top-small-regular"
+      "legacyKey": "table-row-checkbox-to-top-small-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "909ebf8a-eebd-41b6-8fac-8fe31d2bac00",
@@ -18215,9 +18341,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-checkbox-to-top-small-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-checkbox-to-top-small-regular"
+      "legacyKey": "table-row-checkbox-to-top-small-regular",
+      "from": "row-checkbox",
+      "to": "top",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "365d9c3f-d287-4feb-b020-89434dd29378",
@@ -18309,9 +18439,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-extra-large-regular",
+      "property": "height",
       "scale": "desktop",
-      "legacyKey": "table-row-height-extra-large-regular"
+      "legacyKey": "table-row-height-extra-large-regular",
+      "size": "xl",
+      "anatomy": "row",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d52d3141-27a5-40eb-800f-1a09acd42534",
@@ -18325,9 +18458,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-extra-large-regular",
+      "property": "height",
       "scale": "mobile",
-      "legacyKey": "table-row-height-extra-large-regular"
+      "legacyKey": "table-row-height-extra-large-regular",
+      "size": "xl",
+      "anatomy": "row",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c2e3068b-c0be-4615-bbf7-c65e58ef126b",
@@ -18411,9 +18547,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-large-regular",
+      "property": "height",
       "scale": "desktop",
-      "legacyKey": "table-row-height-large-regular"
+      "legacyKey": "table-row-height-large-regular",
+      "anatomy": "row",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d3d9b523-90dc-4532-9cf7-37b568bd6800",
@@ -18427,9 +18566,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-large-regular",
+      "property": "height",
       "scale": "mobile",
-      "legacyKey": "table-row-height-large-regular"
+      "legacyKey": "table-row-height-large-regular",
+      "anatomy": "row",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff04cae7-7f96-4db2-bf64-948c22d104ff",
@@ -18513,9 +18655,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-medium-regular",
+      "property": "height",
       "scale": "desktop",
-      "legacyKey": "table-row-height-medium-regular"
+      "legacyKey": "table-row-height-medium-regular",
+      "anatomy": "row",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9d6dc5e8-d3f0-4f59-b062-756669ff7217",
@@ -18529,9 +18674,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-medium-regular",
+      "property": "height",
       "scale": "mobile",
-      "legacyKey": "table-row-height-medium-regular"
+      "legacyKey": "table-row-height-medium-regular",
+      "anatomy": "row",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2cf7918c-f84a-4903-a6ba-b110807842ba",
@@ -18615,9 +18763,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-small-regular",
+      "property": "height",
       "scale": "desktop",
-      "legacyKey": "table-row-height-small-regular"
+      "legacyKey": "table-row-height-small-regular",
+      "anatomy": "row",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "10b892a0-3c97-4af6-8ecc-3359e8cd1302",
@@ -18631,9 +18782,12 @@
   {
     "name": {
       "component": "table",
-      "property": "row-height-small-regular",
+      "property": "height",
       "scale": "mobile",
-      "legacyKey": "table-row-height-small-regular"
+      "legacyKey": "table-row-height-small-regular",
+      "anatomy": "row",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "77a26f7c-2f71-4021-a1f2-a2af7c69a111",
@@ -18729,9 +18883,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-extra-large-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-top-to-text-extra-large-regular"
+      "legacyKey": "table-row-top-to-text-extra-large-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "xl",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "da7274c6-6f45-4087-b42f-dde7d3ac1af7",
@@ -18745,9 +18903,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-extra-large-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-top-to-text-extra-large-regular"
+      "legacyKey": "table-row-top-to-text-extra-large-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "xl",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "40de40fd-4bae-4a49-8aec-38dad2a1c5fb",
@@ -18851,9 +19013,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-large-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-top-to-text-large-regular"
+      "legacyKey": "table-row-top-to-text-large-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0820aecf-0647-4e51-ae40-44130bc86013",
@@ -18867,9 +19033,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-large-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-top-to-text-large-regular"
+      "legacyKey": "table-row-top-to-text-large-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "l",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4d55e632-588b-4e82-90c0-4fa434998d15",
@@ -18973,9 +19143,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-medium-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-top-to-text-medium-regular"
+      "legacyKey": "table-row-top-to-text-medium-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ae401c94-c643-446f-a44e-38c9f3104fc6",
@@ -18989,9 +19163,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-medium-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-top-to-text-medium-regular"
+      "legacyKey": "table-row-top-to-text-medium-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "m",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0cd86854-57ca-4023-b544-8a4a76418164",
@@ -19095,9 +19273,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-small-regular",
+      "property": "space-between",
       "scale": "desktop",
-      "legacyKey": "table-row-top-to-text-small-regular"
+      "legacyKey": "table-row-top-to-text-small-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "52fb10e1-a45e-4b21-9563-b72a6cf8c7e0",
@@ -19111,9 +19293,13 @@
   {
     "name": {
       "component": "table",
-      "property": "row-top-to-text-small-regular",
+      "property": "space-between",
       "scale": "mobile",
-      "legacyKey": "table-row-top-to-text-small-regular"
+      "legacyKey": "table-row-top-to-text-small-regular",
+      "from": "row-top",
+      "to": "text",
+      "size": "s",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dfa553a2-b771-4a31-9294-3800d2126952",
@@ -19904,10 +20090,11 @@
   },
   {
     "name": {
-      "property": "tag-field-default-width-large",
+      "property": "default-width",
       "component": "tag-field",
       "scale": "desktop",
-      "legacyKey": "tag-field-default-width-large"
+      "legacyKey": "tag-field-default-width-large",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "288px",
@@ -19917,10 +20104,11 @@
   },
   {
     "name": {
-      "property": "tag-field-default-width-large",
+      "property": "default-width",
       "component": "tag-field",
       "scale": "mobile",
-      "legacyKey": "tag-field-default-width-large"
+      "legacyKey": "tag-field-default-width-large",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "312px",
@@ -19930,10 +20118,11 @@
   },
   {
     "name": {
-      "property": "tag-field-default-width-medium",
+      "property": "default-width",
       "component": "tag-field",
       "scale": "desktop",
-      "legacyKey": "tag-field-default-width-medium"
+      "legacyKey": "tag-field-default-width-medium",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "264px",
@@ -19943,10 +20132,11 @@
   },
   {
     "name": {
-      "property": "tag-field-default-width-medium",
+      "property": "default-width",
       "component": "tag-field",
       "scale": "mobile",
-      "legacyKey": "tag-field-default-width-medium"
+      "legacyKey": "tag-field-default-width-medium",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "288px",
@@ -19956,10 +20146,11 @@
   },
   {
     "name": {
-      "property": "tag-field-default-width-small",
+      "property": "default-width",
       "component": "tag-field",
       "scale": "desktop",
-      "legacyKey": "tag-field-default-width-small"
+      "legacyKey": "tag-field-default-width-small",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "240px",
@@ -19969,10 +20160,11 @@
   },
   {
     "name": {
-      "property": "tag-field-default-width-small",
+      "property": "default-width",
       "component": "tag-field",
       "scale": "mobile",
-      "legacyKey": "tag-field-default-width-small"
+      "legacyKey": "tag-field-default-width-small",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "264px",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -213,7 +213,9 @@
   },
   {
     "name": {
-      "property": "banner-gap-horizontal"
+      "property": "gap",
+      "structure": "banner",
+      "orientation": "horizontal"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
@@ -222,7 +224,9 @@
   },
   {
     "name": {
-      "property": "banner-gap-vertical"
+      "property": "gap",
+      "structure": "banner",
+      "orientation": "vertical"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
@@ -231,7 +235,8 @@
   },
   {
     "name": {
-      "property": "banner-padding-horizontal"
+      "property": "padding-horizontal",
+      "structure": "banner"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
@@ -252,7 +257,8 @@
   },
   {
     "name": {
-      "property": "banner-padding-vertical"
+      "property": "padding-vertical",
+      "structure": "banner"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
@@ -712,8 +718,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "size": "xl",
+      "variant": "quiet",
+      "scale": "desktop",
+      "legacyKey": "character-count-to-field-quiet-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-4px",
@@ -724,8 +735,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "size": "xl",
+      "variant": "quiet",
+      "scale": "mobile",
+      "legacyKey": "character-count-to-field-quiet-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-5px",
@@ -736,8 +752,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "variant": "quiet",
+      "size": "l",
+      "scale": "desktop",
+      "legacyKey": "character-count-to-field-quiet-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-3px",
@@ -748,8 +769,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "variant": "quiet",
+      "size": "l",
+      "scale": "mobile",
+      "legacyKey": "character-count-to-field-quiet-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-4px",
@@ -760,8 +786,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "variant": "quiet",
+      "size": "m",
+      "scale": "desktop",
+      "legacyKey": "character-count-to-field-quiet-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-3px",
@@ -772,8 +803,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "variant": "quiet",
+      "size": "m",
+      "scale": "mobile",
+      "legacyKey": "character-count-to-field-quiet-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-4px",
@@ -784,8 +820,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "variant": "quiet",
+      "size": "s",
+      "scale": "desktop",
+      "legacyKey": "character-count-to-field-quiet-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-3px",
@@ -796,8 +837,13 @@
   },
   {
     "name": {
-      "property": "character-count-to-field-quiet-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "character-count",
+      "to": "field",
+      "variant": "quiet",
+      "size": "s",
+      "scale": "mobile",
+      "legacyKey": "character-count-to-field-quiet-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-4px",
@@ -3362,8 +3408,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -3376,8 +3426,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3390,8 +3444,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3404,8 +3462,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "19px",
@@ -3418,8 +3480,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -3432,8 +3498,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3446,7 +3516,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-quiet"
+      "property": "space-between",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "variant": "quiet",
+      "legacyKey": "field-edge-to-alert-icon-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3455,8 +3530,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -3469,8 +3548,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-alert-icon-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "alert",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -3483,7 +3566,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-border-quiet"
+      "component": "field",
+      "variant": "quiet",
+      "object": "edge",
+      "property": "border",
+      "legacyKey": "field-edge-to-border-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3628,7 +3715,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-text-quiet"
+      "property": "space-between",
+      "from": "field-edge",
+      "to": "text",
+      "variant": "quiet",
+      "legacyKey": "field-edge-to-text-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3637,8 +3728,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -3651,8 +3746,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3665,8 +3764,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3679,8 +3782,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "19px",
@@ -3693,8 +3800,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -3707,8 +3818,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3721,7 +3836,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-quiet"
+      "property": "space-between",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "variant": "quiet",
+      "legacyKey": "field-edge-to-validation-icon-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3730,8 +3850,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -3744,8 +3868,12 @@
   },
   {
     "name": {
-      "property": "field-edge-to-validation-icon-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-edge",
+      "to": "icon",
+      "icon": "validation",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -3758,7 +3886,11 @@
   },
   {
     "name": {
-      "property": "field-edge-to-visual-quiet"
+      "property": "space-between",
+      "from": "field-edge",
+      "to": "visual",
+      "variant": "quiet",
+      "legacyKey": "field-edge-to-visual-quiet"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -3904,8 +4036,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "size": "xl",
+      "component": "field"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -3918,8 +4055,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "size": "xl",
+      "component": "field"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -3932,8 +4074,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "component": "field",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3946,8 +4093,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "component": "field",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "19px",
@@ -3960,8 +4112,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "component": "field",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -3974,8 +4131,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "component": "field",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -3988,8 +4150,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "component": "field",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -4002,8 +4169,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-alert-icon-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "alert",
+      "component": "field",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4016,8 +4188,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "size": "xl",
+      "component": "field"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -4030,8 +4207,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "size": "xl",
+      "component": "field"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -4044,8 +4226,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "component": "field",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -4058,8 +4245,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "component": "field",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "19px",
@@ -4072,8 +4264,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "component": "field",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -4086,8 +4283,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "component": "field",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -4100,8 +4302,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "component": "field",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -4114,8 +4321,13 @@
   },
   {
     "name": {
-      "property": "field-text-to-validation-icon-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "text",
+      "to": "icon",
+      "icon": "validation",
+      "component": "field",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4128,8 +4340,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -4142,8 +4358,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -4156,8 +4376,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -4170,8 +4394,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -4184,8 +4412,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -4198,8 +4430,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -4212,8 +4448,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -4226,8 +4466,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-alert-icon-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "alert",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -4376,8 +4620,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "xl",
+      "density": "compact",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-compact-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -4390,8 +4639,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "xl",
+      "density": "compact",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-compact-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "21px",
@@ -4404,8 +4658,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "l",
+      "density": "compact",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-compact-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4418,8 +4677,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "l",
+      "density": "compact",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-compact-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -4432,8 +4696,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "m",
+      "density": "compact",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-compact-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -4446,8 +4715,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "m",
+      "density": "compact",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-compact-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -4460,8 +4734,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "s",
+      "density": "compact",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-compact-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -4474,8 +4753,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-compact-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "s",
+      "density": "compact",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-compact-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -4624,8 +4908,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "xl",
+      "density": "spacious",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "25px",
@@ -4638,8 +4927,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "xl",
+      "density": "spacious",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "31px",
@@ -4652,8 +4946,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "l",
+      "density": "spacious",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -4666,8 +4965,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "l",
+      "density": "spacious",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "27px",
@@ -4680,8 +4984,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "m",
+      "density": "spacious",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "19px",
@@ -4694,8 +5003,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "m",
+      "density": "spacious",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "23px",
@@ -4708,8 +5022,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "s",
+      "density": "spacious",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -4722,8 +5041,13 @@
   },
   {
     "name": {
-      "property": "field-top-to-disclosure-icon-spacious-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "disclosure-icon",
+      "size": "s",
+      "density": "spacious",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-disclosure-icon-spacious-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -4848,8 +5172,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -4862,8 +5190,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -4876,8 +5208,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -4890,8 +5226,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "17px",
@@ -4904,8 +5244,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -4918,8 +5262,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "13px",
@@ -4932,8 +5280,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "scale": "desktop",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -4946,8 +5298,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-validation-icon-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "scale": "mobile",
+      "from": "field-top",
+      "to": "icon",
+      "icon": "validation",
+      "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5283,7 +5639,9 @@
   },
   {
     "name": {
-      "property": "list-gap-regular"
+      "property": "gap",
+      "structure": "list",
+      "weight": "regular"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "576a60a3-ca80-46c5-a066-ba7b6197decd",

--- a/packages/tokens/naming-exceptions.json
+++ b/packages/tokens/naming-exceptions.json
@@ -1483,6 +1483,114 @@
       "file": "layout-component.json",
       "category": "anatomy-decomposition",
       "reason": "Does not roundtrip through canonical generation rules (category: anatomy-decomposition) \u2014 legacyKey pinned to preserve the published key after routing this anatomy sub-part token to its real parent component"
+    },
+    {
+      "token": "field-edge-to-alert-icon-extra-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-alert-icon-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-alert-icon-medium",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-alert-icon-quiet",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-alert-icon-small",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-validation-icon-extra-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-validation-icon-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-validation-icon-medium",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-validation-icon-quiet",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-edge-to-validation-icon-small",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-alert-icon-extra-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-alert-icon-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-alert-icon-medium",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-alert-icon-small",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-validation-icon-extra-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-validation-icon-large",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-validation-icon-medium",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
+    },
+    {
+      "token": "field-top-to-validation-icon-small",
+      "file": "layout.json",
+      "category": "state-position",
+      "reason": "Does not roundtrip through canonical generation rules (category: state-position)"
     }
   ]
 }

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -1130,6 +1130,132 @@
     },
     {
       "file": "./src/layout.json",
+      "token": "field-edge-to-alert-icon-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-alert-icon-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-alert-icon-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-alert-icon-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-alert-icon-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-alert-icon-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-alert-icon-quiet",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-alert-icon-quiet' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-alert-icon-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-alert-icon-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-validation-icon-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-validation-icon-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-validation-icon-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-validation-icon-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-validation-icon-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-validation-icon-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-validation-icon-quiet",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-validation-icon-quiet' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-edge-to-validation-icon-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-edge-to-validation-icon-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-alert-icon-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-alert-icon-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-alert-icon-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-alert-icon-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-alert-icon-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-alert-icon-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-alert-icon-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-alert-icon-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-validation-icon-extra-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-validation-icon-extra-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-validation-icon-large",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-validation-icon-large' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-validation-icon-medium",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-validation-icon-medium' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
+      "token": "field-top-to-validation-icon-small",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'field-top-to-validation-icon-small' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/layout.json",
       "token": "focus-indicator-gap",
       "rule_id": "SPEC-007",
       "severity": "info",

--- a/packages/tokens/src/layout-component.json
+++ b/packages/tokens/src/layout-component.json
@@ -842,7 +842,7 @@
     "uuid": "3116a00c-0ad3-4ae6-9fbb-f9b5624a2708",
     "deprecated": true,
     "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "action-bar-close-button-to-counter": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -881,7 +881,7 @@
     "uuid": "72e276ce-d6ee-4bcf-9955-91c833b8b2cd",
     "deprecated": true,
     "deprecated_comment": "Use semantic token banner-gap-horizontal instead.",
-    "renamed": "banner-gap-horizontal"
+    "renamed": "gap-horizontal"
   },
   "action-bar-minimum-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -896,7 +896,7 @@
     "uuid": "cfa41a43-8fb2-4c3b-a2df-f8658c87b31b",
     "deprecated": true,
     "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "action-bar-top-to-item-counter": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -905,7 +905,7 @@
     "uuid": "73f82d09-7927-461c-b7d7-ab0bc6b3e3f9",
     "deprecated": true,
     "deprecated_comment": "Use semantic token banner-padding-vertical instead.",
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "action-button-edge-to-hold-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1093,7 +1093,7 @@
         "uuid": "5f2b2bc1-ebb0-46dd-a563-58df6307996d"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "alert-banner-minimum-height": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1157,7 +1157,7 @@
         "uuid": "7939208b-2f8c-4569-b7cb-1c1bcfc8705a"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "alert-banner-top-to-text": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1177,7 +1177,7 @@
         "uuid": "8db02117-b543-4b3e-b0ff-203e9a821708"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "alert-banner-top-to-workflow-icon": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -1197,7 +1197,7 @@
         "uuid": "402c755b-322c-4ea0-856c-ca209bdaa8ec"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "alert-banner-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -7304,7 +7304,7 @@
         "uuid": "be37c65c-88c5-48cd-9554-8240909db98d"
       }
     },
-    "renamed": "list-gap-regular"
+    "renamed": "gap-regular"
   },
   "side-navigation-maximum-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -9931,7 +9931,7 @@
         "uuid": "ea902ec1-25d5-47c3-896a-a95d9ca5bd62"
       }
     },
-    "renamed": "list-gap-regular"
+    "renamed": "gap-regular"
   },
   "tab-item-to-tab-item-vertical-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -9951,7 +9951,7 @@
         "uuid": "c193b2ee-a584-41dc-9ef8-3aebb38fb832"
       }
     },
-    "renamed": "list-gap-regular"
+    "renamed": "gap-regular"
   },
   "tab-item-to-tab-item-vertical-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -9971,7 +9971,7 @@
         "uuid": "6b6c960f-adcf-48b0-8310-ba12b47f4d9a"
       }
     },
-    "renamed": "list-gap-regular"
+    "renamed": "gap-regular"
   },
   "tab-item-to-tab-item-vertical-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -9991,7 +9991,7 @@
         "uuid": "d51a6c05-67d0-425f-becf-86e783ab3305"
       }
     },
-    "renamed": "list-gap-regular"
+    "renamed": "gap-regular"
   },
   "tab-item-top-to-text-compact-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -13143,7 +13143,7 @@
         "uuid": "a790fd9e-4e5f-4f4c-a3ca-832540832580"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "toast-height": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -13197,7 +13197,7 @@
         "uuid": "9f0688f5-128f-47c3-8585-94d704214881"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "toast-top-to-workflow-icon": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -13217,7 +13217,7 @@
         "uuid": "1f83245b-3d79-4326-b843-df7b6549cade"
       }
     },
-    "renamed": "banner-padding-vertical"
+    "renamed": "padding-vertical"
   },
   "tooltip-maximum-width": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
@@ -13456,7 +13456,7 @@
         "uuid": "a06c6929-1acc-4084-a8ee-3d4ad5a0064e"
       }
     },
-    "renamed": "list-gap-regular"
+    "renamed": "gap-regular"
   },
   "tree-view-item-to-item": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/tokens/src/layout.json
+++ b/packages/tokens/src/layout.json
@@ -112,35 +112,11 @@
     "value": "2dp",
     "uuid": "f9456531-ab61-4c14-b7af-7016ce1c0d3e"
   },
-  "banner-gap-horizontal": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "value": "{spacing-400}",
-    "uuid": "c0571c46-5946-4896-bcbf-270560de5385",
-    "description": "Spacing between child elements for banner components"
-  },
-  "banner-gap-vertical": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "value": "{spacing-100}",
-    "uuid": "312ebac2-32a0-47a8-9c4e-e366b2232228",
-    "description": "Spacing between child elements for banner components"
-  },
-  "banner-padding-horizontal": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "value": "{spacing-300}",
-    "uuid": "eb386242-21c6-437b-8125-e6d4394dd9c5",
-    "description": "Horizontal internal spacing for banner components"
-  },
   "banner-padding-horizontal-compact": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "value": "{spacing-100}",
     "uuid": "7f237198-3842-49bc-aa79-e723fbe6c78e",
     "description": "Horizontal internal spacing for banner components (compact density)"
-  },
-  "banner-padding-vertical": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "value": "{spacing-200}",
-    "uuid": "64fa4ab7-be93-4420-8cdc-a6ef91499852",
-    "description": "Vertical internal spacing for banner components"
   },
   "base-gap-2x-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -2069,6 +2045,7 @@
   },
   "field-edge-to-alert-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "f68f57de-df8c-49b5-9af8-566c2382f669",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2088,6 +2065,7 @@
   },
   "field-edge-to-alert-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "78b56170-dc93-4f41-a110-94f9415c2222",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2107,6 +2085,7 @@
   },
   "field-edge-to-alert-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "4507a27d-3072-47f0-a2b9-ca8523e7d3c9",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2126,12 +2105,14 @@
   },
   "field-edge-to-alert-icon-quiet": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "alert-icon",
     "value": "0px",
     "uuid": "7858fdf3-e35f-4bc5-997a-0d480ec1cb32",
     "deprecated": true
   },
   "field-edge-to-alert-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "c1aa6fda-f075-415a-b9f4-008885d7fccd",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2151,6 +2132,7 @@
   },
   "field-edge-to-border-quiet": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "field",
     "value": "0px",
     "uuid": "7fb81dcf-3329-4353-917d-75de8f43c05d",
     "deprecated": true
@@ -2239,6 +2221,7 @@
   },
   "field-edge-to-validation-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "81a3d661-160e-448d-8f3a-994a01b4c0e4",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2258,6 +2241,7 @@
   },
   "field-edge-to-validation-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "3efc3753-19da-4e87-9c07-f0b379a3ac98",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2277,6 +2261,7 @@
   },
   "field-edge-to-validation-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "700aa9e4-d819-490f-ac2f-b0311b643620",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2296,12 +2281,14 @@
   },
   "field-edge-to-validation-icon-quiet": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "component": "validation-icon",
     "value": "0px",
     "uuid": "151915e5-f946-474f-9595-18d8a159a6ff",
     "deprecated": true
   },
   "field-edge-to-validation-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "5f116e74-21ad-4397-8fd0-72697de194c0",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-small instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2404,6 +2391,7 @@
   },
   "field-text-to-alert-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "3507c44d-62d4-4422-a62e-d463a23eb9cf",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2423,6 +2411,7 @@
   },
   "field-text-to-alert-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "8cee0a0d-2faf-4620-ad54-0c48780a9add",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2442,6 +2431,7 @@
   },
   "field-text-to-alert-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "dcce6c23-1a67-49db-826f-e4e3e2d94f01",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2461,6 +2451,7 @@
   },
   "field-text-to-alert-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "3975bf43-b0fb-4ab9-92fb-c4936e1d31b9",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
@@ -2480,6 +2471,7 @@
   },
   "field-text-to-validation-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "461753a3-581e-4675-bcff-13386fe17123",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-extra-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2499,6 +2491,7 @@
   },
   "field-text-to-validation-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "5d8df662-c7ca-4b45-931d-92c4b27c00c0",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-large instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2518,6 +2511,7 @@
   },
   "field-text-to-validation-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "ac8e642d-666a-4d38-be97-6fe05edf1006",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-medium instead. Updated to follow Spectrum Future Foundations spacing formula",
@@ -2537,6 +2531,7 @@
   },
   "field-text-to-validation-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "field",
     "uuid": "6d6c6035-1f3f-4e6c-8140-f5dc5a06a8d8",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-horizontal-small instead.",
@@ -2556,6 +2551,7 @@
   },
   "field-top-to-alert-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "91d122d2-799b-45c3-aa4e-4f1a0c7336b2",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead.",
@@ -2575,6 +2571,7 @@
   },
   "field-top-to-alert-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "2ec841a0-c05a-43d6-a77f-093ccf710819",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead.",
@@ -2594,6 +2591,7 @@
   },
   "field-top-to-alert-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "e0425fc4-00bc-4bbd-9d07-576303dca294",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead.",
@@ -2613,6 +2611,7 @@
   },
   "field-top-to-alert-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "alert-icon",
     "uuid": "785eb0f4-da05-495d-820b-b0b0423b1c14",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead.",
@@ -3012,6 +3011,7 @@
   },
   "field-top-to-validation-icon-extra-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "a5ad9ef8-fed7-4726-8ae6-5a87b8ee66c1",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-extra-large instead. Require unified UI icon set.",
@@ -3031,6 +3031,7 @@
   },
   "field-top-to-validation-icon-large": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "5aa2d68f-472b-420e-892d-08025e1e962f",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-large instead. Require unified UI icon set.",
@@ -3050,6 +3051,7 @@
   },
   "field-top-to-validation-icon-medium": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "58d6a35b-1158-43fb-8b0c-06d479682ebf",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-medium instead. Require unified UI icon set.",
@@ -3069,6 +3071,7 @@
   },
   "field-top-to-validation-icon-small": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "component": "validation-icon",
     "uuid": "da1ccd21-d162-464a-8772-2f0609b7accc",
     "deprecated": true,
     "deprecated_comment": "Use semantic token base-padding-vertical-small instead. Require unified UI icon set.",
@@ -3155,6 +3158,24 @@
     "value": "{spacing-50}",
     "uuid": "fb035d45-e63b-4cd4-b220-675a52e99399",
     "description": "Spacing between child elements for focus indicators"
+  },
+  "gap-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{spacing-400}",
+    "uuid": "c0571c46-5946-4896-bcbf-270560de5385",
+    "description": "Spacing between child elements for banner components"
+  },
+  "gap-regular": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{spacing-75}",
+    "uuid": "b7e1af59-753e-4059-8f46-8d862f631ad8",
+    "description": "Spacing between child elements for list structures (regular density)"
+  },
+  "gap-vertical": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{spacing-100}",
+    "uuid": "312ebac2-32a0-47a8-9c4e-e366b2232228",
+    "description": "Spacing between child elements for banner components"
   },
   "gradient-stop-1-genai": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
@@ -3259,12 +3280,6 @@
     "value": "{spacing-50}",
     "uuid": "a66810ec-1839-4ca3-8036-d552a71b1511",
     "description": "Spacing between child elements for list structures (compact density)"
-  },
-  "list-gap-regular": {
-    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
-    "value": "{spacing-75}",
-    "uuid": "b7e1af59-753e-4059-8f46-8d862f631ad8",
-    "description": "Spacing between child elements for list structures (regular density)"
   },
   "list-gap-spacious": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3389,6 +3404,18 @@
       }
     },
     "renamed": "base-padding-vertical-small"
+  },
+  "padding-horizontal": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{spacing-300}",
+    "uuid": "eb386242-21c6-437b-8125-e6d4394dd9c5",
+    "description": "Horizontal internal spacing for banner components"
+  },
+  "padding-vertical": {
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
+    "value": "{spacing-200}",
+    "uuid": "64fa4ab7-be93-4420-8cdc-a6ef91499852",
+    "description": "Vertical internal spacing for banner components"
   },
   "popover-gap": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -344,7 +344,12 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     // the full legacy key in `property` already (e.g. property:"icon-color-disabled-
     // primary", icon:"icon"), with `icon` duplicated as a metadata annotation only.
     // Prepending the owner there would double the prefix.
-    if let Some(ic) = icon {
+    //
+    // Excluded when property is "space-between": an icon-family space-between
+    // endpoint (e.g. {property:"space-between", to:"icon", icon:"alert"}) is
+    // handled by the space-between branch below, which folds `icon` into the
+    // `from`/`to` connective instead of prefixing it as an owner.
+    if let Some(ic) = icon.filter(|_| property != "space-between") {
         let registry = crate::registry::RegistryData::embedded();
         let ic_expanded = registry.token_name("icon", ic).unwrap_or(ic);
         let is_thin =
@@ -382,6 +387,11 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
     // generic position-walk below can't express a joining `-to-` between two field values.
     // e.g. {component:"accordion", property:"space-between", from:"bottom", to:"handle",
     //       size:"xl", state:"hover"} → "accordion-bottom-to-handle-extra-large-hover"
+    //
+    // An icon-family endpoint is stored as the generic anatomy term "icon" plus a
+    // separate `icon` field (e.g. {from:"field-top", to:"icon", icon:"alert"}) rather
+    // than a literal endpoint of its own — expand it via the `icon` field instead of
+    // the (nonexistent) "to"/"from" registry, mirroring JS decomposer.js's serialize().
     if property == "space-between" {
         let from = name.get("from").and_then(|v| v.as_str());
         let to = name.get("to").and_then(|v| v.as_str());
@@ -394,9 +404,22 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
                 if entry.exclude_from_legacy_key {
                     continue;
                 }
+                if entry.name == "icon" && (f == "icon" || t == "icon") {
+                    continue; // already folded into the from/to connective below
+                }
                 if entry.name == "property" {
-                    let f_expanded = registry.token_name("from", f).unwrap_or(f);
-                    let t_expanded = registry.token_name("to", t).unwrap_or(t);
+                    let f_expanded = if f == "icon" {
+                        icon.and_then(|i| registry.token_name("icon", i))
+                            .unwrap_or(f)
+                    } else {
+                        registry.token_name("from", f).unwrap_or(f)
+                    };
+                    let t_expanded = if t == "icon" {
+                        icon.and_then(|i| registry.token_name("icon", i))
+                            .unwrap_or(t)
+                    } else {
+                        registry.token_name("to", t).unwrap_or(t)
+                    };
                     parts.push(format!("{f_expanded}-to-{t_expanded}"));
                     continue;
                 }

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -3100,6 +3100,20 @@ const ICON_TERMS_JSON: &str = r##"{
       "description": "Gripper glyph",
       "tokenName": "gripper-icon",
       "usedIn": ["tokens"]
+    },
+    {
+      "id": "alert",
+      "label": "Alert Icon",
+      "description": "Alert/error glyph",
+      "tokenName": "alert-icon",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "validation",
+      "label": "Validation Icon",
+      "description": "Field validation-state glyph",
+      "tokenName": "validation-icon",
+      "usedIn": ["tokens"]
     }
   ]
 }

--- a/tools/token-mapping-analyzer/src/apply.js
+++ b/tools/token-mapping-analyzer/src/apply.js
@@ -187,21 +187,18 @@ export function applySpaceBetween(tokens, registry, filename) {
     )
       continue;
 
-    const patched = {
-      ...token.name,
-      from: result.nameObject.from,
-      to: result.nameObject.to,
-      property: result.nameObject.property,
-    };
+    // Whole-object merge (see applyField's comment): decompose() may pull
+    // other fields (size, density, icon, ...) out of the property string
+    // alongside from/to — dropping them here would silently break the
+    // roundtrip check below.
+    const patched = { ...token.name, ...result.nameObject };
     if (
       serialize(patched, registry.tokenNameMap, registry.serializationOrder) !==
       legacyKey
     )
       continue;
 
-    token.name.from = result.nameObject.from;
-    token.name.to = result.nameObject.to;
-    token.name.property = result.nameObject.property;
+    Object.assign(token.name, result.nameObject);
     applied++;
   }
 

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -147,6 +147,24 @@ function endpointResolves(
 }
 
 /**
+ * If `endpoint` is exactly a registered icon's expanded legacy form (e.g.
+ * "alert-icon" for icon id "alert"), return that icon id. Bare "icon" is
+ * already a valid SPEC-047 anatomy endpoint (anatomy-terms.json), so an
+ * icon-family compound resolves to the anatomy endpoint "icon" plus a
+ * separate `icon` field — not a literal endpoint string of its own.
+ *
+ * @param {string} endpoint
+ * @param {object} registry
+ * @returns {string|null}
+ */
+function iconEndpointMatch(endpoint, registry) {
+  for (const iconId of registry.byField.icon ?? []) {
+    if (registry.tokenNameMap[iconId] === endpoint) return iconId;
+  }
+  return null;
+}
+
+/**
  * Decompose a token name into a 13-field name object.
  *
  * @param {string} tokenName - kebab-case token name
@@ -260,6 +278,7 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
       // the longest unmatched *suffix* of beforeConnector first.
       let fromStart = -1;
       let fromCandidate = null;
+      let fromIcon = null;
       for (let k = beforeConnector.length; k >= 1; k--) {
         const startOffset = beforeConnector.length - k;
         const absoluteStart = componentEndIdx + startOffset;
@@ -268,6 +287,13 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
           .every((_, j) => !matched[absoluteStart + j]);
         if (!clean) continue;
         const candidate = beforeConnector.slice(startOffset).join("-");
+        const iconId = iconEndpointMatch(candidate, registry);
+        if (iconId) {
+          fromStart = absoluteStart;
+          fromCandidate = "icon";
+          fromIcon = iconId;
+          break;
+        }
         if (
           endpointResolves(
             candidate,
@@ -285,9 +311,16 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
       if (fromCandidate) {
         const rest = segments.slice(connectorIdx + 1);
         let toSegs = null;
+        let toIcon = null;
         for (let k = rest.length; k >= 1; k--) {
           if (matched[connectorIdx + 1 + k - 1]) continue;
           const candidate = rest.slice(0, k).join("-");
+          const iconId = iconEndpointMatch(candidate, registry);
+          if (iconId) {
+            toSegs = rest.slice(0, k);
+            toIcon = iconId;
+            break;
+          }
           if (
             endpointResolves(
               candidate,
@@ -304,7 +337,8 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
         if (toSegs) {
           nameObject.property = "space-between";
           nameObject.from = fromCandidate;
-          nameObject.to = toSegs.join("-");
+          nameObject.to = toIcon ? "icon" : toSegs.join("-");
+          if (fromIcon || toIcon) nameObject.icon = fromIcon || toIcon;
           for (let i = fromStart; i < connectorIdx; i++) {
             matched[i] = true;
             matchDetails[i] = "from";
@@ -741,12 +775,21 @@ export function serialize(
     nameObject.from &&
     nameObject.to
   ) {
+    // An "icon" endpoint (bare anatomy term) paired with nameObject.icon is an
+    // icon-family compound (e.g. to:"icon", icon:"alert" -> "alert-icon") —
+    // expand via the icon's tokenName rather than the literal "icon".
     const parts = [];
     for (const field of serializationOrder) {
-      if (field === "from" || field === "to") continue;
+      if (field === "from" || field === "to" || field === "icon") continue;
       if (field === "property") {
-        const fromExpanded = tokenNameMap[nameObject.from] || nameObject.from;
-        const toExpanded = tokenNameMap[nameObject.to] || nameObject.to;
+        const fromExpanded =
+          nameObject.from === "icon" && nameObject.icon
+            ? tokenNameMap[nameObject.icon] || nameObject.icon
+            : tokenNameMap[nameObject.from] || nameObject.from;
+        const toExpanded =
+          nameObject.to === "icon" && nameObject.icon
+            ? tokenNameMap[nameObject.icon] || nameObject.icon
+            : tokenNameMap[nameObject.to] || nameObject.to;
         parts.push(`${fromExpanded}-to-${toExpanded}`);
         continue;
       }

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -334,6 +334,12 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
           }
         }
 
+        // A single nameObject.icon field can't hold two distinct glyphs; bail
+        // out rather than silently keeping only the `from` side's icon.
+        if (toSegs && fromIcon && toIcon && fromIcon !== toIcon) {
+          toSegs = null;
+        }
+
         if (toSegs) {
           nameObject.property = "space-between";
           nameObject.from = fromCandidate;

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -102,6 +102,22 @@ test("decomposes space-between gap with an icon-family endpoint (alert-icon)", (
   t.true(result.roundtrips);
 });
 
+test("rejects space-between when from and to resolve to different icons", (t) => {
+  // nameObject.icon can only hold one glyph; a from/to pair naming two
+  // distinct icons must not silently keep only the `from` side's icon.
+  const result = decompose(
+    "checkmark-icon-to-alert-icon",
+    {},
+    registry,
+    "test",
+  );
+  t.not(result.nameObject.property, "space-between");
+  t.true(
+    result.gaps.some((g) => g.type === "spacing-between"),
+    "unresolved -to- pattern should surface as a gap, not a silent mismatch",
+  );
+});
+
 test("matches typography family and emphasis as real fields, not gaps", (t) => {
   const result = decompose(
     "body-cjk-emphasized-font-weight",

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -87,15 +87,19 @@ test("decomposes component-height compound with scale index", (t) => {
   t.true(result.roundtrips);
 });
 
-test("detects spacing-between pattern", (t) => {
+test("decomposes space-between gap with an icon-family endpoint (alert-icon)", (t) => {
   const result = decompose(
     "field-top-to-alert-icon-small",
     {},
     registry,
     "test",
   );
-  const spacingGap = result.gaps.find((g) => g.type === "spacing-between");
-  t.truthy(spacingGap);
+  t.is(result.nameObject.property, "space-between");
+  t.is(result.nameObject.from, "field-top");
+  t.is(result.nameObject.to, "icon");
+  t.is(result.nameObject.icon, "alert");
+  t.deepEqual(result.gaps, []);
+  t.true(result.roundtrips);
 });
 
 test("matches typography family and emphasis as real fields, not gaps", (t) => {
@@ -401,6 +405,21 @@ test("serialize() reconstructs the -to- connective for a space-between name", (t
     registry.serializationOrder,
   );
   t.is(legacyKey, "accordion-bottom-to-handle-extra-large-hover");
+});
+
+test("serialize() reconstructs an icon-family -to- endpoint (alert-icon)", (t) => {
+  const legacyKey = serialize(
+    {
+      property: "space-between",
+      from: "field-top",
+      to: "icon",
+      icon: "alert",
+      size: "s",
+    },
+    registry.tokenNameMap,
+    registry.serializationOrder,
+  );
+  t.is(legacyKey, "field-top-to-alert-icon-small");
 });
 
 test("decomposes an icon size-N token and splits the scaleIndex (dsi.6 icon follow-up)", (t) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Structures fused `-to-` spacing/icon compound tokens in
`layout.tokens.json` (and, as a side effect of a shared bug fix,
`layout-component.tokens.json`) into the `name` object per the 13-field
taxonomy spec. Published legacy names are unaffected — every migrated
token's `legacyKey` (explicit or reconstructed) still pins the original
flat output string.

Changes:
- Registered `alert`/`validation` icon ids in `icon-terms.json` so
  icon-family space-between endpoints (`field-top-to-alert-icon-small`)
  resolve.
- Extended `decomposer.js`'s `decompose()`/`serialize()` space-between
  handling to recognize icon-family endpoints, adding a `from`/`to`/`icon`
  shape instead of leaving a decompose gap.
- Fixed a bug in `apply.js`'s `applySpaceBetween`: its roundtrip-safety
  check only merged `from`/`to`/`property` before re-serializing, silently
  dropping `size`/`icon`/`density`/`variant` — so the check could never
  pass and 0 space-between tokens applied corpus-wide. Fixed to a
  whole-object merge (matching `applyField`'s existing pattern).
- Ran the space-between/structure/size/variant/qualifier extractors
  corpus-wide with `--write`, verified via tests + roundtrip.
- Hand-authored + `legacyKey`-pinned 29 tokens with idiosyncratic
  per-component field ordering not worth a generalized decompose branch
  (per the `idiosyncratic-legacy-fusion-pattern` precedent).

## Related Issue

Closes spectrum-design-data-dsi.8. Remaining genuinely-blocked tokens
(8x `field-top-to-progress-circle-*` — SPEC-047 has no component-to-component
relation endpoint; ~27 SPEC-025-blocked structure-scoped anatomy tokens) are
split into spectrum-design-data-bzo pending a taxonomy decision, not fixed
here.

## Motivation and Context

Part of the ongoing Phase D residual-property triage series
(dsi.\* beads) migrating fused legacy property strings into structured
`name` objects so the dataset matches the 13-field taxonomy spec.

## How Has This Been Tested?

- `npx ava` in `tools/token-mapping-analyzer/` — 43/43 tests pass.
- `moon run design-data:roundtrip-verify` — byte-identical legacy key
  reconstruction confirmed.
- `moon run design-data:validate` — exits 0; remaining SPEC-027 warnings
  are pre-existing dangling `tokenBindings` references to token-name
  strings that never existed in the corpus (confirmed via grep), unrelated
  to and unaffected by this change.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset valid.

## Screenshots (if appropriate):

N/A — data/tooling change only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
