### PR TITLE
fix(design-data): pin legacyKey on misc fused-property singletons (dsi.13)

### DIFF
--- a/.changeset/dsi13-pin-misc-singleton-fusions.md
+++ b/.changeset/dsi13-pin-misc-singleton-fusions.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Structured 14 untracked fused-property singleton tokens into the `name`
+object (bead spectrum-design-data-dsi.13). Published legacy names are
+unaffected since each token's `legacyKey` pins the flat output name.
+
+- **packages/design-data/tokens/color-aliases.tokens.json**: extracted
+  `structure`/`emphasis`/`state` from the two `drop-shadow-emphasized(-hover)-key-color`
+  families (6 tokens); extracted `object` (`focus-indicator`/`title`/`track`)
+  and `variant`/`colorFamily` where applicable from 5 generic-alias singletons
+  previously fused as `*-color`.
+- **packages/design-data/tokens/color-palette.tokens.json**: extracted
+  `component:"avatar"` from the 3 `gradient-stop-N-avatar` tokens.
+- **packages/design-data/tokens/color-component.tokens.json**: pinned
+  `legacyKey` on the 3 `opacity-checkerboard` `square-dark` tokens (verified
+  the light/dark/wireframe `colorScheme` mismatch flagged in the bead is a
+  naming artifact — "dark" names the darker of two alternating tiles, not the
+  color scheme — no value change).
+- **packages/design-data/tokens/typography.tokens.json**: pinned `legacyKey`
+  on `default-font-family` (no registered segment to extract).

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -1747,8 +1747,12 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-key-color",
-      "colorScheme": "light"
+      "property": "key-color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "colorScheme": "light",
+      "legacyKey": "drop-shadow-emphasized-hover-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1758,8 +1762,12 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-key-color",
-      "colorScheme": "dark"
+      "property": "key-color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "colorScheme": "dark",
+      "legacyKey": "drop-shadow-emphasized-hover-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.36)",
@@ -1769,8 +1777,12 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-hover-key-color",
-      "colorScheme": "wireframe"
+      "property": "key-color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "state": "hover",
+      "colorScheme": "wireframe",
+      "legacyKey": "drop-shadow-emphasized-hover-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.12)",
@@ -1780,8 +1792,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-key-color",
-      "colorScheme": "light"
+      "property": "key-color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "colorScheme": "light",
+      "legacyKey": "drop-shadow-emphasized-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.08)",
@@ -1791,8 +1806,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-key-color",
-      "colorScheme": "dark"
+      "property": "key-color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "colorScheme": "dark",
+      "legacyKey": "drop-shadow-emphasized-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.24)",
@@ -1802,8 +1820,11 @@
   },
   {
     "name": {
-      "property": "drop-shadow-emphasized-key-color",
-      "colorScheme": "wireframe"
+      "property": "key-color",
+      "emphasis": "emphasized",
+      "structure": "drop-shadow",
+      "colorScheme": "wireframe",
+      "legacyKey": "drop-shadow-emphasized-key-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
     "value": "rgba(0, 0, 0, 0.08)",
@@ -1855,7 +1876,9 @@
   },
   {
     "name": {
-      "property": "focus-indicator-color"
+      "object": "focus-indicator",
+      "property": "color",
+      "legacyKey": "focus-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -4552,7 +4575,11 @@
   },
   {
     "name": {
-      "property": "static-black-focus-indicator-color"
+      "variant": "static",
+      "colorFamily": "black",
+      "object": "focus-indicator",
+      "property": "color",
+      "legacyKey": "static-black-focus-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -4590,7 +4617,11 @@
   },
   {
     "name": {
-      "property": "static-white-focus-indicator-color"
+      "variant": "static",
+      "colorFamily": "white",
+      "object": "focus-indicator",
+      "property": "color",
+      "legacyKey": "static-white-focus-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
@@ -4628,7 +4659,9 @@
   },
   {
     "name": {
-      "property": "title-color"
+      "object": "title",
+      "property": "color",
+      "legacyKey": "title-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -4636,7 +4669,9 @@
   },
   {
     "name": {
-      "property": "track-color"
+      "object": "track",
+      "property": "color",
+      "legacyKey": "track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -625,7 +625,8 @@
     "name": {
       "component": "opacity-checkerboard",
       "property": "square-dark",
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "legacyKey": "opacity-checkerboard-square-dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -637,7 +638,8 @@
     "name": {
       "component": "opacity-checkerboard",
       "property": "square-dark",
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "legacyKey": "opacity-checkerboard-square-dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -649,7 +651,8 @@
     "name": {
       "component": "opacity-checkerboard",
       "property": "square-dark",
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "legacyKey": "opacity-checkerboard-square-dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",

--- a/packages/design-data/tokens/color-palette.tokens.json
+++ b/packages/design-data/tokens/color-palette.tokens.json
@@ -4715,7 +4715,9 @@
   },
   {
     "name": {
-      "property": "gradient-stop-1-avatar"
+      "component": "avatar",
+      "property": "gradient-stop-1",
+      "legacyKey": "gradient-stop-1-avatar"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 0,
@@ -4724,7 +4726,9 @@
   },
   {
     "name": {
-      "property": "gradient-stop-2-avatar"
+      "component": "avatar",
+      "property": "gradient-stop-2",
+      "legacyKey": "gradient-stop-2-avatar"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 0.6666,
@@ -4733,7 +4737,9 @@
   },
   {
     "name": {
-      "property": "gradient-stop-3-avatar"
+      "component": "avatar",
+      "property": "gradient-stop-3",
+      "legacyKey": "gradient-stop-3-avatar"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
     "value": 1,

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -1077,7 +1077,8 @@
   },
   {
     "name": {
-      "property": "default-font-family"
+      "property": "default-font-family",
+      "legacyKey": "default-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a552c422-c51c-458a-87b0-c6fe5178bf4b",

--- a/packages/tokens/naming-exceptions.json
+++ b/packages/tokens/naming-exceptions.json
@@ -3,6 +3,24 @@
   "description": "Legacy token names that cannot be deterministically generated from a structured name object. Each entry tracks a known inconsistency for future remediation.",
   "exceptions": [
     {
+      "token": "gradient-stop-1-avatar",
+      "file": "color-palette.json",
+      "category": "component-ordering",
+      "reason": "Legacy name is property-then-component (category: component-ordering); canonical generation order is component-then-property"
+    },
+    {
+      "token": "gradient-stop-2-avatar",
+      "file": "color-palette.json",
+      "category": "component-ordering",
+      "reason": "Legacy name is property-then-component (category: component-ordering); canonical generation order is component-then-property"
+    },
+    {
+      "token": "gradient-stop-3-avatar",
+      "file": "color-palette.json",
+      "category": "component-ordering",
+      "reason": "Legacy name is property-then-component (category: component-ordering); canonical generation order is component-then-property"
+    },
+    {
       "token": "drop-shadow-emphasized-default-color",
       "file": "color-aliases.json",
       "category": "compound-state",

--- a/packages/tokens/snapshots/validation-snapshot.json
+++ b/packages/tokens/snapshots/validation-snapshot.json
@@ -261,6 +261,27 @@
       "message": "Known naming exception: 'tree-view-selected-row-background-hover' does not match canonical generation rules (tracked in naming-exceptions.json)"
     },
     {
+      "file": "./src/color-palette.json",
+      "token": "gradient-stop-1-avatar",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'gradient-stop-1-avatar' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-palette.json",
+      "token": "gradient-stop-2-avatar",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'gradient-stop-2-avatar' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
+      "file": "./src/color-palette.json",
+      "token": "gradient-stop-3-avatar",
+      "rule_id": "SPEC-007",
+      "severity": "info",
+      "message": "Known naming exception: 'gradient-stop-3-avatar' does not match canonical generation rules (tracked in naming-exceptions.json)"
+    },
+    {
       "file": "./src/icons.json",
       "token": "icon-color-disabled-primary",
       "rule_id": "SPEC-007",

--- a/packages/tokens/src/color-palette.json
+++ b/packages/tokens/src/color-palette.json
@@ -2471,18 +2471,21 @@
   },
   "gradient-stop-1-avatar": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "component": "avatar",
     "value": 0,
     "uuid": "8d9e0c2d-d692-47a0-86cd-6349649ec6e2",
     "private": true
   },
   "gradient-stop-2-avatar": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "component": "avatar",
     "value": 0.6666,
     "uuid": "a7791b29-4e4d-4b9f-ab34-0240ac4d6769",
     "private": true
   },
   "gradient-stop-3-avatar": {
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/gradient-stop.json",
+    "component": "avatar",
     "value": 1,
     "uuid": "620ee6f3-eb3d-40ad-854b-9edceb897c7f",
     "private": true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Structures 14 untracked fused-property singleton tokens into the `name`
object (bead `spectrum-design-data-dsi.13`, part of the Phase D residual
triage series). Each token's `legacyKey` is pinned so the published legacy
name is unaffected by the decomposition.

- **`color-aliases.tokens.json`**: extracted `structure:"drop-shadow"`,
  `emphasis:"emphasized"`, `state:"hover"` from the
  `drop-shadow-emphasized(-hover)-key-color` families (6 tokens); extracted
  `object` (`focus-indicator`/`title`/`track`) and `variant`/`colorFamily`
  from 5 generic-alias singletons previously fused as `*-color`.
- **`color-palette.tokens.json`**: extracted `component:"avatar"` from the 3
  `gradient-stop-N-avatar` tokens.
- **`color-component.tokens.json`**: pinned `legacyKey` on the 3
  `opacity-checkerboard` `square-dark` tokens. Investigated the
  colorScheme/name mismatch flagged in the bead — verified it's a naming
  artifact ("dark" names the darker of two alternating checkerboard tiles,
  not the color scheme; the `light`-scheme entry correctly resolves to a
  light gray) — no value change.
- **`typography.tokens.json`**: pinned `legacyKey` on `default-font-family`
  (no registered segment to extract).

## Related Issue

Bead `spectrum-design-data-dsi.13` (parent: `spectrum-design-data-dsi`,
Phase D residual triage).

## Motivation and Context

Registry-membership scan found these tokens had no `legacyKey` and no
registered property term, meaning renames/refactors elsewhere could silently
break their legacy output. Decomposing (where a registered scope term
exists) and pinning `legacyKey` (always) closes that gap while guaranteeing
zero change to published token names.

Note: `anatomy` was considered for the `focus-indicator`/`title`/`track`
singletons but rejected — `anatomy` requires a `component` field (SPEC-025),
and these are ownerless generic aliases. Used `object` instead, matching the
existing `static-black-track-indicator-color` precedent in the same file.

## How Has This Been Tested?

- `moon run design-data:roundtrip-verify` — passes (`Roundtrip OK`).
- `moon run design-data:legacy-output` — regenerated; only diff is a new
  `component` metadata field in `color-palette.json`, legacy key names
  unchanged.
- `moon run design-data:validate` — 0 errors, same as pre-change baseline
  (only pre-existing-pattern SPEC-009 advisory warnings for still-unregistered
  residual property terms, matching existing sibling tokens).
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
