### PR TITLE
feat(design-data): structure field-top-to-progress-circle tokens (bzo bucket 1)

### DIFF
--- a/.changeset/bzo-progress-circle-structure.md
+++ b/.changeset/bzo-progress-circle-structure.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Added the `in-field-progress-circle` anatomy term and structured the last 8
+fused `field-top-to-progress-circle-*` layout tokens accordingly (bead
+spectrum-design-data-bzo, bucket 1); legacy names are unaffected.
+
+- **packages/design-data/registry/anatomy-terms.json**: added
+  `in-field-progress-circle` anatomy term.
+- **packages/design-data/tokens/layout.tokens.json**: structured the 8
+  `field-top-to-progress-circle-*` tokens into `space-between`/`from`/`to`
+  form with `legacyKey`.

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -438,6 +438,11 @@
       "usedIn": ["s2-docs"]
     },
     {
+      "id": "in-field-progress-circle",
+      "label": "In-field Progress Circle",
+      "description": "Progress circle rendered inside a field element to indicate a loading state (e.g. in picker, combo-box, text-field)"
+    },
+    {
       "id": "leading-icon",
       "label": "Leading Icon",
       "description": "Icon placed at the leading (start) edge inside a field (e.g. search icon in search-field)",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -5084,8 +5084,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-extra-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "xl",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-progress-circle-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -5098,8 +5102,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-extra-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "xl",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-progress-circle-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -5112,8 +5120,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-large",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "l",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-progress-circle-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5126,8 +5138,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-large",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "l",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-progress-circle-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "11px",
@@ -5140,8 +5156,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-medium",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "m",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-progress-circle-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5154,8 +5174,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-medium",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "m",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-progress-circle-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -5168,8 +5192,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-small",
-      "scale": "desktop"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "s",
+      "scale": "desktop",
+      "legacyKey": "field-top-to-progress-circle-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -5182,8 +5210,12 @@
   },
   {
     "name": {
-      "property": "field-top-to-progress-circle-small",
-      "scale": "mobile"
+      "property": "space-between",
+      "from": "field-top",
+      "to": "in-field-progress-circle",
+      "size": "s",
+      "scale": "mobile",
+      "legacyKey": "field-top-to-progress-circle-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1335,6 +1335,11 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "usedIn": ["s2-docs"]
     },
     {
+      "id": "in-field-progress-circle",
+      "label": "In-field Progress Circle",
+      "description": "Progress circle rendered inside a field element to indicate a loading state (e.g. in picker, combo-box, text-field)"
+    },
+    {
       "id": "leading-icon",
       "label": "Leading Icon",
       "description": "Icon placed at the leading (start) edge inside a field (e.g. search icon in search-field)",


### PR DESCRIPTION
## Description

Structures the last 8 fused `field-top-to-progress-circle-*` tokens in `packages/design-data/tokens/layout.tokens.json` into the standard `space-between`/`from`/`to` name form, and adds the new `in-field-progress-circle` generic anatomy registry term they resolve `to` against.

Modeling decision (confirmed this session): the progress circle endpoint is a **registry anatomy term**, matching how the analogous `in-field-button` is modeled — not a component-declared `field.json` anatomy part, and not a SPEC-047 component-to-component relation (which doesn't exist as a category). `legacyKey` is set on each token so the old fused name reconstructs exactly on round-trip.

## Related Issue

Bead `spectrum-design-data-bzo` (P3), bucket 1 — bucket 2 already landed via #1280.

## Motivation and Context

These 8 tokens were the last fused/passthrough holdouts in the `field-top-to-*` family; every sibling (`disclosure-icon`, validation `icon`) is already structured. This closes that inconsistency without changing any legacy output.

## How Has This Been Tested?

- `moon run sdk:codegen` — regenerated `sdk/core/src/registry_data.rs` from the updated `anatomy-terms.json`; `sdk:codegen-check` confirms it's in sync.
- `moon run design-data:validate`, `validate-dataset`, `roundtrip-verify` — all exit 0. Full `validate` surfaces two pre-existing SPEC-027 errors on `combo-box.json` (unrelated unknown-token references); confirmed via `git stash` that these exist identically on `main` without this change, so they're an existing backlog item (bead spectrum-design-data-0jm), not a regression.
- `cargo test -p design-data-core` — 649 passed, 0 failed, including the SPEC-047/049 rule tests directly exercising this change (`component_declared_anatomy_endpoint_no_error`, `edge_to_generic_anatomy_no_error`, `unrelated_token_no_error`, `no_anatomy_no_error`, `unknown_anatomy_without_component_errors`).
- Changeset linted clean via `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.
- Note: this sandbox has no network access, so full-workspace commands (`moon run :test`, `cargo test --workspace`) hang indefinitely on a network-dependent target; scoped equivalents above were run instead and are the correct substitutes per this repo's own guidance for single-package verification.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.