### PR TITLE
fix(design-data): pin legacyKey on registry-gap residual tokens (rst)

### DIFF
--- a/.changeset/rst-pin-registry-gap-residual.md
+++ b/.changeset/rst-pin-registry-gap-residual.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Pinned `legacyKey` on the 25 remaining registry-gap residual tokens in
+`layout.tokens.json` (bead spectrum-design-data-rst). 22 of the 25 are already
+deprecated with a `replaced_by` token, so registering new anatomy/qualifier
+vocabulary for them was not worthwhile; published legacy names are unaffected.
+
+- **packages/design-data/tokens/layout.tokens.json**: pinned `legacyKey` on
+  `android-elevation`, `corner-triangle-icon-size-*` (8),
+  `navigational-indicator-top-to-back-icon-*` (8), `side-focus-indicator`,
+  and `side-label-character-count-*` (6).

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -229,7 +229,8 @@
   },
   {
     "name": {
-      "property": "android-elevation"
+      "property": "android-elevation",
+      "legacyKey": "android-elevation"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2dp",
@@ -2918,7 +2919,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-100",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "corner-triangle-icon-size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -2930,7 +2932,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-100",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "corner-triangle-icon-size-100"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -2942,7 +2945,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-200",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "corner-triangle-icon-size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -2954,7 +2958,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-200",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "corner-triangle-icon-size-200"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -2966,7 +2971,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-300",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "corner-triangle-icon-size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -2978,7 +2984,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-300",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "corner-triangle-icon-size-300"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "8px",
@@ -2990,7 +2997,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-75",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "corner-triangle-icon-size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "5px",
@@ -3002,7 +3010,8 @@
   {
     "name": {
       "property": "corner-triangle-icon-size-75",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "corner-triangle-icon-size-75"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5820,7 +5829,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-extra-large",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "navigational-indicator-top-to-back-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -5834,7 +5844,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-extra-large",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "navigational-indicator-top-to-back-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "19px",
@@ -5848,7 +5859,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-large",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "navigational-indicator-top-to-back-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -5862,7 +5874,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-large",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "navigational-indicator-top-to-back-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -5876,7 +5889,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-medium",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "navigational-indicator-top-to-back-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "9px",
@@ -5890,7 +5904,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-medium",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "navigational-indicator-top-to-back-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -5904,7 +5919,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-small",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "navigational-indicator-top-to-back-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "6px",
@@ -5918,7 +5934,8 @@
   {
     "name": {
       "property": "navigational-indicator-top-to-back-icon-small",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "navigational-indicator-top-to-back-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "7px",
@@ -5951,7 +5968,8 @@
   },
   {
     "name": {
-      "property": "side-focus-indicator"
+      "property": "side-focus-indicator",
+      "legacyKey": "side-focus-indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "4px",
@@ -5960,7 +5978,8 @@
   {
     "name": {
       "property": "side-label-character-count-to-field",
-      "scale": "desktop"
+      "scale": "desktop",
+      "legacyKey": "side-label-character-count-to-field"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -5974,7 +5993,8 @@
   {
     "name": {
       "property": "side-label-character-count-to-field",
-      "scale": "mobile"
+      "scale": "mobile",
+      "legacyKey": "side-label-character-count-to-field"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "15px",
@@ -5987,7 +6007,8 @@
   },
   {
     "name": {
-      "property": "side-label-character-count-top-margin-extra-large"
+      "property": "side-label-character-count-top-margin-extra-large",
+      "legacyKey": "side-label-character-count-top-margin-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -5997,7 +6018,8 @@
   },
   {
     "name": {
-      "property": "side-label-character-count-top-margin-large"
+      "property": "side-label-character-count-top-margin-large",
+      "legacyKey": "side-label-character-count-top-margin-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -6007,7 +6029,8 @@
   },
   {
     "name": {
-      "property": "side-label-character-count-top-margin-medium"
+      "property": "side-label-character-count-top-margin-medium",
+      "legacyKey": "side-label-character-count-top-margin-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -6017,7 +6040,8 @@
   },
   {
     "name": {
-      "property": "side-label-character-count-top-margin-small"
+      "property": "side-label-character-count-top-margin-small",
+      "legacyKey": "side-label-character-count-top-margin-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "0px",
@@ -6727,7 +6751,8 @@
   },
   {
     "name": {
-      "property": "window-to-edge"
+      "property": "window-to-edge",
+      "legacyKey": "window-to-edge"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",


### PR DESCRIPTION
## Description

Pins `legacyKey` on the last 25 registry-membership-scan residual tokens in
`layout.tokens.json` (bead `spectrum-design-data-rst`, sibling of the
`dsi.8`/`bzo` triage series). Each token's leading `name.property` scope word
(`android-elevation`, `corner-triangle`, `navigational-indicator`,
`side-focus`, `side-label`, `window-to`) didn't resolve to any registry
(`components.json` / `structures.json` / `anatomy-terms.json`).

Per-term verification showed 22 of the 25 tokens are already deprecated with
a `replaced_by` successor token, so registering new anatomy/qualifier
vocabulary for data scheduled for removal wasn't worthwhile. Instead, every
token gets a hand-authored `legacyKey` pin (the existing escape hatch) so a
future `decompose()` migration can't silently rename them, following the
`a9t` precedent (#1257) rather than the `bzo` registration precedent (#1280,
#1281). `property` is left untouched.

## Related Issue

Closes bead `spectrum-design-data-rst`.

## Motivation and Context

Forward-compatibility safeguard — without a pinned `legacyKey`, a future
registry-driven `decompose()` pass could rewrite these tokens' published
legacy names.

## How Has This Been Tested?

- `moon run design-data:legacy-output` — regenerated `packages/tokens/src`;
  output is byte-identical, confirming the pins preserve published names.
- `moon run design-data:roundtrip-verify` — clean before and after the edit.
- `moon run design-data:validate`, `tokens:test`, `design-data-spec:check` —
  all pass (pre-existing unrelated warnings only).
- `moon run sdk:test` — full Rust workspace suite passes.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
