### PR TITLE
fix(sdk/wasm): derive suggest() tokenName via display_name(), not raw graph key

### DIFF
--- a/.changeset/wasm-suggest-display-name.md
+++ b/.changeset/wasm-suggest-display-name.md
@@ -1,0 +1,11 @@
+---
+"@adobe/design-data-wasm": patch
+---
+
+Fixed `Dataset.suggest()` returning raw `"<file>:<index>"` graph keys as
+`tokenName` for cascade-format tokens instead of the readable legacy name,
+since it skipped the `display_name()` derivation every other surface (diff,
+TUI wizard) already uses.
+
+- **sdk/wasm/src/types.rs**: `SuggestResult::from` now derives `token_name`
+  via `SuggestionResult::display_name()`.

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -1388,7 +1388,7 @@ fn run_suggest(
             .iter()
             .map(|r| {
                 serde_json::json!({
-                    "token_name": r.token_name,
+                    "token_name": r.display_name(),
                     "token_uuid": r.token_uuid,
                     "file": r.file.display().to_string(),
                     "layer": serde_json::to_value(r.layer).unwrap_or_default(),
@@ -1410,7 +1410,7 @@ fn run_suggest(
             println!(
                 "  {}. {} (confidence: {:.2})",
                 i + 1,
-                r.token_name,
+                r.display_name(),
                 r.confidence
             );
             if let Some(v) = &r.value {

--- a/sdk/tui/src/wizard/build.rs
+++ b/sdk/tui/src/wizard/build.rs
@@ -113,9 +113,37 @@ pub(super) fn build_value_rows(
 fn seed_alias(graph: &TokenGraph, intent: &str, property_hint: Option<&str>) -> Input {
     let suggestions = suggest::suggest(graph, intent, property_hint, 1);
     if let Some(top) = suggestions.into_iter().next() {
-        Input::from(top.token_name)
+        Input::from(top.display_name())
     } else {
         Input::default()
+    }
+}
+
+#[cfg(test)]
+mod seed_alias_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn seed_alias_uses_readable_legacy_key_for_cascade_token() {
+        // Cascade tokens are keyed "<file>:<index>" in the graph, not a
+        // readable name — seed_alias must resolve to the name object's
+        // legacyKey, never leak that raw graph key into the wizard input.
+        let graph = TokenGraph::from_pairs(vec![(
+            "color-aliases.tokens.json:0".to_string(),
+            PathBuf::from("color-aliases.tokens.json"),
+            json!({
+                "name": {
+                    "colorRole": "accent",
+                    "property": "background-color",
+                    "state": "default",
+                    "legacyKey": "accent-background-color-default",
+                }
+            }),
+        )]);
+
+        let seeded = seed_alias(&graph, "accent background color", None);
+        assert_eq!(seeded.value(), "accent-background-color-default");
     }
 }
 

--- a/sdk/wasm/src/types.rs
+++ b/sdk/wasm/src/types.rs
@@ -293,15 +293,66 @@ impl ResolutionContext {
 
 impl From<design_data_core::suggest::SuggestionResult> for SuggestResult {
     fn from(r: design_data_core::suggest::SuggestionResult) -> Self {
+        // Cascade-format tokens key the graph by "<file>:<index>", not a
+        // readable name — display_name() derives the legacy key from the
+        // name object (falling back to the raw graph key) the same way
+        // diff.rs and the TUI wizard already do.
+        let token_name = r.display_name();
         Self {
             token_uuid: r.token_uuid,
-            token_name: r.token_name,
+            token_name,
             file: r.file.to_string_lossy().into_owned(),
             layer: format!("{:?}", r.layer).to_lowercase(),
             confidence: r.confidence,
             name_object: r.name_object,
             value: r.value,
         }
+    }
+}
+
+#[cfg(test)]
+mod suggest_result_tests {
+    use super::*;
+    use design_data_core::graph::Layer;
+    use design_data_core::suggest::SuggestionResult;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    #[test]
+    fn conversion_uses_display_name_for_cascade_token() {
+        let result = SuggestionResult {
+            token_uuid: Some("uuid-1".to_string()),
+            token_name: "color-aliases.tokens.json:24".to_string(),
+            file: PathBuf::from("color-aliases.tokens.json"),
+            layer: Layer::Foundation,
+            confidence: 0.5,
+            name_object: Some(json!({
+                "colorRole": "accent",
+                "property": "background-color",
+                "state": "default",
+                "legacyKey": "accent-background-color-default",
+            })),
+            value: None,
+        };
+
+        let converted = SuggestResult::from(result);
+        assert_eq!(converted.token_name, "accent-background-color-default");
+    }
+
+    #[test]
+    fn conversion_falls_back_to_graph_key_without_name_object() {
+        let result = SuggestionResult {
+            token_uuid: None,
+            token_name: "some-legacy-string-key".to_string(),
+            file: PathBuf::from("legacy.tokens.json"),
+            layer: Layer::Foundation,
+            confidence: 0.5,
+            name_object: None,
+            value: None,
+        };
+
+        let converted = SuggestResult::from(result);
+        assert_eq!(converted.token_name, "some-legacy-string-key");
     }
 }
 

--- a/sdk/wasm/test/parity.test.js
+++ b/sdk/wasm/test/parity.test.js
@@ -92,6 +92,23 @@ test("Dataset.embedded() returns consistent results on repeated calls", (t) => {
   t.is(ds1.tokenCount(), ds2.tokenCount());
 });
 
+// A raw cascade graph key looks like "some-file.tokens.json:24" — suggest()
+// must never leak that shape as tokenName; it should resolve to the token's
+// legacyKey/readable name via display_name().
+const RAW_GRAPH_KEY_PATTERN = /\.json:\d+$/;
+
+test("Dataset.embedded() suggest returns readable token names, not raw graph keys", (t) => {
+  const ds = wasm.Dataset.embedded();
+  const results = ds.suggest("accent background color", undefined, 5);
+  t.true(results.length > 0, "Expected suggestions for a common intent");
+  for (const r of results) {
+    t.false(
+      RAW_GRAPH_KEY_PATTERN.test(r.tokenName),
+      `tokenName "${r.tokenName}" looks like a raw "<file>:<index>" graph key, not a resolved name`,
+    );
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Registry helpers — embedded RegistryData (no tokens needed)
 // ---------------------------------------------------------------------------

--- a/tools/design-data-mcp/test/design-data.test.js
+++ b/tools/design-data-mcp/test/design-data.test.js
@@ -43,6 +43,12 @@ test("design-data-suggest returns ranked results in richer Rust shape", async (t
     t.true(Object.hasOwn(r, "layer"), "result has layer");
     t.is(typeof r.confidence, "number");
     t.true(r.confidence > 0 && r.confidence <= 1);
+    // tokenName must be a resolved name (e.g. legacyKey), never the raw
+    // "<file>:<index>" cascade graph key.
+    t.false(
+      /\.json:\d+$/.test(r.tokenName),
+      `tokenName "${r.tokenName}" looks like a raw graph key, not a resolved name`,
+    );
   }
 });
 


### PR DESCRIPTION
## Description

`Dataset.suggest()` (and the `design-data-suggest` MCP tool built on it) was
returning the raw cascade graph key — `"<file>.tokens.json:<index>"` — as
`tokenName`, instead of the token's resolved legacy name.

## Related Issue

Reported by a design-data-mcp consumer (Cable) via a suggest() call returning
`tokenName: ".../color-aliases.tokens.json:24"` and an empty `nameObject`. No
tracked issue number.

## Motivation and Context

Cascade-format tokens are keyed in the graph by `"<file>:<index>"`, not a
readable name. `SuggestionResult::display_name()` already exists to resolve
that back to the token's `legacyKey` via its `name` object, and every other
consumer (`diff.rs`, the TUI wizard) already uses it — the wasm `SuggestResult`
conversion was the one place that skipped it and returned the raw graph key
straight through.

The empty `nameObject`/`/home/runner/...` paths the reporter also saw are a
separate, unrelated issue: the *published* `@adobe/design-data-wasm@0.4.2`
embeds a stale pre-cascade dataset snapshot. That resolves on its own once a
new version is published (out of scope for this PR).

## How Has This Been Tested?

- `cargo test -p design-data-wasm -p design-data-core` — 666 passed, including
  new unit tests on the `SuggestResult` conversion (cascade token with
  `legacyKey`, and the no-`name_object` fallback case).
- Added a `sdk/wasm/test/parity.test.js` case that runs `suggest()` against the
  real embedded dataset and asserts no result's `tokenName` matches the raw
  `"<file>:<index>"` pattern.
- Tightened the existing `design-data-suggest` test in
  `tools/design-data-mcp/test/design-data.test.js` with the same assertion.
- Verified the new tests actually catch the regression: reverted just the
  `types.rs` fix, rebuilt, and confirmed the new parity test failed with the
  exact reported symptom (`.../color-aliases.tokens.json:0`); restored the fix
  and confirmed all 61 `sdk-wasm:test` cases pass.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.