### PR TITLE
fix(sdk/wasm): serialize nested JSON fields as plain objects, not Maps

### DIFF
--- a/.changeset/wasm-suggest-hashmap-as-object.md
+++ b/.changeset/wasm-suggest-hashmap-as-object.md
@@ -1,0 +1,9 @@
+---
+"@adobe/design-data-wasm": patch
+---
+
+Fix `nameObject`/`raw`/`value` serializing as a JS `Map`, rendered as `{}` by
+`JSON.stringify`.
+
+- **sdk/wasm/src/types.rs**: added `#[tsify(hashmap_as_object)]` to the
+  wasm-boundary result types so nested JSON fields cross as plain objects.

--- a/sdk/wasm/src/types.rs
+++ b/sdk/wasm/src/types.rs
@@ -62,8 +62,10 @@ pub struct TokenResult {
 }
 
 /// A single resolved token result from `Dataset.resolve()`.
+///
+/// `hashmap_as_object`: nests `TokenResult.raw`, see `TokenResultArray`.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveResult {
     pub token: TokenResult,
@@ -189,8 +191,11 @@ pub struct UpdatedToken {
 /// The result of `Dataset.diff()`.
 ///
 /// Mirrors `design_data_core::diff::DiffReport` with typed arrays for each change category.
+///
+/// `hashmap_as_object`: `PropertyChange.new_value`/`.original_value` are
+/// `serde_json::Value`, see `TokenResultArray`.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct DiffResult {
     pub renamed: Vec<RenamedToken>,
     pub deprecated: Vec<DeprecatedToken>,
@@ -209,8 +214,12 @@ pub struct DiffResult {
 // ---------------------------------------------------------------------------
 
 /// A list of token results from a query. Typed as `TokenResult[]` in TypeScript.
+///
+/// `hashmap_as_object`: `TokenResult.raw` is a `serde_json::Value` — without this,
+/// serde-wasm-bindgen's default serializer turns nested JSON objects into JS `Map`s,
+/// which `JSON.stringify` (used by every MCP tool response) silently renders as `{}`.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct TokenResultArray(Vec<TokenResult>);
 
 impl TokenResultArray {
@@ -237,8 +246,10 @@ pub struct SuggestResult {
 }
 
 /// A list of suggestion results from `Dataset.suggest()`. Typed as `SuggestResult[]` in TypeScript.
+///
+/// `hashmap_as_object`: nests `SuggestResult.name_object`/`value`, see `TokenResultArray`.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct SuggestResultArray(Vec<SuggestResult>);
 
 impl SuggestResultArray {
@@ -258,8 +269,10 @@ impl SuggestResultArray {
 /// // r.chain → ["{accent-color-100}", "{blue-100}", "rgb(245, 249, 255)"]
 /// // r.value → "rgb(245, 249, 255)"
 /// ```
+///
+/// `hashmap_as_object`: `value` is a `serde_json::Value`, see `TokenResultArray`.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 #[serde(rename_all = "camelCase")]
 pub struct ReferenceChainResult {
     /// The resolved terminal value (absent if the chain is empty or all aliases dangle).

--- a/sdk/wasm/test/parity.test.js
+++ b/sdk/wasm/test/parity.test.js
@@ -109,6 +109,51 @@ test("Dataset.embedded() suggest returns readable token names, not raw graph key
   }
 });
 
+// serde-wasm-bindgen's default serializer turns nested serde_json::Value
+// objects into JS Maps, which JSON.stringify (used by MCP tool responses)
+// silently renders as "{}" — the exact symptom Cable reported for nameObject.
+// These assert the JSON-value-bearing fields are plain objects, not Maps.
+
+test("Dataset.embedded() query result .raw is a plain object, not a Map", (t) => {
+  const ds = wasm.Dataset.embedded();
+  const results = ds.query("property=background-color,colorScheme=light");
+  t.true(results.length > 0);
+  const { raw } = results[0];
+  t.false(raw instanceof Map, ".raw should not be a JS Map");
+  t.truthy(raw.name, ".raw should have own enumerable properties");
+  t.notDeepEqual(JSON.parse(JSON.stringify(raw)), {});
+});
+
+test("Dataset.embedded() suggest result .nameObject is a plain object, not a Map", (t) => {
+  const ds = wasm.Dataset.embedded();
+  const results = ds.suggest("accent background color", undefined, 5);
+  t.true(results.length > 0);
+  for (const r of results) {
+    if (r.nameObject !== undefined) {
+      t.false(
+        r.nameObject instanceof Map,
+        ".nameObject should not be a JS Map",
+      );
+      t.notDeepEqual(JSON.parse(JSON.stringify(r.nameObject)), {});
+    }
+  }
+});
+
+test("Dataset.embedded() resolve result .token.raw is a plain object, not a Map", (t) => {
+  const ds = wasm.Dataset.embedded();
+  const result = ds.resolve("background-color", { colorScheme: "light" });
+  t.truthy(result);
+  t.false(result.token.raw instanceof Map, "token.raw should not be a JS Map");
+  t.notDeepEqual(JSON.parse(JSON.stringify(result.token.raw)), {});
+});
+
+test("Dataset.embedded() resolveReference result .value is not a Map", (t) => {
+  const ds = wasm.Dataset.embedded();
+  const r = ds.resolveReference("{blue-100}", { colorScheme: "light" });
+  t.truthy(r);
+  t.false(r.value instanceof Map, "value should not be a JS Map");
+});
+
 // ---------------------------------------------------------------------------
 // Registry helpers — embedded RegistryData (no tokens needed)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`serde-wasm-bindgen`'s default serializer converts nested `serde_json::Value`
objects (as carried by `TokenResult.raw`, `SuggestResult.nameObject`/`value`,
`ReferenceChainResult.value`, and `PropertyChange.new_value`/`original_value`)
into JS `Map` instances rather than plain objects when they cross the WASM
boundary. A `Map` has no own enumerable properties, so `JSON.stringify()` —
which the MCP server uses to format every tool response — silently renders it
as `{}`.

Adds `#[tsify(hashmap_as_object)]` to the five WASM-boundary result types
(`TokenResultArray`, `SuggestResultArray`, `ResolveResult`,
`ReferenceChainResult`, `DiffResult`) so their generated `into_js()` uses
`serde_wasm_bindgen`'s `serialize_maps_as_objects(true)`. The config threads
through the whole nested `serialize()` call, so nested structs (`TokenResult`,
`SuggestResult`, `PropertyChange`, etc.) don't need their own tagging.
`dataset.rs`'s `primer()` already worked around this exact bug manually for
its own ad-hoc JSON value — this applies the equivalent, idiomatic fix to the
tsify-derived result types.

## Related Issue

Fast-follow on #1284. Closes spectrum-design-data-ubr.

`#1284` fixed `tokenName` resolving to a raw `"<file>:<index>"` graph key.
This PR fixes the other half of Cable's original report: `nameObject`
appearing as `{}` even on current, non-stale data — an independent bug with a
different root cause than what `#1284`'s PR comment assumed.

## Motivation and Context

Cable (a `@adobe/design-data-mcp` consumer) reported `design-data-suggest`
returning an empty `nameObject`. After `#1284` shipped and released as
`@adobe/design-data-wasm@0.4.3`, verifying against the published package
showed `tokenName` was fixed but `nameObject`/`raw` were still `{}` on
`JSON.stringify()` — despite the underlying WASM data being fully correct
(confirmed via `Object.fromEntries()` on the raw `Map`).

## How Has This Been Tested?

- Added regression tests in `sdk/wasm/test/parity.test.js` asserting
  `query()`, `suggest()`, `resolve()`, and `resolveReference()` results are
  not `instanceof Map` and round-trip through `JSON.stringify` with non-empty
  content.
- Reverted the fix and rebuilt (`moon run sdk-wasm:build --force`) to confirm
  the new tests fail on the pre-fix code, then restored and confirmed they
  pass.
- `moon run sdk-wasm:test` — all 65 tests pass.
- `moon run sdk:test` (full Rust workspace, `cargo test --workspace`) — all
  pass.
- `pnpm --filter @adobe/design-data-mcp exec ava` — all 39 tests pass.
- Manually exercised the exact MCP `design-data-suggest` handler path end to
  end and confirmed `nameObject` now serializes with full content (e.g.
  `colorRole`, `property`, `state`, `legacyKey`) instead of `{}`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
