### PR TITLE
fix(design-data-glue): update test for plain-object raw field

### DIFF
--- a/tools/design-data/test/load.test.js
+++ b/tools/design-data/test/load.test.js
@@ -62,8 +62,8 @@ test("loadDataset tokens are queryable", async (t) => {
   const ds = await loadDataset(TMP);
   const results = ds.query("property=background-color");
   t.is(results.length, 1);
-  // result.name is the UUID key; property lives in the raw Map under name.property
-  t.is(results[0].raw.get("name")?.get("property"), "background-color");
+  // result.name is the UUID key; property lives in raw.name.property
+  t.is(results[0].raw.name?.property, "background-color");
 });
 
 test("loadDataset walks subdirectories", async (t) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a `tools/design-data` test broken by #1285, which changed the WASM
`raw` field from a JS `Map` to a plain object. The test still accessed it
via `.get("name")?.get("property")`, which encoded the pre-#1285 bug
(nested JSON fields serializing as `Map`) as expected behavior. Updates it
to plain property access.

## Related Issue

Follow-up on #1285. This broke CI on the release PR (#1286) since #1285
merged before this consumer test was updated.

## Motivation and Context

`design-data-glue:test` failed with `results[0].raw.get is not a function`
once #1285 landed on `main`, because `raw` is now a plain object, not a
`Map`.

## How Has This Been Tested?

- `moon run design-data-glue:test` — all 14 tests pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
