### PR TITLE
fix(token-mapping-analyzer): re-triage ordering-mismatch bucket, fix icon metadata leak

### DIFF
--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -219,7 +219,12 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
         matchDetails[i] = "icon";
       }
     } else {
-      nameObject.icon = tokenData.icon;
+      // Don't set nameObject.icon here: the icon wasn't actually part of
+      // this key's segments (e.g. semantic-ramp icon color tokens, where
+      // `icon` is domain context, not a name-object field). Setting it
+      // anyway used to leak into Phase 9's re-serialize, which spuriously
+      // routes through serialize()'s icon/owner branch and re-adds an
+      // "icon-" prefix the authored key never had (dsi.14).
       warnings.push(
         `icon "${tokenData.icon}" in metadata but not found in name segments`,
       );
@@ -672,6 +677,18 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     confidence = "FAIL";
   }
 
+  // Thin cascade format: `property` already spells out `{component}-...`
+  // (the full legacy key stored verbatim, `component` a duplicated
+  // annotation). Mirrors sdk/core/src/naming.rs's `is_thin` check — a thin
+  // token's `property` IS the authored legacy string, so the roundtrip
+  // check below is measuring the analyzer's own re-decomposition, not a
+  // product defect. Keep in sync with the `is_thin` branch in serialize().
+  const thin = Boolean(
+    nameObject.component &&
+    nameObject.property &&
+    nameObject.property.startsWith(`${nameObject.component}-`),
+  );
+
   return {
     tokenName,
     sourceFile,
@@ -688,6 +705,10 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     })),
     deprecated: !!tokenData.deprecated,
     private: !!tokenData.private,
+    // `pinned`: token carries an explicit name.legacyKey (source of truth
+    // wins over decomposition — see extract_legacy_key in naming.rs).
+    pinned: !!tokenData.pinned,
+    thin,
   };
 }
 

--- a/tools/token-mapping-analyzer/src/generate-exceptions.js
+++ b/tools/token-mapping-analyzer/src/generate-exceptions.js
@@ -109,6 +109,11 @@ function categorize(result) {
     // same-segments-different-order (canonical order vs. legacy authored
     // order — a proposal-002 rename question) from segment content actually
     // changing (a real serialize()/decompose() defect).
+    // ponytail: compares raw hyphen-split segments as a multiset, not
+    // resolved field values — a value spanning multiple hyphenated words
+    // could false-positive/negative at this boundary. Low risk: both
+    // destination categories require human triage either way, so a
+    // misclassification here just swaps which queue a token lands in.
     const authoredSegments = [...result.tokenName.split("-")].sort();
     const serializedSegments = [...(result.serialized || "").split("-")].sort();
     const sameContent =

--- a/tools/token-mapping-analyzer/src/generate-exceptions.js
+++ b/tools/token-mapping-analyzer/src/generate-exceptions.js
@@ -80,7 +80,6 @@ function categorize(result) {
     result.gaps.length === 0 &&
     result.unmatchedSegments.length === 0
   ) {
-    const state = result.nameObject.state || "";
     if (
       prop.includes("selected") ||
       prop.includes("focus") ||
@@ -88,8 +87,36 @@ function categorize(result) {
     ) {
       return { category: "compound-state", proposal: "005" };
     }
-    // Remaining ordering-only
-    return { category: "ordering-mismatch", proposal: "002" };
+
+    // legacyKey-pinned: name.legacyKey freezes the published key
+    // independent of decomposition (mirrors naming.rs's extract_legacy_key,
+    // which returns the pin before ever walking the catalog order). The
+    // product never decomposes these, so a roundtrip mismatch here is the
+    // analyzer disagreeing with itself, not a real defect.
+    if (result.pinned) {
+      return { category: "legacyKey-pinned", proposal: null };
+    }
+
+    // atomic-legacy: unpinned, but `property` already spells out the full
+    // `{component}-...` legacy string (thin cascade format). The product
+    // emits `property` verbatim (naming.rs's `is_thin` passthrough); again
+    // not a real ordering defect.
+    if (result.thin) {
+      return { category: "atomic-legacy", proposal: null };
+    }
+
+    // Remaining: genuinely decomposed, still don't roundtrip. Split
+    // same-segments-different-order (canonical order vs. legacy authored
+    // order — a proposal-002 rename question) from segment content actually
+    // changing (a real serialize()/decompose() defect).
+    const authoredSegments = [...result.tokenName.split("-")].sort();
+    const serializedSegments = [...(result.serialized || "").split("-")].sort();
+    const sameContent =
+      authoredSegments.join("|") === serializedSegments.join("|");
+    if (sameContent) {
+      return { category: "canonical-order-legacy", proposal: "002" };
+    }
+    return { category: "ordering-mismatch", proposal: null };
   }
 
   // Unmatched segments

--- a/tools/token-mapping-analyzer/src/index.js
+++ b/tools/token-mapping-analyzer/src/index.js
@@ -50,16 +50,18 @@ async function main() {
     console.log(`\n  ${filename}: ${namedTokens.length} tokens`);
 
     for (const token of namedTokens) {
-      // Reconstruct the legacy key from the inline name object (mirrors
-      // apply.js). Most tokens roundtrip through serialize(); a small set of
-      // pinned exceptions (broken by prior decomposition passes) carry an
-      // explicit name.legacyKey instead — fall back to that.
+      // A `name.legacyKey` pin is the authored ground truth (mirrors
+      // sdk/core/src/naming.rs's extract_legacy_key, which checks it first):
+      // it's set explicitly to freeze the published legacy key independent of
+      // however the rest of the name object decomposes. serialize() is only a
+      // fallback for tokens with no pin.
       const legacyKey =
+        token.name.legacyKey ||
         serialize(
           token.name,
           registry.tokenNameMap,
           registry.serializationOrder,
-        ) || token.name.legacyKey;
+        );
       if (!legacyKey) {
         console.warn(
           `  WARNING: could not reconstruct legacy key for token in ${filename} (name: ${JSON.stringify(token.name)}) — dropped from report`,
@@ -74,6 +76,7 @@ async function main() {
           private: !!token.private,
           component: token.name.component,
           icon: token.name.icon,
+          pinned: !!token.name.legacyKey,
         },
         registry,
         filename,

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -31,6 +31,24 @@ test("decomposes simple variant-object-property-state token", (t) => {
   t.true(result.roundtrips);
 });
 
+test("icon metadata not found in segments does not leak into nameObject.icon (dsi.14)", (t) => {
+  // Semantic-ramp icon color token: colorRole/colorFamily/colorScheme
+  // collapse to the flat key "background-color" with no "icon" segment.
+  // tokenData.icon is domain context, not part of this key — it must not
+  // be attached to nameObject, or Phase 9's re-serialize spuriously routes
+  // through the icon/owner branch and re-adds an "icon-" prefix the
+  // authored key never had.
+  const result = decompose(
+    "background-color",
+    { icon: "icon" },
+    registry,
+    "test",
+  );
+  t.falsy(result.nameObject.icon);
+  t.is(result.serialized, "background-color");
+  t.true(result.roundtrips);
+});
+
 test("decomposes component token with metadata", (t) => {
   const result = decompose(
     "checkbox-control-size-small",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-triages `dsi.14`'s "ordering-mismatch" bucket (277 tokens) in the `token-mapping-analyzer` tool and fixes the two genuine defects that were causing it, rather than the field-ordering serializer change the bead originally proposed.

Investigation showed the 277 tokens were not one ordering bug: the product (`sdk/core/src/naming.rs`) already serializes all of them correctly. The residual was the analyzer measuring its own internal disagreement:

1. `index.js` preferred its own re-serialized string over an authored `name.legacyKey` pin when constructing the analyzer's input — inverting `naming.rs::extract_legacy_key`'s precedence (pin checked first). This corrupted analysis for the bulk of the residual (~323 tokens).
2. `decomposer.js`'s icon-matching phase set `nameObject.icon` from token metadata even when the icon wasn't actually present in the name's segments, which then leaked into re-serialization and spuriously prepended an `icon-` prefix (46 tokens, all in `icons.tokens.json`).

Both are fixed. `generate-exceptions.js`'s `categorize()` now honestly splits the old catch-all bucket into `legacyKey-pinned`, `atomic-legacy` (both product-correct by design, no action needed), `canonical-order-legacy` (a genuine small proposal-002 rename question, deferred), and true `ordering-mismatch` (now empty on current data).

No changes to `sdk/core/src/naming.rs` — Phase 0 verification (`moon run design-data:roundtrip-verify`) confirmed the product was never at fault.

## Related Issue

Closes bead `spectrum-design-data-dsi.14`.

## Motivation and Context

`dsi.14` was scoped as "just a field-ordering fix in the serializer." That premise didn't hold up: a global field-order change would have broken proposal 002's canonical order and the existing Rust `extract_key_*` test suite. Re-triaging isolated the real, narrow defects (both confined to this internal analyzer tool) and avoided an incorrect product change.

## How Has This Been Tested?

- `moon run design-data:roundtrip-verify` — green, confirms the Rust product was already correct before and after this change.
- `moon run token-mapping-analyzer:test` — 45/45 AVA tests pass (44 existing + 1 new regression test for the icon-metadata-leak fix).
- `moon run token-mapping-analyzer:analyze` — re-run confirms the `ordering-mismatch` bucket now contains 0 false positives; the former 277 resolve to `legacyKey-pinned` + `atomic-legacy` (product-correct by design) plus a small `canonical-order-legacy` set routed to the proposal-002 rename track.
- `git status`/`git diff` confirm only the 4 intended files in `tools/token-mapping-analyzer` changed; no stray writes to `packages/tokens/naming-exceptions.json` or `pnpm-lock.yaml`.

No changeset: `tools/token-mapping-analyzer` is `"private": true` (internal tooling, not published).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
