### PR TITLE
fix(token-mapping-analyzer): honor legacyKey pin in vocabulary-gap bucket

### DIFF
--- a/tools/token-mapping-analyzer/src/generate-exceptions.js
+++ b/tools/token-mapping-analyzer/src/generate-exceptions.js
@@ -126,6 +126,16 @@ function categorize(result) {
 
   // Unmatched segments
   if (result.unmatchedSegments.length > 0) {
+    // Same pin/thin short-circuit as the ordering block above (dsi.14): a
+    // legacyKey pin or thin passthrough means the product never decomposes
+    // this token, so an unmatched segment here is the analyzer disagreeing
+    // with itself, not a real vocabulary gap.
+    if (result.pinned) {
+      return { category: "legacyKey-pinned", proposal: null };
+    }
+    if (result.thin) {
+      return { category: "atomic-legacy", proposal: null };
+    }
     return { category: "vocabulary-gap", proposal: "006" };
   }
 
@@ -197,4 +207,10 @@ function main() {
   }
 }
 
-main();
+// Guard so importing this module (e.g. from a test) doesn't trigger the
+// naming-exceptions.json write as a side effect of module load.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { categorize };

--- a/tools/token-mapping-analyzer/test/generate-exceptions.test.js
+++ b/tools/token-mapping-analyzer/test/generate-exceptions.test.js
@@ -1,0 +1,53 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { loadRegistries } from "../src/registry-index.js";
+import { decompose } from "../src/decomposer.js";
+import { categorize } from "../src/generate-exceptions.js";
+
+let registry;
+test.before(() => {
+  registry = loadRegistries();
+});
+
+test("legacyKey-pinned token with an unmatched segment categorizes as legacyKey-pinned, not vocabulary-gap (dsi.15)", (t) => {
+  // "key" isn't a registered standalone segment, so this pinned token leaves
+  // an unmatched segment. Before dsi.15, the vocabulary-gap branch didn't
+  // check `pinned`, so this fell into vocabulary-gap even though naming.rs
+  // never decomposes a pinned token — the analyzer was disagreeing with
+  // itself, not flagging a real gap.
+  const result = decompose(
+    "drop-shadow-emphasized-key-color",
+    { pinned: true },
+    registry,
+    "test",
+  );
+  t.true(result.pinned);
+  t.true(result.unmatchedSegments.length > 0);
+
+  const { category } = categorize(result);
+  t.is(category, "legacyKey-pinned");
+});
+
+test("unpinned token with a genuinely unmatched segment still categorizes as vocabulary-gap", (t) => {
+  const result = decompose(
+    "drop-shadow-emphasized-key-color",
+    {},
+    registry,
+    "test",
+  );
+  t.falsy(result.pinned);
+  t.true(result.unmatchedSegments.length > 0);
+
+  const { category, proposal } = categorize(result);
+  t.is(category, "vocabulary-gap");
+  t.is(proposal, "006");
+});


### PR DESCRIPTION
## Description

`token-mapping-analyzer`'s "vocabulary-gap" bucket (81 unique tokens) was mostly
the analyzer disagreeing with itself, not real vocabulary gaps — the same shape
of bug dsi.14 fixed one bucket over.

A `name.legacyKey` pin means `naming.rs::extract_legacy_key` returns the pin
verbatim and never decomposes the token, so an unmatched name segment on a
pinned token isn't a product defect. dsi.14 added a `pinned`/`thin`
short-circuit to the ordering-mismatch branch, but that branch is gated on
`unmatchedSegments.length === 0` — mutually exclusive with the vocabulary-gap
branch (gated on `> 0`) — so the pin check never ran there.

This PR adds the same short-circuit to the vocabulary-gap branch.

- **src/generate-exceptions.js**: check `result.pinned`/`result.thin` before
  falling through to `vocabulary-gap`. Collapses the bucket 81 → 6 unique
  tokens (75 were pinned self-disagreement, 0 thin). Guards `main()`'s
  side-effecting write behind an entrypoint check and exports `categorize` so
  it's testable without triggering the `naming-exceptions.json` write on
  import.
- **test/generate-exceptions.test.js** (new): a pinned token with an unmatched
  segment categorizes as `legacyKey-pinned`; an unpinned one still correctly
  categorizes as `vocabulary-gap`.

Remaining 6 genuine vocabulary-gap tokens:
- 5 are compound-state artifacts — a second registered state left unmatched
  because the state slot already holds one (e.g.
  `stack-item-selected-background-opacity-emphasized-hover`) — a proposal-005
  multi-state shape, not a vocabulary gap.
- 1 (`color-slider-minimum-length`) is a candidate real property term.

Segments `layer`/`hero`/`filled`/`key` are genuinely unregistered but only
appear on pinned, product-correct tokens, so registering them is cosmetic —
deferred to a taxonomy follow-up rather than guessed here.

No changeset: `token-mapping-analyzer` is `private: true`, internal tooling
(same as dsi.14).

## Related Issue

Closes spectrum-design-data-dsi.15 (bd bead; parent epic dsi: Phase D residual
triage). Sibling of #1288 (dsi.14).

## Motivation and Context

Keeps the analyzer's residual triage buckets honest so future Phase D work
isn't chasing false positives.

## How Has This Been Tested?

- `npx ava` in `tools/token-mapping-analyzer` — all 47 tests pass (2 new).
- `moon run design-data:roundtrip-verify` — green; confirms no product/SDK
  defect, only an analyzer self-disagreement.
- Manually replayed `categorize()` over `output/all-decompositions.json`:
  vocabulary-gap unique count 81 → 6, matching the tokens described above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
