### PR TITLE
feat(design-data): excludeFromLegacy token field + button corner-radius fix

### DIFF
--- a/.changeset/button-corner-radius-exclude-from-legacy.md
+++ b/.changeset/button-corner-radius-exclude-from-legacy.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Add an `excludeFromLegacy` token field so new tokens without Tokens Studio
+precedent can be authored directly in design-data without publishing to the
+legacy flat-key mirror, and use it to fix SPEC-027 dangling `button.json`
+corner-radius bindings (bead spectrum-design-data-vpk.1).
+
+- **packages/design-data-spec/schemas/token.schema.json**: new optional
+  `excludeFromLegacy: boolean` on both token shapes.
+- **sdk/core/src/legacy.rs**: `convert_array` skips any token with
+  `excludeFromLegacy: true` before it's grouped into legacy output.
+- **packages/design-data/tokens/layout.tokens.json**: add
+  `button`/`corner-radius` tokens for `small`/`medium`/`large`/`extra-large`
+  (desktop + mobile), literal pixel values derived from
+  `component-height-*` ÷ 2, marked `excludeFromLegacy` — no legacy output
+  change.
+- **packages/design-data/components/button.json**: rebind the three
+  corner-radius entries from the non-existent literal strings
+  `corner-radius-button-{small,large,extra-large}` to the new tokens'
+  resolved key `button-corner-radius-{small,large,extra-large}`.

--- a/.changeset/vpk1-fix-workflow-icon-400-gap.md
+++ b/.changeset/vpk1-fix-workflow-icon-400-gap.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Fix SPEC-027 dangling `component-top-to-workflow-icon-400` tokenBindings
+(bead spectrum-design-data-vpk.1, group A).
+
+- **packages/design-data/components/combo-box.json**, **number-field.json**,
+  **text-area.json**, **text-field.json**: rebind the leading-icon spacing
+  entry from `component-top-to-workflow-icon-400` — a step that doesn't
+  exist in the token family (which caps at `-300`) and isn't referenced
+  anywhere else — to the existing `component-top-to-workflow-icon-300`.

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -189,6 +189,10 @@
         "private": {
           "type": "boolean"
         },
+        "excludeFromLegacy": {
+          "type": "boolean",
+          "description": "When true, this token is omitted from the generated packages/tokens/src legacy output."
+        },
         "description": {
           "type": "string",
           "description": "Plain text describing the token's purpose (aligns with DTCG $description)."
@@ -272,6 +276,10 @@
         },
         "private": {
           "type": "boolean"
+        },
+        "excludeFromLegacy": {
+          "type": "boolean",
+          "description": "When true, this token is omitted from the generated packages/tokens/src legacy output."
         },
         "description": {
           "type": "string",

--- a/packages/design-data/components/button.json
+++ b/packages/design-data/components/button.json
@@ -139,7 +139,7 @@
     { "token": "component-height-300", "context": "Minimum height" },
     { "token": "corner-radius-full", "context": "Rounding" },
     {
-      "token": "corner-radius-button-small",
+      "token": "button-corner-radius-small",
       "context": "Rounding (with wrapping)"
     },
     {
@@ -147,11 +147,11 @@
       "context": "Rounding (with wrapping)"
     },
     {
-      "token": "corner-radius-button-large",
+      "token": "button-corner-radius-large",
       "context": "Rounding (with wrapping)"
     },
     {
-      "token": "corner-radius-button-extra-large",
+      "token": "button-corner-radius-extra-large",
       "context": "Rounding (with wrapping)"
     },
     {

--- a/packages/design-data/components/combo-box.json
+++ b/packages/design-data/components/combo-box.json
@@ -246,7 +246,7 @@
       "context": "S2 Leading icon (top/bottom edge to leading icon) position: inline"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "S2 Leading icon (top/bottom edge to leading icon) position: inline"
     },
     {

--- a/packages/design-data/components/number-field.json
+++ b/packages/design-data/components/number-field.json
@@ -412,7 +412,7 @@
       "context": "Spacing (top/bottom edge to text)"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     { "token": "positive-visual-color", "context": "Positive icon" }

--- a/packages/design-data/components/text-area.json
+++ b/packages/design-data/components/text-area.json
@@ -402,7 +402,7 @@
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {

--- a/packages/design-data/components/text-field.json
+++ b/packages/design-data/components/text-field.json
@@ -404,7 +404,7 @@
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -1621,6 +1621,118 @@
   },
   {
     "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "small",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "12px",
+    "uuid": "375c1ab1-bee4-499b-b257-931bb4bc56d0",
+    "set_uuid": "6f73478a-407b-45fb-ac13-44f3911515cb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "small",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "15px",
+    "uuid": "fae7af5b-4754-4031-b070-c644e172450a",
+    "set_uuid": "6f73478a-407b-45fb-ac13-44f3911515cb",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "medium",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "16px",
+    "uuid": "903865b1-0c75-41c6-84f3-efd6b5205f29",
+    "set_uuid": "5c0d060f-7ab0-4c40-a907-4006ae45a0d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "medium",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "d1bcb014-35ee-47a1-baf1-6d55d908cb20",
+    "set_uuid": "5c0d060f-7ab0-4c40-a907-4006ae45a0d7",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "20px",
+    "uuid": "e86a15c7-9715-42b5-9cc5-1f438c278df1",
+    "set_uuid": "9f45a388-c93b-41da-8ab3-cb1145bd613b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "25px",
+    "uuid": "12f28a62-a19c-401c-b65b-d746c9dfcc75",
+    "set_uuid": "9f45a388-c93b-41da-8ab3-cb1145bd613b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "extra-large",
+      "scale": "desktop"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "24px",
+    "uuid": "1850a55a-9e06-406d-b3db-ccc1c3adf7da",
+    "set_uuid": "8b7938de-34f9-4b5f-ad13-3cf01149814b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
+      "component": "button",
+      "property": "corner-radius",
+      "size": "extra-large",
+      "scale": "mobile"
+    },
+    "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
+    "value": "30px",
+    "uuid": "06240f78-2979-458a-83cf-46e2476d68e1",
+    "set_uuid": "8b7938de-34f9-4b5f-ad13-3cf01149814b",
+    "set_schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/scale-set.json",
+    "excludeFromLegacy": true
+  },
+  {
+    "name": {
       "property": "component-padding-vertical-100",
       "scale": "desktop"
     },

--- a/sdk/core/src/legacy.rs
+++ b/sdk/core/src/legacy.rs
@@ -481,6 +481,9 @@ fn convert_array(
         let Some(tok) = item.as_object() else {
             continue;
         };
+        if tok.get("excludeFromLegacy").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
         // extract_legacy_key handles both object names (decomposed or thin) and
         // string names (SPEC-017 escape hatch).
         let Some(key) = tok.get("name").and_then(extract_legacy_key) else {
@@ -869,6 +872,21 @@ mod tests {
         let (name, entry) = convert_token(&tok).unwrap();
         assert_eq!(name, "spacing-100");
         assert_eq!(entry["value"], "8px");
+    }
+
+    #[test]
+    fn exclude_from_legacy_flag_skips_token() {
+        let arr = json!([
+            {"name": {"property": "spacing-100"}, "value": "8px", "uuid": "excl-0001"},
+            {"name": {"component": "button", "property": "corner-radius", "size": "small"},
+             "value": "12px", "uuid": "excl-0002", "excludeFromLegacy": true}
+        ]);
+        let mut summary = LegacySummary::default();
+        let out = convert_array(arr.as_array().unwrap(), &mut summary, &HashMap::new()).unwrap();
+
+        assert!(out.contains_key("spacing-100"));
+        assert!(!out.contains_key("button-corner-radius-small"));
+        assert_eq!(out.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Adds an `excludeFromLegacy` boolean token field: when true, the token is
skipped during legacy-output generation (`packages/tokens/src`) instead of
being written there. This lets new tokens without Tokens Studio precedent be
authored directly in `packages/design-data` without polluting the legacy
mirror.

Uses the new flag to add real `button` `corner-radius` tokens
(small/medium/large/extra-large, desktop+mobile) with literal pixel values
derived from `component-height-*` ÷ 2 — replacing the previously-dangling,
calculated-only bindings in `button.json`. Also fixes the binding key order
mismatch (`corner-radius-button-*` → `button-corner-radius-*`) that was
causing SPEC-027 warnings.

## Related Issue

bead `spectrum-design-data-vpk.1` (SPEC-027 dangling `tokenBindings`
triage).

## Motivation and Context

`button.json`'s three corner-radius bindings referenced literal strings with
no matching token anywhere in the corpus (`corner-radius-button-small` etc.)
— these were purely calculated (height ÷ 2) design values with no design-data
representation. Rather than requiring Tokens Studio to publish first, this
adds a general mechanism for authoring net-new structured tokens directly in
`design-data`, opting them out of the legacy mirror until/unless Tokens
Studio catches up.

## How Has This Been Tested?

- `cargo test -p design-data-core legacy::` — all tests pass, including a
  new unit test for `excludeFromLegacy`.
- Built the CLI and ran `migrate legacy-output` against
  `packages/design-data/tokens`; diffed the generated `layout.json` against
  the currently committed `packages/tokens/src/layout.json` — byte-identical
  (confirms zero legacy-output impact from the new tokens).
- `moon run sdk:codegen` + `moon run design-data:validate` — clean, no more
  SPEC-027 warnings for `button.json`'s corner-radius bindings (remaining
  warnings are pre-existing, unrelated vpk.1 items).
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
