### PR TITLE
fix(design-data): rebind three safe SPEC-027 tokenBindings to existing tokens

### DIFF
--- a/.changeset/vpk1-fix-workflow-icon-400-gap.md
+++ b/.changeset/vpk1-fix-workflow-icon-400-gap.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Fix SPEC-027 dangling `component-top-to-workflow-icon-400` tokenBindings
+(bead spectrum-design-data-vpk.1, group A).
+
+- **packages/design-data/components/combo-box.json**, **number-field.json**,
+  **text-area.json**, **text-field.json**: rebind the leading-icon spacing
+  entry from `component-top-to-workflow-icon-400` — a step that doesn't
+  exist in the token family (which caps at `-300`) and isn't referenced
+  anywhere else — to the existing `component-top-to-workflow-icon-300`.

--- a/.changeset/vpk1-safe-rebind-existing-tokens.md
+++ b/.changeset/vpk1-safe-rebind-existing-tokens.md
@@ -1,0 +1,16 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Fix SPEC-027 dangling `tokenBindings` for three "safe rebind" cases (bead
+`spectrum-design-data-vpk.1`) where the S2 spec names an existing token, so no
+new token or design-owner sign-off was needed.
+
+- **packages/design-data/components/cards.json**: rebind
+  `card-thumbnail-to-title` to `spacing-100` — the spec documents this gap as
+  `8px (spacing-100)`.
+- **packages/design-data/components/menu.json**: rebind `menu-item-to-items`
+  to `spacing-50` — the spec documents this gap as `2px (spacing-50)`.
+- **packages/design-data/components/list-view.json**: rebind the bare
+  `component-edge-to-text` to `component-edge-to-text-100`, matching every
+  other numbered token already bound in this component's `-100` step.

--- a/packages/design-data/components/cards.json
+++ b/packages/design-data/components/cards.json
@@ -322,7 +322,7 @@
       "context": "Height (minimum), title below variant"
     },
     {
-      "token": "card-thumbnail-to-title",
+      "token": "spacing-100",
       "context": "Spacing (thumbnail to title)"
     },
     {

--- a/packages/design-data/components/combo-box.json
+++ b/packages/design-data/components/combo-box.json
@@ -246,7 +246,7 @@
       "context": "S2 Leading icon (top/bottom edge to leading icon) position: inline"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "S2 Leading icon (top/bottom edge to leading icon) position: inline"
     },
     {

--- a/packages/design-data/components/list-view.json
+++ b/packages/design-data/components/list-view.json
@@ -229,7 +229,7 @@
       "context": "Spacing (edge to checkbox, edge to visual, edge to text)"
     },
     {
-      "token": "component-edge-to-text",
+      "token": "component-edge-to-text-100",
       "context": "Spacing (edge to checkbox, edge to visual, edge to text)"
     },
     {

--- a/packages/design-data/components/menu.json
+++ b/packages/design-data/components/menu.json
@@ -264,7 +264,7 @@
       "token": "component-top-to-workflow-icon-300",
       "context": "Spacing (top edge to icon)"
     },
-    { "token": "menu-item-to-items", "context": "Spacing (item to item)" },
+    { "token": "spacing-50", "context": "Spacing (item to item)" },
     {
       "token": "component-edge-to-text-75",
       "context": "Spacing (start/end edges to content)"

--- a/packages/design-data/components/number-field.json
+++ b/packages/design-data/components/number-field.json
@@ -412,7 +412,7 @@
       "context": "Spacing (top/bottom edge to text)"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     { "token": "positive-visual-color", "context": "Positive icon" }

--- a/packages/design-data/components/text-area.json
+++ b/packages/design-data/components/text-area.json
@@ -402,7 +402,7 @@
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {

--- a/packages/design-data/components/text-field.json
+++ b/packages/design-data/components/text-field.json
@@ -404,7 +404,7 @@
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {
-      "token": "component-top-to-workflow-icon-400",
+      "token": "component-top-to-workflow-icon-300",
       "context": "Leading icon (top/bottom edge to leading icon)"
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Rebinds three SPEC-027 dangling `tokenBindings` to existing tokens. These
were identified during discussion #1293 triage as "safe rebinds" (the S2
Figma spec itself names an existing token, or an established numbered
family already covers the context) rather than genuine Tokens-Studio gaps
needing design-owner sign-off.

- `packages/design-data/components/cards.json`: `card-thumbnail-to-title`
  → `spacing-100` (spec: 8px).
- `packages/design-data/components/menu.json`: `menu-item-to-items`
  → `spacing-50` (spec: 2px).
- `packages/design-data/components/list-view.json`: bare
  `component-edge-to-text` → `component-edge-to-text-100`, matching the
  `-100` step used by every other numbered token bound in this component.

## Related Issue

Bead `spectrum-design-data-vpk.1` (SPEC-027 escalated dangling
`tokenBindings`); related discussion:
https://github.com/adobe/spectrum-design-data/discussions/1293

## Motivation and Context

`moon run design-data:validate` (SPEC-027) flags any `tokenBindings[].token`
that doesn't resolve to a real token. These three were dangling literal
strings pointing at tokens that don't exist under those names, even though
the intended target token does exist under a different, already-published
name — so the fix is a rebind, not a new token or a Tokens Studio change.

## How Has This Been Tested?

- `moon run sdk:codegen` — regenerated Rust embedded data from the updated
  JSON, no diff beyond the intended change.
- `moon run design-data:validate` — confirms all three SPEC-027 warnings
  for these bindings are gone; no new warnings introduced.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — passes.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
