### PR TITLE
fix(design-data): resolve generic-scope taxonomy call (closes #1290)

### DIFF
--- a/.changeset/warm-crickets-migrate-generic-scope.md
+++ b/.changeset/warm-crickets-migrate-generic-scope.md
@@ -1,0 +1,17 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+Resolve the generic-scope taxonomy call from issue #1290 (bead
+`spectrum-design-data-88m`): decompose `container-*`/`text-*`/`workflow-icon-*`
+layout tokens into structured name objects, each pinned with a `legacyKey` so
+the fused legacy key is unchanged.
+
+- **packages/design-data/registry/anatomy-terms.json**: flag `text` and
+  `workflow-icon` as `standaloneScope: true` so SPEC-025 accepts them as a
+  bare `anatomy` value with no owning component/structure.
+- **packages/design-data/tokens/layout.tokens.json**: re-author 37 active
+  tokens — 15 `container-*` to `structure: "container"`, 6 `text-*` to
+  `anatomy: "text"`, 16 `workflow-icon-*` to `anatomy: "workflow-icon"` —
+  each with an explicit `property`/`size` and pinned `legacyKey`.
+  `component-*` tokens are left unchanged (intentionally scopeless).

--- a/.changeset/warm-crickets-migrate-generic-scope.md
+++ b/.changeset/warm-crickets-migrate-generic-scope.md
@@ -15,3 +15,5 @@ the fused legacy key is unchanged.
   `anatomy: "text"`, 16 `workflow-icon-*` to `anatomy: "workflow-icon"` —
   each with an explicit `property`/`size` and pinned `legacyKey`.
   `component-*` tokens are left unchanged (intentionally scopeless).
+  `workflow-icon-*`'s `property: "size"` is a distinct name-object field from
+  the `size` t-shirt-scale field on the same token (e.g. `xxl`) — no collision.

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -7,7 +7,8 @@
       "id": "text",
       "label": "Text",
       "description": "Text content or labels",
-      "usedIn": ["tokens"]
+      "usedIn": ["tokens"],
+      "standaloneScope": true
     },
     {
       "id": "control",
@@ -255,7 +256,8 @@
       "id": "workflow-icon",
       "label": "Workflow Icon",
       "description": "Standard workflow icon element within a component (distinct from UI icons)",
-      "usedIn": ["tokens", "s2-docs"]
+      "usedIn": ["tokens", "s2-docs"],
+      "standaloneScope": true
     },
     {
       "id": "ui-icon",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -2525,7 +2525,10 @@
   },
   {
     "name": {
-      "property": "container-gap-2x-large"
+      "property": "gap",
+      "structure": "container",
+      "size": "xxl",
+      "legacyKey": "container-gap-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
@@ -2534,7 +2537,10 @@
   },
   {
     "name": {
-      "property": "container-gap-2x-small"
+      "property": "gap",
+      "structure": "container",
+      "size": "xxs",
+      "legacyKey": "container-gap-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
@@ -2543,7 +2549,10 @@
   },
   {
     "name": {
-      "property": "container-gap-extra-large"
+      "property": "gap",
+      "structure": "container",
+      "size": "xl",
+      "legacyKey": "container-gap-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
@@ -2552,7 +2561,10 @@
   },
   {
     "name": {
-      "property": "container-gap-extra-small"
+      "property": "gap",
+      "structure": "container",
+      "size": "xs",
+      "legacyKey": "container-gap-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
@@ -2561,7 +2573,10 @@
   },
   {
     "name": {
-      "property": "container-gap-large"
+      "property": "gap",
+      "structure": "container",
+      "size": "l",
+      "legacyKey": "container-gap-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b352f0f0-5843-4c65-8357-625b938ccaa0",
@@ -2570,7 +2585,10 @@
   },
   {
     "name": {
-      "property": "container-gap-medium"
+      "property": "gap",
+      "structure": "container",
+      "size": "m",
+      "legacyKey": "container-gap-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
@@ -2579,7 +2597,10 @@
   },
   {
     "name": {
-      "property": "container-gap-small"
+      "property": "gap",
+      "structure": "container",
+      "size": "s",
+      "legacyKey": "container-gap-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
@@ -2588,7 +2609,10 @@
   },
   {
     "name": {
-      "property": "container-padding-2x-large"
+      "property": "padding",
+      "structure": "container",
+      "size": "xxl",
+      "legacyKey": "container-padding-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
@@ -2597,7 +2621,10 @@
   },
   {
     "name": {
-      "property": "container-padding-2x-small"
+      "property": "padding",
+      "structure": "container",
+      "size": "xxs",
+      "legacyKey": "container-padding-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4adbd869-2ead-49b8-bed6-950fb14c695d",
@@ -2606,7 +2633,10 @@
   },
   {
     "name": {
-      "property": "container-padding-3x-large"
+      "property": "padding",
+      "structure": "container",
+      "size": "xxxl",
+      "legacyKey": "container-padding-3x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6d0b881-d25e-452c-9069-c18745d21f33",
@@ -2615,7 +2645,10 @@
   },
   {
     "name": {
-      "property": "container-padding-extra-large"
+      "property": "padding",
+      "structure": "container",
+      "size": "xl",
+      "legacyKey": "container-padding-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec565065-0820-460f-9a1b-b81911c48cb5",
@@ -2624,7 +2657,10 @@
   },
   {
     "name": {
-      "property": "container-padding-extra-small"
+      "property": "padding",
+      "structure": "container",
+      "size": "xs",
+      "legacyKey": "container-padding-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
@@ -2633,7 +2669,10 @@
   },
   {
     "name": {
-      "property": "container-padding-large"
+      "property": "padding",
+      "structure": "container",
+      "size": "l",
+      "legacyKey": "container-padding-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b352f0f0-5843-4c65-8357-625b938ccaa0",
@@ -2642,7 +2681,10 @@
   },
   {
     "name": {
-      "property": "container-padding-medium"
+      "property": "padding",
+      "structure": "container",
+      "size": "m",
+      "legacyKey": "container-padding-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ba632ede-84a7-4e56-91ef-8143b2499452",
@@ -2651,7 +2693,10 @@
   },
   {
     "name": {
-      "property": "container-padding-small"
+      "property": "padding",
+      "structure": "container",
+      "size": "s",
+      "legacyKey": "container-padding-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
@@ -6278,7 +6323,10 @@
   },
   {
     "name": {
-      "property": "text-gap-extra-large"
+      "property": "gap",
+      "anatomy": "text",
+      "size": "xl",
+      "legacyKey": "text-gap-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -6287,7 +6335,10 @@
   },
   {
     "name": {
-      "property": "text-gap-extra-small"
+      "property": "gap",
+      "anatomy": "text",
+      "size": "xs",
+      "legacyKey": "text-gap-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -6296,7 +6347,10 @@
   },
   {
     "name": {
-      "property": "text-gap-large"
+      "property": "gap",
+      "anatomy": "text",
+      "size": "l",
+      "legacyKey": "text-gap-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "2px",
@@ -6305,7 +6359,10 @@
   },
   {
     "name": {
-      "property": "text-gap-medium"
+      "property": "gap",
+      "anatomy": "text",
+      "size": "m",
+      "legacyKey": "text-gap-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -6314,7 +6371,10 @@
   },
   {
     "name": {
-      "property": "text-gap-small"
+      "property": "gap",
+      "anatomy": "text",
+      "size": "s",
+      "legacyKey": "text-gap-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -6708,8 +6768,9 @@
   },
   {
     "name": {
-      "property": "text-underline-thickness",
-      "legacyKey": "text-underline-thickness"
+      "property": "underline-thickness",
+      "legacyKey": "text-underline-thickness",
+      "anatomy": "text"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "1px",
@@ -6763,8 +6824,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-2x-large",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "xxl",
+      "legacyKey": "workflow-icon-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -6774,8 +6838,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-2x-large",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "xxl",
+      "legacyKey": "workflow-icon-2x-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "32px",
@@ -6785,8 +6852,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-2x-small",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "xxs",
+      "legacyKey": "workflow-icon-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6796,8 +6866,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-2x-small",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "xxs",
+      "legacyKey": "workflow-icon-2x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6807,8 +6880,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-3x-small",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "xxxs",
+      "legacyKey": "workflow-icon-3x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "10px",
@@ -6818,8 +6894,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-3x-small",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "xxxs",
+      "legacyKey": "workflow-icon-3x-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "12px",
@@ -6829,8 +6908,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-extra-large",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "xl",
+      "legacyKey": "workflow-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "22px",
@@ -6840,8 +6922,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-extra-large",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "xl",
+      "legacyKey": "workflow-icon-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "30px",
@@ -6851,8 +6936,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-extra-small",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "xs",
+      "legacyKey": "workflow-icon-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "14px",
@@ -6862,8 +6950,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-extra-small",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "xs",
+      "legacyKey": "workflow-icon-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -6873,8 +6964,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-large",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "l",
+      "legacyKey": "workflow-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "20px",
@@ -6884,8 +6978,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-large",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "l",
+      "legacyKey": "workflow-icon-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "28px",
@@ -6895,8 +6992,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-medium",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "m",
+      "legacyKey": "workflow-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",
@@ -6906,8 +7006,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-medium",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "m",
+      "legacyKey": "workflow-icon-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -7046,8 +7149,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-small",
-      "scale": "desktop"
+      "property": "size",
+      "scale": "desktop",
+      "anatomy": "workflow-icon",
+      "size": "s",
+      "legacyKey": "workflow-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "16px",
@@ -7057,8 +7163,11 @@
   },
   {
     "name": {
-      "property": "workflow-icon-small",
-      "scale": "mobile"
+      "property": "size",
+      "scale": "mobile",
+      "anatomy": "workflow-icon",
+      "size": "s",
+      "legacyKey": "workflow-icon-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "18px",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -904,7 +904,8 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "text",
       "label": "Text",
       "description": "Text content or labels",
-      "usedIn": ["tokens"]
+      "usedIn": ["tokens"],
+      "standaloneScope": true
     },
     {
       "id": "control",
@@ -1152,7 +1153,8 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "workflow-icon",
       "label": "Workflow Icon",
       "description": "Standard workflow icon element within a component (distinct from UI icons)",
-      "usedIn": ["tokens", "s2-docs"]
+      "usedIn": ["tokens", "s2-docs"],
+      "standaloneScope": true
     },
     {
       "id": "ui-icon",


### PR DESCRIPTION
## Description

Resolves the taxonomy call requested in #1290: `layout.tokens.json` had 37 active
tokens whose leading name segment was a generic grouping word
(`container`, `text`, `workflow-icon`) rather than a registered id. This decomposes
them into the structured name object:

- `container-*` (15 tokens) → `structure: "container"`
- `text-*` (6 tokens) → `anatomy: "text"`
- `workflow-icon-*` (16 tokens) → `anatomy: "workflow-icon"`
- `component-*` (18 tokens) → left unchanged, intentionally scopeless (already
  ratified in `token-terminology.json`, cites `component-edge-to-text` verbatim)

Each migrated token is re-authored with an explicit `property`/`size` field plus
a pinned `legacyKey` equal to its original fused property string, so the legacy
key is byte-for-byte unchanged — no downstream consumer sees a rename.

`text` and `workflow-icon` are flagged `standaloneScope: true` in
`anatomy-terms.json` so SPEC-025 accepts them as a bare `anatomy` value with no
owning component/structure (mirrors the existing `focus-ring`/`focus-indicator`
pattern).

**Why the legacyKey-pin approach instead of flipping `structure`'s
`excludeFromLegacyKey`:** the naming.rs code comment anticipated the latter, but
simulating that flip against the current corpus showed it would change legacy-key
reconstruction for 33 *existing* structure-scoped tokens (protected only by their
own pins today) — too broad a blast radius for this change. Per-token pinning is
the same mechanism already used for the `weight`/`style` Phase D migration.

## Related Issue

Closes #1290

## Motivation and Context

Unblocks `spectrum-design-data-88m`, which was stalled pending this taxonomy
ruling. The original bead over-counted the problem (163 tokens); a corpus
re-scan found only 55 active tokens across the four prefixes, of which 37 have a
clean decomposition (`component-*`'s 18 are intentionally left alone).

## How Has This Been Tested?

- `moon run sdk:codegen` — regenerated `registry_data.rs` from the registry edit
- `moon run design-data:legacy-output` — regenerated legacy output from the
  migrated cascade
- `moon run design-data:roundtrip-verify` — pass (cascade ↔ legacy parity)
- `moon run design-data:validate` (full, with `--components-path`) — pass, zero
  new warnings on any of the 37 migrated tokens or on SPEC-025
- `moon run sdk:test` — pass, full Rust workspace incl. the wasm
  Rust↔JS serializer parity suite
- Manual diff review: confirmed only the 37 targeted active tokens changed, all
  113 deprecated tokens and all 18 `component-*` tokens are untouched

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (data-only change verified via existing roundtrip/validate/wasm-parity gates, see above)
- [x] All new and existing tests passed.
