### PR TITLE
feat(design-data): compound states as an ordered array (Proposal 006)

### DIFF
--- a/.changeset/proposal-006-state-array.md
+++ b/.changeset/proposal-006-state-array.md
@@ -19,5 +19,6 @@ hyphenated-compound encoding).
   migrated to array form (`"hover"` → `["hover"]`, `"selected-hover"` →
   `["selected", "hover"]`).
 - **sdk/core**: `NameObject.state` is `Option<Vec<String>>`; legacy-key
-  generation, validation rules, and the query engine updated for array state.
+  generation and validation rules updated for array state. Query filters
+  (`state=x`) now match any element of a compound array — see `spec/query.md`.
 - **tools/token-mapping-analyzer**: JS decomposer kept in parity with Rust.

--- a/.changeset/proposal-006-state-array.md
+++ b/.changeset/proposal-006-state-array.md
@@ -13,7 +13,8 @@ hyphenated-compound encoding).
 - **packages/design-data/fields/state.json**, **registry/states.json**: `state`
   is now `array` type; dropped the dead compound-hyphenation pattern.
 - **packages/design-data-spec/schemas**: name-object `state` is now an array of
-  atomic ids, `minItems: 1`.
+  atomic ids, `minItems: 1`; `field.schema.json`'s `valueType` enum gained
+  `"array"` so `state.json` validates structurally.
 - **packages/design-data/tokens/\*.tokens.json**: every token's `name.state`
   migrated to array form (`"hover"` → `["hover"]`, `"selected-hover"` →
   `["selected", "hover"]`).

--- a/.changeset/proposal-006-state-array.md
+++ b/.changeset/proposal-006-state-array.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": major
+"@adobe/design-data-spec": major
+"@adobe/design-data-tui": minor
+---
+
+Change token name-object `state` from a single (optionally hyphenated) string to
+an ordered array of atomic state ids (Proposal 006, supersedes Proposal 005's
+hyphenated-compound encoding).
+
+- **docs/proposals/006-compound-states-as-array.md**: new proposal; Proposal 005
+  marked superseded.
+- **packages/design-data/fields/state.json**, **registry/states.json**: `state`
+  is now `array` type; dropped the dead compound-hyphenation pattern.
+- **packages/design-data-spec/schemas**: name-object `state` is now an array of
+  atomic ids, `minItems: 1`.
+- **packages/design-data/tokens/\*.tokens.json**: every token's `name.state`
+  migrated to array form (`"hover"` → `["hover"]`, `"selected-hover"` →
+  `["selected", "hover"]`).
+- **sdk/core**: `NameObject.state` is `Option<Vec<String>>`; legacy-key
+  generation, validation rules, and the query engine updated for array state.
+- **tools/token-mapping-analyzer**: JS decomposer kept in parity with Rust.

--- a/docs/proposals/005-compound-states.md
+++ b/docs/proposals/005-compound-states.md
@@ -1,6 +1,6 @@
 # Proposal 005: Compound States
 
-**Status:** Accepted — implemented for the `color-aliases.json` instances (dsi.9); the `color-component.json` instances (`stack-item-selected-background-color-*`, `table-selected-row-background-*`) are tracked separately under dsi.11.\
+**Status:** Superseded by [Proposal 006](006-compound-states-as-array.md) — the hyphenated-string encoding below shipped for the `color-aliases.json` instances (dsi.9) and the `color-component.json` instances (`stack-item-selected-background-color-*`, `table-selected-row-background-*`, tracked under dsi.11), but proved undecomposable (state ids like `keyboard-focus` themselves contain a hyphen, so a compound value can't be split back into its parts without guessing) and re-fused the concepts Epic 284 exists to pull apart. Proposal 006 replaces the string with an ordered array holding the same content.\
 **Affects:** 13 active tokens in `color-aliases.json`, `color-component.json`\
 **Spec reference:** taxonomy.md — state field definition
 

--- a/docs/proposals/006-compound-states-as-array.md
+++ b/docs/proposals/006-compound-states-as-array.md
@@ -1,0 +1,118 @@
+# Proposal 006: Compound States as an Ordered Array
+
+**Status:** Accepted — supersedes [Proposal 005](005-compound-states.md)\
+**Affects:** the `state` field on every token name object (all stateful tokens, not just compounds)\
+**Spec reference:** taxonomy.md — state field definition; [state-model.md](../../packages/design-data-spec/spec/state-model.md)
+
+## Problem
+
+Proposal 005 encoded two simultaneous states as a single hyphenated string, e.g.
+`state: "selected-hover"`. This has two problems:
+
+1. **Not cleanly decomposable.** State ids themselves contain hyphens
+   (`keyboard-focus`, `key-focus`, `drag-and-drop`), so a value like
+   `selected-keyboard-focus` cannot be split back into its parts by hyphen position
+   alone. The validator (`is_valid_compound_state` in `spec009.rs`) copes by trying
+   every hyphen boundary and accepting any split where both halves are known state
+   words — enough to *validate* the string, not enough to *parse* it back into
+   structured parts.
+2. **It re-fuses.** Epic `spectrum-design-data-284` exists to decompose tokens that
+   fuse multiple concepts into one string field. Encoding two states as one
+   hyphenated string is the same fusion, just moved from `property` into `state`.
+
+## Proposal
+
+Represent `state` as an **ordered array of atomic state ids** instead of a string:
+
+```json
+"state": ["selected", "hover"]
+```
+
+Applied uniformly — every stateful token uses the array form, not just compounds:
+
+```json
+"state": ["hover"]
+"state": ["disabled"]
+"state": ["selected", "hover"]
+```
+
+### Ordering convention (unchanged from Proposal 005)
+
+The first element is the **mode state** (persistent selection or focus mode); the
+second is the **interaction state** (transient pointer/keyboard interaction):
+
+| Mode states | Interaction states                           |
+| ----------- | -------------------------------------------- |
+| `selected`  | `default`, `hover`, `down`, `keyboard-focus` |
+| `focus`     | `hover`                                      |
+
+### Examples
+
+| Current (Proposal 005) string | Proposal 006 array              |
+| ----------------------------- | ------------------------------- |
+| `state: "selected-default"`   | `state: ["selected","default"]` |
+| `state: "selected-hover"`     | `state: ["selected","hover"]`   |
+| `state: "focus-hover"`        | `state: ["focus","hover"]`      |
+| `state: "hover"`              | `state: ["hover"]`              |
+
+Each array element is validated independently against the `states` registry — no
+segment-splitting heuristic needed, since the elements are already atomic.
+
+### Legacy-key serialization
+
+Legacy kebab-case token names are unaffected: the legacy key still joins the state
+segments with `-` in array order, producing byte-identical output to today
+(`["selected","hover"]` → `...-selected-hover`, same as the Proposal 005 string).
+Tokens with a pinned `legacyKey` (the `compound-state` exceptions in
+`naming-exceptions.json`) keep that pin — the array changes only the structured
+`name.state` field, not the exception mechanism.
+
+### Schema
+
+* `packages/design-data/fields/state.json`: `valueType` becomes `"array"`.
+* `packages/design-data-spec/schemas/token.schema.json`: `state` becomes
+  `{"type": "array", "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]*$"}, "minItems": 1}`.
+* `packages/design-data/registry/states.json`: `customPattern` simplifies to
+  `^[a-z][a-z0-9-]*$` (the array structure now carries compounding; the registry
+  pattern only needs to validate one atomic id at a time). The dead `+`-joined
+  compound branch in the old pattern is removed.
+
+### Validation
+
+* `SPEC-009` (`name-field-enum-sync`): validates each array element against the
+  registry set directly. `is_valid_compound_state`'s hyphen-boundary guessing is
+  removed — no longer needed once elements are atomic.
+* `SPEC-022` (`component-state-valid`): each array element must match a state
+  declared on the referenced component.
+* `SPEC-026` / `SPEC-037`: read array elements instead of a string.
+
+### Migration
+
+Every token with a `name.state` value migrates from string to array. Single states
+gain a one-element array (`"hover"` → `["hover"]`); compounds split on their known
+Proposal-005 boundary into ordered elements. Legacy hyphenated *state ids* that are
+themselves compound-looking but are **one state** (`keyboard-focus`, `key-focus`,
+`drag-and-drop`) stay as a single array element — they are not split.
+
+## Alternatives considered
+
+* **Keep the hyphenated string (status quo, Proposal 005).** Rejected: undecomposable
+  on state ids that themselves contain a hyphen; re-fuses concepts Epic 284 is
+  pulling apart.
+* **Unordered array.** Rejected: order is semantically load-bearing (mode-state
+  before interaction-state per the convention above); an unordered set would make
+  `["selected","hover"]` and `["hover","selected"]` equivalent, breaking
+  deterministic serialization and discarding the mode-vs-interaction distinction.
+* **Array only for compounds, string for single states (`string | array`).** Rejected:
+  minimizes data churn but forces every consumer to branch on two shapes
+  permanently. A uniform array means every reader handles exactly one shape.
+
+## Impact
+
+* Every stateful token's `name.state` field changes shape (string → array); legacy
+  key output is unchanged.
+* `naming.rs`: `NameObject.state` becomes `Option<Vec<String>>`; the three legacy-key
+  serialization sites join the array; `split_trailing_state` returns ordered segments.
+* Validators `SPEC-009`, `SPEC-022`, `SPEC-026`, `SPEC-037` read arrays.
+* No change to the `compound-state` category or pinned `legacyKey` mechanism in
+  `naming-exceptions.json`.

--- a/packages/design-data-spec/conformance/invalid/SPEC-022/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-022/dataset.json
@@ -3,7 +3,7 @@
     {
       "name": {
         "component": "button",
-        "state": "jello",
+        "state": ["jello"],
         "property": "background-color"
       },
       "value": "#ff0000"

--- a/packages/design-data-spec/conformance/invalid/SPEC-037/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-037/dataset.json
@@ -11,7 +11,7 @@
     {
       "name": {
         "component": "button",
-        "state": "pressed",
+        "state": ["pressed"],
         "property": "background-color"
       },
       "value": "#cccccc"

--- a/packages/design-data-spec/conformance/invalid/SPEC-043/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-043/dataset.json
@@ -4,7 +4,7 @@
       "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/color.json",
       "name": {
         "property": "color",
-        "state": "hover"
+        "state": ["hover"]
       },
       "value": "#0265dc"
     },

--- a/packages/design-data-spec/conformance/query/and-conditions/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/query/and-conditions/input/tokens.tokens.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": { "property": "bg", "component": "button", "state": "hover" },
+    "name": { "property": "bg", "component": "button", "state": ["hover"] },
     "value": "#aaaaaa",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001"
   },
@@ -10,7 +10,7 @@
     "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
   },
   {
-    "name": { "property": "bg", "component": "checkbox", "state": "hover" },
+    "name": { "property": "bg", "component": "checkbox", "state": ["hover"] },
     "value": "#cccccc",
     "uuid": "aaaaaaaa-0003-4000-8000-000000000001"
   }

--- a/packages/design-data-spec/conformance/query/and-or-precedence/input/tokens.tokens.json
+++ b/packages/design-data-spec/conformance/query/and-or-precedence/input/tokens.tokens.json
@@ -1,21 +1,21 @@
 [
   {
-    "name": { "property": "bg", "component": "button", "state": "hover" },
+    "name": { "property": "bg", "component": "button", "state": ["hover"] },
     "value": "#aaaaaa",
     "uuid": "aaaaaaaa-0001-4000-8000-000000000001"
   },
   {
-    "name": { "property": "bg", "component": "button", "state": "default" },
+    "name": { "property": "bg", "component": "button", "state": ["default"] },
     "value": "#bbbbbb",
     "uuid": "aaaaaaaa-0002-4000-8000-000000000001"
   },
   {
-    "name": { "property": "bg", "component": "checkbox", "state": "default" },
+    "name": { "property": "bg", "component": "checkbox", "state": ["default"] },
     "value": "#cccccc",
     "uuid": "aaaaaaaa-0003-4000-8000-000000000001"
   },
   {
-    "name": { "property": "bg", "component": "slider", "state": "hover" },
+    "name": { "property": "bg", "component": "slider", "state": ["hover"] },
     "value": "#dddddd",
     "uuid": "aaaaaaaa-0004-4000-8000-000000000001"
   }

--- a/packages/design-data-spec/conformance/valid/SPEC-037/dataset.json
+++ b/packages/design-data-spec/conformance/valid/SPEC-037/dataset.json
@@ -20,7 +20,7 @@
     {
       "name": {
         "component": "button",
-        "state": "hover",
+        "state": ["hover"],
         "property": "background-color"
       },
       "value": "#eeeeee"
@@ -28,7 +28,7 @@
     {
       "name": {
         "component": "button",
-        "state": "pressed",
+        "state": ["pressed"],
         "property": "background-color"
       },
       "value": "#cccccc",

--- a/packages/design-data-spec/conformance/valid/component-refs/dataset.json
+++ b/packages/design-data-spec/conformance/valid/component-refs/dataset.json
@@ -19,7 +19,7 @@
     {
       "name": {
         "component": "button",
-        "state": "hover",
+        "state": ["hover"],
         "property": "background-color"
       },
       "value": "#0255be"

--- a/packages/design-data-spec/schemas/field.schema.json
+++ b/packages/design-data-spec/schemas/field.schema.json
@@ -76,7 +76,7 @@
     },
     "valueType": {
       "type": "string",
-      "enum": ["string", "integer"],
+      "enum": ["string", "integer", "array"],
       "description": "Type of the field value. Default: 'string'.",
       "default": "string"
     },

--- a/packages/design-data-spec/schemas/state-declaration.schema.json
+++ b/packages/design-data-spec/schemas/state-declaration.schema.json
@@ -10,7 +10,7 @@
       "type": "string",
       "pattern": "^[a-z][a-z0-9-]*$",
       "minLength": 1,
-      "description": "Kebab-case state identifier. Must match the value used in token name-object 'state' fields."
+      "description": "Kebab-case state identifier. Must match an element of the token name-object 'state' array."
     },
     "description": {
       "type": "string",

--- a/packages/design-data-spec/schemas/token.schema.json
+++ b/packages/design-data-spec/schemas/token.schema.json
@@ -48,8 +48,13 @@
           "description": "Semantic: variant within a component (e.g. accent, negative, primary)."
         },
         "state": {
-          "type": "string",
-          "description": "Semantic: interactive or semantic state (e.g. hover, focus, disabled)."
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "minItems": 1,
+          "description": "Semantic: interactive or semantic state, as an ordered array of atomic state ids (e.g. [\"hover\"], [\"selected\", \"hover\"])."
         },
         "qualifier": {
           "type": "string",

--- a/packages/design-data-spec/spec/query.md
+++ b/packages/design-data-spec/spec/query.md
@@ -77,6 +77,10 @@ The expression `a=x,b=y|c=z` is equivalent to `(a=x AND b=y) OR (c=z)`.
 
 **RATIONALE:** Negation matching absent fields follows the convention that "not equal to X" includes "does not exist" — the same semantics as label selectors in Kubernetes and CSS attribute selectors.
 
+**NORMATIVE:** `state` (and any future array-valued key) resolves to each element of the array individually. For equality (`=`), a condition matches when **any** element equals the specified value. For negation (`!=`), a condition matches when **no** element equals the specified value (or the field is absent). For example, a token with `name.state: ["selected", "hover"]` matches `state=hover` and does **not** match `state!=hover`.
+
+**RATIONALE:** A compound state (Proposal 006) represents a token that is simultaneously in multiple states; querying for one of those states should find it, consistent with treating the array as a set of active states rather than requiring an exact-array match.
+
 ## Glob matching
 
 **NORMATIVE:** The `*` character in a value is a **glob wildcard** matching zero or more characters.

--- a/packages/design-data-spec/spec/state-model.md
+++ b/packages/design-data-spec/spec/state-model.md
@@ -10,7 +10,7 @@ Scoped under [RFC-A — Component Contract in Design Data Spec](https://github.c
 
 A **component state** is a named condition under which a component's visual presentation differs from its baseline. States drive token resolution: when a component is in a given state, the design system selects tokens scoped to that state name rather than (or layered on top of) the baseline tokens.
 
-State names appear in the `state` field of token name objects (see [Token format — Name object](token-format.md#name-object)). A token with `"state": "hover"` applies only when the component is in the `hover` state. For this cross-reference to be machine-enforceable, state declarations **MUST** be present on the component declaration.
+State names appear in the `state` field of token name objects, an ordered array of one or more atomic state ids (see [Token format — Name object](token-format.md#name-object) and [Proposal 006](../../../docs/proposals/006-compound-states-as-array.md)). A token with `"state": ["hover"]` applies only when the component is in the `hover` state; `"state": ["selected", "hover"]` applies when both states are simultaneously active. For this cross-reference to be machine-enforceable, state declarations **MUST** be present on the component declaration.
 
 States fall into two trigger types:
 
@@ -188,7 +188,7 @@ See [Token format — Name object](token-format.md#name-object) for the full nam
     "component": "checkbox",
     "anatomy": "checkmark",
     "property": "color",
-    "state": "selected"
+    "state": ["selected"]
   },
   "value": "#0265dc"
 }

--- a/packages/design-data-spec/spec/token-format.md
+++ b/packages/design-data-spec/spec/token-format.md
@@ -55,25 +55,25 @@ The table below lists all semantic fields. Fields marked with a scope are domain
 
 **Universal semantic fields** (`scope: null` — apply to all token types):
 
-| Field          | Status   | Taxonomy category | Description                                                                                                                                                              |
-| -------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `property`     | REQUIRED | Property          | The stylistic attribute being defined (e.g. `color`, `width`, `padding`, `gap`).                                                                                         |
-| `component`    | OPTIONAL | Component         | Component name when the token is component-scoped.                                                                                                                       |
-| `structure`    | OPTIONAL | Structure         | Reusable visual pattern or object category (e.g. `base`, `container`, `list`, `accessory`). Distinct from `component`.                                                   |
-| `substructure` | OPTIONAL | Sub-structure     | A structure that only exists within its parent structure (e.g. `item` in `list-item`).                                                                                   |
-| `anatomy`      | OPTIONAL | Anatomy           | A visible, named part of a component as defined by designers (e.g. `handle`, `icon`, `label`). See [Taxonomy — Component anatomy](taxonomy.md#component-anatomy).        |
-| `object`       | OPTIONAL | Object            | Styling surface to which a visual property is applied (e.g. `background`, `border`, `edge`). See [Taxonomy — Token objects](taxonomy.md#token-objects-styling-surfaces). |
-| `variant`      | OPTIONAL | Variant           | Variant within a component (e.g. `accent`, `negative`, `primary`).                                                                                                       |
-| `state`        | OPTIONAL | State             | Interactive or semantic state (e.g. `hover`, `focus`, `disabled`).                                                                                                       |
-| `orientation`  | OPTIONAL | Orientation       | Direction or order of structures and elements (e.g. `vertical`, `horizontal`).                                                                                           |
-| `position`     | OPTIONAL | Position          | Location of an object relative to another (e.g. `affixed`).                                                                                                              |
-| `size`         | OPTIONAL | Size              | Relative t-shirt sizing for relationships across tokens (e.g. `small`, `medium`, `large`).                                                                               |
-| `density`      | OPTIONAL | Density           | Space within or around component parts (e.g. `spacious`, `compact`).                                                                                                     |
-| `shape`        | OPTIONAL | Shape             | Relative to overall component shape (e.g. `uniform`).                                                                                                                    |
-| `role`         | OPTIONAL | Role              | An object's role within a nesting relationship (e.g. `container`, `control`), distinct from `size`.                                                                      |
-| `scaleIndex`   | OPTIONAL | —                 | Numeric scale index appended at the end of the serialized name (e.g. `100`, `200`, `900`). Used by color palette, spacing, font-size, and motion duration tokens.        |
-| `from`         | OPTIONAL | —                 | Starting endpoint of a `space-between` measurement (e.g. `top`, `edge`, `text`). See [Space-between endpoints](#space-between-endpoints).                                |
-| `to`           | OPTIONAL | —                 | Ending endpoint of a `space-between` measurement (e.g. `text`, `visual`, `control`). See [Space-between endpoints](#space-between-endpoints).                            |
+| Field          | Status   | Taxonomy category | Description                                                                                                                                                                           |
+| -------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `property`     | REQUIRED | Property          | The stylistic attribute being defined (e.g. `color`, `width`, `padding`, `gap`).                                                                                                      |
+| `component`    | OPTIONAL | Component         | Component name when the token is component-scoped.                                                                                                                                    |
+| `structure`    | OPTIONAL | Structure         | Reusable visual pattern or object category (e.g. `base`, `container`, `list`, `accessory`). Distinct from `component`.                                                                |
+| `substructure` | OPTIONAL | Sub-structure     | A structure that only exists within its parent structure (e.g. `item` in `list-item`).                                                                                                |
+| `anatomy`      | OPTIONAL | Anatomy           | A visible, named part of a component as defined by designers (e.g. `handle`, `icon`, `label`). See [Taxonomy — Component anatomy](taxonomy.md#component-anatomy).                     |
+| `object`       | OPTIONAL | Object            | Styling surface to which a visual property is applied (e.g. `background`, `border`, `edge`). See [Taxonomy — Token objects](taxonomy.md#token-objects-styling-surfaces).              |
+| `variant`      | OPTIONAL | Variant           | Variant within a component (e.g. `accent`, `negative`, `primary`).                                                                                                                    |
+| `state`        | OPTIONAL | State             | Ordered array of one or more interactive or semantic states (e.g. `["hover"]`, `["selected", "hover"]`). See [Proposal 006](../../../docs/proposals/006-compound-states-as-array.md). |
+| `orientation`  | OPTIONAL | Orientation       | Direction or order of structures and elements (e.g. `vertical`, `horizontal`).                                                                                                        |
+| `position`     | OPTIONAL | Position          | Location of an object relative to another (e.g. `affixed`).                                                                                                                           |
+| `size`         | OPTIONAL | Size              | Relative t-shirt sizing for relationships across tokens (e.g. `small`, `medium`, `large`).                                                                                            |
+| `density`      | OPTIONAL | Density           | Space within or around component parts (e.g. `spacious`, `compact`).                                                                                                                  |
+| `shape`        | OPTIONAL | Shape             | Relative to overall component shape (e.g. `uniform`).                                                                                                                                 |
+| `role`         | OPTIONAL | Role              | An object's role within a nesting relationship (e.g. `container`, `control`), distinct from `size`.                                                                                   |
+| `scaleIndex`   | OPTIONAL | —                 | Numeric scale index appended at the end of the serialized name (e.g. `100`, `200`, `900`). Used by color palette, spacing, font-size, and motion duration tokens.                     |
+| `from`         | OPTIONAL | —                 | Starting endpoint of a `space-between` measurement (e.g. `top`, `edge`, `text`). See [Space-between endpoints](#space-between-endpoints).                                             |
+| `to`           | OPTIONAL | —                 | Ending endpoint of a `space-between` measurement (e.g. `text`, `visual`, `control`). See [Space-between endpoints](#space-between-endpoints).                                         |
 
 #### Space-between endpoints
 
@@ -122,7 +122,7 @@ When **`$ref`** is present, the token is an **alias**. The value **MUST** be a n
 
 ```json
 // Cascade canonical form (recommended) — the UUID is stable across renames.
-{ "name": { "property": "accent-background-color", "state": "default", "colorScheme": "dark" },
+{ "name": { "property": "accent-background-color", "state": ["default"], "colorScheme": "dark" },
   "$schema": "…/alias.json",
   "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
   "uuid": "f24eb871-6419-4cef-88a2-cca8548ae31e" }

--- a/packages/design-data/fields/state.json
+++ b/packages/design-data/fields/state.json
@@ -2,7 +2,7 @@
   "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/v0/field.schema.json",
   "specVersion": "1.0.0-draft",
   "name": "state",
-  "description": "Interactive or semantic state (e.g. hover, focus, disabled, selected). Compound states use hyphenation (e.g. selected-hover).",
+  "description": "Interactive or semantic state (e.g. hover, focus, disabled, selected), as an ordered array of atomic state ids. Compound states list mode-state before interaction-state (e.g. [\"selected\", \"hover\"]).",
   "kind": "semantic",
   "registry": "packages/design-data/registry/states.json",
   "validation": "advisory",
@@ -11,5 +11,5 @@
   },
   "scope": null,
   "required": false,
-  "valueType": "string"
+  "valueType": "array"
 }

--- a/packages/design-data/registry/states.json
+++ b/packages/design-data/registry/states.json
@@ -3,7 +3,7 @@
   "type": "state",
   "description": "Interaction states for components",
   "allowCustom": true,
-  "customPattern": "^[a-z][a-z0-9-]*(\\s\\+\\s[a-z][a-z0-9-]*)*$",
+  "customPattern": "^[a-z][a-z0-9-]*$",
   "values": [
     {
       "id": "default",

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -3,7 +3,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "accent-background-color-default"
     },
@@ -17,7 +17,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "accent-background-color-default"
     },
@@ -31,7 +31,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "accent-background-color-default"
     },
@@ -45,7 +45,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "legacyKey": "accent-background-color-down"
     },
@@ -59,7 +59,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "legacyKey": "accent-background-color-down"
     },
@@ -73,7 +73,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "legacyKey": "accent-background-color-down"
     },
@@ -87,7 +87,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "legacyKey": "accent-background-color-hover"
     },
@@ -101,7 +101,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "legacyKey": "accent-background-color-hover"
     },
@@ -115,7 +115,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "legacyKey": "accent-background-color-hover"
     },
@@ -129,7 +129,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "accent-background-color-key-focus"
     },
@@ -143,7 +143,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "accent-background-color-key-focus"
     },
@@ -157,7 +157,7 @@
     "name": {
       "colorRole": "accent",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "accent-background-color-key-focus"
     },
@@ -171,7 +171,7 @@
     "name": {
       "colorRole": "accent",
       "property": "content-color",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "accent-content-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -182,7 +182,7 @@
     "name": {
       "colorRole": "accent",
       "property": "content-color",
-      "state": "down",
+      "state": ["down"],
       "legacyKey": "accent-content-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -193,7 +193,7 @@
     "name": {
       "colorRole": "accent",
       "property": "content-color",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "accent-content-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -204,7 +204,7 @@
     "name": {
       "colorRole": "accent",
       "property": "content-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "accent-content-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -215,7 +215,7 @@
     "name": {
       "colorRole": "accent",
       "property": "content-color",
-      "state": "selected",
+      "state": ["selected"],
       "legacyKey": "accent-content-color-selected"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -364,7 +364,7 @@
   {
     "name": {
       "property": "opacity",
-      "state": "default",
+      "state": ["default"],
       "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -374,7 +374,7 @@
   {
     "name": {
       "property": "opacity",
-      "state": "down",
+      "state": ["down"],
       "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -384,7 +384,7 @@
   {
     "name": {
       "property": "opacity",
-      "state": "hover",
+      "state": ["hover"],
       "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -394,7 +394,7 @@
   {
     "name": {
       "property": "background-opacity",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "background-opacity-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -447,7 +447,7 @@
     "name": {
       "colorFamily": "blue",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "blue-background-color-default"
     },
@@ -461,7 +461,7 @@
     "name": {
       "colorFamily": "blue",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "blue-background-color-default"
     },
@@ -475,7 +475,7 @@
     "name": {
       "colorFamily": "blue",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "blue-background-color-default"
     },
@@ -490,7 +490,7 @@
       "colorFamily": "blue",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "blue-subtle-background-color-default"
     },
@@ -505,7 +505,7 @@
       "colorFamily": "blue",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "blue-subtle-background-color-default"
     },
@@ -520,7 +520,7 @@
       "colorFamily": "blue",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "blue-subtle-background-color-default"
     },
@@ -573,7 +573,7 @@
     "name": {
       "colorFamily": "brown",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "brown-background-color-default"
     },
@@ -587,7 +587,7 @@
     "name": {
       "colorFamily": "brown",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "brown-background-color-default"
     },
@@ -601,7 +601,7 @@
     "name": {
       "colorFamily": "brown",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "brown-background-color-default"
     },
@@ -616,7 +616,7 @@
       "colorFamily": "brown",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "brown-subtle-background-color-default"
     },
@@ -631,7 +631,7 @@
       "colorFamily": "brown",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "brown-subtle-background-color-default"
     },
@@ -646,7 +646,7 @@
       "colorFamily": "brown",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "brown-subtle-background-color-default"
     },
@@ -699,7 +699,7 @@
     "name": {
       "colorFamily": "celery",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "celery-background-color-default"
     },
@@ -713,7 +713,7 @@
     "name": {
       "colorFamily": "celery",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "celery-background-color-default"
     },
@@ -727,7 +727,7 @@
     "name": {
       "colorFamily": "celery",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "celery-background-color-default"
     },
@@ -742,7 +742,7 @@
       "colorFamily": "celery",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "celery-subtle-background-color-default"
     },
@@ -757,7 +757,7 @@
       "colorFamily": "celery",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "celery-subtle-background-color-default"
     },
@@ -772,7 +772,7 @@
       "colorFamily": "celery",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "celery-subtle-background-color-default"
     },
@@ -825,7 +825,7 @@
     "name": {
       "colorFamily": "chartreuse",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "chartreuse-background-color-default"
     },
@@ -839,7 +839,7 @@
     "name": {
       "colorFamily": "chartreuse",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "chartreuse-background-color-default"
     },
@@ -853,7 +853,7 @@
     "name": {
       "colorFamily": "chartreuse",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "chartreuse-background-color-default"
     },
@@ -868,7 +868,7 @@
       "colorFamily": "chartreuse",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "chartreuse-subtle-background-color-default"
     },
@@ -883,7 +883,7 @@
       "colorFamily": "chartreuse",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "chartreuse-subtle-background-color-default"
     },
@@ -898,7 +898,7 @@
       "colorFamily": "chartreuse",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "chartreuse-subtle-background-color-default"
     },
@@ -951,7 +951,7 @@
     "name": {
       "colorFamily": "cinnamon",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "cinnamon-background-color-default"
     },
@@ -965,7 +965,7 @@
     "name": {
       "colorFamily": "cinnamon",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "cinnamon-background-color-default"
     },
@@ -979,7 +979,7 @@
     "name": {
       "colorFamily": "cinnamon",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "cinnamon-background-color-default"
     },
@@ -994,7 +994,7 @@
       "colorFamily": "cinnamon",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "cinnamon-subtle-background-color-default"
     },
@@ -1009,7 +1009,7 @@
       "colorFamily": "cinnamon",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "cinnamon-subtle-background-color-default"
     },
@@ -1024,7 +1024,7 @@
       "colorFamily": "cinnamon",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "cinnamon-subtle-background-color-default"
     },
@@ -1077,7 +1077,7 @@
     "name": {
       "colorFamily": "cyan",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "cyan-background-color-default"
     },
@@ -1091,7 +1091,7 @@
     "name": {
       "colorFamily": "cyan",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "cyan-background-color-default"
     },
@@ -1105,7 +1105,7 @@
     "name": {
       "colorFamily": "cyan",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "cyan-background-color-default"
     },
@@ -1120,7 +1120,7 @@
       "colorFamily": "cyan",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "cyan-subtle-background-color-default"
     },
@@ -1135,7 +1135,7 @@
       "colorFamily": "cyan",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "cyan-subtle-background-color-default"
     },
@@ -1150,7 +1150,7 @@
       "colorFamily": "cyan",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "cyan-subtle-background-color-default"
     },
@@ -1202,7 +1202,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1212,7 +1212,7 @@
   {
     "name": {
       "property": "border-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1222,7 +1222,7 @@
   {
     "name": {
       "property": "content-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-content-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1234,7 +1234,7 @@
       "variant": "static",
       "colorFamily": "black",
       "property": "background-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-static-black-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1246,7 +1246,7 @@
       "variant": "static",
       "colorFamily": "black",
       "property": "border-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-static-black-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1258,7 +1258,7 @@
       "variant": "static",
       "colorFamily": "black",
       "property": "content-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-static-black-content-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1270,7 +1270,7 @@
       "variant": "static",
       "colorFamily": "white",
       "property": "background-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-static-white-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1282,7 +1282,7 @@
       "variant": "static",
       "colorFamily": "white",
       "property": "border-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-static-white-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1294,7 +1294,7 @@
       "variant": "static",
       "colorFamily": "white",
       "property": "content-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "disabled-static-white-content-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1693,7 +1693,7 @@
       "property": "color",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "drop-shadow-emphasized-default-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1704,7 +1704,7 @@
     "name": {
       "property": "drop-shadow",
       "variant": "emphasized",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "drop-shadow-emphasized-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/drop-shadow.json",
@@ -1738,7 +1738,7 @@
       "property": "color",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "drop-shadow-emphasized-hover-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1750,7 +1750,7 @@
       "property": "key-color",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "legacyKey": "drop-shadow-emphasized-hover-key-color"
     },
@@ -1765,7 +1765,7 @@
       "property": "key-color",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "legacyKey": "drop-shadow-emphasized-hover-key-color"
     },
@@ -1780,7 +1780,7 @@
       "property": "key-color",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "legacyKey": "drop-shadow-emphasized-hover-key-color"
     },
@@ -1888,7 +1888,7 @@
     "name": {
       "colorFamily": "fuchsia",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "fuchsia-background-color-default"
     },
@@ -1902,7 +1902,7 @@
     "name": {
       "colorFamily": "fuchsia",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "fuchsia-background-color-default"
     },
@@ -1916,7 +1916,7 @@
     "name": {
       "colorFamily": "fuchsia",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "fuchsia-background-color-default"
     },
@@ -1931,7 +1931,7 @@
       "colorFamily": "fuchsia",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "fuchsia-subtle-background-color-default"
     },
@@ -1946,7 +1946,7 @@
       "colorFamily": "fuchsia",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "fuchsia-subtle-background-color-default"
     },
@@ -1961,7 +1961,7 @@
       "colorFamily": "fuchsia",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "fuchsia-subtle-background-color-default"
     },
@@ -2014,7 +2014,7 @@
     "name": {
       "colorFamily": "gray",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "gray-background-color-default"
     },
@@ -2028,7 +2028,7 @@
     "name": {
       "colorFamily": "gray",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "gray-background-color-default"
     },
@@ -2042,7 +2042,7 @@
     "name": {
       "colorFamily": "gray",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "gray-background-color-default"
     },
@@ -2057,7 +2057,7 @@
       "colorFamily": "gray",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "gray-subtle-background-color-default"
     },
@@ -2072,7 +2072,7 @@
       "colorFamily": "gray",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "gray-subtle-background-color-default"
     },
@@ -2087,7 +2087,7 @@
       "colorFamily": "gray",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "gray-subtle-background-color-default"
     },
@@ -2140,7 +2140,7 @@
     "name": {
       "colorFamily": "green",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "green-background-color-default"
     },
@@ -2154,7 +2154,7 @@
     "name": {
       "colorFamily": "green",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "green-background-color-default"
     },
@@ -2168,7 +2168,7 @@
     "name": {
       "colorFamily": "green",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "green-background-color-default"
     },
@@ -2183,7 +2183,7 @@
       "colorFamily": "green",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "green-subtle-background-color-default"
     },
@@ -2198,7 +2198,7 @@
       "colorFamily": "green",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "green-subtle-background-color-default"
     },
@@ -2213,7 +2213,7 @@
       "colorFamily": "green",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "green-subtle-background-color-default"
     },
@@ -2266,7 +2266,7 @@
     "name": {
       "colorFamily": "indigo",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "indigo-background-color-default"
     },
@@ -2280,7 +2280,7 @@
     "name": {
       "colorFamily": "indigo",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "indigo-background-color-default"
     },
@@ -2294,7 +2294,7 @@
     "name": {
       "colorFamily": "indigo",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "indigo-background-color-default"
     },
@@ -2309,7 +2309,7 @@
       "colorFamily": "indigo",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "indigo-subtle-background-color-default"
     },
@@ -2324,7 +2324,7 @@
       "colorFamily": "indigo",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "indigo-subtle-background-color-default"
     },
@@ -2339,7 +2339,7 @@
       "colorFamily": "indigo",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "indigo-subtle-background-color-default"
     },
@@ -2391,7 +2391,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "variant": "informative"
     },
@@ -2404,7 +2404,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "variant": "informative"
     },
@@ -2417,7 +2417,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "variant": "informative"
     },
@@ -2430,7 +2430,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "variant": "informative"
     },
@@ -2443,7 +2443,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "variant": "informative"
     },
@@ -2456,7 +2456,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "variant": "informative"
     },
@@ -2469,7 +2469,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "variant": "informative"
     },
@@ -2482,7 +2482,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "variant": "informative"
     },
@@ -2495,7 +2495,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "variant": "informative"
     },
@@ -2508,7 +2508,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "informative-background-color-key-focus",
       "variant": "informative"
@@ -2522,7 +2522,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "informative-background-color-key-focus",
       "variant": "informative"
@@ -2536,7 +2536,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "informative-background-color-key-focus",
       "variant": "informative"
@@ -2590,7 +2590,7 @@
     "name": {
       "colorFamily": "magenta",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "magenta-background-color-default"
     },
@@ -2604,7 +2604,7 @@
     "name": {
       "colorFamily": "magenta",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "magenta-background-color-default"
     },
@@ -2618,7 +2618,7 @@
     "name": {
       "colorFamily": "magenta",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "magenta-background-color-default"
     },
@@ -2633,7 +2633,7 @@
       "colorFamily": "magenta",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "magenta-subtle-background-color-default"
     },
@@ -2648,7 +2648,7 @@
       "colorFamily": "magenta",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "magenta-subtle-background-color-default"
     },
@@ -2663,7 +2663,7 @@
       "colorFamily": "magenta",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "magenta-subtle-background-color-default"
     },
@@ -2715,7 +2715,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "variant": "negative"
     },
@@ -2728,7 +2728,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "variant": "negative"
     },
@@ -2741,7 +2741,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "variant": "negative"
     },
@@ -2754,7 +2754,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "variant": "negative"
     },
@@ -2767,7 +2767,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "variant": "negative"
     },
@@ -2780,7 +2780,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "variant": "negative"
     },
@@ -2793,7 +2793,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "variant": "negative"
     },
@@ -2806,7 +2806,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "variant": "negative"
     },
@@ -2819,7 +2819,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "variant": "negative"
     },
@@ -2832,7 +2832,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "negative-background-color-key-focus",
       "variant": "negative"
@@ -2846,7 +2846,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "negative-background-color-key-focus",
       "variant": "negative"
@@ -2860,7 +2860,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "negative-background-color-key-focus",
       "variant": "negative"
@@ -2874,7 +2874,7 @@
   {
     "name": {
       "property": "border-color",
-      "state": "default",
+      "state": ["default"],
       "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2884,7 +2884,7 @@
   {
     "name": {
       "property": "border-color",
-      "state": "down",
+      "state": ["down"],
       "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2894,7 +2894,7 @@
   {
     "name": {
       "property": "border-color",
-      "state": "focus",
+      "state": ["focus"],
       "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2905,7 +2905,7 @@
     "name": {
       "colorRole": "negative",
       "property": "border-color",
-      "state": "focus-hover",
+      "state": ["focus-hover"],
       "legacyKey": "negative-border-color-focus-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2915,7 +2915,7 @@
   {
     "name": {
       "property": "border-color",
-      "state": "hover",
+      "state": ["hover"],
       "variant": "negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2925,7 +2925,7 @@
   {
     "name": {
       "property": "border-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "negative-border-color-key-focus",
       "variant": "negative"
     },
@@ -2937,7 +2937,7 @@
     "name": {
       "colorRole": "negative",
       "property": "content-color",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "negative-content-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2948,7 +2948,7 @@
     "name": {
       "colorRole": "negative",
       "property": "content-color",
-      "state": "down",
+      "state": ["down"],
       "legacyKey": "negative-content-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2959,7 +2959,7 @@
     "name": {
       "colorRole": "negative",
       "property": "content-color",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "negative-content-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2969,7 +2969,7 @@
   {
     "name": {
       "property": "content-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "negative-content-color-key-focus",
       "variant": "negative"
     },
@@ -3019,7 +3019,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3029,7 +3029,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3039,7 +3039,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "variant": "neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3049,7 +3049,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "neutral-background-color-key-focus",
       "variant": "neutral"
     },
@@ -3061,7 +3061,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "background-color",
-      "state": "selected-default",
+      "state": ["selected", "default"],
       "legacyKey": "neutral-background-color-selected-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3072,7 +3072,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "background-color",
-      "state": "selected-down",
+      "state": ["selected", "down"],
       "legacyKey": "neutral-background-color-selected-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3083,7 +3083,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "background-color",
-      "state": "selected-hover",
+      "state": ["selected", "hover"],
       "legacyKey": "neutral-background-color-selected-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3094,7 +3094,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "background-color",
-      "state": "selected-key-focus",
+      "state": ["selected-key-focus"],
       "legacyKey": "neutral-background-color-selected-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3105,7 +3105,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "content-color",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "neutral-content-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3116,7 +3116,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "content-color",
-      "state": "down",
+      "state": ["down"],
       "legacyKey": "neutral-content-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3127,7 +3127,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "content-color",
-      "state": "focus",
+      "state": ["focus"],
       "legacyKey": "neutral-content-color-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3138,7 +3138,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "content-color",
-      "state": "focus-hover",
+      "state": ["focus-hover"],
       "legacyKey": "neutral-content-color-focus-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3149,7 +3149,7 @@
     "name": {
       "colorRole": "neutral",
       "property": "content-color",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "neutral-content-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3159,7 +3159,7 @@
   {
     "name": {
       "property": "content-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "neutral-content-color-key-focus",
       "variant": "neutral"
     },
@@ -3172,7 +3172,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "neutral-subdued-background-color-default"
     },
@@ -3187,7 +3187,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "neutral-subdued-background-color-default"
     },
@@ -3202,7 +3202,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "neutral-subdued-background-color-default"
     },
@@ -3217,7 +3217,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "legacyKey": "neutral-subdued-background-color-down"
     },
@@ -3232,7 +3232,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "legacyKey": "neutral-subdued-background-color-down"
     },
@@ -3247,7 +3247,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "legacyKey": "neutral-subdued-background-color-down"
     },
@@ -3262,7 +3262,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "legacyKey": "neutral-subdued-background-color-hover"
     },
@@ -3277,7 +3277,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "legacyKey": "neutral-subdued-background-color-hover"
     },
@@ -3292,7 +3292,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "legacyKey": "neutral-subdued-background-color-hover"
     },
@@ -3307,7 +3307,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "neutral-subdued-background-color-key-focus"
     },
@@ -3322,7 +3322,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "neutral-subdued-background-color-key-focus"
     },
@@ -3337,7 +3337,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "neutral-subdued-background-color-key-focus"
     },
@@ -3352,7 +3352,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "content-color",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "neutral-subdued-content-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3364,7 +3364,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "content-color",
-      "state": "down",
+      "state": ["down"],
       "legacyKey": "neutral-subdued-content-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3376,7 +3376,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "content-color",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "neutral-subdued-content-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3388,7 +3388,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "content-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "neutral-subdued-content-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3400,7 +3400,7 @@
       "colorRole": "neutral",
       "variant": "subdued",
       "property": "content-color",
-      "state": "selected",
+      "state": ["selected"],
       "legacyKey": "neutral-subdued-content-color-selected"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3412,7 +3412,7 @@
       "colorRole": "neutral",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "neutral-subtle-background-color-default"
     },
@@ -3427,7 +3427,7 @@
       "colorRole": "neutral",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "neutral-subtle-background-color-default"
     },
@@ -3442,7 +3442,7 @@
       "colorRole": "neutral",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "neutral-subtle-background-color-default"
     },
@@ -3494,7 +3494,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "variant": "notice"
     },
@@ -3507,7 +3507,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "variant": "notice"
     },
@@ -3520,7 +3520,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "variant": "notice"
     },
@@ -3572,7 +3572,7 @@
   {
     "name": {
       "property": "opacity",
-      "state": "disabled"
+      "state": ["disabled"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.3",
@@ -3582,7 +3582,7 @@
     "name": {
       "colorFamily": "orange",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "orange-background-color-default"
     },
@@ -3596,7 +3596,7 @@
     "name": {
       "colorFamily": "orange",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "orange-background-color-default"
     },
@@ -3610,7 +3610,7 @@
     "name": {
       "colorFamily": "orange",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "orange-background-color-default"
     },
@@ -3625,7 +3625,7 @@
       "colorFamily": "orange",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "orange-subtle-background-color-default"
     },
@@ -3640,7 +3640,7 @@
       "colorFamily": "orange",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "orange-subtle-background-color-default"
     },
@@ -3655,7 +3655,7 @@
       "colorFamily": "orange",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "orange-subtle-background-color-default"
     },
@@ -3749,7 +3749,7 @@
     "name": {
       "colorFamily": "pink",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "pink-background-color-default"
     },
@@ -3763,7 +3763,7 @@
     "name": {
       "colorFamily": "pink",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "pink-background-color-default"
     },
@@ -3777,7 +3777,7 @@
     "name": {
       "colorFamily": "pink",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "pink-background-color-default"
     },
@@ -3792,7 +3792,7 @@
       "colorFamily": "pink",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "pink-subtle-background-color-default"
     },
@@ -3807,7 +3807,7 @@
       "colorFamily": "pink",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "pink-subtle-background-color-default"
     },
@@ -3822,7 +3822,7 @@
       "colorFamily": "pink",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "pink-subtle-background-color-default"
     },
@@ -3874,7 +3874,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "variant": "positive"
     },
@@ -3887,7 +3887,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "variant": "positive"
     },
@@ -3900,7 +3900,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "variant": "positive"
     },
@@ -3913,7 +3913,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "variant": "positive"
     },
@@ -3926,7 +3926,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "variant": "positive"
     },
@@ -3939,7 +3939,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "variant": "positive"
     },
@@ -3952,7 +3952,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "variant": "positive"
     },
@@ -3965,7 +3965,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "variant": "positive"
     },
@@ -3978,7 +3978,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "variant": "positive"
     },
@@ -3991,7 +3991,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "positive-background-color-key-focus",
       "variant": "positive"
@@ -4005,7 +4005,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "positive-background-color-key-focus",
       "variant": "positive"
@@ -4019,7 +4019,7 @@
   {
     "name": {
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "positive-background-color-key-focus",
       "variant": "positive"
@@ -4073,7 +4073,7 @@
     "name": {
       "colorFamily": "purple",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "purple-background-color-default"
     },
@@ -4087,7 +4087,7 @@
     "name": {
       "colorFamily": "purple",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "purple-background-color-default"
     },
@@ -4101,7 +4101,7 @@
     "name": {
       "colorFamily": "purple",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "purple-background-color-default"
     },
@@ -4116,7 +4116,7 @@
       "colorFamily": "purple",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "purple-subtle-background-color-default"
     },
@@ -4131,7 +4131,7 @@
       "colorFamily": "purple",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "purple-subtle-background-color-default"
     },
@@ -4146,7 +4146,7 @@
       "colorFamily": "purple",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "purple-subtle-background-color-default"
     },
@@ -4199,7 +4199,7 @@
     "name": {
       "colorFamily": "red",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "red-background-color-default"
     },
@@ -4213,7 +4213,7 @@
     "name": {
       "colorFamily": "red",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "red-background-color-default"
     },
@@ -4227,7 +4227,7 @@
     "name": {
       "colorFamily": "red",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "red-background-color-default"
     },
@@ -4242,7 +4242,7 @@
       "colorFamily": "red",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "red-subtle-background-color-default"
     },
@@ -4257,7 +4257,7 @@
       "colorFamily": "red",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "red-subtle-background-color-default"
     },
@@ -4272,7 +4272,7 @@
       "colorFamily": "red",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "red-subtle-background-color-default"
     },
@@ -4325,7 +4325,7 @@
     "name": {
       "colorFamily": "seafoam",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "seafoam-background-color-default"
     },
@@ -4339,7 +4339,7 @@
     "name": {
       "colorFamily": "seafoam",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "seafoam-background-color-default"
     },
@@ -4353,7 +4353,7 @@
     "name": {
       "colorFamily": "seafoam",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "seafoam-background-color-default"
     },
@@ -4368,7 +4368,7 @@
       "colorFamily": "seafoam",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "seafoam-subtle-background-color-default"
     },
@@ -4383,7 +4383,7 @@
       "colorFamily": "seafoam",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "seafoam-subtle-background-color-default"
     },
@@ -4398,7 +4398,7 @@
       "colorFamily": "seafoam",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "seafoam-subtle-background-color-default"
     },
@@ -4451,7 +4451,7 @@
     "name": {
       "colorFamily": "silver",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "silver-background-color-default"
     },
@@ -4465,7 +4465,7 @@
     "name": {
       "colorFamily": "silver",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "silver-background-color-default"
     },
@@ -4479,7 +4479,7 @@
     "name": {
       "colorFamily": "silver",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "silver-background-color-default"
     },
@@ -4494,7 +4494,7 @@
       "colorFamily": "silver",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "silver-subtle-background-color-default"
     },
@@ -4509,7 +4509,7 @@
       "colorFamily": "silver",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "silver-subtle-background-color-default"
     },
@@ -4524,7 +4524,7 @@
       "colorFamily": "silver",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "silver-subtle-background-color-default"
     },
@@ -4681,7 +4681,7 @@
     "name": {
       "colorFamily": "turquoise",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "turquoise-background-color-default"
     },
@@ -4695,7 +4695,7 @@
     "name": {
       "colorFamily": "turquoise",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "turquoise-background-color-default"
     },
@@ -4709,7 +4709,7 @@
     "name": {
       "colorFamily": "turquoise",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "turquoise-background-color-default"
     },
@@ -4724,7 +4724,7 @@
       "colorFamily": "turquoise",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "turquoise-subtle-background-color-default"
     },
@@ -4739,7 +4739,7 @@
       "colorFamily": "turquoise",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "turquoise-subtle-background-color-default"
     },
@@ -4754,7 +4754,7 @@
       "colorFamily": "turquoise",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "turquoise-subtle-background-color-default"
     },
@@ -4807,7 +4807,7 @@
     "name": {
       "colorFamily": "yellow",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "yellow-background-color-default"
     },
@@ -4821,7 +4821,7 @@
     "name": {
       "colorFamily": "yellow",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "yellow-background-color-default"
     },
@@ -4835,7 +4835,7 @@
     "name": {
       "colorFamily": "yellow",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "yellow-background-color-default"
     },
@@ -4850,7 +4850,7 @@
       "colorFamily": "yellow",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "yellow-subtle-background-color-default"
     },
@@ -4865,7 +4865,7 @@
       "colorFamily": "yellow",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "yellow-subtle-background-color-default"
     },
@@ -4880,7 +4880,7 @@
       "colorFamily": "yellow",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "yellow-subtle-background-color-default"
     },
@@ -4931,7 +4931,7 @@
   },
   {
     "name": {
-      "state": "selected",
+      "state": ["selected"],
       "property": "stack-item-background-color",
       "qualifier": "highlight",
       "legacyKey": "stack-item-selected-background-color-highlight"

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -48,7 +48,7 @@
     "name": {
       "component": "avatar",
       "property": "opacity",
-      "state": "disabled"
+      "state": ["disabled"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74",
@@ -366,7 +366,7 @@
       "component": "drop-zone",
       "object": "background",
       "property": "opacity",
-      "state": "filled",
+      "state": ["filled"],
       "legacyKey": "drop-zone-background-color-opacity-filled"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -402,7 +402,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-default",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -417,7 +417,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-default",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -432,7 +432,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-default",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -447,7 +447,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-disabled",
       "property": "background-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -462,7 +462,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-disabled",
       "property": "background-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -477,7 +477,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-disabled",
       "property": "background-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -492,7 +492,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-down",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -507,7 +507,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-down",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -522,7 +522,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-down",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -537,7 +537,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-hover",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -552,7 +552,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-hover",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -567,7 +567,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-hover",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -582,7 +582,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-keyboard-focus",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "light"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -597,7 +597,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-keyboard-focus",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "dark"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -612,7 +612,7 @@
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-keyboard-focus",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "colorScheme": "wireframe"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -746,7 +746,7 @@
     "name": {
       "component": "select-box",
       "property": "border-color",
-      "state": "selected",
+      "state": ["selected"],
       "legacyKey": "select-box-selected-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -757,7 +757,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "down"
+      "state": ["down"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -767,7 +767,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "hover"
+      "state": ["hover"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -777,7 +777,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "stack-item-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -788,7 +788,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "selected-default",
+      "state": ["selected", "default"],
       "legacyKey": "stack-item-selected-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -799,7 +799,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "selected-down",
+      "state": ["selected", "down"],
       "legacyKey": "stack-item-selected-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -810,7 +810,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "selected",
+      "state": ["selected"],
       "emphasis": "emphasized",
       "legacyKey": "stack-item-selected-background-color-emphasized"
     },
@@ -822,7 +822,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "selected-hover",
+      "state": ["selected", "hover"],
       "legacyKey": "stack-item-selected-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -833,7 +833,7 @@
     "name": {
       "component": "stack-item",
       "property": "background-color",
-      "state": "selected-keyboard-focus",
+      "state": ["selected", "keyboard-focus"],
       "legacyKey": "stack-item-selected-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -886,7 +886,7 @@
       "component": "swatch",
       "anatomy": "icon",
       "property": "border-color",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "swatch-disabled-icon-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -898,7 +898,7 @@
       "component": "swatch",
       "anatomy": "icon",
       "property": "border-opacity",
-      "state": "disabled",
+      "state": ["disabled"],
       "legacyKey": "swatch-disabled-icon-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -919,7 +919,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "opacity",
-      "state": "down",
+      "state": ["down"],
       "legacyKey": "table-row-down-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -931,7 +931,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "table-row-hover-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -943,7 +943,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "opacity",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "table-row-hover-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -955,7 +955,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "background-color",
-      "state": "selected",
+      "state": ["selected"],
       "legacyKey": "table-selected-row-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -967,7 +967,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "background-color",
-      "state": "selected",
+      "state": ["selected"],
       "emphasis": "non-emphasized",
       "legacyKey": "table-selected-row-background-color-non-emphasized"
     },
@@ -980,7 +980,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "background-opacity",
-      "state": "selected",
+      "state": ["selected"],
       "legacyKey": "table-selected-row-background-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -992,7 +992,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "background-opacity",
-      "state": "selected-hover",
+      "state": ["selected", "hover"],
       "legacyKey": "table-selected-row-background-opacity-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -1004,7 +1004,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "background-opacity",
-      "state": "selected",
+      "state": ["selected"],
       "emphasis": "non-emphasized",
       "legacyKey": "table-selected-row-background-opacity-non-emphasized"
     },
@@ -1017,7 +1017,7 @@
       "component": "table",
       "anatomy": "row",
       "property": "background-opacity",
-      "state": "selected-hover",
+      "state": ["selected", "hover"],
       "emphasis": "non-emphasized",
       "legacyKey": "table-selected-row-background-opacity-non-emphasized-hover"
     },
@@ -1047,7 +1047,7 @@
     "name": {
       "component": "thumbnail",
       "property": "opacity",
-      "state": "disabled"
+      "state": ["disabled"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74",
@@ -1057,7 +1057,7 @@
     "name": {
       "component": "tree-view",
       "property": "row-background",
-      "state": "hover"
+      "state": ["hover"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -1068,7 +1068,7 @@
       "component": "tree-view",
       "anatomy": "row",
       "property": "background-color",
-      "state": "selected",
+      "state": ["selected"],
       "emphasis": "emphasized",
       "legacyKey": "tree-view-selected-row-background-color-emphasized"
     },
@@ -1081,7 +1081,7 @@
       "component": "tree-view",
       "anatomy": "row",
       "property": "background",
-      "state": "selected-default",
+      "state": ["selected", "default"],
       "legacyKey": "tree-view-selected-row-background-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -1093,7 +1093,7 @@
       "component": "tree-view",
       "anatomy": "row",
       "property": "background",
-      "state": "selected-hover",
+      "state": ["selected", "hover"],
       "legacyKey": "tree-view-selected-row-background-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -45,7 +45,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -60,7 +60,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -75,7 +75,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -90,7 +90,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -105,7 +105,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -120,7 +120,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -135,7 +135,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -150,7 +150,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -165,7 +165,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "blue"
@@ -222,7 +222,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -237,7 +237,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -252,7 +252,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -267,7 +267,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -282,7 +282,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -297,7 +297,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -312,7 +312,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -327,7 +327,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -342,7 +342,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "brown"
@@ -399,7 +399,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -414,7 +414,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -429,7 +429,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -444,7 +444,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -459,7 +459,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -474,7 +474,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -489,7 +489,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -504,7 +504,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -519,7 +519,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "celery"
@@ -576,7 +576,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -591,7 +591,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -606,7 +606,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -621,7 +621,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -636,7 +636,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -651,7 +651,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -666,7 +666,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -681,7 +681,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -696,7 +696,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "chartreuse"
@@ -753,7 +753,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorRole": "primary",
       "colorFamily": "cinnamon"
     },
@@ -765,7 +765,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorRole": "primary",
       "colorFamily": "cinnamon"
     },
@@ -777,7 +777,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorRole": "primary",
       "colorFamily": "cinnamon"
     },
@@ -831,7 +831,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorRole": "primary",
       "colorFamily": "cyan"
     },
@@ -843,7 +843,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorRole": "primary",
       "colorFamily": "cyan"
     },
@@ -855,7 +855,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorRole": "primary",
       "colorFamily": "cyan"
     },
@@ -898,7 +898,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -913,7 +913,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -928,7 +928,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -943,7 +943,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -958,7 +958,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -973,7 +973,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -988,7 +988,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -1003,7 +1003,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -1018,7 +1018,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "fuchsia"
@@ -1075,7 +1075,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorRole": "primary",
       "colorFamily": "green"
     },
@@ -1087,7 +1087,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorRole": "primary",
       "colorFamily": "green"
     },
@@ -1099,7 +1099,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorRole": "primary",
       "colorFamily": "green"
     },
@@ -1153,7 +1153,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1168,7 +1168,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1183,7 +1183,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1198,7 +1198,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1213,7 +1213,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1228,7 +1228,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1243,7 +1243,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1258,7 +1258,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1273,7 +1273,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "indigo"
@@ -1322,7 +1322,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1337,7 +1337,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1352,7 +1352,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1367,7 +1367,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1382,7 +1382,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1397,7 +1397,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1412,7 +1412,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1427,7 +1427,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1442,7 +1442,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "magenta"
@@ -1499,7 +1499,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1514,7 +1514,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1529,7 +1529,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1544,7 +1544,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1559,7 +1559,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1574,7 +1574,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1589,7 +1589,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1604,7 +1604,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1619,7 +1619,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "orange"
@@ -1645,7 +1645,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1660,7 +1660,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1675,7 +1675,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1690,7 +1690,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1705,7 +1705,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1720,7 +1720,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1735,7 +1735,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1750,7 +1750,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1765,7 +1765,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "pink"
@@ -1780,7 +1780,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorRole": "primary",
       "legacyKey": "icon-color-primary-default"
     },
@@ -1792,7 +1792,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorRole": "primary",
       "legacyKey": "icon-color-primary-down"
     },
@@ -1804,7 +1804,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorRole": "primary",
       "legacyKey": "icon-color-primary-hover"
     },
@@ -1827,7 +1827,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1842,7 +1842,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1857,7 +1857,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1872,7 +1872,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1887,7 +1887,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1902,7 +1902,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1917,7 +1917,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1932,7 +1932,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -1947,7 +1947,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "purple"
@@ -2004,7 +2004,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2019,7 +2019,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2034,7 +2034,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2049,7 +2049,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2064,7 +2064,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2079,7 +2079,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2094,7 +2094,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2109,7 +2109,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2124,7 +2124,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "red"
@@ -2181,7 +2181,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorRole": "primary",
       "colorFamily": "seafoam"
     },
@@ -2193,7 +2193,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorRole": "primary",
       "colorFamily": "seafoam"
     },
@@ -2205,7 +2205,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorRole": "primary",
       "colorFamily": "seafoam"
     },
@@ -2259,7 +2259,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2274,7 +2274,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2289,7 +2289,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2304,7 +2304,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2319,7 +2319,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2334,7 +2334,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2349,7 +2349,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2364,7 +2364,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2379,7 +2379,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "silver"
@@ -2436,7 +2436,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2451,7 +2451,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2466,7 +2466,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2481,7 +2481,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2496,7 +2496,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2511,7 +2511,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2526,7 +2526,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2541,7 +2541,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2556,7 +2556,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "turquoise"
@@ -2613,7 +2613,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2628,7 +2628,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2643,7 +2643,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2658,7 +2658,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2673,7 +2673,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2688,7 +2688,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "down",
+      "state": ["down"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2703,7 +2703,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "light",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2718,7 +2718,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "dark",
       "colorRole": "primary",
       "colorFamily": "yellow"
@@ -2733,7 +2733,7 @@
     "name": {
       "icon": "icon",
       "property": "color",
-      "state": "hover",
+      "state": ["hover"],
       "colorScheme": "wireframe",
       "colorRole": "primary",
       "colorFamily": "yellow"

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -4278,7 +4278,7 @@
     "name": {
       "component": "card-horizontal",
       "property": "space-between",
-      "state": "default",
+      "state": ["default"],
       "from": "edge",
       "to": "content"
     },
@@ -4420,7 +4420,7 @@
     "name": {
       "component": "card",
       "property": "minimum-width",
-      "state": "default"
+      "state": ["default"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "100px",
@@ -6009,7 +6009,7 @@
     "name": {
       "component": "color-handle",
       "property": "size",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "scale": "desktop",
       "legacyKey": "color-handle-size-key-focus"
     },
@@ -6023,7 +6023,7 @@
     "name": {
       "component": "color-handle",
       "property": "size",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "scale": "mobile",
       "legacyKey": "color-handle-size-key-focus"
     },
@@ -22372,7 +22372,7 @@
     "name": {
       "component": "tree-view",
       "property": "space-between",
-      "state": "default",
+      "state": ["default"],
       "from": "item",
       "to": "item"
     },

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -2098,7 +2098,7 @@
   {
     "name": {
       "property": "component-size-difference",
-      "state": "down"
+      "state": ["down"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "-2px",
@@ -2107,7 +2107,7 @@
   {
     "name": {
       "property": "component-size-maximum-perspective",
-      "state": "down"
+      "state": ["down"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "96px",
@@ -2116,7 +2116,7 @@
   {
     "name": {
       "property": "component-size-minimum-perspective",
-      "state": "down"
+      "state": ["down"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
     "value": "24px",
@@ -2125,7 +2125,7 @@
   {
     "name": {
       "property": "component-size-width-ratio",
-      "state": "down"
+      "state": ["down"]
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/multiplier.json",
     "value": 0.3333,
@@ -2805,7 +2805,7 @@
   {
     "name": {
       "property": "corner-radius",
-      "state": "default",
+      "state": ["default"],
       "size": "xl"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2825,7 +2825,7 @@
   {
     "name": {
       "property": "corner-radius",
-      "state": "default",
+      "state": ["default"],
       "size": "l"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2835,7 +2835,7 @@
   {
     "name": {
       "property": "corner-radius",
-      "state": "default",
+      "state": ["default"],
       "size": "m"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -2910,7 +2910,7 @@
   {
     "name": {
       "property": "corner-radius",
-      "state": "default",
+      "state": ["default"],
       "size": "s"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3308,7 +3308,7 @@
       "property": "blur",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "drop-shadow-emphasized-default-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3320,7 +3320,7 @@
       "property": "x",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "drop-shadow-emphasized-default-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3332,7 +3332,7 @@
       "property": "y",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "drop-shadow-emphasized-default-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3344,7 +3344,7 @@
       "property": "blur",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "drop-shadow-emphasized-hover-blur"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3356,7 +3356,7 @@
       "property": "x",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "drop-shadow-emphasized-hover-x"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -3368,7 +3368,7 @@
       "property": "y",
       "emphasis": "emphasized",
       "structure": "drop-shadow",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "drop-shadow-emphasized-hover-y"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -164,7 +164,7 @@
       "colorRole": "accent",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "accent-subtle-background-color-default"
     },
@@ -179,7 +179,7 @@
       "colorRole": "accent",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "accent-subtle-background-color-default"
     },
@@ -194,7 +194,7 @@
       "colorRole": "accent",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "accent-subtle-background-color-default"
     },
@@ -414,7 +414,7 @@
       "colorRole": "informative",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "informative-subtle-background-color-default"
     },
@@ -429,7 +429,7 @@
       "colorRole": "informative",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "informative-subtle-background-color-default"
     },
@@ -444,7 +444,7 @@
       "colorRole": "informative",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "informative-subtle-background-color-default"
     },
@@ -619,7 +619,7 @@
       "colorRole": "negative",
       "variant": "subdued",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "legacyKey": "negative-subdued-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -632,7 +632,7 @@
       "colorRole": "negative",
       "variant": "subdued",
       "property": "background-color",
-      "state": "down",
+      "state": ["down"],
       "legacyKey": "negative-subdued-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -645,7 +645,7 @@
       "colorRole": "negative",
       "variant": "subdued",
       "property": "background-color",
-      "state": "hover",
+      "state": ["hover"],
       "legacyKey": "negative-subdued-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -658,7 +658,7 @@
       "colorRole": "negative",
       "variant": "subdued",
       "property": "background-color",
-      "state": "keyboard-focus",
+      "state": ["keyboard-focus"],
       "legacyKey": "negative-subdued-background-color-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -671,7 +671,7 @@
       "colorRole": "negative",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "negative-subtle-background-color-default"
     },
@@ -686,7 +686,7 @@
       "colorRole": "negative",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "negative-subtle-background-color-default"
     },
@@ -701,7 +701,7 @@
       "colorRole": "negative",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "negative-subtle-background-color-default"
     },
@@ -876,7 +876,7 @@
       "colorRole": "notice",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "notice-subtle-background-color-default"
     },
@@ -891,7 +891,7 @@
       "colorRole": "notice",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "notice-subtle-background-color-default"
     },
@@ -906,7 +906,7 @@
       "colorRole": "notice",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "notice-subtle-background-color-default"
     },
@@ -1081,7 +1081,7 @@
       "colorRole": "positive",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "light",
       "legacyKey": "positive-subtle-background-color-default"
     },
@@ -1096,7 +1096,7 @@
       "colorRole": "positive",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "dark",
       "legacyKey": "positive-subtle-background-color-default"
     },
@@ -1111,7 +1111,7 @@
       "colorRole": "positive",
       "variant": "subtle",
       "property": "background-color",
-      "state": "default",
+      "state": ["default"],
       "colorScheme": "wireframe",
       "legacyKey": "positive-subtle-background-color-default"
     },

--- a/sdk/core/src/cache/mod.rs
+++ b/sdk/core/src/cache/mod.rs
@@ -682,7 +682,7 @@ fn write_tables(db: &Database, graph: &TokenGraph, hash: u64) -> Result<(), Cach
         };
         let mut table = wtx.open_multimap_table(def)?;
         for (key, record) in &graph.tokens {
-            if let Some(value) = query::resolve_key(&record.raw, field) {
+            for value in query::resolve_key(&record.raw, field) {
                 table.insert(value.as_str(), key.as_str())?;
             }
         }

--- a/sdk/core/src/migrate.rs
+++ b/sdk/core/src/migrate.rs
@@ -245,8 +245,11 @@ fn decomposed_name_val(parsed: &naming::NameObject) -> Value {
         name.insert("component".into(), Value::String(c.clone()));
     }
     name.insert("property".into(), Value::String(parsed.property.clone()));
-    if let Some(s) = &parsed.state {
-        name.insert("state".into(), Value::String(s.clone()));
+    if let Some(states) = &parsed.state {
+        name.insert(
+            "state".into(),
+            Value::Array(states.iter().cloned().map(Value::String).collect()),
+        );
     }
     Value::Object(name)
 }
@@ -1223,7 +1226,7 @@ mod tests {
         let forced = HashSet::new();
         let ctx = empty_ctx(&sidecar, &forced);
         let tok = obj(json!({
-            "name": {"component": "button", "property": "background-color", "state": "hover"},
+            "name": {"component": "button", "property": "background-color", "state": ["hover"]},
             "uuid": "0000"
         }));
         let (name, kind) = resolve_name("button-background-color-hover", &tok, &ctx);
@@ -1275,7 +1278,7 @@ mod tests {
         assert_eq!(kind, NameKind::Decomposed);
         assert_eq!(name["component"], "button");
         assert_eq!(name["property"], "background-color");
-        assert_eq!(name["state"], "hover");
+        assert_eq!(name["state"], json!(["hover"]));
     }
 
     #[test]

--- a/sdk/core/src/naming.rs
+++ b/sdk/core/src/naming.rs
@@ -80,8 +80,10 @@ pub struct NameObject {
     pub component: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variant: Option<String>,
+    /// Ordered array of atomic state ids (Proposal 006). A compound state lists
+    /// the mode-state before the interaction-state, e.g. `["selected", "hover"]`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<String>,
+    pub state: Option<Vec<String>>,
 }
 
 /// Generate the canonical legacy name from a [`NameObject`].
@@ -91,7 +93,7 @@ pub struct NameObject {
 ///    the field-catalog serialization order in `extract_legacy_key`).
 /// 2. If `component` is present, emit `{component}-`.
 /// 3. Always emit `{property}`.
-/// 4. If `state` is present, append `-{state}`.
+/// 4. If `state` is present, append each ordered element as `-{state}`.
 pub fn generate_legacy_name(obj: &NameObject) -> String {
     let mut parts: Vec<&str> = Vec::new();
     if let Some(v) = &obj.variant {
@@ -101,8 +103,8 @@ pub fn generate_legacy_name(obj: &NameObject) -> String {
         parts.push(c);
     }
     parts.push(&obj.property);
-    if let Some(s) = &obj.state {
-        parts.push(s);
+    if let Some(states) = &obj.state {
+        parts.extend(states.iter().map(String::as_str));
     }
     parts.join("-")
 }
@@ -132,7 +134,7 @@ pub fn parse_legacy_name(key: &str, component_hint: Option<&str>) -> NameObject 
         property: property.to_string(),
         component: component_hint.map(str::to_string),
         variant: variant.map(str::to_string),
-        state: state.map(str::to_string),
+        state: state.map(|s| vec![s.to_string()]),
     }
 }
 
@@ -321,8 +323,8 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         if let Some(cr) = color_role {
             parts.push(cr.to_string());
         }
-        if let Some(st) = name.get("state").and_then(|v| v.as_str()) {
-            parts.push(st.to_string());
+        if let Some(states) = name.get("state").and_then(|v| v.as_array()) {
+            parts.extend(states.iter().filter_map(|s| s.as_str()).map(str::to_string));
         }
         return Some(parts.join("-"));
     }
@@ -361,8 +363,8 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
         if let Some(i) = name.get("scaleIndex").and_then(|v| v.as_i64()) {
             parts.push(i.to_string());
         }
-        if let Some(st) = name.get("state").and_then(|v| v.as_str()) {
-            parts.push(st.to_string());
+        if let Some(states) = name.get("state").and_then(|v| v.as_array()) {
+            parts.extend(states.iter().filter_map(|s| s.as_str()).map(str::to_string));
         }
         return Some(parts.join("-"));
     }
@@ -423,6 +425,17 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
                     parts.push(format!("{f_expanded}-to-{t_expanded}"));
                     continue;
                 }
+                // `state` (Proposal 006) is an ordered array of atomic ids, not a
+                // single string like every other catalog field.
+                if entry.name == "state" {
+                    if let Some(states) = name.get("state").and_then(|v| v.as_array()) {
+                        for s in states.iter().filter_map(|v| v.as_str()) {
+                            let expanded = registry.token_name("state", s).unwrap_or(s);
+                            parts.push(expanded.to_string());
+                        }
+                    }
+                    continue;
+                }
                 if let Some(v) = name.get(entry.name).and_then(|v| v.as_str()) {
                     let expanded = registry.token_name(entry.name, v).unwrap_or(v);
                     parts.push(expanded.to_string());
@@ -479,6 +492,17 @@ pub fn extract_legacy_key(name_val: &Value) -> Option<String> {
 
     for entry in catalog.entries_by_position() {
         if entry.exclude_from_legacy_key {
+            continue;
+        }
+        // `state` (Proposal 006) is an ordered array of atomic ids, not a single
+        // string like every other catalog field — walk its elements in order.
+        if entry.name == "state" {
+            if let Some(states) = name.get("state").and_then(|v| v.as_array()) {
+                for s in states.iter().filter_map(|v| v.as_str()) {
+                    let expanded = registry.token_name("state", s).unwrap_or(s);
+                    parts.push(expanded.to_string());
+                }
+            }
             continue;
         }
         if let Some(v) = name.get(entry.name).and_then(|v| v.as_str()) {
@@ -598,7 +622,7 @@ mod tests {
         let obj = parse_legacy_name("menu-item-background-color-hover", Some("menu-item"));
         assert_eq!(obj.component.as_deref(), Some("menu-item"));
         assert_eq!(obj.property, "background-color");
-        assert_eq!(obj.state.as_deref(), Some("hover"));
+        assert_eq!(obj.state.as_deref(), Some(&["hover".to_string()][..]));
         assert!(roundtrips(
             "menu-item-background-color-hover",
             Some("menu-item")
@@ -620,7 +644,10 @@ mod tests {
             "menu-item-background-color-keyboard-focus",
             Some("menu-item"),
         );
-        assert_eq!(obj.state.as_deref(), Some("keyboard-focus"));
+        assert_eq!(
+            obj.state.as_deref(),
+            Some(&["keyboard-focus".to_string()][..])
+        );
         assert_eq!(obj.property, "background-color");
         assert!(roundtrips(
             "menu-item-background-color-keyboard-focus",
@@ -651,7 +678,7 @@ mod tests {
     fn foundation_with_trailing_state() {
         let obj = parse_legacy_name("accent-background-color-default", None);
         assert_eq!(obj.property, "accent-background-color");
-        assert_eq!(obj.state.as_deref(), Some("default"));
+        assert_eq!(obj.state.as_deref(), Some(&["default".to_string()][..]));
         assert!(roundtrips("accent-background-color-default", None));
     }
 
@@ -694,7 +721,8 @@ mod tests {
     #[test]
     fn extract_key_decomposed_component_property_state() {
         // General / decomposed format: generate_legacy_name path.
-        let name = json!({"component": "button", "property": "background-color", "state": "hover"});
+        let name =
+            json!({"component": "button", "property": "background-color", "state": ["hover"]});
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("button-background-color-hover")
@@ -736,7 +764,7 @@ mod tests {
     #[test]
     fn extract_key_no_property_no_color_family_returns_none() {
         // Object with neither property nor colorFamily → None.
-        let name = json!({"state": "hover"});
+        let name = json!({"state": ["hover"]});
         assert_eq!(extract_legacy_key(&name), None);
     }
 
@@ -782,7 +810,7 @@ mod tests {
             "component": "accordion",
             "property": "bottom-to-handle",
             "size": "xl",
-            "state": "hover"
+            "state": ["hover"]
         });
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
@@ -801,7 +829,7 @@ mod tests {
             "from": "bottom",
             "to": "handle",
             "size": "xl",
-            "state": "hover"
+            "state": ["hover"]
         });
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
@@ -946,7 +974,7 @@ mod tests {
             "property": "color",
             "colorFamily": "blue",
             "colorRole": "primary",
-            "state": "default"
+            "state": ["default"]
         });
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
@@ -975,7 +1003,7 @@ mod tests {
             "component": "icon",
             "property": "color",
             "colorRole": "primary",
-            "state": "default"
+            "state": ["default"]
         });
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
@@ -1022,7 +1050,7 @@ mod tests {
 
     #[test]
     fn extract_key_icon_non_color_with_state() {
-        let name = json!({"icon": "checkmark", "property": "size", "state": "hover"});
+        let name = json!({"icon": "checkmark", "property": "size", "state": ["hover"]});
         assert_eq!(
             extract_legacy_key(&name).as_deref(),
             Some("checkmark-icon-size-hover")
@@ -1071,7 +1099,7 @@ mod tests {
             "icon": "checkmark",
             "property": "size",
             "scaleIndex": 75,
-            "state": "hover"
+            "state": ["hover"]
         });
         assert_eq!(
             extract_legacy_key(&name).as_deref(),

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -210,32 +210,46 @@ fn matches_expr(raw: &serde_json::Value, expr: &FilterExpr) -> bool {
 }
 
 /// Evaluate a single condition against a token's raw JSON.
+///
+/// A field can resolve to more than one value (Proposal 006: `state` is an
+/// ordered array), so `Eq` matches if *any* value matches, and `NotEq` matches
+/// if *no* value matches — this is also correct for the single-value case, and
+/// for a missing field (empty list): `Eq` → false, `NotEq` → true.
 fn matches_condition(raw: &serde_json::Value, cond: &Condition) -> bool {
-    let field_value = resolve_key(raw, &cond.key);
+    let values = resolve_key(raw, &cond.key);
+    let any_match = values.iter().any(|v| glob_match(&cond.value, v));
 
-    match (&cond.op, field_value) {
-        (Operator::Eq, Some(actual)) => glob_match(&cond.value, &actual),
-        (Operator::Eq, None) => false,
-        (Operator::NotEq, Some(actual)) => !glob_match(&cond.value, &actual),
-        (Operator::NotEq, None) => true, // Missing field satisfies !=
+    match cond.op {
+        Operator::Eq => any_match,
+        Operator::NotEq => !any_match,
     }
 }
 
-/// Resolve a query key to the field value in a token's raw JSON.
-pub(crate) fn resolve_key(raw: &serde_json::Value, key: &str) -> Option<String> {
-    if NAME_OBJECT_KEYS.contains(&key) {
-        raw.get("name")
-            .and_then(|n| n.get(key))
-            .and_then(|v| v.as_str())
-            .map(String::from)
+/// Resolve a query key to the field's value(s) in a token's raw JSON.
+///
+/// Most name-object fields are a single string. `state` (Proposal 006) is an
+/// ordered array of atomic ids — handled generically here so any array-valued
+/// field resolves to each of its elements.
+pub(crate) fn resolve_key(raw: &serde_json::Value, key: &str) -> Vec<String> {
+    let field = if NAME_OBJECT_KEYS.contains(&key) {
+        raw.get("name").and_then(|n| n.get(key))
     } else if key == "uuid" {
-        raw.get("uuid").and_then(|v| v.as_str()).map(String::from)
+        raw.get("uuid")
     } else if key == "$schema" {
         raw.get("$schema")
-            .and_then(|v| v.as_str())
-            .map(String::from)
     } else {
         None
+    };
+
+    match field {
+        Some(v) if v.is_string() => v.as_str().map(String::from).into_iter().collect(),
+        Some(v) if v.is_array() => v
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|e| e.as_str().map(String::from))
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -294,7 +308,7 @@ impl TokenIndex {
         let mut index = TokenIndex::default();
         for (graph_key, token) in &graph.tokens {
             for key in ALLOWED_KEYS {
-                if let Some(value) = resolve_key(&token.raw, key) {
+                for value in resolve_key(&token.raw, key) {
                     index.insert(key, &value, graph_key);
                 }
             }
@@ -346,7 +360,7 @@ impl TokenIndex {
 pub fn build_index(graph: &TokenGraph, key: &str) -> HashMap<String, Vec<String>> {
     let mut index: HashMap<String, Vec<String>> = HashMap::new();
     for (graph_key, token) in &graph.tokens {
-        if let Some(value) = resolve_key(&token.raw, key) {
+        for value in resolve_key(&token.raw, key) {
             index.entry(value).or_default().push(graph_key.clone());
         }
     }
@@ -372,7 +386,7 @@ pub fn facet_counts(
     let records = filter_with_index(graph, index, expr);
     let mut counts: HashMap<String, usize> = HashMap::new();
     for rec in records {
-        if let Some(value) = resolve_key(&rec.raw, field) {
+        for value in resolve_key(&rec.raw, field) {
             *counts.entry(value).or_insert(0) += 1;
         }
     }
@@ -661,7 +675,7 @@ mod tests {
         let g = make_graph(vec![
             (
                 "btn-hover",
-                json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"}),
+                json!({"name": {"property": "bg", "component": "button", "state": ["hover"]}, "value": "1"}),
             ),
             (
                 "btn-default",
@@ -669,7 +683,7 @@ mod tests {
             ),
             (
                 "chk-hover",
-                json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "3"}),
+                json!({"name": {"property": "bg", "component": "checkbox", "state": ["hover"]}, "value": "3"}),
             ),
         ]);
         let f = parse("component=button,state=hover").unwrap();
@@ -815,15 +829,15 @@ mod tests {
         let g = make_graph(vec![
             (
                 "btn",
-                json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"}),
+                json!({"name": {"property": "bg", "component": "button", "state": ["hover"]}, "value": "1"}),
             ),
             (
                 "chk",
-                json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "2"}),
+                json!({"name": {"property": "bg", "component": "checkbox", "state": ["hover"]}, "value": "2"}),
             ),
             (
                 "slider",
-                json!({"name": {"property": "bg", "component": "slider", "state": "default"}, "value": "3"}),
+                json!({"name": {"property": "bg", "component": "slider", "state": ["default"]}, "value": "3"}),
             ),
             (
                 "light",
@@ -949,15 +963,15 @@ mod tests {
         let g = make_graph(vec![
             (
                 "a",
-                json!({"name": {"property": "bg", "component": "button", "state": "hover"}, "value": "1"}),
+                json!({"name": {"property": "bg", "component": "button", "state": ["hover"]}, "value": "1"}),
             ),
             (
                 "b",
-                json!({"name": {"property": "bg", "component": "button", "state": "default"}, "value": "2"}),
+                json!({"name": {"property": "bg", "component": "button", "state": ["default"]}, "value": "2"}),
             ),
             (
                 "c",
-                json!({"name": {"property": "bg", "component": "checkbox", "state": "hover"}, "value": "3"}),
+                json!({"name": {"property": "bg", "component": "checkbox", "state": ["hover"]}, "value": "3"}),
             ),
         ]);
         let idx = TokenIndex::build(&g);

--- a/sdk/core/src/query.rs
+++ b/sdk/core/src/query.rs
@@ -692,6 +692,29 @@ mod tests {
     }
 
     #[test]
+    fn filter_state_matches_any_element_of_compound_array() {
+        let g = make_graph(vec![
+            (
+                "btn-selected-hover",
+                json!({"name": {"property": "bg", "component": "button", "state": ["selected", "hover"]}, "value": "1"}),
+            ),
+            (
+                "btn-default",
+                json!({"name": {"property": "bg", "component": "button", "state": ["default"]}, "value": "2"}),
+            ),
+        ]);
+        let f = parse("state=hover").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].raw["value"], "1");
+
+        let f = parse("state!=hover").unwrap();
+        let results = filter(&g, &f);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].raw["value"], "2");
+    }
+
+    #[test]
     fn filter_or() {
         let g = make_graph(vec![
             (

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -2395,7 +2395,7 @@ const STATES_JSON: &str = r##"{
   "type": "state",
   "description": "Interaction states for components",
   "allowCustom": true,
-  "customPattern": "^[a-z][a-z0-9-]*(\\s\\+\\s[a-z][a-z0-9-]*)*$",
+  "customPattern": "^[a-z][a-z0-9-]*$",
   "values": [
     {
       "id": "default",
@@ -3273,7 +3273,7 @@ pub(crate) fn build_field_catalog() -> Vec<FieldCatalogEntry> {
         FieldCatalogEntry { name: "size", position: 12, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "density", position: 13, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "shape", position: 14, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
-        FieldCatalogEntry { name: "state", position: 15, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "string", exclude_from_legacy_key: false },
+        FieldCatalogEntry { name: "state", position: 15, validation: FieldValidation::Advisory, scope: None, required: false, has_registry: true, value_type: "array", exclude_from_legacy_key: false },
         FieldCatalogEntry { name: "colorScheme", position: 16, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "scale", position: 17, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },
         FieldCatalogEntry { name: "contrast", position: 18, validation: FieldValidation::Strict, scope: None, required: false, has_registry: false, value_type: "string", exclude_from_legacy_key: true },

--- a/sdk/core/src/suggest.rs
+++ b/sdk/core/src/suggest.rs
@@ -349,7 +349,7 @@ mod tests {
             Some(json!({
                 "property": "background-color",
                 "component": "button",
-                "state": "hover"
+                "state": ["hover"]
             })),
         );
         assert_eq!(s.display_name(), "button-background-color-hover");

--- a/sdk/core/src/validate/rules/spec009.rs
+++ b/sdk/core/src/validate/rules/spec009.rs
@@ -20,26 +20,12 @@
 //! this check:
 //! - `colorScheme`, `scale`, `contrast` — mode-set fields, validated by SPEC-005/SPEC-008
 //!
-//! Per Proposal 005, `state` also accepts compound values (`{mode-state}-{interaction-state}`,
-//! e.g. `"selected-hover"`, `"selected-key-focus"`). A compound value that fails the
-//! whole-string registry lookup is checked segment-by-segment before warning.
-
-use std::collections::HashSet;
+//! Per Proposal 006, `state` is an ordered array of atomic state ids (e.g.
+//! `["selected", "hover"]`) rather than a single string — each element is checked
+//! against the registry independently.
 
 use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
-
-/// Per Proposal 005, a compound state is `{mode-state}-{interaction-state}`.
-/// Since either segment (e.g. `keyboard-focus`) may itself contain a hyphen,
-/// try every hyphen boundary rather than assuming one fixed split point.
-/// Valid only if some split has both halves individually known to the registry.
-fn is_valid_compound_state(value: &str, registry_set: &HashSet<String>) -> bool {
-    value.match_indices('-').any(|(i, _)| {
-        let (mode_state, rest) = value.split_at(i);
-        let interaction_state = &rest[1..];
-        registry_set.contains(mode_state) && registry_set.contains(interaction_state)
-    })
-}
 
 pub struct Rule;
 
@@ -62,36 +48,43 @@ impl ValidationRule for Rule {
             };
 
             for &field in ctx.registry.advisory_fields() {
-                let value = match name_obj.get(field).and_then(|v| v.as_str()) {
-                    Some(v) => v,
-                    None => continue,
-                };
-
                 let registry_set = match ctx.registry.for_field(field) {
                     Some(s) => s,
                     None => continue,
                 };
 
-                if registry_set.contains(value) {
-                    continue;
-                }
+                // `state` (Proposal 006) is an ordered array of atomic ids; every
+                // other advisory field is a single string.
+                let values: Vec<&str> = if field == "state" {
+                    match name_obj.get(field).and_then(|v| v.as_array()) {
+                        Some(arr) => arr.iter().filter_map(|v| v.as_str()).collect(),
+                        None => continue,
+                    }
+                } else {
+                    match name_obj.get(field).and_then(|v| v.as_str()) {
+                        Some(v) => vec![v],
+                        None => continue,
+                    }
+                };
 
-                if field == "state" && is_valid_compound_state(value, registry_set) {
-                    continue;
-                }
+                for value in values {
+                    if registry_set.contains(value) {
+                        continue;
+                    }
 
-                diags.push(Diagnostic {
-                    file: record.file.clone(),
-                    token: Some(record.name.clone()),
-                    rule_id: Some("SPEC-009".into()),
-                    severity: Severity::Warning,
-                    message: format!(
-                        "name.{field} value \"{value}\" is not in the spectrum-design-data \
-                         registry/{field} vocabulary"
-                    ),
-                    instance_path: Some(format!("/name/{field}")),
-                    schema_path: None,
-                });
+                    diags.push(Diagnostic {
+                        file: record.file.clone(),
+                        token: Some(record.name.clone()),
+                        rule_id: Some("SPEC-009".into()),
+                        severity: Severity::Warning,
+                        message: format!(
+                            "name.{field} value \"{value}\" is not in the spectrum-design-data \
+                             registry/{field} vocabulary"
+                        ),
+                        instance_path: Some(format!("/name/{field}")),
+                        schema_path: None,
+                    });
+                }
             }
         }
 
@@ -138,7 +131,7 @@ mod tests {
         let g = TokenGraph::from_pairs(vec![(
             "t".into(),
             PathBuf::from("a.tokens.json"),
-            json!({"name": {"property": "color", "state": "hover"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "state": ["hover"]}, "value": "#fff"}),
         )]);
         assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
     }
@@ -215,7 +208,7 @@ mod tests {
         let g = TokenGraph::from_pairs(vec![(
             "t".into(),
             PathBuf::from("a.tokens.json"),
-            json!({"name": {"property": "color", "state": "selected-hover"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "state": ["selected", "hover"]}, "value": "#fff"}),
         )]);
         assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
     }
@@ -223,12 +216,11 @@ mod tests {
     #[test]
     fn compound_state_with_hyphenated_segment_no_warning() {
         // "keyboard-focus" (aliased as "key-focus") is itself a single registry
-        // value, so "selected-key-focus" must split as selected + key-focus,
-        // not selected + key + focus.
+        // value and stays a single array element — not split into "key" + "focus".
         let g = TokenGraph::from_pairs(vec![(
             "t".into(),
             PathBuf::from("a.tokens.json"),
-            json!({"name": {"property": "color", "state": "selected-key-focus"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "state": ["selected", "key-focus"]}, "value": "#fff"}),
         )]);
         assert!(diagnostics_for_rule(&g, "SPEC-009").is_empty());
     }
@@ -238,11 +230,11 @@ mod tests {
         let g = TokenGraph::from_pairs(vec![(
             "t".into(),
             PathBuf::from("a.tokens.json"),
-            json!({"name": {"property": "color", "state": "selected-nonexistent"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "state": ["selected", "nonexistent"]}, "value": "#fff"}),
         )]);
         let diags = diagnostics_for_rule(&g, "SPEC-009");
         assert_eq!(diags.len(), 1);
-        assert!(diags[0].message.contains("selected-nonexistent"));
+        assert!(diags[0].message.contains("nonexistent"));
     }
 
     #[test]
@@ -250,7 +242,7 @@ mod tests {
         let g = TokenGraph::from_pairs(vec![(
             "t".into(),
             PathBuf::from("a.tokens.json"),
-            json!({"name": {"property": "color", "component": "nope", "state": "nah"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "component": "nope", "state": ["nah"]}, "value": "#fff"}),
         )]);
         let diags = diagnostics_for_rule(&g, "SPEC-009");
         assert_eq!(diags.len(), 2);

--- a/sdk/core/src/validate/rules/spec022.rs
+++ b/sdk/core/src/validate/rules/spec022.rs
@@ -44,7 +44,9 @@ impl ValidationRule for Rule {
             let Some(component) = name_obj.get("component").and_then(|v| v.as_str()) else {
                 continue;
             };
-            let Some(state) = name_obj.get("state").and_then(|v| v.as_str()) else {
+            // Proposal 006: `state` is an ordered array of atomic ids. Every
+            // element must be a declared state on the referenced component.
+            let Some(states) = name_obj.get("state").and_then(|v| v.as_array()) else {
                 continue;
             };
             let Some(comp) = comp_map.get(component) else {
@@ -62,19 +64,25 @@ impl ValidationRule for Rule {
                 })
                 .unwrap_or_default();
 
-            if !declared_states.is_empty() && !declared_states.contains(state) {
-                let token_label = serde_json::to_string(name_obj).unwrap_or_default();
-                out.push(Diagnostic {
-                    file: t.file.clone(),
-                    token: Some(t.name.clone()),
-                    rule_id: Some(self.id().to_string()),
-                    severity: Severity::Error,
-                    message: format!(
-                        "Token '{token_label}' references undeclared state '{state}' on component '{component}'"
-                    ),
-                    instance_path: None,
-                    schema_path: None,
-                });
+            if declared_states.is_empty() {
+                continue;
+            }
+
+            for state in states.iter().filter_map(|s| s.as_str()) {
+                if !declared_states.contains(state) {
+                    let token_label = serde_json::to_string(name_obj).unwrap_or_default();
+                    out.push(Diagnostic {
+                        file: t.file.clone(),
+                        token: Some(t.name.clone()),
+                        rule_id: Some(self.id().to_string()),
+                        severity: Severity::Error,
+                        message: format!(
+                            "Token '{token_label}' references undeclared state '{state}' on component '{component}'"
+                        ),
+                        instance_path: None,
+                        schema_path: None,
+                    });
+                }
             }
         }
 
@@ -141,7 +149,7 @@ mod tests {
     #[test]
     fn declared_state_no_error() {
         let diags = run(
-            json!({"name": {"property": "color", "component": "button", "state": "hover"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "component": "button", "state": ["hover"]}, "value": "#fff"}),
             json!({"name": "button", "states": [{"name": "hover"}]}),
         );
         assert!(diags.is_empty());
@@ -150,7 +158,7 @@ mod tests {
     #[test]
     fn undeclared_state_error() {
         let diags = run(
-            json!({"name": {"property": "color", "component": "button", "state": "jello"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "component": "button", "state": ["jello"]}, "value": "#fff"}),
             json!({"name": "button", "states": [{"name": "hover"}]}),
         );
         assert_eq!(diags.len(), 1);
@@ -162,7 +170,7 @@ mod tests {
     #[test]
     fn no_states_declared_no_error() {
         let diags = run(
-            json!({"name": {"property": "color", "component": "button", "state": "anything"}, "value": "#fff"}),
+            json!({"name": {"property": "color", "component": "button", "state": ["anything"]}, "value": "#fff"}),
             json!({"name": "button"}),
         );
         assert!(diags.is_empty());

--- a/sdk/core/src/validate/rules/spec037.rs
+++ b/sdk/core/src/validate/rules/spec037.rs
@@ -87,34 +87,39 @@ impl ValidationRule for Rule {
             }
 
             // --- state cascade ---
-            if let Some(state_name) = name_obj.get("state").and_then(|v| v.as_str()) {
-                let dep_version = comp
-                    .raw
-                    .get("states")
-                    .and_then(|v| v.as_array())
-                    .and_then(|arr| {
-                        arr.iter()
-                            .find(|s| s.get("name").and_then(|n| n.as_str()) == Some(state_name))
-                    })
-                    .and_then(|s| s.get("lifecycle"))
-                    .and_then(|l| l.get("deprecated"))
-                    .and_then(|v| v.as_str());
+            // Proposal 006: `state` is an ordered array of atomic ids — check each
+            // element independently.
+            if let Some(states) = name_obj.get("state").and_then(|v| v.as_array()) {
+                for state_name in states.iter().filter_map(|v| v.as_str()) {
+                    let dep_version = comp
+                        .raw
+                        .get("states")
+                        .and_then(|v| v.as_array())
+                        .and_then(|arr| {
+                            arr.iter().find(|s| {
+                                s.get("name").and_then(|n| n.as_str()) == Some(state_name)
+                            })
+                        })
+                        .and_then(|s| s.get("lifecycle"))
+                        .and_then(|l| l.get("deprecated"))
+                        .and_then(|v| v.as_str());
 
-                if let Some(version) = dep_version {
-                    out.push(Diagnostic {
-                        file: t.file.clone(),
-                        token: Some(t.name.clone()),
-                        rule_id: Some(self.id().to_string()),
-                        severity: Severity::Warning,
-                        message: format!(
-                            "Token '{}' references deprecated state '{state_name}' \
-                             on component '{component}' (deprecated since {version}); \
-                             update the reference or mark the token deprecated",
-                            t.name
-                        ),
-                        instance_path: Some("/name/state".to_string()),
-                        schema_path: None,
-                    });
+                    if let Some(version) = dep_version {
+                        out.push(Diagnostic {
+                            file: t.file.clone(),
+                            token: Some(t.name.clone()),
+                            rule_id: Some(self.id().to_string()),
+                            severity: Severity::Warning,
+                            message: format!(
+                                "Token '{}' references deprecated state '{state_name}' \
+                                 on component '{component}' (deprecated since {version}); \
+                                 update the reference or mark the token deprecated",
+                                t.name
+                            ),
+                            instance_path: Some("/name/state".to_string()),
+                            schema_path: None,
+                        });
+                    }
                 }
             }
 
@@ -257,7 +262,7 @@ mod tests {
     #[test]
     fn non_deprecated_state_no_warning() {
         let diags = run(
-            json!({"name": {"component": "button", "state": "hover", "property": "background-color"}, "value": "#eee"}),
+            json!({"name": {"component": "button", "state": ["hover"], "property": "background-color"}, "value": "#eee"}),
             json!({"name": "button", "states": [{"name": "hover"}]}),
         );
         assert!(diags.is_empty());
@@ -266,7 +271,7 @@ mod tests {
     #[test]
     fn deprecated_state_warns() {
         let diags = run(
-            json!({"name": {"component": "button", "state": "pressed", "property": "background-color"}, "value": "#ccc"}),
+            json!({"name": {"component": "button", "state": ["pressed"], "property": "background-color"}, "value": "#ccc"}),
             json!({"name": "button", "states": [{"name": "pressed", "lifecycle": {"deprecated": "1.0.0-draft"}}]}),
         );
         assert_eq!(diags.len(), 1);
@@ -336,7 +341,7 @@ mod tests {
         // deprecated: false is not a string — must NOT suppress the warning.
         let diags = run(
             json!({
-                "name": {"component": "button", "state": "pressed", "property": "background-color"},
+                "name": {"component": "button", "state": ["pressed"], "property": "background-color"},
                 "value": "#ccc",
                 "deprecated": false
             }),
@@ -362,7 +367,7 @@ mod tests {
     fn multiple_cascades_in_one_token() {
         // Token references both a deprecated anatomy part and a deprecated state — two warnings.
         let diags = run(
-            json!({"name": {"component": "slider", "anatomy": "handle", "state": "pressed", "property": "color"}, "value": "#000"}),
+            json!({"name": {"component": "slider", "anatomy": "handle", "state": ["pressed"], "property": "color"}, "value": "#000"}),
             json!({
                 "name": "slider",
                 "anatomy": [{"name": "handle", "lifecycle": {"deprecated": "1.0.0-draft"}}],

--- a/sdk/core/tests/prop_naming.rs
+++ b/sdk/core/tests/prop_naming.rs
@@ -78,11 +78,12 @@ fn optional_component() -> impl Strategy<Value = Option<String>> {
     .prop_map(|o| o.map(str::to_string))
 }
 
-/// Generate an optional state word (drawn directly from the known set).
-fn optional_state() -> impl Strategy<Value = Option<String>> {
+/// Generate an optional state array (drawn directly from the known set).
+fn optional_state() -> impl Strategy<Value = Option<Vec<String>>> {
     // Sample from non-compound states only; compound states like "key-focus"
     // and "keyboard-focus" interact with the two-segment rmatch logic and are
-    // better tested as dedicated unit tests.
+    // better tested as dedicated unit tests. Proposal 006: `state` is always
+    // an array, so a single sampled state becomes a one-element vec.
     prop::option::of(prop::sample::select(vec![
         "default",
         "hover",
@@ -98,7 +99,7 @@ fn optional_state() -> impl Strategy<Value = Option<String>> {
         "closed",
         "indeterminate",
     ]))
-    .prop_map(|o| o.map(str::to_string))
+    .prop_map(|o| o.map(|s| vec![s.to_string()]))
 }
 
 // ── Properties ────────────────────────────────────────────────────────────────

--- a/sdk/wasm/test/parity.test.js
+++ b/sdk/wasm/test/parity.test.js
@@ -699,7 +699,7 @@ test("resolveReference: follows a one-hop alias chain", (t) => {
     {
       name: {
         property: "accent-background-color",
-        state: "default",
+        state: ["default"],
         colorScheme: "light",
       },
       $schema:
@@ -709,7 +709,7 @@ test("resolveReference: follows a one-hop alias chain", (t) => {
     },
   ]);
 
-  // Note: extract_legacy_key({ property: "accent-background-color", state: "default" })
+  // Note: extract_legacy_key({ property: "accent-background-color", state: ["default"] })
   // → "accent-background-color-default" (via generate_legacy_name).
   const r = ds.resolveReference("{accent-background-color-default}", {
     colorScheme: "light",

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -488,7 +488,10 @@ export function decompose(tokenName, tokenData, registry, sourceFile) {
     }
     if (conflict) continue;
 
-    nameObject[field] = id;
+    // Proposal 006: `state` is an ordered array of atomic ids, not a single
+    // string like every other catalog field. Legacy strings never encode a
+    // true multi-part compound (see naming.rs), so this is always one element.
+    nameObject[field] = field === "state" ? [id] : id;
     for (let i = startIndex; i < startIndex + length; i++) {
       matched[i] = true;
       matchDetails[i] = field;
@@ -774,8 +777,10 @@ export function serialize(
     const parts = [component, nameObject.property];
     if (colorFamily) parts.push(tokenNameMap[colorFamily] || colorFamily);
     if (colorRole) parts.push(tokenNameMap[colorRole] || colorRole);
-    if (nameObject.state)
-      parts.push(tokenNameMap[nameObject.state] || nameObject.state);
+    // Proposal 006: `state` is an ordered array of atomic ids.
+    if (nameObject.state) {
+      for (const s of nameObject.state) parts.push(tokenNameMap[s] || s);
+    }
     return parts.join("-");
   }
 
@@ -820,6 +825,14 @@ export function serialize(
         parts.push(`${fromExpanded}-to-${toExpanded}`);
         continue;
       }
+      // Proposal 006: `state` is an ordered array of atomic ids, not a single
+      // string like every other catalog field.
+      if (field === "state") {
+        if (nameObject.state) {
+          for (const s of nameObject.state) parts.push(tokenNameMap[s] || s);
+        }
+        continue;
+      }
       if (nameObject[field]) {
         parts.push(tokenNameMap[nameObject[field]] || nameObject[field]);
       }
@@ -843,14 +856,24 @@ export function serialize(
     const parts = [icExpanded, nameObject.property];
     if (nameObject.scaleIndex != null)
       parts.push(String(nameObject.scaleIndex));
-    if (nameObject.state)
-      parts.push(tokenNameMap[nameObject.state] || nameObject.state);
+    // Proposal 006: `state` is an ordered array of atomic ids.
+    if (nameObject.state) {
+      for (const s of nameObject.state) parts.push(tokenNameMap[s] || s);
+    }
     return parts.join("-");
   }
 
   // General path (non-color tokens)
   const parts = [];
   for (const field of serializationOrder) {
+    // Proposal 006: `state` is an ordered array of atomic ids, not a single
+    // string like every other catalog field.
+    if (field === "state") {
+      if (nameObject.state) {
+        for (const s of nameObject.state) parts.push(tokenNameMap[s] || s);
+      }
+      continue;
+    }
     if (nameObject[field]) {
       const value = nameObject[field];
       // Use tokenName long form if available (e.g., xl → extra-large)

--- a/tools/token-mapping-analyzer/test/decomposer.test.js
+++ b/tools/token-mapping-analyzer/test/decomposer.test.js
@@ -26,7 +26,7 @@ test("decomposes simple variant-object-property-state token", (t) => {
   t.is(result.nameObject.variant, "accent");
   t.is(result.nameObject.object, "edge");
   t.is(result.nameObject.property, "color");
-  t.is(result.nameObject.state, "default");
+  t.deepEqual(result.nameObject.state, ["default"]);
   t.is(result.confidence, "HIGH");
   t.true(result.roundtrips);
 });
@@ -226,7 +226,7 @@ test("matches key-focus as keyboard-focus state", (t) => {
     registry,
     "test",
   );
-  t.is(result.nameObject.state, "keyboard-focus");
+  t.deepEqual(result.nameObject.state, ["keyboard-focus"]);
 });
 
 test("matches with-stepper as has-stepper qualifier", (t) => {
@@ -247,7 +247,7 @@ test("serializes name object in spec order", (t) => {
     component: "button",
     object: "background",
     property: "color",
-    state: "hover",
+    state: ["hover"],
   };
   t.is(serialize(nameObj), "accent-button-background-color-hover");
 });
@@ -433,7 +433,7 @@ test("serialize() reconstructs the -to- connective for a space-between name", (t
       from: "bottom",
       to: "handle",
       size: "xl",
-      state: "hover",
+      state: ["hover"],
     },
     registry.tokenNameMap,
     registry.serializationOrder,
@@ -467,7 +467,7 @@ test("decomposes an icon size-N token and splits the scaleIndex (dsi.6 icon foll
 
 test("serialize() reconstructs an icon size-N key with state", (t) => {
   const legacyKey = serialize(
-    { icon: "checkmark", property: "size", scaleIndex: 75, state: "hover" },
+    { icon: "checkmark", property: "size", scaleIndex: 75, state: ["hover"] },
     registry.tokenNameMap,
     registry.serializationOrder,
   );


### PR DESCRIPTION
## Description

Moves the token name-object `state` field from a single (optionally hyphenated)
string to an ordered array of atomic state ids — `"hover"` → `["hover"]`,
`"selected-hover"` → `["selected", "hover"]`. This is **Proposal 006**, which
supersedes Proposal 005's hyphenated-compound encoding: state ids themselves
contain hyphens (`keyboard-focus`, `drag-and-drop`), so a hyphenated compound
string can't be split deterministically, and fusing two states into one string
re-introduces the kind of fusion that epic #284 exists to remove.

Every stateful token in the corpus is migrated (uniform array — not just the
previously-compound ones), and the Rust/JS layers are updated end to end:

- `packages/design-data/fields/state.json`, `registry/states.json`: `state` is
  now `array` type; dropped the dead hyphenated-compound pattern.
- `packages/design-data-spec/schemas`: name-object `state` is an array of
  atomic ids, `minItems: 1`. Docs (`token-format.md`, `state-model.md`)
  updated to match.
- `sdk/core`: `NameObject.state` is `Option<Vec<String>>`; legacy-key
  generation (`naming.rs`, 3 serialization branches), migration (`migrate.rs`),
  the query/index engine (`query.rs`, `cache/mod.rs` — generalized to support
  any array-valued name-object field, not just `state`), and validation rules
  (SPEC-009/022/037) all read/write/index the array form.
- `tools/token-mapping-analyzer`: JS decomposer/serializer kept in parity with
  the Rust naming logic (both serialize and parse directions).
- `packages/tokens/naming-exceptions.json`'s 27 `compound-state` entries were
  checked against the fix and confirmed still legitimately non-roundtripping —
  they exercise a separate legacy-string parser path this change doesn't
  touch, so nothing was removed there.

## Related Issue

Closes bead `spectrum-design-data-8fj`. Unblocks `spectrum-design-data-284.5`
(part of epic `spectrum-design-data-284`).

## Motivation and Context

Proposal 005's hyphenated-string encoding for compound (simultaneous) states
was accepted as a stopgap but has two structural problems: it isn't cleanly
decomposable (state ids contain hyphens), and it re-fuses two concepts into
one string, working against the goal of epic #284 (decomposing fused token
names into structured fields). An ordered array is the only representation
that's correct on the hyphen edge cases and aligned with that decomposition
goal.

## How Has This Been Tested?

- `moon run sdk:codegen` + `cargo test --workspace`: 1248 passed, 2 ignored,
  0 failed.
- `moon run :test` (full monorepo — all AVA suites across JS/TS packages,
  the Rust workspace, and the WASM bindings): all 29 tasks completed
  successfully.
- `tools/token-mapping-analyzer`: 47/47 AVA tests, verifying the JS decomposer
  mirror stays in parity with the Rust serializer/parser.
- Manually verified all 27 `naming-exceptions.json` compound-state entries are
  still (correctly) flagged as non-roundtripping via a throwaway check against
  `naming::roundtrips`.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
