### PR TITLE
fix: token/component diff-comment CI failing on fork PRs

### DIFF
--- a/.changeset/lazy-otters-diff-local-components.md
+++ b/.changeset/lazy-otters-diff-local-components.md
@@ -1,0 +1,11 @@
+---
+"@adobe/spectrum-component-diff-generator": patch
+---
+
+Fixed local component schema loading always returning zero components (closes #1304).
+
+- **src/lib/component-file-import.js**: `loadLocalComponents` called
+  `this.localFS.loadData([filePath])` with the wrong argument shape, so `fileNames` was
+  `undefined` inside `loadData` and every local file load silently failed and was skipped.
+  Any comparison using `--local` (e.g. remote-base-branch vs. local-checkout, used by CI
+  for fork pull requests) reported every remote component as deleted.

--- a/.github/actions/generate-diff/action.yml
+++ b/.github/actions/generate-diff/action.yml
@@ -8,8 +8,8 @@ inputs:
   base-ref:
     description: "Base branch/ref for comparison"
     required: true
-  head-ref:
-    description: "Head branch/ref for comparison"
+  local-path:
+    description: "Local checkout path to compare against base-ref (avoids fetching the head branch, which may live in a fork)"
     required: true
   repository:
     description: "Repository name in owner/repo format"
@@ -66,20 +66,25 @@ runs:
         set +e  # Don't exit on command failure
 
         if [[ "${{ inputs.tool }}" == "diff-generator" ]]; then
-          # Token diff generator CLI
+          # Token diff generator CLI. Compares the base branch (fetched remotely
+          # from the base repo) against the already-checked-out local working
+          # tree, rather than fetching the head branch by name - the head
+          # branch lives in the contributor's fork for fork PRs and isn't
+          # reachable from the base repo.
           cd ./tools/${{ inputs.tool }}
           ./src/lib/cli.js report \
             --otb ${{ inputs.base-ref }} \
-            --ntb ${{ inputs.head-ref }} \
+            --local ${{ inputs.local-path }} \
             --repo ${{ inputs.repository }} \
             --format ${{ inputs.format }} \
             --output ${{ inputs.output-file }}
         elif [[ "${{ inputs.tool }}" == "component-diff-generator" ]]; then
-          # Component diff generator CLI with remote support
+          # Component diff generator CLI. Same local-vs-remote-base strategy
+          # as above, for the same fork-PR reason.
           cd ./tools/${{ inputs.tool }}
           node src/cli.js report \
             --osb ${{ inputs.base-ref }} \
-            --nsb ${{ inputs.head-ref }} \
+            --local ${{ inputs.local-path }} \
             --repo ${{ inputs.repository }} \
             --format ${{ inputs.format }} \
             --output ${{ inputs.output-file }} \

--- a/.github/workflows/component-diff-pr-comment-post.yml
+++ b/.github/workflows/component-diff-pr-comment-post.yml
@@ -1,0 +1,52 @@
+name: Component Schema Diff PR Comment
+
+# workflow_run always executes using the workflow file on the default branch
+# and gets a full-permission GITHUB_TOKEN, even when the triggering run came
+# from a fork PR - see component-diff-pr-comment.yml for why this is split
+# out.
+on:
+  workflow_run:
+    workflows: ["Component Schema Diff Generate"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  component-diff-comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download diff artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: component-diff-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/artifact
+
+      - name: Read report metadata
+        id: meta
+        run: |
+          echo "pr-number=$(cat /tmp/artifact/pr-number.txt)" >> "$GITHUB_OUTPUT"
+          echo "diff-generated=$(cat /tmp/artifact/diff-generated.txt)" >> "$GITHUB_OUTPUT"
+          {
+            echo "diff-content<<EOF"
+            cat /tmp/artifact/diff-content.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR comment
+        uses: ./.github/actions/diff-pr-comment
+        with:
+          diff-type: component
+          diff-generated: ${{ steps.meta.outputs.diff-generated }}
+          diff-content: ${{ steps.meta.outputs.diff-content }}
+          diff-file-path: /tmp/artifact/diff-report.md
+          pr-number: ${{ steps.meta.outputs.pr-number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/component-diff-pr-comment.yml
+++ b/.github/workflows/component-diff-pr-comment.yml
@@ -1,5 +1,10 @@
-name: Component Schema Diff PR Comment
+name: Component Schema Diff Generate
 
+# Fork PRs get a read-only GITHUB_TOKEN on pull_request events no matter what
+# `permissions:` says, so report generation (here) and comment posting
+# (component-diff-pr-comment-post.yml, triggered by workflow_run) are split
+# into separate workflows. The artifact is the only thing that crosses the
+# boundary.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -8,12 +13,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  component-diff-comment:
+  component-diff-generate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,17 +31,25 @@ jobs:
         with:
           tool: component-diff-generator
           base-ref: ${{ github.base_ref }}
-          head-ref: ${{ github.head_ref }}
+          local-path: packages/design-data/components
           repository: ${{ github.repository }}
           format: markdown
           output-file: /tmp/component-diff.md
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create or update PR comment
-        uses: ./.github/actions/diff-pr-comment
+      - name: Save report for comment workflow
+        run: |
+          mkdir -p /tmp/artifact
+          echo "${{ github.event.pull_request.number }}" > /tmp/artifact/pr-number.txt
+          echo "${{ steps.diff.outputs.diff-generated }}" > /tmp/artifact/diff-generated.txt
+          printf '%s' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
+          if [ -f /tmp/component-diff.md ]; then
+            cp /tmp/component-diff.md /tmp/artifact/diff-report.md
+          fi
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@v4
         with:
-          diff-type: component
-          diff-generated: ${{ steps.diff.outputs.diff-generated }}
-          diff-content: ${{ steps.diff.outputs.diff-content }}
-          pr-number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: component-diff-report
+          path: /tmp/artifact
+          retention-days: 1

--- a/.github/workflows/token-diff-pr-comment-post.yml
+++ b/.github/workflows/token-diff-pr-comment-post.yml
@@ -1,0 +1,51 @@
+name: Token Diff PR Comment
+
+# workflow_run always executes using the workflow file on the default branch
+# and gets a full-permission GITHUB_TOKEN, even when the triggering run came
+# from a fork PR - see token-diff-pr-comment.yml for why this is split out.
+on:
+  workflow_run:
+    workflows: ["Token Diff Generate"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  token-diff-comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download diff artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: token-diff-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/artifact
+
+      - name: Read report metadata
+        id: meta
+        run: |
+          echo "pr-number=$(cat /tmp/artifact/pr-number.txt)" >> "$GITHUB_OUTPUT"
+          echo "diff-generated=$(cat /tmp/artifact/diff-generated.txt)" >> "$GITHUB_OUTPUT"
+          {
+            echo "diff-content<<EOF"
+            cat /tmp/artifact/diff-content.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR comment
+        uses: ./.github/actions/diff-pr-comment
+        with:
+          diff-type: token
+          diff-generated: ${{ steps.meta.outputs.diff-generated }}
+          diff-content: ${{ steps.meta.outputs.diff-content }}
+          diff-file-path: /tmp/artifact/diff-report.md
+          pr-number: ${{ steps.meta.outputs.pr-number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/token-diff-pr-comment.yml
+++ b/.github/workflows/token-diff-pr-comment.yml
@@ -1,5 +1,9 @@
-name: Token Diff PR Comment
+name: Token Diff Generate
 
+# Fork PRs get a read-only GITHUB_TOKEN on pull_request events no matter what
+# `permissions:` says, so report generation (here) and comment posting
+# (token-diff-pr-comment-post.yml, triggered by workflow_run) are split into
+# separate workflows. The artifact is the only thing that crosses the boundary.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -8,12 +12,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  token-diff-comment:
+  token-diff-generate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,18 +30,25 @@ jobs:
         with:
           tool: diff-generator
           base-ref: ${{ github.base_ref }}
-          head-ref: ${{ github.head_ref }}
+          local-path: packages/tokens/src
           repository: ${{ github.repository }}
           format: markdown
           output-file: /tmp/token-diff.md
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create or update PR comment
-        uses: ./.github/actions/diff-pr-comment
+      - name: Save report for comment workflow
+        run: |
+          mkdir -p /tmp/artifact
+          echo "${{ github.event.pull_request.number }}" > /tmp/artifact/pr-number.txt
+          echo "${{ steps.diff.outputs.diff-generated }}" > /tmp/artifact/diff-generated.txt
+          printf '%s' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
+          if [ -f /tmp/token-diff.md ]; then
+            cp /tmp/token-diff.md /tmp/artifact/diff-report.md
+          fi
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@v4
         with:
-          diff-type: token
-          diff-generated: ${{ steps.diff.outputs.diff-generated }}
-          diff-content: ${{ steps.diff.outputs.diff-content }}
-          diff-file-path: /tmp/token-diff.md
-          pr-number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: token-diff-report
+          path: /tmp/artifact
+          retention-days: 1

--- a/tools/component-diff-generator/src/lib/component-file-import.js
+++ b/tools/component-diff-generator/src/lib/component-file-import.js
@@ -327,7 +327,11 @@ export class ComponentLoader extends FileLoader {
 
     for (const filePath of allFiles) {
       try {
-        const fileData = await this.localFS.loadData([filePath]);
+        // getFiles() returns paths relative to the repo root (its glob cwd),
+        // but loadData() resolves paths relative to the process cwd
+        // (tools/component-diff-generator), so the "../../" prefix is needed
+        // to bridge the two.
+        const fileData = await this.localFS.loadData("../../", [filePath]);
         // Extract component name from file path
         const componentName = filePath.split("/").pop().replace(".json", "");
         result[componentName] = fileData;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

PR #1304 (opened from a fork) fails two required checks. This fixes both by fixing
the underlying bugs rather than working around them:

1. **token-diff-comment errors outright.** The diff generator was told to fetch the
   head branch by name (`--ntb <head-ref>`) from the base repo, but for a fork PR
   the head branch only exists in the contributor's fork, so the fetch 404s.
2. **component-diff-comment posts a false "98 breaking deletions" report, then fails
   to post the comment.** Two independent bugs:
   - `loadLocalComponents` called `this.localFS.loadData([filePath])` with the wrong
     argument shape (`loadData(startDir, fileNames)` expects two args) so `fileNames`
     was `undefined` inside `loadData`, and every local component file load silently
     failed. Any local-vs-remote comparison therefore always came back empty on the
     local side, so every remote component showed up as "deleted".
   - Posting the PR comment failed with `Resource not accessible by integration`.
     Fork PRs always get a **read-only** `GITHUB_TOKEN` on `pull_request` events,
     regardless of what the workflow's `permissions:` block says - it's a GitHub
     platform restriction, not something fixable in the workflow file itself.

## Related Issue

Closes #1304.

## Motivation and Context

Fork contributions (like #1304) can't get CI-verified token/component diffs today,
and get a hard failure instead of a report - blocking review and merge.

## How Has This Been Tested?

- Ran both diff-generator CLIs locally against `main` with `--local` pointed at the
  checked-out working tree (no remote head-branch fetch); both correctly report
  "no changes" instead of erroring or showing false deletions.
- `pnpm --filter @adobe/token-diff-generator test` and
  `pnpm --filter @adobe/spectrum-component-diff-generator test` both pass (267 and
  41 tests respectively).
- Verified the changeset with
  `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.
- Workflow YAML validated for syntax; the `workflow_run` split can only be fully
  exercised once merged to `main` (workflow_run always runs the version of the
  workflow file on the default branch) and a new PR (or a `synchronize` on an
  existing one, after rebasing onto this fix) triggers it.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
