### PR TITLE
fix(sdk): update stale TUI snapshot fixtures to v0.6.0

### DIFF
--- a/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__palette_open_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.5.0
+  Spectrum Design Data  v0.6.0
   ↑↓ history/list · Tab complete · Enter run · Esc back · Ctrl+C quit
   ──────────────────────────────────────────────────────────────────────────────
   > :

--- a/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
+++ b/sdk/tui/tests/snapshots/snapshots__wizard_screen1_80x24.snap
@@ -3,7 +3,7 @@ source: tui/tests/snapshots.rs
 expression: rendered
 ---
 ▶ test · 0 tokens
-  Spectrum Design Data  v0.5.0
+  Spectrum Design Data  v0.6.0
   ↑↓ hi┌ Step 1 of 4 — Intent ──────────────────────────────────────────┐
   ─────│Intent: background-color                                        │───────
   >    │  These tokens already exist for similar intents.               │


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `design-data-tui` crate was version-bumped 0.5.0 → 0.6.0 by a prior "Version
Packages" release, but the two insta snapshot fixtures under `sdk/tui/tests/snapshots/`
still hardcoded the old `v0.5.0` string rendered in the TUI header. This updates both
fixtures to `v0.6.0` to match the current crate version.

## Related Issue

Surfaced by CI on #1304: `sdk:test` only runs when a PR's changed files mark it as
affected (e.g. token files under `packages/design-data/tokens/`), so most PRs never
exercise this crate's snapshot tests and the drift went unnoticed until now.

## Motivation and Context

Any PR that touches files affecting `sdk:test` currently fails CI on unrelated,
pre-existing snapshot drift, blocking unrelated changes from merging.

## How Has This Been Tested?

- `cargo test -p design-data-tui snapshot` passes locally (4 snapshot tests, 0 failures).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
