### PR TITLE
fix(ci): add trailing newline to diff-content artifact file

### DIFF
--- a/.github/workflows/component-diff-pr-comment.yml
+++ b/.github/workflows/component-diff-pr-comment.yml
@@ -42,7 +42,7 @@ jobs:
           mkdir -p /tmp/artifact
           echo "${{ github.event.pull_request.number }}" > /tmp/artifact/pr-number.txt
           echo "${{ steps.diff.outputs.diff-generated }}" > /tmp/artifact/diff-generated.txt
-          printf '%s' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
+          printf '%s\n' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
           if [ -f /tmp/component-diff.md ]; then
             cp /tmp/component-diff.md /tmp/artifact/diff-report.md
           fi

--- a/.github/workflows/token-diff-pr-comment.yml
+++ b/.github/workflows/token-diff-pr-comment.yml
@@ -41,7 +41,7 @@ jobs:
           mkdir -p /tmp/artifact
           echo "${{ github.event.pull_request.number }}" > /tmp/artifact/pr-number.txt
           echo "${{ steps.diff.outputs.diff-generated }}" > /tmp/artifact/diff-generated.txt
-          printf '%s' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
+          printf '%s\n' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
           if [ -f /tmp/token-diff.md ]; then
             cp /tmp/token-diff.md /tmp/artifact/diff-report.md
           fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `token-diff-pr-comment.yml` / `component-diff-pr-comment.yml` "generate"
workflows write the diff content to an artifact file with:

```
printf '%s' "${{ steps.diff.outputs.diff-content }}" > /tmp/artifact/diff-content.txt
```

`printf '%s'` writes no trailing newline. The paired "post comment" workflows
(`*-post.yml`) then read it back into a `GITHUB_OUTPUT` multiline heredoc:

```
echo "diff-content<<EOF"
cat /tmp/artifact/diff-content.txt
echo "EOF"
```

With no trailing newline in the file, `cat`'s output runs directly into the
following `echo "EOF"` with no line break, producing a single concatenated
line (e.g. `...base64dataEOF`) instead of a bare `EOF` line. GitHub's
`GITHUB_OUTPUT` parser requires the closing delimiter on its own line, so this
failed with `Invalid value. Matching delimiter not found 'EOF'` and the PR
comment was never posted - on every PR, not just forks.

Fix: `printf '%s\n'` so the file always ends with a newline.

## Related Issue

Found while investigating why #1304 had no token/component diff comment
despite `token-diff-generate` and `component-diff-generate` passing.

## Motivation and Context

The fork-PR CI split introduced in #1305 generates the diff report
successfully but the comment-posting half silently fails on every PR
(fork or not), so no PR ever gets a diff comment.

## How Has This Been Tested?

- Downloaded the actual `token-diff-report` artifact from #1304's CI run and
  confirmed `diff-content.txt` has no trailing newline, reproducing the
  reported parser error locally with the same `cat | echo "EOF"` sequence.
- Validated both workflow YAML files parse correctly.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
