### PR TITLE
feat(design-data-spec): add SPEC-050 property-decomposition audit

### DIFF
--- a/.changeset/loud-plums-detect.md
+++ b/.changeset/loud-plums-detect.md
@@ -1,0 +1,12 @@
+---
+"@adobe/design-data-spec": minor
+---
+
+Add SPEC-050 to detect fused `name.property` values independent of roundtrip status
+(closes spectrum-design-data-284.1).
+
+- **rules/rules.yaml**: new advisory rule `SPEC-050` (`property-decomposition-complete`)
+  flags a `property` value that fuses a structured field (anatomy, object, position,
+  size, state, colorRole, emphasis) instead of being atomic, regardless of roundtrip
+  or `naming-exceptions.json` status.
+- **conformance/invalid/SPEC-050/**: new fixture covering the fused-property case.

--- a/packages/design-data-spec/conformance/invalid/SPEC-050/dataset.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-050/dataset.json
@@ -1,0 +1,11 @@
+{
+  "tokens": [
+    {
+      "name": {
+        "property": "icon-color-informative"
+      },
+      "value": "#0265dc"
+    }
+  ],
+  "components": []
+}

--- a/packages/design-data-spec/conformance/invalid/SPEC-050/expected-errors.json
+++ b/packages/design-data-spec/conformance/invalid/SPEC-050/expected-errors.json
@@ -1,0 +1,10 @@
+{
+  "layer": 2,
+  "errors": [
+    {
+      "rule_id": "SPEC-050",
+      "severity": "warning",
+      "message_pattern": ".*fuses.*name.property.*"
+    }
+  ]
+}

--- a/packages/design-data-spec/rules/rules.yaml
+++ b/packages/design-data-spec/rules/rules.yaml
@@ -578,3 +578,19 @@ rules:
     message: "Token '{token}' references anatomy part '{anatomy}' which is not in the spectrum-design-data registry/anatomy-terms vocabulary"
     spec_ref: spec/anatomy-format.md#cross-reference-with-token-name-objects
     introduced_in: "1.0.0-draft"
+
+  - id: SPEC-050
+    name: property-decomposition-complete
+    severity: warning
+    layer: 2
+    category: naming-consistency
+    assert: >
+      A token name-object's `property` value SHOULD be atomic. It MUST NOT fuse a
+      segment that belongs to another structured field (anatomy, object, position,
+      size, state, colorRole, emphasis) -- detected independent of whether the token
+      roundtrips through canonical name generation (SPEC-007) or is listed in
+      naming-exceptions.json. Roundtripping cleanly does not mean a property is
+      decomposed (spectrum-design-data-284).
+    message: "Token '{token}' fuses '{field}' concept '{value}' into name.property; decompose into the structured field"
+    spec_ref: spec/token-format.md#name-object
+    introduced_in: "1.0.0-draft"

--- a/sdk/core/src/validate/rules/mod.rs
+++ b/sdk/core/src/validate/rules/mod.rs
@@ -60,6 +60,7 @@ mod spec046;
 mod spec047;
 mod spec048;
 mod spec049;
+mod spec050;
 
 use std::collections::HashSet;
 
@@ -169,6 +170,7 @@ pub fn default_rules() -> Vec<Box<dyn ValidationRule>> {
         Box::new(spec047::Rule),
         Box::new(spec048::Rule),
         Box::new(spec049::Rule),
+        Box::new(spec050::Rule),
     ]
 }
 

--- a/sdk/core/src/validate/rules/spec050.rs
+++ b/sdk/core/src/validate/rules/spec050.rs
@@ -32,7 +32,11 @@ use crate::report::{Diagnostic, Severity};
 use crate::validate::rule::{ValidationContext, ValidationRule};
 
 /// Keep in sync with tools/token-mapping-analyzer/src/decomposer.js
-/// `COMPOUND_PROPERTIES`.
+/// `COMPOUND_PROPERTIES`. Matching is exact-string only, not prefix -- a new
+/// compound term used with a suffix not yet listed here (e.g.
+/// "border-width-thick") won't be exempted and its trailing segment(s) will
+/// be checked against the structural-field registries like any other
+/// property. Add the full suffixed form here if that's a false positive.
 const COMPOUND_PROPERTIES: &[&str] = &[
     "font-size",
     "font-weight",

--- a/sdk/core/src/validate/rules/spec050.rs
+++ b/sdk/core/src/validate/rules/spec050.rs
@@ -1,0 +1,227 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+//! SPEC-050: property-decomposition-complete
+//!
+//! Detects `name.property` values that fuse a structured-field concept
+//! (anatomy/object/position/size/state/colorRole/emphasis) instead of being
+//! atomic, independent of whether the token roundtrips through canonical name
+//! generation or is listed in naming-exceptions.json (spectrum-design-data-284.1).
+//!
+//! SPEC-007 (name-roundtrip) only catches fusion that also breaks
+//! serialization; a token like "icon-color-informative" can roundtrip
+//! cleanly while still smuggling anatomy ("icon") and colorRole
+//! ("informative") into `property`. This rule flags that case directly by
+//! scanning `property`'s hyphen-segments for a match against any advisory
+//! structured-field registry.
+//!
+//! `COMPOUND_PROPERTIES` mirrors the same list in
+//! tools/token-mapping-analyzer/src/decomposer.js — keep both in sync. It
+//! short-circuits legitimate multi-word CSS properties (e.g. "text-align")
+//! whose segments would otherwise coincidentally collide with a registry
+//! term (anatomy has a "text" part).
+
+use crate::report::{Diagnostic, Severity};
+use crate::validate::rule::{ValidationContext, ValidationRule};
+
+/// Keep in sync with tools/token-mapping-analyzer/src/decomposer.js
+/// `COMPOUND_PROPERTIES`.
+const COMPOUND_PROPERTIES: &[&str] = &[
+    "font-size",
+    "font-weight",
+    "font-family",
+    "font-style",
+    "line-height",
+    "text-transform",
+    "text-align",
+    "text-decoration",
+    "corner-radius",
+    "border-width",
+    "minimum-width",
+    "minimum-height",
+    "minimum-padding-vertical",
+    "component-size-minimum-perspective",
+    "maximum-width",
+    "maximum-height",
+    "underline-gap",
+    "typography-scale",
+    "line-height-font-size",
+    "component-height",
+    "component-size-difference",
+    "component-size-maximum-perspective",
+    "component-size-width-ratio",
+    "width-multiplier",
+    "minimum-width-multiplier",
+    "maximum-width-multiplier",
+];
+
+/// Structured fields whose presence inside `name.property` means the
+/// property isn't atomic. Deliberately excludes `property` itself and
+/// non-taxonomy fields (component, variant, icon, ...).
+const STRUCTURAL_FIELDS: &[&str] = &[
+    "anatomy",
+    "object",
+    "position",
+    "size",
+    "state",
+    "colorRole",
+    "emphasis",
+];
+
+/// Scan `property`'s hyphen-segments for every contiguous run that matches a
+/// registered id in one of `STRUCTURAL_FIELDS`. Returns `(field, matched)`
+/// pairs, deduplicated and sorted for deterministic diagnostic ordering.
+fn structural_hits(property: &str, ctx: &ValidationContext<'_>) -> Vec<(&'static str, String)> {
+    let segments: Vec<&str> = property.split('-').collect();
+    let mut hits = Vec::new();
+
+    for &field in STRUCTURAL_FIELDS {
+        let Some(registry_set) = ctx.registry.for_field(field) else {
+            continue;
+        };
+        for start in 0..segments.len() {
+            for end in (start + 1)..=segments.len() {
+                let candidate = segments[start..end].join("-");
+                if registry_set.contains(&candidate) {
+                    hits.push((field, candidate));
+                }
+            }
+        }
+    }
+
+    hits.sort();
+    hits.dedup();
+    hits
+}
+
+pub struct Rule;
+
+impl ValidationRule for Rule {
+    fn id(&self) -> &'static str {
+        "SPEC-050"
+    }
+
+    fn name(&self) -> &'static str {
+        "property-decomposition-complete"
+    }
+
+    fn validate(&self, ctx: &ValidationContext<'_>) -> Vec<Diagnostic> {
+        let mut diags = Vec::new();
+
+        for record in ctx.graph.tokens.values() {
+            let Some(property) = record
+                .raw
+                .get("name")
+                .and_then(|v| v.as_object())
+                .and_then(|n| n.get("property"))
+                .and_then(|v| v.as_str())
+            else {
+                continue;
+            };
+
+            if COMPOUND_PROPERTIES.contains(&property) {
+                continue;
+            }
+
+            for (field, value) in structural_hits(property, ctx) {
+                diags.push(Diagnostic {
+                    file: record.file.clone(),
+                    token: Some(record.name.clone()),
+                    rule_id: Some("SPEC-050".into()),
+                    severity: Severity::Warning,
+                    message: format!(
+                        "Token '{token}' fuses '{field}' concept '{value}' into \
+                         name.property; decompose into the structured field",
+                        token = record.name,
+                    ),
+                    instance_path: Some("/name/property".into()),
+                    schema_path: None,
+                });
+            }
+        }
+
+        diags
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+
+    use crate::graph::TokenGraph;
+    use crate::validate::relational::diagnostics_for_rule;
+
+    #[test]
+    fn atomic_property_no_warning() {
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color"}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-050").is_empty());
+    }
+
+    #[test]
+    fn compound_css_property_no_warning() {
+        // "text" alone is a registered anatomy part, but "font-size" is a
+        // legitimate atomic CSS property and must not be flagged.
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "font-size"}, "value": "12px"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-050").is_empty());
+    }
+
+    #[test]
+    fn icon_color_informative_warns_anatomy_and_color_role() {
+        // Roundtrips cleanly through legacy-name generation today (property
+        // is emitted verbatim), so SPEC-007 never flags it -- this is the
+        // exact spectrum-design-data-284 blind spot SPEC-050 exists to catch.
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "icon-color-informative"}, "value": "#fff"}),
+        )]);
+        let diags = diagnostics_for_rule(&g, "SPEC-050");
+        assert_eq!(diags.len(), 2);
+        assert!(diags.iter().any(|d| d.message.contains("anatomy")));
+        assert!(diags.iter().any(|d| d.message.contains("colorRole")));
+    }
+
+    #[test]
+    fn background_color_warns_despite_being_a_registered_legacy_alias() {
+        // "background-color" is itself a property-terms.json id (a legacy
+        // roundtrip alias), but "background" independently collides with the
+        // object/colorRole registries -- SPEC-050 must flag it regardless.
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "background-color"}, "value": "#fff"}),
+        )]);
+        assert!(!diagnostics_for_rule(&g, "SPEC-050").is_empty());
+    }
+
+    #[test]
+    fn already_decomposed_property_no_warning() {
+        // Property is atomic once object/colorRole/state are split into their
+        // own fields -- nothing left inside `property` to flag.
+        let g = TokenGraph::from_pairs(vec![(
+            "t".into(),
+            PathBuf::from("a.tokens.json"),
+            json!({"name": {"property": "color", "object": "background", "state": ["selected"]}, "value": "#fff"}),
+        )]);
+        assert!(diagnostics_for_rule(&g, "SPEC-050").is_empty());
+    }
+}

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -37,6 +37,13 @@ const FALLBACK_SERIALIZATION_ORDER = [
  * Exported for src/property-atomicity.js, which checks this list first
  * (mirroring Phase 2 below) so a legitimate CSS compound like "text-align"
  * isn't misread as anatomy "text" + a stray "align" segment.
+ *
+ * Matching is exact-string only, not prefix -- a new compound term used with
+ * a suffix not yet listed here (e.g. "border-width-thick") won't be exempted
+ * and its trailing segment(s) will be checked against the structural-field
+ * registries like any other property. Add the full suffixed form here if
+ * that's a false positive; this list already required the same manual
+ * enumeration before property-atomicity.js existed.
  */
 export const COMPOUND_PROPERTIES = [
   "font-size",

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -33,8 +33,12 @@ const FALLBACK_SERIALIZATION_ORDER = [
 /**
  * Known compound properties that span multiple segments.
  * These are treated as single property values.
+ *
+ * Exported for src/property-atomicity.js, which checks this list first
+ * (mirroring Phase 2 below) so a legitimate CSS compound like "text-align"
+ * isn't misread as anatomy "text" + a stray "align" segment.
  */
-const COMPOUND_PROPERTIES = [
+export const COMPOUND_PROPERTIES = [
   "font-size",
   "font-weight",
   "font-family",

--- a/tools/token-mapping-analyzer/src/index.js
+++ b/tools/token-mapping-analyzer/src/index.js
@@ -14,6 +14,7 @@ import { fileURLToPath } from "url";
 import { loadRegistries } from "./registry-index.js";
 import { decompose, serialize } from "./decomposer.js";
 import { generateReport } from "./report.js";
+import { analyzeProperty } from "./property-atomicity.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Structured cascade tree (inline name objects) — the source of truth for
@@ -39,6 +40,11 @@ async function main() {
 
   console.log("\nAnalyzing tokens...");
   const allResults = [];
+  // spectrum-design-data-284.1: property-fusion detection is independent of
+  // roundtrip/allowlist status, so it runs against the authored
+  // `token.name.property` directly rather than reusing `decompose()`'s
+  // confidence/roundtrip machinery.
+  const fusionResults = [];
 
   for (const filename of TOKEN_FILES) {
     const filePath = resolve(TOKENS_DIR, filename);
@@ -82,6 +88,21 @@ async function main() {
         filename,
       );
       allResults.push(result);
+
+      if (token.name.property) {
+        const fusion = analyzeProperty(token.name.property, registry);
+        if (fusion.fused) {
+          fusionResults.push({
+            token: legacyKey,
+            file: filename,
+            property: fusion.property,
+            fields: fusion.fields,
+            bucket: fusion.bucket,
+            deprecated: !!token.deprecated,
+            private: !!token.private,
+          });
+        }
+      }
     }
 
     // Per-file quick stats
@@ -106,6 +127,32 @@ async function main() {
   writeFileSync(
     resolve(OUTPUT_DIR, "all-decompositions.json"),
     JSON.stringify(allResults, null, 2),
+  );
+
+  // spectrum-design-data-284.1: property-fusion inventory, independent of
+  // roundtrip/naming-exceptions status. See src/property-atomicity.js.
+  const activeFusion = fusionResults.filter((r) => !r.deprecated && !r.private);
+  const fusionByBucket = {};
+  for (const r of activeFusion) {
+    (fusionByBucket[r.bucket] ??= []).push(r);
+  }
+  writeFileSync(
+    resolve(OUTPUT_DIR, "property-fusion-inventory.json"),
+    JSON.stringify(
+      {
+        total: fusionResults.length,
+        active: activeFusion.length,
+        byBucket: Object.fromEntries(
+          Object.entries(fusionByBucket).map(([bucket, tokens]) => [
+            bucket,
+            tokens.length,
+          ]),
+        ),
+        tokens: fusionResults,
+      },
+      null,
+      2,
+    ),
   );
 
   // Print summary
@@ -142,8 +189,22 @@ async function main() {
     console.log(`  "${item.segment}" (${item.count}x) e.g. ${item.tokens[0]}`);
   }
 
+  console.log(
+    "\n=== PROPERTY FUSION (spectrum-design-data-284.1, independent of roundtrip) ===",
+  );
+  console.log(`Fused properties (active): ${activeFusion.length}`);
+  for (const [bucket, tokens] of Object.entries(fusionByBucket)) {
+    console.log(`  ${bucket}: ${tokens.length}`);
+    for (const ex of tokens.slice(0, 3)) {
+      console.log(`    - ${ex.token} (${ex.file})`);
+    }
+  }
+
   console.log(`\nFull report written to: output/analysis-report.json`);
   console.log(`All decompositions written to: output/all-decompositions.json`);
+  console.log(
+    `Property fusion inventory written to: output/property-fusion-inventory.json`,
+  );
 }
 
 main().catch((err) => {

--- a/tools/token-mapping-analyzer/src/property-atomicity.js
+++ b/tools/token-mapping-analyzer/src/property-atomicity.js
@@ -8,7 +8,6 @@
 // OF ANY KIND, either express or implied. See the License for the specific language
 // governing permissions and limitations under the License.
 
-import { matchLongestTerm } from "./registry-index.js";
 import { COMPOUND_PROPERTIES } from "./decomposer.js";
 
 // Fields whose presence in name.property means the property is fusing a
@@ -25,6 +24,40 @@ const STRUCTURAL_FIELDS = [
   "colorRole",
   "emphasis",
 ];
+
+/**
+ * Scan `property`'s hyphen-segments for every contiguous run that matches a
+ * registered id in one of STRUCTURAL_FIELDS. Mirrors
+ * sdk/core/src/validate/rules/spec050.rs::structural_hits exactly -- both
+ * check every contiguous substring against each field's id set, not just the
+ * longest match anchored at each start position (unlike matchLongestTerm,
+ * which is tuned for left-to-right decomposition, not fusion detection).
+ *
+ * @param {string} property
+ * @param {ReturnType<import("./registry-index.js").loadRegistries>} registry
+ * @returns {Record<string, string[]>}
+ */
+function structuralHits(property, registry) {
+  const segments = property.split("-");
+  const fields = {};
+
+  for (const field of STRUCTURAL_FIELDS) {
+    const ids = registry.byField[field];
+    if (!ids) continue;
+    for (let start = 0; start < segments.length; start++) {
+      for (let end = start + 1; end <= segments.length; end++) {
+        const candidate = segments.slice(start, end).join("-");
+        if (ids.has(candidate)) {
+          (fields[field] ??= new Set()).add(candidate);
+        }
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(fields).map(([field, ids]) => [field, [...ids].sort()]),
+  );
+}
 
 /**
  * Classify a single token's `name.property` string for decomposition
@@ -48,22 +81,7 @@ export function analyzeProperty(property, registry) {
     return { property, atomic: true, fused: false, fields: {}, bucket: null };
   }
 
-  const segments = property.split("-");
-  const structuralTerms = registry.terms.filter((t) =>
-    STRUCTURAL_FIELDS.includes(t.field),
-  );
-
-  const fields = {};
-  for (let i = 0; i < segments.length; i++) {
-    const match = matchLongestTerm(segments, i, structuralTerms);
-    if (match) {
-      (fields[match.field] ??= new Set()).add(match.id);
-    }
-  }
-
-  const fieldsOut = Object.fromEntries(
-    Object.entries(fields).map(([field, ids]) => [field, [...ids]]),
-  );
+  const fieldsOut = structuralHits(property, registry);
   const fused = Object.keys(fieldsOut).length > 0;
 
   if (fused) {

--- a/tools/token-mapping-analyzer/src/property-atomicity.js
+++ b/tools/token-mapping-analyzer/src/property-atomicity.js
@@ -1,0 +1,115 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import { matchLongestTerm } from "./registry-index.js";
+import { COMPOUND_PROPERTIES } from "./decomposer.js";
+
+// Fields whose presence in name.property means the property is fusing a
+// concept that belongs in a dedicated structured field instead (spectrum-design-data-284).
+// Deliberately excludes "property" itself and non-taxonomy fields (component,
+// variant, icon, ...) -- this detector only asks "does this property string
+// smuggle one of these seven concepts?"
+const STRUCTURAL_FIELDS = [
+  "anatomy",
+  "object", // "surface" in the epic's language
+  "position",
+  "size",
+  "state",
+  "colorRole",
+  "emphasis",
+];
+
+/**
+ * Classify a single token's `name.property` string for decomposition
+ * completeness, independent of roundtrip or naming-exceptions allowlist
+ * status (that's the point of spectrum-design-data-284.1 -- SPEC-007's
+ * roundtrip-keyed MEDIUM bucket misses fused properties that happen to
+ * serialize back cleanly, e.g. "icon-color-informative", "background-color").
+ *
+ * Note this deliberately does NOT ask "is the whole property string a
+ * registered property-terms id" -- legacy aliases like "background-color"
+ * and "icon-color" ARE registered there, but their *segments* also
+ * independently collide with the object/anatomy registries, which is
+ * exactly the fusion this bead exists to surface.
+ *
+ * @param {string} property - the authored `name.property` value
+ * @param {ReturnType<import("./registry-index.js").loadRegistries>} registry
+ * @returns {{ property: string, atomic: boolean, fused: boolean, fields: Record<string, string[]>, bucket: string|null }}
+ */
+export function analyzeProperty(property, registry) {
+  if (COMPOUND_PROPERTIES.includes(property)) {
+    return { property, atomic: true, fused: false, fields: {}, bucket: null };
+  }
+
+  const segments = property.split("-");
+  const structuralTerms = registry.terms.filter((t) =>
+    STRUCTURAL_FIELDS.includes(t.field),
+  );
+
+  const fields = {};
+  for (let i = 0; i < segments.length; i++) {
+    const match = matchLongestTerm(segments, i, structuralTerms);
+    if (match) {
+      (fields[match.field] ??= new Set()).add(match.id);
+    }
+  }
+
+  const fieldsOut = Object.fromEntries(
+    Object.entries(fields).map(([field, ids]) => [field, [...ids]]),
+  );
+  const fused = Object.keys(fieldsOut).length > 0;
+
+  if (fused) {
+    return {
+      property,
+      atomic: false,
+      fused: true,
+      fields: fieldsOut,
+      bucket: classifyBucket(fieldsOut),
+    };
+  }
+
+  const atomic = !!registry.byField.property?.has(property);
+  return {
+    property,
+    atomic,
+    fused: false,
+    fields: {},
+    bucket: atomic ? null : "unclassified",
+  };
+}
+
+/**
+ * Map a fused-property's matched structural fields to the sibling bead that
+ * owns that decomposition work.
+ *
+ * @param {Record<string, string[]>} fields
+ * @returns {"compound-state" | "surface-colorRole" | "position-size-state" | "other"}
+ */
+export function classifyBucket(fields) {
+  const stateCount = fields.state?.length ?? 0;
+  if (stateCount >= 2 || (stateCount >= 1 && fields.emphasis)) {
+    return "compound-state"; // spectrum-design-data-284.5
+  }
+  // position/size checked before object/colorRole: a layout token like
+  // "edge-to-content-default-large" matches object ("edge") *and* size
+  // ("large"), but it lives in layout*.tokens.json and belongs to 284.2, not
+  // the color/typography scope of 284.3.
+  if (fields.position || fields.size) {
+    return "position-size-state"; // spectrum-design-data-284.2
+  }
+  if (fields.object || fields.colorRole) {
+    return "surface-colorRole"; // spectrum-design-data-284.3
+  }
+  if (fields.state) {
+    return "position-size-state"; // spectrum-design-data-284.2
+  }
+  return "other";
+}

--- a/tools/token-mapping-analyzer/test/property-atomicity.test.js
+++ b/tools/token-mapping-analyzer/test/property-atomicity.test.js
@@ -1,0 +1,80 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+import test from "ava";
+import { loadRegistries } from "../src/registry-index.js";
+import { analyzeProperty } from "../src/property-atomicity.js";
+
+let registry;
+test.before(() => {
+  registry = loadRegistries();
+});
+
+test("atomic: plain registered property term", (t) => {
+  const result = analyzeProperty("color", registry);
+  t.true(result.atomic);
+  t.false(result.fused);
+});
+
+test("atomic: compound CSS property short-circuits before structural scan", (t) => {
+  const result = analyzeProperty("font-size", registry);
+  t.true(result.atomic);
+  t.false(result.fused);
+});
+
+test("fused: background-color roundtrips cleanly (registered legacy alias) but still fuses surface + property (spectrum-design-data-284 example)", (t) => {
+  const result = analyzeProperty("background-color", registry);
+  t.false(result.atomic);
+  t.true(result.fused);
+  // "background" is a registered id in both object.json (surface) and
+  // color-roles.json -- either match is a legitimate structural collision,
+  // so assert the union rather than a specific field.
+  t.true(!!result.fields.object || !!result.fields.colorRole);
+  t.is(result.bucket, "surface-colorRole");
+});
+
+test("fused: icon-color-informative fuses anatomy + colorRole (spectrum-design-data-284 primary example)", (t) => {
+  const result = analyzeProperty("icon-color-informative", registry);
+  t.true(result.fused);
+  t.deepEqual(result.fields.anatomy, ["icon"]);
+  t.deepEqual(result.fields.colorRole, ["informative"]);
+  // colorRole present -> surface-colorRole bucket takes priority over anatomy-only "other"
+  t.is(result.bucket, "surface-colorRole");
+});
+
+test("fused: edge-to-content-default-large fuses object + size, but routes to position-size-state (284.2) since it's a layout token, not color/typography", (t) => {
+  const result = analyzeProperty("edge-to-content-default-large", registry);
+  t.true(result.fused);
+  t.truthy(result.fields.object);
+  t.truthy(result.fields.size);
+  t.is(result.bucket, "position-size-state");
+});
+
+test("fused: two state segments classify as compound-state", (t) => {
+  const result = analyzeProperty("selected-hover", registry);
+  t.true(result.fused);
+  t.is(result.fields.state.length, 2);
+  t.is(result.bucket, "compound-state");
+});
+
+test("fused: state + emphasis classifies as compound-state", (t) => {
+  const result = analyzeProperty("emphasized-hover", registry);
+  t.true(result.fused);
+  t.truthy(result.fields.state);
+  t.truthy(result.fields.emphasis);
+  t.is(result.bucket, "compound-state");
+});
+
+test("unclassified: unregistered property with no structural collision", (t) => {
+  const result = analyzeProperty("totally-unregistered-property-xyz", registry);
+  t.false(result.atomic);
+  t.false(result.fused);
+  t.is(result.bucket, "unclassified");
+});


### PR DESCRIPTION
## Description

Adds a detector for fused `name.property` values (e.g. `icon-color-informative`,
`background-color`, `edge-to-content-default-large`) that keys on
**decomposition-completeness** rather than roundtrip status. The prior detector
(SPEC-007 / token-mapping-analyzer's MEDIUM-confidence bucket) only flags tokens
that fail to roundtrip through canonical name generation, which misses tokens
whose property still fuses concepts but happen to serialize back cleanly.

Ships as both:
- a JS audit extension in `tools/token-mapping-analyzer` (new
  `src/property-atomicity.js`, wired into `src/index.js` to emit a
  `output/property-fusion-inventory.json` inventory + console bucket counts)
- a standing Rust advisory validation rule, `SPEC-050`
  (`property-decomposition-complete`, warning severity), mirroring the
  SPEC-009 pattern, with a conformance fixture

## Related Issue

Closes bead `spectrum-design-data-284.1` (child of epic `spectrum-design-data-284`,
"Decompose fused token-name property values into structured fields"). Exact
per-bucket counts produced by this audit have already been written into the
descriptions of sibling beads `284.2`, `284.3`, `284.5`, and the `284` epic,
replacing their previous approximate estimates.

## Motivation and Context

Detection independent of roundtrip/allowlist status is required to unblock the
sibling decomposition beads with exact counts instead of approximations, and to
give ongoing standing enforcement (SPEC-050) so newly-authored tokens don't
reintroduce property fusion.

## How Has This Been Tested?

- `cargo test --workspace` (`sdk/`): full suite passes, 0 failed (core, tui,
  wasm, doc-tests).
- New AVA suite `tools/token-mapping-analyzer/test/property-atomicity.test.js`
  (8 cases) covering atomic, fused, and unclassified properties across all
  structural-field buckets.
- New SPEC-050 unit tests in `sdk/core/src/validate/rules/spec050.rs` (5 cases)
  plus the `packages/design-data-spec/conformance/invalid/SPEC-050/` fixture.
- Changeset validated: `node tools/changeset-linter/src/cli.js check --fail-on-warnings`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
