### PR TITLE
fix(design-data): decompose compound-state opacity tokens (284.5)

### DIFF
--- a/.changeset/decompose-compound-state-opacity.md
+++ b/.changeset/decompose-compound-state-opacity.md
@@ -1,0 +1,12 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose 8 fused compound-state opacity tokens in `stack-item`/`tree-view`
+into structured `name` fields (closes spectrum-design-data-284.5).
+
+- **packages/design-data/tokens/layout-component.tokens.json**: split each
+  token's fused `property` string (e.g.
+  `stack-item-selected-background-opacity-emphasized-hover`) into
+  `component`/`anatomy`/`object`/`property`/`state`/`emphasis`/`qualifier`,
+  keeping the existing pinned `legacyKey` unchanged.

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -13795,8 +13795,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-opacity-emphasized",
       "component": "stack-item",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected"],
+      "emphasis": "emphasized",
       "legacyKey": "stack-item-selected-background-opacity-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -13805,8 +13808,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-opacity-emphasized-down",
       "component": "stack-item",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected", "down"],
+      "emphasis": "emphasized",
       "legacyKey": "stack-item-selected-background-opacity-emphasized-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -13815,8 +13821,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-opacity-emphasized-hover",
       "component": "stack-item",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected", "hover"],
+      "emphasis": "emphasized",
       "legacyKey": "stack-item-selected-background-opacity-emphasized-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -13825,8 +13834,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-opacity-emphasized-key-focus",
       "component": "stack-item",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected", "keyboard-focus"],
+      "emphasis": "emphasized",
       "legacyKey": "stack-item-selected-background-opacity-emphasized-key-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -13835,8 +13847,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-opacity-highlight",
       "component": "stack-item",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected"],
+      "qualifier": "highlight",
       "legacyKey": "stack-item-selected-background-opacity-highlight"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -13845,8 +13860,11 @@
   },
   {
     "name": {
-      "property": "stack-item-selected-background-opacity-highlight-hover",
       "component": "stack-item",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected", "hover"],
+      "qualifier": "highlight",
       "legacyKey": "stack-item-selected-background-opacity-highlight-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -22543,8 +22561,12 @@
   },
   {
     "name": {
-      "property": "tree-view-selected-row-background-opacity-emphasized",
       "component": "tree-view",
+      "anatomy": "row",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected"],
+      "emphasis": "emphasized",
       "legacyKey": "tree-view-selected-row-background-opacity-emphasized"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
@@ -22553,8 +22575,12 @@
   },
   {
     "name": {
-      "property": "tree-view-selected-row-background-opacity-emphasized-hover",
       "component": "tree-view",
+      "anatomy": "row",
+      "object": "background",
+      "property": "opacity",
+      "state": ["selected", "hover"],
+      "emphasis": "emphasized",
       "legacyKey": "tree-view-selected-row-background-opacity-emphasized-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes the 8 fused compound-state opacity tokens (`stack-item`/`tree-view`) in
`packages/design-data/tokens/layout-component.tokens.json`. Previously each token's
entire legacy name string was dumped verbatim into `name.property` with no structure.
Each is now split into proper `component`/`anatomy`/`object`/`property`/`state`/
`emphasis`/`qualifier` fields (`state` as an ordered array, e.g. `["selected", "hover"]`).
Each token keeps its existing pinned `legacyKey` unchanged since the legacy field order
doesn't roundtrip through canonical serialization, so the generated legacy output is
byte-identical.

## Related Issue

Closes bead `spectrum-design-data-284.5` (part of epic `284`, the property-decomposition
initiative from SPEC-050's audit).

## Motivation and Context

SPEC-050 flags `name.property` strings whose hyphen segments collide with structural
fields (anatomy/object/state/etc.) as "fused" — i.e. not actually decomposed, just
allowlisted via `naming-exceptions.json` + a pinned `legacyKey`. This bead does the real
decomposition work for the last coherent bucket of fused compound-state tokens, lifting
the concepts into structured fields while keeping the published legacy package unchanged.

## How Has This Been Tested?

- `moon run sdk:codegen-check` and `moon run sdk:build` — confirmed Rust side in sync.
- `moon run design-data:roundtrip-verify` then `design-data:legacy-output` — confirmed the
  8 legacy keys generate byte-identical output.
- `moon run design-data:validate` (full validate, not `validate-dataset`) — confirmed
  SPEC-050 no longer flags these 8 tokens and SPEC-007 stays green (the existing
  `naming-exceptions.json` entries are still required — they silence a separate
  roundtrip check on the generated legacy package, which only carries
  `component`+`value`+`uuid`+`$schema` per token and can't reflect the new structured
  fields).
- `moon run tokens:verifyDesignDataSnapshot` — golden snapshot unchanged (no diff).
- `node tools/token-mapping-analyzer/src/index.js` — compound-state fusion bucket
  dropped 7→0; all 8 tokens absent from every fusion bucket.
- `moon run sdk:test` — full Rust suite (naming.rs roundtrip tests included), 0 failures.
- `moon run :test` — full monorepo suite, 29/29 tasks passed.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
