### PR TITLE
fix(design-data): decompose surface/colorRole property fusion (closes spectrum-design-data-284.3)

### DIFF
--- a/.changeset/decompose-surface-colorrole.md
+++ b/.changeset/decompose-surface-colorrole.md
@@ -1,0 +1,20 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose fused surface/anatomy + colorRole property values into structured
+`name` fields (closes spectrum-design-data-284.3).
+
+- **packages/design-data/tokens/color-aliases.tokens.json**: split
+  `overlay-color`/`overlay-opacity`, `static-*-text-color`,
+  `static-*-track-color`, and `static-*-track-indicator-color` into
+  `object`/`anatomy` + atomic `property`, keeping existing `legacyKey` pins.
+- **packages/design-data/tokens/icons.tokens.json**: split
+  `icon-color-disabled-primary` and `icon-color-emphasized-background` into
+  `icon` + `property`/`state`/`colorRole`/`emphasis`.
+- **packages/design-data/tokens/semantic-color-palette.tokens.json**: split
+  `icon-color-{informative,negative,neutral,notice,positive}` into
+  `anatomy:"icon"` + `property`/`colorRole`.
+- `background-color`, `border-color`, `visual-color`, `content-color`, and
+  `fill-color` are registered atomic property terms and were intentionally
+  left unsplit.

--- a/packages/design-data/registry/anatomy-terms.json
+++ b/packages/design-data/registry/anatomy-terms.json
@@ -20,7 +20,8 @@
       "id": "icon",
       "label": "Icon",
       "description": "Icon elements",
-      "usedIn": ["tokens", "component-schemas"]
+      "usedIn": ["tokens", "component-schemas"],
+      "standaloneScope": true
     },
     {
       "id": "label",
@@ -62,13 +63,15 @@
       "id": "indicator",
       "label": "Indicator",
       "description": "Visual indicator or marker",
-      "usedIn": ["tokens"]
+      "usedIn": ["tokens"],
+      "standaloneScope": true
     },
     {
       "id": "track",
       "label": "Track",
       "description": "Track or rail element (e.g., in sliders)",
-      "usedIn": ["tokens"]
+      "usedIn": ["tokens"],
+      "standaloneScope": true
     },
     {
       "id": "thumb",
@@ -538,7 +541,8 @@
       "id": "overlay",
       "label": "Overlay",
       "description": "Semi-transparent backdrop element behind modal dialogs (alert-dialog, standard-dialog, takeover-dialog)",
-      "usedIn": ["s2-docs"]
+      "usedIn": ["s2-docs"],
+      "standaloneScope": true
     },
     {
       "id": "header-area",

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -3706,7 +3706,9 @@
   },
   {
     "name": {
-      "property": "overlay-color"
+      "anatomy": "overlay",
+      "property": "color",
+      "legacyKey": "overlay-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -3714,8 +3716,10 @@
   },
   {
     "name": {
-      "property": "overlay-opacity",
-      "colorScheme": "light"
+      "anatomy": "overlay",
+      "property": "opacity",
+      "colorScheme": "light",
+      "legacyKey": "overlay-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.4",
@@ -3725,8 +3729,10 @@
   },
   {
     "name": {
-      "property": "overlay-opacity",
-      "colorScheme": "dark"
+      "anatomy": "overlay",
+      "property": "opacity",
+      "colorScheme": "dark",
+      "legacyKey": "overlay-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.6",
@@ -3736,8 +3742,10 @@
   },
   {
     "name": {
-      "property": "overlay-opacity",
-      "colorScheme": "wireframe"
+      "anatomy": "overlay",
+      "property": "opacity",
+      "colorScheme": "wireframe",
+      "legacyKey": "overlay-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.4",
@@ -4587,7 +4595,10 @@
   },
   {
     "name": {
-      "property": "static-black-text-color",
+      "variant": "static",
+      "colorFamily": "black",
+      "object": "text",
+      "property": "color",
       "legacyKey": "static-black-text-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -4596,7 +4607,10 @@
   },
   {
     "name": {
-      "property": "static-black-track-color",
+      "variant": "static",
+      "colorFamily": "black",
+      "object": "track",
+      "property": "color",
       "legacyKey": "static-black-track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -4608,7 +4622,8 @@
       "variant": "static",
       "colorFamily": "black",
       "object": "track",
-      "property": "indicator-color",
+      "anatomy": "indicator",
+      "property": "color",
       "legacyKey": "static-black-track-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -4629,7 +4644,10 @@
   },
   {
     "name": {
-      "property": "static-white-text-color",
+      "variant": "static",
+      "colorFamily": "white",
+      "object": "text",
+      "property": "color",
       "legacyKey": "static-white-text-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -4638,7 +4656,10 @@
   },
   {
     "name": {
-      "property": "static-white-track-color",
+      "variant": "static",
+      "colorFamily": "white",
+      "object": "track",
+      "property": "color",
       "legacyKey": "static-white-track-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -4650,7 +4671,8 @@
       "variant": "static",
       "colorFamily": "white",
       "object": "track",
-      "property": "indicator-color",
+      "anatomy": "indicator",
+      "property": "color",
       "legacyKey": "static-white-track-indicator-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -4597,7 +4597,7 @@
     "name": {
       "variant": "static",
       "colorFamily": "black",
-      "object": "text",
+      "anatomy": "text",
       "property": "color",
       "legacyKey": "static-black-text-color"
     },
@@ -4609,7 +4609,7 @@
     "name": {
       "variant": "static",
       "colorFamily": "black",
-      "object": "track",
+      "anatomy": "track",
       "property": "color",
       "legacyKey": "static-black-track-color"
     },
@@ -4646,7 +4646,7 @@
     "name": {
       "variant": "static",
       "colorFamily": "white",
-      "object": "text",
+      "anatomy": "text",
       "property": "color",
       "legacyKey": "static-white-text-color"
     },
@@ -4658,7 +4658,7 @@
     "name": {
       "variant": "static",
       "colorFamily": "white",
-      "object": "track",
+      "anatomy": "track",
       "property": "color",
       "legacyKey": "static-white-track-color"
     },

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -865,8 +865,10 @@
   },
   {
     "name": {
-      "property": "icon-color-disabled-primary",
       "icon": "icon",
+      "property": "color",
+      "state": ["disabled"],
+      "colorRole": "primary",
       "legacyKey": "icon-color-disabled-primary"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -875,8 +877,10 @@
   },
   {
     "name": {
-      "property": "icon-color-emphasized-background",
       "icon": "icon",
+      "property": "color",
+      "colorRole": "background",
+      "emphasis": "emphasized",
       "legacyKey": "icon-color-emphasized-background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -206,7 +206,9 @@
   },
   {
     "name": {
-      "property": "icon-color-informative",
+      "anatomy": "icon",
+      "property": "color",
+      "colorRole": "informative",
       "legacyKey": "icon-color-informative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -215,7 +217,9 @@
   },
   {
     "name": {
-      "property": "icon-color-negative",
+      "anatomy": "icon",
+      "property": "color",
+      "colorRole": "negative",
       "legacyKey": "icon-color-negative"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -224,7 +228,9 @@
   },
   {
     "name": {
-      "property": "icon-color-neutral",
+      "anatomy": "icon",
+      "property": "color",
+      "colorRole": "neutral",
       "legacyKey": "icon-color-neutral"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -233,7 +239,9 @@
   },
   {
     "name": {
-      "property": "icon-color-notice",
+      "anatomy": "icon",
+      "property": "color",
+      "colorRole": "notice",
       "legacyKey": "icon-color-notice"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -242,7 +250,9 @@
   },
   {
     "name": {
-      "property": "icon-color-positive",
+      "anatomy": "icon",
+      "property": "color",
+      "colorRole": "positive",
       "legacyKey": "icon-color-positive"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -917,7 +917,8 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "icon",
       "label": "Icon",
       "description": "Icon elements",
-      "usedIn": ["tokens", "component-schemas"]
+      "usedIn": ["tokens", "component-schemas"],
+      "standaloneScope": true
     },
     {
       "id": "label",
@@ -959,13 +960,15 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "indicator",
       "label": "Indicator",
       "description": "Visual indicator or marker",
-      "usedIn": ["tokens"]
+      "usedIn": ["tokens"],
+      "standaloneScope": true
     },
     {
       "id": "track",
       "label": "Track",
       "description": "Track or rail element (e.g., in sliders)",
-      "usedIn": ["tokens"]
+      "usedIn": ["tokens"],
+      "standaloneScope": true
     },
     {
       "id": "thumb",
@@ -1435,7 +1438,8 @@ const ANATOMY_TERMS_JSON: &str = r##"{
       "id": "overlay",
       "label": "Overlay",
       "description": "Semi-transparent backdrop element behind modal dialogs (alert-dialog, standard-dialog, takeover-dialog)",
-      "usedIn": ["s2-docs"]
+      "usedIn": ["s2-docs"],
+      "standaloneScope": true
     },
     {
       "id": "header-area",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Decomposes remaining fused surface/anatomy + colorRole property values in the
color token cascade into structured `name` fields, instead of leaving them as
compound `property` strings.

- **packages/design-data/tokens/color-aliases.tokens.json**: split
  `overlay-color`/`overlay-opacity`, `static-*-text-color`,
  `static-*-track-color`, and `static-*-track-indicator-color` into
  `object`/`anatomy` + atomic `property`.
- **packages/design-data/tokens/icons.tokens.json**: split
  `icon-color-disabled-primary` and `icon-color-emphasized-background` into
  `icon` + `property`/`state`/`colorRole`/`emphasis`.
- **packages/design-data/tokens/semantic-color-palette.tokens.json**: split
  `icon-color-{informative,negative,neutral,notice,positive}` into
  `anatomy:"icon"` + `property`/`colorRole`.

All existing `legacyKey` pins are kept unchanged, so legacy JSON output stays
byte-identical.

`background-color`, `border-color`, `visual-color`, `content-color`, and
`fill-color` are registered atomic property terms and were intentionally
left unsplit (confirmed with @garthdb).

## Related Issue

Closes spectrum-design-data-284.3 (part of epic spectrum-design-data-284,
"Decompose fused token-name property values into structured fields").

## Motivation and Context

Fused `property` strings like `icon-color-informative` serialize to a clean
legacy key and pass roundtrip checks, but the taxonomy is not actually
decomposed (the SPEC-007 blind spot). This splits the surface/anatomy +
colorRole segments into their own structured fields.

## How Has This Been Tested?

- `cargo run -p design-data-cli -- migrate legacy-verify --reference packages/tokens/src packages/design-data/tokens` — 0 differences (byte-identical legacy output).
- `cargo run -p design-data-cli -- migrate roundtrip-verify packages/tokens/src` — OK.
- `moon run sdk:codegen-check`, `moon run sdk:test`, `moon run sdk:lint` — all pass.
- `moon run :test` (JS/AVA across the monorepo) — all pass.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — changeset valid.

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
