### PR TITLE
fix(design-data): decompose background/opacity + misc fusion residue (284.6, 284.7, 284.8)

### DIFF
--- a/.changeset/decompose-background-residue.md
+++ b/.changeset/decompose-background-residue.md
@@ -1,0 +1,20 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose remaining background/opacity fusion residue missed by 284.3
+(closes spectrum-design-data-284.6).
+
+- **packages/design-data/tokens/color-aliases.tokens.json**:
+  `background-opacity-key-focus` split into `object`/`property`, matching
+  the sibling `background-*-opacity` state tokens.
+- **packages/design-data/tokens/color-component.tokens.json**:
+  `card-background-loading-color`, `table-selected-row-background-opacity`
+  (+ hover/non-emphasized variants), `tree-view-row-background-hover`, and
+  `tree-view-selected-row-background-{default,hover}` split into
+  `object`/`property`, keeping existing `legacyKey` pins.
+- `background-base-color`, `background-layer-1-color`/`-2-color`, and
+  `stack-item-selected-background-color-highlight` left unsplit — they'd
+  need a new registered `variant`/`anatomy` id (`base`, `layer`, `item`)
+  that doesn't exist today; that's a registry decision, not a data-only
+  change, so out of scope here.

--- a/.changeset/decompose-fusion-residue-sweep.md
+++ b/.changeset/decompose-fusion-residue-sweep.md
@@ -1,0 +1,22 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose the final grab-bag of fused `name.property` residue left after
+284.3/284.6 (closes spectrum-design-data-284.7).
+
+- **registry/variants.json**: register `base`/`layer` (context) and `hero`
+  (card emphasis) variant ids.
+- **registry/property-terms.json**: register `rounding-increment`.
+- **color-aliases.tokens.json**: `background-{base,layer-1,layer-2}-color`
+  split into `variant`/`object`/`property`.
+- **typography.tokens.json**: `default-font-family` simplified to atomic
+  `property:"font-family"`.
+- **layout-component.tokens.json**: split `card-selection-background-size`,
+  coach-indicator ring rounding-increments, `menu-item-section-divider-
+  height`, `radio-button-selection-indicator`, `table-border-divider-width`,
+  `collection-card-minimum-height-hero-*`, `drop-zone-cjk-title-font-size`.
+- **layout.tokens.json**: `side-focus-indicator` split into
+  `orientation`/`anatomy`/`property`.
+- `opacity-checkerboard-square-{dark,light}` intentionally left atomic
+  (design-asset swatch).

--- a/.changeset/decompose-surface-color-object.md
+++ b/.changeset/decompose-surface-color-object.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose the four registered legacy-alias surface-color properties into
+`object` + `property` (closes spectrum-design-data-284.8).
+
+- **color-aliases.tokens.json**, **color-component.tokens.json**,
+  **icons.tokens.json**, **layout-component.tokens.json**,
+  **semantic-color-palette.tokens.json**: split `background-color`,
+  `border-color`, `visual-color`, and `border-opacity` into
+  `object:"background"|"border"|"visual"` + `property:"color"|"opacity"`,
+  pinning an explicit `legacyKey` on every changed token.
+- `content-color`/`fill-color` intentionally left atomic (already-registered
+  atomic property terms, per prior epic-284 decisions).

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -144,6 +144,11 @@
       "description": "Corner rounding radius"
     },
     {
+      "id": "rounding-increment",
+      "label": "Rounding Increment",
+      "description": "Step size added to a ring or ring-like anatomy's corner rounding per nesting level"
+    },
+    {
       "id": "outline-width",
       "label": "Outline Width",
       "description": "CSS outline thickness"

--- a/packages/design-data/registry/variants.json
+++ b/packages/design-data/registry/variants.json
@@ -222,6 +222,13 @@
       "usedIn": ["tokens"]
     },
     {
+      "id": "hero",
+      "label": "Hero",
+      "description": "Large featured-card layout variant with maximized visual prominence",
+      "category": "emphasis",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "static",
       "label": "Static",
       "description": "Context variant indicating the token does not change with theme",
@@ -310,6 +317,20 @@
       "id": "elevated",
       "label": "Elevated",
       "description": "Elevated surface or shadow context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "base",
+      "label": "Base",
+      "description": "Base (lowest) surface context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "layer",
+      "label": "Layer",
+      "description": "Stacked surface layer context",
       "category": "context",
       "usedIn": ["tokens"]
     },

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -263,7 +263,9 @@
   },
   {
     "name": {
-      "property": "background-base-color",
+      "variant": "base",
+      "object": "background",
+      "property": "color",
       "legacyKey": "background-base-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -314,7 +316,9 @@
   },
   {
     "name": {
-      "property": "background-layer-color",
+      "variant": "layer",
+      "object": "background",
+      "property": "color",
       "scaleIndex": 1,
       "legacyKey": "background-layer-1-color"
     },
@@ -324,7 +328,9 @@
   },
   {
     "name": {
-      "property": "background-layer-color",
+      "variant": "layer",
+      "object": "background",
+      "property": "color",
       "scaleIndex": 2,
       "colorScheme": "light",
       "legacyKey": "background-layer-2-color"
@@ -337,7 +343,9 @@
   },
   {
     "name": {
-      "property": "background-layer-color",
+      "variant": "layer",
+      "object": "background",
+      "property": "color",
       "scaleIndex": 2,
       "colorScheme": "dark",
       "legacyKey": "background-layer-2-color"
@@ -350,7 +358,9 @@
   },
   {
     "name": {
-      "property": "background-layer-color",
+      "variant": "layer",
+      "object": "background",
+      "property": "color",
       "scaleIndex": 2,
       "colorScheme": "wireframe",
       "legacyKey": "background-layer-2-color"

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -2,10 +2,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "accent-background-color-default"
+      "legacyKey": "accent-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
@@ -16,10 +17,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "accent-background-color-default"
+      "legacyKey": "accent-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
@@ -30,10 +32,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "accent-background-color-default"
+      "legacyKey": "accent-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
@@ -44,10 +47,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "light",
-      "legacyKey": "accent-background-color-down"
+      "legacyKey": "accent-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -58,10 +62,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "dark",
-      "legacyKey": "accent-background-color-down"
+      "legacyKey": "accent-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
@@ -72,10 +77,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "wireframe",
-      "legacyKey": "accent-background-color-down"
+      "legacyKey": "accent-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -86,10 +92,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "light",
-      "legacyKey": "accent-background-color-hover"
+      "legacyKey": "accent-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -100,10 +107,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "dark",
-      "legacyKey": "accent-background-color-hover"
+      "legacyKey": "accent-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
@@ -114,10 +122,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "wireframe",
-      "legacyKey": "accent-background-color-hover"
+      "legacyKey": "accent-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -128,10 +137,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "light",
-      "legacyKey": "accent-background-color-key-focus"
+      "legacyKey": "accent-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -142,10 +152,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "dark",
-      "legacyKey": "accent-background-color-key-focus"
+      "legacyKey": "accent-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
@@ -156,10 +167,11 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
-      "legacyKey": "accent-background-color-key-focus"
+      "legacyKey": "accent-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
@@ -225,9 +237,10 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "accent-visual-color"
+      "legacyKey": "accent-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
@@ -238,9 +251,10 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "accent-visual-color"
+      "legacyKey": "accent-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
@@ -251,9 +265,10 @@
   {
     "name": {
       "colorRole": "accent",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "accent-visual-color"
+      "legacyKey": "accent-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
@@ -457,10 +472,11 @@
   {
     "name": {
       "colorFamily": "blue",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "blue-background-color-default"
+      "legacyKey": "blue-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -471,10 +487,11 @@
   {
     "name": {
       "colorFamily": "blue",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "blue-background-color-default"
+      "legacyKey": "blue-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -485,10 +502,11 @@
   {
     "name": {
       "colorFamily": "blue",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "blue-background-color-default"
+      "legacyKey": "blue-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -500,10 +518,11 @@
     "name": {
       "colorFamily": "blue",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "blue-subtle-background-color-default"
+      "legacyKey": "blue-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -515,10 +534,11 @@
     "name": {
       "colorFamily": "blue",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "blue-subtle-background-color-default"
+      "legacyKey": "blue-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d434be86-0614-481b-bf30-6f7494f562d5",
@@ -530,10 +550,11 @@
     "name": {
       "colorFamily": "blue",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "blue-subtle-background-color-default"
+      "legacyKey": "blue-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce69a96f-663b-4922-89a3-4ece7acb6d55",
@@ -544,9 +565,10 @@
   {
     "name": {
       "colorFamily": "blue",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "blue-visual-color"
+      "legacyKey": "blue-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -557,9 +579,10 @@
   {
     "name": {
       "colorFamily": "blue",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "blue-visual-color"
+      "legacyKey": "blue-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "81bffb1e-f9d6-49c8-be17-8c298bcfc0e0",
@@ -570,9 +593,10 @@
   {
     "name": {
       "colorFamily": "blue",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "blue-visual-color"
+      "legacyKey": "blue-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "85be576c-6810-4971-9748-e558384b903d",
@@ -583,10 +607,11 @@
   {
     "name": {
       "colorFamily": "brown",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "brown-background-color-default"
+      "legacyKey": "brown-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -597,10 +622,11 @@
   {
     "name": {
       "colorFamily": "brown",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "brown-background-color-default"
+      "legacyKey": "brown-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -611,10 +637,11 @@
   {
     "name": {
       "colorFamily": "brown",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "brown-background-color-default"
+      "legacyKey": "brown-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -626,10 +653,11 @@
     "name": {
       "colorFamily": "brown",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "brown-subtle-background-color-default"
+      "legacyKey": "brown-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
@@ -641,10 +669,11 @@
     "name": {
       "colorFamily": "brown",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "brown-subtle-background-color-default"
+      "legacyKey": "brown-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ecb0d9f6-5007-4bf9-9dd3-40fb328bea13",
@@ -656,10 +685,11 @@
     "name": {
       "colorFamily": "brown",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "brown-subtle-background-color-default"
+      "legacyKey": "brown-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ce145d13-f1b1-46a7-9c17-0b7fab97022e",
@@ -670,9 +700,10 @@
   {
     "name": {
       "colorFamily": "brown",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "brown-visual-color"
+      "legacyKey": "brown-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -683,9 +714,10 @@
   {
     "name": {
       "colorFamily": "brown",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "brown-visual-color"
+      "legacyKey": "brown-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6c05dc34-9a1b-4bf7-a476-f093c45275f5",
@@ -696,9 +728,10 @@
   {
     "name": {
       "colorFamily": "brown",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "brown-visual-color"
+      "legacyKey": "brown-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bfbde25d-e087-444a-b26f-6568325a7d2e",
@@ -709,10 +742,11 @@
   {
     "name": {
       "colorFamily": "celery",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "celery-background-color-default"
+      "legacyKey": "celery-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b908fb61-f581-4942-9d00-57a828a0660b",
@@ -723,10 +757,11 @@
   {
     "name": {
       "colorFamily": "celery",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "celery-background-color-default"
+      "legacyKey": "celery-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "363508bf-9c3a-4e8e-9865-2b4915d2f097",
@@ -737,10 +772,11 @@
   {
     "name": {
       "colorFamily": "celery",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "celery-background-color-default"
+      "legacyKey": "celery-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b908fb61-f581-4942-9d00-57a828a0660b",
@@ -752,10 +788,11 @@
     "name": {
       "colorFamily": "celery",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "celery-subtle-background-color-default"
+      "legacyKey": "celery-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d22658b0-6638-45f9-8567-a2ad056f7c10",
@@ -767,10 +804,11 @@
     "name": {
       "colorFamily": "celery",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "celery-subtle-background-color-default"
+      "legacyKey": "celery-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "577626d4-7631-4de5-bd71-350b9748a4dd",
@@ -782,10 +820,11 @@
     "name": {
       "colorFamily": "celery",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "celery-subtle-background-color-default"
+      "legacyKey": "celery-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d22658b0-6638-45f9-8567-a2ad056f7c10",
@@ -796,9 +835,10 @@
   {
     "name": {
       "colorFamily": "celery",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "celery-visual-color"
+      "legacyKey": "celery-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
@@ -809,9 +849,10 @@
   {
     "name": {
       "colorFamily": "celery",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "celery-visual-color"
+      "legacyKey": "celery-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b6a6ad0f-71ed-40b9-bacf-8c945cb5d338",
@@ -822,9 +863,10 @@
   {
     "name": {
       "colorFamily": "celery",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "celery-visual-color"
+      "legacyKey": "celery-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "95228111-9945-410f-bd26-ea2bb1f5ddf8",
@@ -835,10 +877,11 @@
   {
     "name": {
       "colorFamily": "chartreuse",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "chartreuse-background-color-default"
+      "legacyKey": "chartreuse-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b72ad072-4768-463a-b951-00f1cbe4f657",
@@ -849,10 +892,11 @@
   {
     "name": {
       "colorFamily": "chartreuse",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "chartreuse-background-color-default"
+      "legacyKey": "chartreuse-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e26e1c23-490a-41f6-ba57-dd10bc58e504",
@@ -863,10 +907,11 @@
   {
     "name": {
       "colorFamily": "chartreuse",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "chartreuse-background-color-default"
+      "legacyKey": "chartreuse-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b72ad072-4768-463a-b951-00f1cbe4f657",
@@ -878,10 +923,11 @@
     "name": {
       "colorFamily": "chartreuse",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "chartreuse-subtle-background-color-default"
+      "legacyKey": "chartreuse-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
@@ -893,10 +939,11 @@
     "name": {
       "colorFamily": "chartreuse",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "chartreuse-subtle-background-color-default"
+      "legacyKey": "chartreuse-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5e69e639-7b35-404f-a144-3e4ab6e16ea7",
@@ -908,10 +955,11 @@
     "name": {
       "colorFamily": "chartreuse",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "chartreuse-subtle-background-color-default"
+      "legacyKey": "chartreuse-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "af7dfd23-39e4-4e6e-a4b2-992eca33812d",
@@ -922,9 +970,10 @@
   {
     "name": {
       "colorFamily": "chartreuse",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "chartreuse-visual-color"
+      "legacyKey": "chartreuse-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
@@ -935,9 +984,10 @@
   {
     "name": {
       "colorFamily": "chartreuse",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "chartreuse-visual-color"
+      "legacyKey": "chartreuse-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5e0f4672-e34c-4ffb-b403-ae4f2dff7484",
@@ -948,9 +998,10 @@
   {
     "name": {
       "colorFamily": "chartreuse",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "chartreuse-visual-color"
+      "legacyKey": "chartreuse-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bd902ac-d5b1-4edb-9afc-b122d9f3c3fb",
@@ -961,10 +1012,11 @@
   {
     "name": {
       "colorFamily": "cinnamon",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "cinnamon-background-color-default"
+      "legacyKey": "cinnamon-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -975,10 +1027,11 @@
   {
     "name": {
       "colorFamily": "cinnamon",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "cinnamon-background-color-default"
+      "legacyKey": "cinnamon-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -989,10 +1042,11 @@
   {
     "name": {
       "colorFamily": "cinnamon",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "cinnamon-background-color-default"
+      "legacyKey": "cinnamon-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -1004,10 +1058,11 @@
     "name": {
       "colorFamily": "cinnamon",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "cinnamon-subtle-background-color-default"
+      "legacyKey": "cinnamon-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
@@ -1019,10 +1074,11 @@
     "name": {
       "colorFamily": "cinnamon",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "cinnamon-subtle-background-color-default"
+      "legacyKey": "cinnamon-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "3527fc94-a410-4933-bbb7-bedecd37e477",
@@ -1034,10 +1090,11 @@
     "name": {
       "colorFamily": "cinnamon",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "cinnamon-subtle-background-color-default"
+      "legacyKey": "cinnamon-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "322b71ea-2187-4fce-90e7-2db63d037368",
@@ -1048,9 +1105,10 @@
   {
     "name": {
       "colorFamily": "cinnamon",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "cinnamon-visual-color"
+      "legacyKey": "cinnamon-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -1061,9 +1119,10 @@
   {
     "name": {
       "colorFamily": "cinnamon",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "cinnamon-visual-color"
+      "legacyKey": "cinnamon-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0ac8a0b0-793c-47dd-a508-520e4a3da4b9",
@@ -1074,9 +1133,10 @@
   {
     "name": {
       "colorFamily": "cinnamon",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "cinnamon-visual-color"
+      "legacyKey": "cinnamon-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8ea9b668-f9df-460f-8af5-c7fbcc3de67f",
@@ -1087,10 +1147,11 @@
   {
     "name": {
       "colorFamily": "cyan",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "cyan-background-color-default"
+      "legacyKey": "cyan-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -1101,10 +1162,11 @@
   {
     "name": {
       "colorFamily": "cyan",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "cyan-background-color-default"
+      "legacyKey": "cyan-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "96e75cf8-2f23-47ee-b79b-618a28d2cceb",
@@ -1115,10 +1177,11 @@
   {
     "name": {
       "colorFamily": "cyan",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "cyan-background-color-default"
+      "legacyKey": "cyan-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -1130,10 +1193,11 @@
     "name": {
       "colorFamily": "cyan",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "cyan-subtle-background-color-default"
+      "legacyKey": "cyan-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c7fd6eda-f850-4dec-a883-e970cdfca622",
@@ -1145,10 +1209,11 @@
     "name": {
       "colorFamily": "cyan",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "cyan-subtle-background-color-default"
+      "legacyKey": "cyan-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "49bb7f35-e7b5-4e72-9e31-73b3e31df0a7",
@@ -1160,10 +1225,11 @@
     "name": {
       "colorFamily": "cyan",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "cyan-subtle-background-color-default"
+      "legacyKey": "cyan-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c7fd6eda-f850-4dec-a883-e970cdfca622",
@@ -1174,9 +1240,10 @@
   {
     "name": {
       "colorFamily": "cyan",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "cyan-visual-color"
+      "legacyKey": "cyan-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
@@ -1187,9 +1254,10 @@
   {
     "name": {
       "colorFamily": "cyan",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "cyan-visual-color"
+      "legacyKey": "cyan-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee2ce3c0-207d-4c24-b939-189b9b9e2972",
@@ -1200,9 +1268,10 @@
   {
     "name": {
       "colorFamily": "cyan",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "cyan-visual-color"
+      "legacyKey": "cyan-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6dd8a7f6-0fbf-42a8-b6bc-3fa0b1eed670",
@@ -1212,9 +1281,10 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "disabled-background-color"
+      "legacyKey": "disabled-background-color",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -1222,9 +1292,10 @@
   },
   {
     "name": {
-      "property": "border-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "disabled-border-color"
+      "legacyKey": "disabled-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
@@ -1244,9 +1315,10 @@
     "name": {
       "variant": "static",
       "colorFamily": "black",
-      "property": "background-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "disabled-static-black-background-color"
+      "legacyKey": "disabled-static-black-background-color",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7565eb32-d745-4fc3-8779-a717f8ba910a",
@@ -1256,9 +1328,10 @@
     "name": {
       "variant": "static",
       "colorFamily": "black",
-      "property": "border-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "disabled-static-black-border-color"
+      "legacyKey": "disabled-static-black-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16a871e1-d9df-42bb-8889-99059d70e82e",
@@ -1280,9 +1353,10 @@
     "name": {
       "variant": "static",
       "colorFamily": "white",
-      "property": "background-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "disabled-static-white-background-color"
+      "legacyKey": "disabled-static-white-background-color",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a1b64a62-7c78-415e-a9be-c86acbf361ca",
@@ -1292,9 +1366,10 @@
     "name": {
       "variant": "static",
       "colorFamily": "white",
-      "property": "border-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "disabled-static-white-border-color"
+      "legacyKey": "disabled-static-white-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
@@ -1898,10 +1973,11 @@
   {
     "name": {
       "colorFamily": "fuchsia",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "fuchsia-background-color-default"
+      "legacyKey": "fuchsia-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -1912,10 +1988,11 @@
   {
     "name": {
       "colorFamily": "fuchsia",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "fuchsia-background-color-default"
+      "legacyKey": "fuchsia-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -1926,10 +2003,11 @@
   {
     "name": {
       "colorFamily": "fuchsia",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "fuchsia-background-color-default"
+      "legacyKey": "fuchsia-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -1941,10 +2019,11 @@
     "name": {
       "colorFamily": "fuchsia",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "fuchsia-subtle-background-color-default"
+      "legacyKey": "fuchsia-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
@@ -1956,10 +2035,11 @@
     "name": {
       "colorFamily": "fuchsia",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "fuchsia-subtle-background-color-default"
+      "legacyKey": "fuchsia-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "09aef364-8827-48fa-9888-b0424ce8981c",
@@ -1971,10 +2051,11 @@
     "name": {
       "colorFamily": "fuchsia",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "fuchsia-subtle-background-color-default"
+      "legacyKey": "fuchsia-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "078936af-2556-4ee2-a849-e7f19088b0ee",
@@ -1985,9 +2066,10 @@
   {
     "name": {
       "colorFamily": "fuchsia",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "fuchsia-visual-color"
+      "legacyKey": "fuchsia-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -1998,9 +2080,10 @@
   {
     "name": {
       "colorFamily": "fuchsia",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "fuchsia-visual-color"
+      "legacyKey": "fuchsia-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad5957c2-2829-450e-973c-bf0075e1fa67",
@@ -2011,9 +2094,10 @@
   {
     "name": {
       "colorFamily": "fuchsia",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "fuchsia-visual-color"
+      "legacyKey": "fuchsia-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1bcf666f-165b-4ec9-b360-c891109a2f5c",
@@ -2024,10 +2108,11 @@
   {
     "name": {
       "colorFamily": "gray",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "gray-background-color-default"
+      "legacyKey": "gray-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -2038,10 +2123,11 @@
   {
     "name": {
       "colorFamily": "gray",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "gray-background-color-default"
+      "legacyKey": "gray-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -2052,10 +2138,11 @@
   {
     "name": {
       "colorFamily": "gray",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "gray-background-color-default"
+      "legacyKey": "gray-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -2067,10 +2154,11 @@
     "name": {
       "colorFamily": "gray",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "gray-subtle-background-color-default"
+      "legacyKey": "gray-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -2082,10 +2170,11 @@
     "name": {
       "colorFamily": "gray",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "gray-subtle-background-color-default"
+      "legacyKey": "gray-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
@@ -2097,10 +2186,11 @@
     "name": {
       "colorFamily": "gray",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "gray-subtle-background-color-default"
+      "legacyKey": "gray-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -2111,9 +2201,10 @@
   {
     "name": {
       "colorFamily": "gray",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "gray-visual-color"
+      "legacyKey": "gray-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -2124,9 +2215,10 @@
   {
     "name": {
       "colorFamily": "gray",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "gray-visual-color"
+      "legacyKey": "gray-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
@@ -2137,9 +2229,10 @@
   {
     "name": {
       "colorFamily": "gray",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "gray-visual-color"
+      "legacyKey": "gray-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -2150,10 +2243,11 @@
   {
     "name": {
       "colorFamily": "green",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "green-background-color-default"
+      "legacyKey": "green-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
@@ -2164,10 +2258,11 @@
   {
     "name": {
       "colorFamily": "green",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "green-background-color-default"
+      "legacyKey": "green-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
@@ -2178,10 +2273,11 @@
   {
     "name": {
       "colorFamily": "green",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "green-background-color-default"
+      "legacyKey": "green-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "c0f6d150-e59f-4ee9-bf85-087c67258767",
@@ -2193,10 +2289,11 @@
     "name": {
       "colorFamily": "green",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "green-subtle-background-color-default"
+      "legacyKey": "green-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
@@ -2208,10 +2305,11 @@
     "name": {
       "colorFamily": "green",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "green-subtle-background-color-default"
+      "legacyKey": "green-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9e090cbf-c8c4-40a1-9ba6-b7bdd01bf15c",
@@ -2223,10 +2321,11 @@
     "name": {
       "colorFamily": "green",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "green-subtle-background-color-default"
+      "legacyKey": "green-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "4f7df0e3-fed5-4f7a-8783-c367c1457796",
@@ -2237,9 +2336,10 @@
   {
     "name": {
       "colorFamily": "green",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "green-visual-color"
+      "legacyKey": "green-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
@@ -2250,9 +2350,10 @@
   {
     "name": {
       "colorFamily": "green",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "green-visual-color"
+      "legacyKey": "green-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6d8cdeaa-c122-4bba-9867-8634e78e767a",
@@ -2263,9 +2364,10 @@
   {
     "name": {
       "colorFamily": "green",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "green-visual-color"
+      "legacyKey": "green-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a2d13cc0-1445-46ca-b941-c50f04127376",
@@ -2276,10 +2378,11 @@
   {
     "name": {
       "colorFamily": "indigo",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "indigo-background-color-default"
+      "legacyKey": "indigo-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -2290,10 +2393,11 @@
   {
     "name": {
       "colorFamily": "indigo",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "indigo-background-color-default"
+      "legacyKey": "indigo-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -2304,10 +2408,11 @@
   {
     "name": {
       "colorFamily": "indigo",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "indigo-background-color-default"
+      "legacyKey": "indigo-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -2319,10 +2424,11 @@
     "name": {
       "colorFamily": "indigo",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "indigo-subtle-background-color-default"
+      "legacyKey": "indigo-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
@@ -2334,10 +2440,11 @@
     "name": {
       "colorFamily": "indigo",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "indigo-subtle-background-color-default"
+      "legacyKey": "indigo-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "571bb191-0f29-4a11-95a2-831a454b4df1",
@@ -2349,10 +2456,11 @@
     "name": {
       "colorFamily": "indigo",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "indigo-subtle-background-color-default"
+      "legacyKey": "indigo-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "03acbe76-ab2c-493b-8dbf-624802f4ff1d",
@@ -2363,9 +2471,10 @@
   {
     "name": {
       "colorFamily": "indigo",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "indigo-visual-color"
+      "legacyKey": "indigo-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -2376,9 +2485,10 @@
   {
     "name": {
       "colorFamily": "indigo",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "indigo-visual-color"
+      "legacyKey": "indigo-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f482731c-c07e-4323-bf79-6e45cdce4052",
@@ -2389,9 +2499,10 @@
   {
     "name": {
       "colorFamily": "indigo",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "indigo-visual-color"
+      "legacyKey": "indigo-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "54c17da1-02fe-4b9c-9d07-0d5a3e839310",
@@ -2401,10 +2512,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
@@ -2414,10 +2527,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
@@ -2427,10 +2542,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
@@ -2440,10 +2557,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "light",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2453,10 +2572,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "dark",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2466,10 +2587,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "wireframe",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2479,10 +2602,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "light",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2492,10 +2617,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "dark",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2505,10 +2632,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "wireframe",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background",
+      "legacyKey": "informative-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2518,11 +2647,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "informative-background-color-key-focus",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2532,11 +2662,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "informative-background-color-key-focus",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "04a018bd-229c-47da-99e9-d338d05f0fb6",
@@ -2546,11 +2677,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "informative-background-color-key-focus",
-      "variant": "informative"
+      "variant": "informative",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b609325-2bcf-491a-ad38-1409025caae0",
@@ -2561,9 +2693,10 @@
   {
     "name": {
       "colorRole": "informative",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "informative-visual-color"
+      "legacyKey": "informative-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
@@ -2574,9 +2707,10 @@
   {
     "name": {
       "colorRole": "informative",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "informative-visual-color"
+      "legacyKey": "informative-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "41b73196-0bc1-493e-9b5d-49f608914f5a",
@@ -2587,9 +2721,10 @@
   {
     "name": {
       "colorRole": "informative",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "informative-visual-color"
+      "legacyKey": "informative-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
@@ -2600,10 +2735,11 @@
   {
     "name": {
       "colorFamily": "magenta",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "magenta-background-color-default"
+      "legacyKey": "magenta-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -2614,10 +2750,11 @@
   {
     "name": {
       "colorFamily": "magenta",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "magenta-background-color-default"
+      "legacyKey": "magenta-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -2628,10 +2765,11 @@
   {
     "name": {
       "colorFamily": "magenta",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "magenta-background-color-default"
+      "legacyKey": "magenta-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -2643,10 +2781,11 @@
     "name": {
       "colorFamily": "magenta",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "magenta-subtle-background-color-default"
+      "legacyKey": "magenta-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
@@ -2658,10 +2797,11 @@
     "name": {
       "colorFamily": "magenta",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "magenta-subtle-background-color-default"
+      "legacyKey": "magenta-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9378740c-7cd3-42a1-8d2c-6dcdbc44d856",
@@ -2673,10 +2813,11 @@
     "name": {
       "colorFamily": "magenta",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "magenta-subtle-background-color-default"
+      "legacyKey": "magenta-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f7909075-b049-43d4-bae5-bd74c7827174",
@@ -2687,9 +2828,10 @@
   {
     "name": {
       "colorFamily": "magenta",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "magenta-visual-color"
+      "legacyKey": "magenta-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -2700,9 +2842,10 @@
   {
     "name": {
       "colorFamily": "magenta",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "magenta-visual-color"
+      "legacyKey": "magenta-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d8eb420e-b2d5-4bbe-baad-955009069eff",
@@ -2713,9 +2856,10 @@
   {
     "name": {
       "colorFamily": "magenta",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "magenta-visual-color"
+      "legacyKey": "magenta-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ff51c954-677f-4053-8426-b7fbc3d2d155",
@@ -2725,10 +2869,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -2738,10 +2884,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
@@ -2751,10 +2899,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -2764,10 +2914,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "light",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2777,10 +2929,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "dark",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2790,10 +2944,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "wireframe",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2803,10 +2959,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "light",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2816,10 +2974,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "dark",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2829,10 +2989,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "wireframe",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background",
+      "legacyKey": "negative-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2842,11 +3004,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "negative-background-color-key-focus",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2856,11 +3019,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "negative-background-color-key-focus",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
@@ -2870,11 +3034,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "negative-background-color-key-focus",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2884,9 +3049,11 @@
   },
   {
     "name": {
-      "property": "border-color",
+      "property": "color",
       "state": ["default"],
-      "variant": "negative"
+      "variant": "negative",
+      "object": "border",
+      "legacyKey": "negative-border-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -2894,9 +3061,11 @@
   },
   {
     "name": {
-      "property": "border-color",
+      "property": "color",
       "state": ["down"],
-      "variant": "negative"
+      "variant": "negative",
+      "object": "border",
+      "legacyKey": "negative-border-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489",
@@ -2904,9 +3073,11 @@
   },
   {
     "name": {
-      "property": "border-color",
+      "property": "color",
       "state": ["focus"],
-      "variant": "negative"
+      "variant": "negative",
+      "object": "border",
+      "legacyKey": "negative-border-color-focus"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2915,9 +3086,10 @@
   {
     "name": {
       "colorRole": "negative",
-      "property": "border-color",
+      "property": "color",
       "state": ["focus-hover"],
-      "legacyKey": "negative-border-color-focus-hover"
+      "legacyKey": "negative-border-color-focus-hover",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0c35da5c-cf37-4349-82e4-8739ea94aa65",
@@ -2925,9 +3097,11 @@
   },
   {
     "name": {
-      "property": "border-color",
+      "property": "color",
       "state": ["hover"],
-      "variant": "negative"
+      "variant": "negative",
+      "object": "border",
+      "legacyKey": "negative-border-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2935,10 +3109,11 @@
   },
   {
     "name": {
-      "property": "border-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "legacyKey": "negative-border-color-key-focus",
-      "variant": "negative"
+      "variant": "negative",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
@@ -2991,9 +3166,10 @@
   {
     "name": {
       "colorRole": "negative",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "negative-visual-color"
+      "legacyKey": "negative-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
@@ -3004,9 +3180,10 @@
   {
     "name": {
       "colorRole": "negative",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "negative-visual-color"
+      "legacyKey": "negative-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
@@ -3017,9 +3194,10 @@
   {
     "name": {
       "colorRole": "negative",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "negative-visual-color"
+      "legacyKey": "negative-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d858b481-8970-4547-aed1-b6388c36aba4",
@@ -3029,9 +3207,11 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
-      "variant": "neutral"
+      "variant": "neutral",
+      "object": "background",
+      "legacyKey": "neutral-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3039,9 +3219,11 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
-      "variant": "neutral"
+      "variant": "neutral",
+      "object": "background",
+      "legacyKey": "neutral-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3049,9 +3231,11 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
-      "variant": "neutral"
+      "variant": "neutral",
+      "object": "background",
+      "legacyKey": "neutral-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3059,10 +3243,11 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "legacyKey": "neutral-background-color-key-focus",
-      "variant": "neutral"
+      "variant": "neutral",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3071,9 +3256,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "default"],
-      "legacyKey": "neutral-background-color-selected-default"
+      "legacyKey": "neutral-background-color-selected-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3082,9 +3268,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "down"],
-      "legacyKey": "neutral-background-color-selected-down"
+      "legacyKey": "neutral-background-color-selected-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3093,9 +3280,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "hover"],
-      "legacyKey": "neutral-background-color-selected-hover"
+      "legacyKey": "neutral-background-color-selected-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3104,9 +3292,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected-key-focus"],
-      "legacyKey": "neutral-background-color-selected-key-focus"
+      "legacyKey": "neutral-background-color-selected-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e0eaa59c-81ad-4632-a61d-ab0bee53af4a",
@@ -3182,10 +3371,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "neutral-subdued-background-color-default"
+      "legacyKey": "neutral-subdued-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -3197,10 +3387,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "neutral-subdued-background-color-default"
+      "legacyKey": "neutral-subdued-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -3212,10 +3403,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "neutral-subdued-background-color-default"
+      "legacyKey": "neutral-subdued-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5bed317b-eaa5-4f93-bc0d-d8f51e0b4680",
@@ -3227,10 +3419,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "light",
-      "legacyKey": "neutral-subdued-background-color-down"
+      "legacyKey": "neutral-subdued-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3242,10 +3435,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "dark",
-      "legacyKey": "neutral-subdued-background-color-down"
+      "legacyKey": "neutral-subdued-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -3257,10 +3451,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "wireframe",
-      "legacyKey": "neutral-subdued-background-color-down"
+      "legacyKey": "neutral-subdued-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3272,10 +3467,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "light",
-      "legacyKey": "neutral-subdued-background-color-hover"
+      "legacyKey": "neutral-subdued-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3287,10 +3483,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "dark",
-      "legacyKey": "neutral-subdued-background-color-hover"
+      "legacyKey": "neutral-subdued-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -3302,10 +3499,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "wireframe",
-      "legacyKey": "neutral-subdued-background-color-hover"
+      "legacyKey": "neutral-subdued-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3317,10 +3515,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "light",
-      "legacyKey": "neutral-subdued-background-color-key-focus"
+      "legacyKey": "neutral-subdued-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3332,10 +3531,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "dark",
-      "legacyKey": "neutral-subdued-background-color-key-focus"
+      "legacyKey": "neutral-subdued-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -3347,10 +3547,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subdued",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
-      "legacyKey": "neutral-subdued-background-color-key-focus"
+      "legacyKey": "neutral-subdued-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -3422,10 +3623,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "neutral-subtle-background-color-default"
+      "legacyKey": "neutral-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -3437,10 +3639,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "neutral-subtle-background-color-default"
+      "legacyKey": "neutral-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
@@ -3452,10 +3655,11 @@
     "name": {
       "colorRole": "neutral",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "neutral-subtle-background-color-default"
+      "legacyKey": "neutral-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -3466,9 +3670,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "neutral-visual-color"
+      "legacyKey": "neutral-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -3479,9 +3684,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "neutral-visual-color"
+      "legacyKey": "neutral-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b49953b7-ef80-4e57-b1e7-546279b36bb4",
@@ -3492,9 +3698,10 @@
   {
     "name": {
       "colorRole": "neutral",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "neutral-visual-color"
+      "legacyKey": "neutral-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "60077744-c665-4c80-8f88-dff31a10219e",
@@ -3504,10 +3711,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "variant": "notice"
+      "variant": "notice",
+      "object": "background",
+      "legacyKey": "notice-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "716af828-c64d-465d-8476-d142892ca59c",
@@ -3517,10 +3726,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "variant": "notice"
+      "variant": "notice",
+      "object": "background",
+      "legacyKey": "notice-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
@@ -3530,10 +3741,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "variant": "notice"
+      "variant": "notice",
+      "object": "background",
+      "legacyKey": "notice-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "716af828-c64d-465d-8476-d142892ca59c",
@@ -3544,9 +3757,10 @@
   {
     "name": {
       "colorRole": "notice",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "notice-visual-color"
+      "legacyKey": "notice-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a83cdd4d-b8a9-42af-98c4-459f721abbff",
@@ -3557,9 +3771,10 @@
   {
     "name": {
       "colorRole": "notice",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "notice-visual-color"
+      "legacyKey": "notice-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
@@ -3570,9 +3785,10 @@
   {
     "name": {
       "colorRole": "notice",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "notice-visual-color"
+      "legacyKey": "notice-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a83cdd4d-b8a9-42af-98c4-459f721abbff",
@@ -3592,10 +3808,11 @@
   {
     "name": {
       "colorFamily": "orange",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "orange-background-color-default"
+      "legacyKey": "orange-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
@@ -3606,10 +3823,11 @@
   {
     "name": {
       "colorFamily": "orange",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "orange-background-color-default"
+      "legacyKey": "orange-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -3620,10 +3838,11 @@
   {
     "name": {
       "colorFamily": "orange",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "orange-background-color-default"
+      "legacyKey": "orange-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1c185916-6dc9-41df-b01d-24187d7d6fb0",
@@ -3635,10 +3854,11 @@
     "name": {
       "colorFamily": "orange",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "orange-subtle-background-color-default"
+      "legacyKey": "orange-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -3650,10 +3870,11 @@
     "name": {
       "colorFamily": "orange",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "orange-subtle-background-color-default"
+      "legacyKey": "orange-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec281039-7256-4db9-8261-d0af048d3e6d",
@@ -3665,10 +3886,11 @@
     "name": {
       "colorFamily": "orange",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "orange-subtle-background-color-default"
+      "legacyKey": "orange-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a4287e01-3b0a-45e2-9118-d2ec157805c3",
@@ -3679,9 +3901,10 @@
   {
     "name": {
       "colorFamily": "orange",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "orange-visual-color"
+      "legacyKey": "orange-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -3692,9 +3915,10 @@
   {
     "name": {
       "colorFamily": "orange",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "orange-visual-color"
+      "legacyKey": "orange-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b2e24ca2-6bfb-43c6-ab37-f6107563a371",
@@ -3705,9 +3929,10 @@
   {
     "name": {
       "colorFamily": "orange",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "orange-visual-color"
+      "legacyKey": "orange-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a43502bd-ffae-4544-a3d0-08288cff141d",
@@ -3767,10 +3992,11 @@
   {
     "name": {
       "colorFamily": "pink",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "pink-background-color-default"
+      "legacyKey": "pink-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -3781,10 +4007,11 @@
   {
     "name": {
       "colorFamily": "pink",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "pink-background-color-default"
+      "legacyKey": "pink-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -3795,10 +4022,11 @@
   {
     "name": {
       "colorFamily": "pink",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "pink-background-color-default"
+      "legacyKey": "pink-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -3810,10 +4038,11 @@
     "name": {
       "colorFamily": "pink",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "pink-subtle-background-color-default"
+      "legacyKey": "pink-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
@@ -3825,10 +4054,11 @@
     "name": {
       "colorFamily": "pink",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "pink-subtle-background-color-default"
+      "legacyKey": "pink-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7bb48388-b3bc-47eb-a7ab-b15327996714",
@@ -3840,10 +4070,11 @@
     "name": {
       "colorFamily": "pink",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "pink-subtle-background-color-default"
+      "legacyKey": "pink-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "500888e2-48c7-4962-8323-f160cc7a07d6",
@@ -3854,9 +4085,10 @@
   {
     "name": {
       "colorFamily": "pink",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "pink-visual-color"
+      "legacyKey": "pink-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -3867,9 +4099,10 @@
   {
     "name": {
       "colorFamily": "pink",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "pink-visual-color"
+      "legacyKey": "pink-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "242b7614-2f02-4227-a94c-7b7d419e1b4e",
@@ -3880,9 +4113,10 @@
   {
     "name": {
       "colorFamily": "pink",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "pink-visual-color"
+      "legacyKey": "pink-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a93e5c04-3ae7-4eda-8c06-9ba2e4e44987",
@@ -3892,10 +4126,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
@@ -3905,10 +4141,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
@@ -3918,10 +4156,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-default"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
@@ -3931,10 +4171,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "light",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3944,10 +4186,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "dark",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -3957,10 +4201,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
       "colorScheme": "wireframe",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3970,10 +4216,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "light",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -3983,10 +4231,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "dark",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -3996,10 +4246,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
       "colorScheme": "wireframe",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background",
+      "legacyKey": "positive-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -4009,11 +4261,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "light",
       "legacyKey": "positive-background-color-key-focus",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -4023,11 +4276,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "dark",
       "legacyKey": "positive-background-color-key-focus",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ffdde321-5c1d-489e-8a0f-afc582248594",
@@ -4037,11 +4291,12 @@
   },
   {
     "name": {
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
       "colorScheme": "wireframe",
       "legacyKey": "positive-background-color-key-focus",
-      "variant": "positive"
+      "variant": "positive",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "82d9fc42-d750-43d2-b227-b8df29abaca4",
@@ -4052,9 +4307,10 @@
   {
     "name": {
       "colorRole": "positive",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "positive-visual-color"
+      "legacyKey": "positive-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
@@ -4065,9 +4321,10 @@
   {
     "name": {
       "colorRole": "positive",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "positive-visual-color"
+      "legacyKey": "positive-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "1cd86108-ff79-4ccf-911e-8de9986c9053",
@@ -4078,9 +4335,10 @@
   {
     "name": {
       "colorRole": "positive",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "positive-visual-color"
+      "legacyKey": "positive-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
@@ -4091,10 +4349,11 @@
   {
     "name": {
       "colorFamily": "purple",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "purple-background-color-default"
+      "legacyKey": "purple-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -4105,10 +4364,11 @@
   {
     "name": {
       "colorFamily": "purple",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "purple-background-color-default"
+      "legacyKey": "purple-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -4119,10 +4379,11 @@
   {
     "name": {
       "colorFamily": "purple",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "purple-background-color-default"
+      "legacyKey": "purple-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -4134,10 +4395,11 @@
     "name": {
       "colorFamily": "purple",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "purple-subtle-background-color-default"
+      "legacyKey": "purple-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
@@ -4149,10 +4411,11 @@
     "name": {
       "colorFamily": "purple",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "purple-subtle-background-color-default"
+      "legacyKey": "purple-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "61b16d70-8650-4e61-9446-a5f2c4f197b9",
@@ -4164,10 +4427,11 @@
     "name": {
       "colorFamily": "purple",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "purple-subtle-background-color-default"
+      "legacyKey": "purple-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "745626e1-7c10-4e35-a99f-03c252bd441d",
@@ -4178,9 +4442,10 @@
   {
     "name": {
       "colorFamily": "purple",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "purple-visual-color"
+      "legacyKey": "purple-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -4191,9 +4456,10 @@
   {
     "name": {
       "colorFamily": "purple",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "purple-visual-color"
+      "legacyKey": "purple-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "630e0415-8751-4a1c-8f1f-96800ff93802",
@@ -4204,9 +4470,10 @@
   {
     "name": {
       "colorFamily": "purple",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "purple-visual-color"
+      "legacyKey": "purple-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "55055ac5-ca49-40c5-8d6b-c3c752f5c00f",
@@ -4217,10 +4484,11 @@
   {
     "name": {
       "colorFamily": "red",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "red-background-color-default"
+      "legacyKey": "red-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -4231,10 +4499,11 @@
   {
     "name": {
       "colorFamily": "red",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "red-background-color-default"
+      "legacyKey": "red-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -4245,10 +4514,11 @@
   {
     "name": {
       "colorFamily": "red",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "red-background-color-default"
+      "legacyKey": "red-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "80450bb0-85ac-4dd5-b6e8-56d2c628c0d8",
@@ -4260,10 +4530,11 @@
     "name": {
       "colorFamily": "red",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "red-subtle-background-color-default"
+      "legacyKey": "red-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -4275,10 +4546,11 @@
     "name": {
       "colorFamily": "red",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "red-subtle-background-color-default"
+      "legacyKey": "red-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6329f7cb-bb13-4231-ab91-4ed9dc8e7242",
@@ -4290,10 +4562,11 @@
     "name": {
       "colorFamily": "red",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "red-subtle-background-color-default"
+      "legacyKey": "red-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ebf4003d-ce93-4026-8e3b-13e128e014e7",
@@ -4304,9 +4577,10 @@
   {
     "name": {
       "colorFamily": "red",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "red-visual-color"
+      "legacyKey": "red-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -4317,9 +4591,10 @@
   {
     "name": {
       "colorFamily": "red",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "red-visual-color"
+      "legacyKey": "red-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e96c54da-a4e2-4735-91b4-784d0ce275d0",
@@ -4330,9 +4605,10 @@
   {
     "name": {
       "colorFamily": "red",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "red-visual-color"
+      "legacyKey": "red-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cee84ce0-439b-444c-bb7e-a77777da716d",
@@ -4343,10 +4619,11 @@
   {
     "name": {
       "colorFamily": "seafoam",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "seafoam-background-color-default"
+      "legacyKey": "seafoam-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
@@ -4357,10 +4634,11 @@
   {
     "name": {
       "colorFamily": "seafoam",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "seafoam-background-color-default"
+      "legacyKey": "seafoam-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
@@ -4371,10 +4649,11 @@
   {
     "name": {
       "colorFamily": "seafoam",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "seafoam-background-color-default"
+      "legacyKey": "seafoam-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "de37323c-69e7-476b-a62e-467e104c5d36",
@@ -4386,10 +4665,11 @@
     "name": {
       "colorFamily": "seafoam",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "seafoam-subtle-background-color-default"
+      "legacyKey": "seafoam-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
@@ -4401,10 +4681,11 @@
     "name": {
       "colorFamily": "seafoam",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "seafoam-subtle-background-color-default"
+      "legacyKey": "seafoam-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6085bce9-27e8-43c1-b2ce-8b259e03b0d9",
@@ -4416,10 +4697,11 @@
     "name": {
       "colorFamily": "seafoam",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "seafoam-subtle-background-color-default"
+      "legacyKey": "seafoam-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "92b7d64b-e8ae-4261-adf3-55b7435fce69",
@@ -4430,9 +4712,10 @@
   {
     "name": {
       "colorFamily": "seafoam",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "seafoam-visual-color"
+      "legacyKey": "seafoam-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad52345b-0360-4819-9fe8-b6e07249810d",
@@ -4443,9 +4726,10 @@
   {
     "name": {
       "colorFamily": "seafoam",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "seafoam-visual-color"
+      "legacyKey": "seafoam-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "472d8ac6-f0ae-4a37-9990-28773c10c959",
@@ -4456,9 +4740,10 @@
   {
     "name": {
       "colorFamily": "seafoam",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "seafoam-visual-color"
+      "legacyKey": "seafoam-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ad52345b-0360-4819-9fe8-b6e07249810d",
@@ -4469,10 +4754,11 @@
   {
     "name": {
       "colorFamily": "silver",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "silver-background-color-default"
+      "legacyKey": "silver-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -4483,10 +4769,11 @@
   {
     "name": {
       "colorFamily": "silver",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "silver-background-color-default"
+      "legacyKey": "silver-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -4497,10 +4784,11 @@
   {
     "name": {
       "colorFamily": "silver",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "silver-background-color-default"
+      "legacyKey": "silver-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -4512,10 +4800,11 @@
     "name": {
       "colorFamily": "silver",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "silver-subtle-background-color-default"
+      "legacyKey": "silver-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
@@ -4527,10 +4816,11 @@
     "name": {
       "colorFamily": "silver",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "silver-subtle-background-color-default"
+      "legacyKey": "silver-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "bbdff4c8-a79d-4df2-bdae-7ed10058ac28",
@@ -4542,10 +4832,11 @@
     "name": {
       "colorFamily": "silver",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "silver-subtle-background-color-default"
+      "legacyKey": "silver-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f2c7f530-ba13-4459-bc3c-2b26e4e7e4c1",
@@ -4556,9 +4847,10 @@
   {
     "name": {
       "colorFamily": "silver",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "silver-visual-color"
+      "legacyKey": "silver-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -4569,9 +4861,10 @@
   {
     "name": {
       "colorFamily": "silver",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "silver-visual-color"
+      "legacyKey": "silver-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d522fe05-cad5-4484-89e0-65c524f92e89",
@@ -4582,9 +4875,10 @@
   {
     "name": {
       "colorFamily": "silver",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "silver-visual-color"
+      "legacyKey": "silver-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2fe35623-7905-48c1-84f7-b0ad2b362ba1",
@@ -4713,10 +5007,11 @@
   {
     "name": {
       "colorFamily": "turquoise",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "turquoise-background-color-default"
+      "legacyKey": "turquoise-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -4727,10 +5022,11 @@
   {
     "name": {
       "colorFamily": "turquoise",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "turquoise-background-color-default"
+      "legacyKey": "turquoise-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -4741,10 +5037,11 @@
   {
     "name": {
       "colorFamily": "turquoise",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "turquoise-background-color-default"
+      "legacyKey": "turquoise-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -4756,10 +5053,11 @@
     "name": {
       "colorFamily": "turquoise",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "turquoise-subtle-background-color-default"
+      "legacyKey": "turquoise-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7720aa32-deea-454b-a593-f1234e638565",
@@ -4771,10 +5069,11 @@
     "name": {
       "colorFamily": "turquoise",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "turquoise-subtle-background-color-default"
+      "legacyKey": "turquoise-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "47de7f9a-3e02-4824-b667-ad499729c9ff",
@@ -4786,10 +5085,11 @@
     "name": {
       "colorFamily": "turquoise",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "turquoise-subtle-background-color-default"
+      "legacyKey": "turquoise-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "7720aa32-deea-454b-a593-f1234e638565",
@@ -4800,9 +5100,10 @@
   {
     "name": {
       "colorFamily": "turquoise",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "turquoise-visual-color"
+      "legacyKey": "turquoise-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -4813,9 +5114,10 @@
   {
     "name": {
       "colorFamily": "turquoise",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "turquoise-visual-color"
+      "legacyKey": "turquoise-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "084c9ba0-6ac6-40c9-afa8-4a06eefa3f9c",
@@ -4826,9 +5128,10 @@
   {
     "name": {
       "colorFamily": "turquoise",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "turquoise-visual-color"
+      "legacyKey": "turquoise-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf7c3e33-031a-46c2-84a1-b13a6b83b8b2",
@@ -4839,10 +5142,11 @@
   {
     "name": {
       "colorFamily": "yellow",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "yellow-background-color-default"
+      "legacyKey": "yellow-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -4853,10 +5157,11 @@
   {
     "name": {
       "colorFamily": "yellow",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "yellow-background-color-default"
+      "legacyKey": "yellow-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
@@ -4867,10 +5172,11 @@
   {
     "name": {
       "colorFamily": "yellow",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "yellow-background-color-default"
+      "legacyKey": "yellow-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0bc3e99e-6f92-47c9-90ae-593363bef6aa",
@@ -4882,10 +5188,11 @@
     "name": {
       "colorFamily": "yellow",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "yellow-subtle-background-color-default"
+      "legacyKey": "yellow-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
@@ -4897,10 +5204,11 @@
     "name": {
       "colorFamily": "yellow",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "yellow-subtle-background-color-default"
+      "legacyKey": "yellow-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ec693e13-b1f3-40e3-9a8e-5d48f38b0c98",
@@ -4912,10 +5220,11 @@
     "name": {
       "colorFamily": "yellow",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "yellow-subtle-background-color-default"
+      "legacyKey": "yellow-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "519b2bdf-d04a-40e4-9ad6-843b0562c6e1",
@@ -4926,9 +5235,10 @@
   {
     "name": {
       "colorFamily": "yellow",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "light",
-      "legacyKey": "yellow-visual-color"
+      "legacyKey": "yellow-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",
@@ -4939,9 +5249,10 @@
   {
     "name": {
       "colorFamily": "yellow",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "dark",
-      "legacyKey": "yellow-visual-color"
+      "legacyKey": "yellow-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cce2b2d8-1969-4a1e-9bc0-b3286b1adbe9",
@@ -4952,9 +5263,10 @@
   {
     "name": {
       "colorFamily": "yellow",
-      "property": "visual-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "legacyKey": "yellow-visual-color"
+      "legacyKey": "yellow-visual-color",
+      "object": "visual"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "51dbf5af-ca84-4c05-9d1f-e516c859d4cc",

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -393,7 +393,8 @@
   },
   {
     "name": {
-      "property": "background-opacity",
+      "object": "background",
+      "property": "opacity",
       "state": ["keyboard-focus"],
       "legacyKey": "background-opacity-key-focus"
     },

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -80,7 +80,9 @@
   {
     "name": {
       "component": "card",
-      "property": "background-loading-color",
+      "object": "background",
+      "property": "color",
+      "state": ["loading"],
       "legacyKey": "card-background-loading-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -979,7 +981,8 @@
     "name": {
       "component": "table",
       "anatomy": "row",
-      "property": "background-opacity",
+      "object": "background",
+      "property": "opacity",
       "state": ["selected"],
       "legacyKey": "table-selected-row-background-opacity"
     },
@@ -991,7 +994,8 @@
     "name": {
       "component": "table",
       "anatomy": "row",
-      "property": "background-opacity",
+      "object": "background",
+      "property": "opacity",
       "state": ["selected", "hover"],
       "legacyKey": "table-selected-row-background-opacity-hover"
     },
@@ -1003,7 +1007,8 @@
     "name": {
       "component": "table",
       "anatomy": "row",
-      "property": "background-opacity",
+      "object": "background",
+      "property": "opacity",
       "state": ["selected"],
       "emphasis": "non-emphasized",
       "legacyKey": "table-selected-row-background-opacity-non-emphasized"
@@ -1016,7 +1021,8 @@
     "name": {
       "component": "table",
       "anatomy": "row",
-      "property": "background-opacity",
+      "object": "background",
+      "property": "opacity",
       "state": ["selected", "hover"],
       "emphasis": "non-emphasized",
       "legacyKey": "table-selected-row-background-opacity-non-emphasized-hover"
@@ -1056,8 +1062,11 @@
   {
     "name": {
       "component": "tree-view",
-      "property": "row-background",
-      "state": ["hover"]
+      "anatomy": "row",
+      "object": "background",
+      "property": "color",
+      "state": ["hover"],
+      "legacyKey": "tree-view-row-background-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -1080,7 +1089,8 @@
     "name": {
       "component": "tree-view",
       "anatomy": "row",
-      "property": "background",
+      "object": "background",
+      "property": "color",
       "state": ["selected", "default"],
       "legacyKey": "tree-view-selected-row-background-default"
     },
@@ -1092,7 +1102,8 @@
     "name": {
       "component": "tree-view",
       "anatomy": "row",
-      "property": "background",
+      "object": "background",
+      "property": "color",
       "state": ["selected", "hover"],
       "legacyKey": "tree-view-selected-row-background-hover"
     },

--- a/packages/design-data/tokens/color-component.tokens.json
+++ b/packages/design-data/tokens/color-component.tokens.json
@@ -2,8 +2,10 @@
   {
     "name": {
       "component": "action-bar",
-      "property": "border-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "object": "border",
+      "legacyKey": "action-bar-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
@@ -14,8 +16,10 @@
   {
     "name": {
       "component": "action-bar",
-      "property": "border-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "object": "border",
+      "legacyKey": "action-bar-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -26,8 +30,10 @@
   {
     "name": {
       "component": "action-bar",
-      "property": "border-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "object": "border",
+      "legacyKey": "action-bar-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
@@ -38,7 +44,9 @@
   {
     "name": {
       "component": "avatar",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "avatar-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "306be0f2-7644-4480-8c83-3bdb1afed54e",
@@ -93,8 +101,9 @@
     "name": {
       "component": "card",
       "anatomy": "well",
-      "property": "background-color",
-      "legacyKey": "card-background-well-color"
+      "property": "color",
+      "legacyKey": "card-background-well-color",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -103,9 +112,11 @@
   {
     "name": {
       "component": "card",
-      "property": "background-color",
+      "property": "color",
       "colorScheme": "light",
-      "anatomy": "selection"
+      "anatomy": "selection",
+      "object": "background",
+      "legacyKey": "card-selection-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
@@ -116,9 +127,11 @@
   {
     "name": {
       "component": "card",
-      "property": "background-color",
+      "property": "color",
       "colorScheme": "dark",
-      "anatomy": "selection"
+      "anatomy": "selection",
+      "object": "background",
+      "legacyKey": "card-selection-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
@@ -129,9 +142,11 @@
   {
     "name": {
       "component": "card",
-      "property": "background-color",
+      "property": "color",
       "colorScheme": "wireframe",
-      "anatomy": "selection"
+      "anatomy": "selection",
+      "object": "background",
+      "legacyKey": "card-selection-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
@@ -174,7 +189,9 @@
   {
     "name": {
       "component": "color-area",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "color-area-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
@@ -183,7 +200,9 @@
   {
     "name": {
       "component": "color-area",
-      "property": "border-opacity"
+      "property": "opacity",
+      "object": "border",
+      "legacyKey": "color-area-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -207,8 +226,9 @@
     "name": {
       "component": "color-handle",
       "position": "inner",
-      "property": "border-color",
-      "legacyKey": "color-handle-inner-border-color"
+      "property": "color",
+      "legacyKey": "color-handle-inner-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -218,8 +238,9 @@
     "name": {
       "component": "color-handle",
       "position": "inner",
-      "property": "border-opacity",
-      "legacyKey": "color-handle-inner-border-opacity"
+      "property": "opacity",
+      "legacyKey": "color-handle-inner-border-opacity",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
@@ -229,8 +250,9 @@
     "name": {
       "component": "color-handle",
       "position": "outer",
-      "property": "border-color",
-      "legacyKey": "color-handle-outer-border-color"
+      "property": "color",
+      "legacyKey": "color-handle-outer-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -240,8 +262,9 @@
     "name": {
       "component": "color-handle",
       "position": "outer",
-      "property": "border-opacity",
-      "legacyKey": "color-handle-outer-border-opacity"
+      "property": "opacity",
+      "legacyKey": "color-handle-outer-border-opacity",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "72b473c6-ec9b-4830-a0f8-48b80070e7b8",
@@ -289,8 +312,9 @@
     "name": {
       "component": "color-loupe",
       "position": "inner",
-      "property": "border-color",
-      "legacyKey": "color-loupe-inner-border"
+      "property": "color",
+      "legacyKey": "color-loupe-inner-border",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
@@ -300,8 +324,9 @@
     "name": {
       "component": "color-loupe",
       "position": "outer",
-      "property": "border-color",
-      "legacyKey": "color-loupe-outer-border"
+      "property": "color",
+      "legacyKey": "color-loupe-outer-border",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "9b799da8-2130-417e-b7ee-5e1154a89837",
@@ -310,7 +335,9 @@
   {
     "name": {
       "component": "color-slider",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "color-slider-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
@@ -319,7 +346,9 @@
   {
     "name": {
       "component": "color-slider",
-      "property": "border-opacity"
+      "property": "opacity",
+      "object": "border",
+      "legacyKey": "color-slider-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -328,7 +357,9 @@
   {
     "name": {
       "component": "color-wheel",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "color-wheel-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
@@ -337,7 +368,9 @@
   {
     "name": {
       "component": "color-wheel",
-      "property": "border-opacity"
+      "property": "opacity",
+      "object": "border",
+      "legacyKey": "color-wheel-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -346,7 +379,9 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "background-color"
+      "property": "color",
+      "object": "background",
+      "legacyKey": "drop-zone-background-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d7414fe1-8b85-45d9-952e-ab6c4c7b7620",
@@ -403,9 +438,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-default",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -418,9 +454,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-default",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -433,9 +470,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-default",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -448,9 +486,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-disabled",
-      "property": "background-color",
+      "property": "color",
       "state": ["disabled"],
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -463,9 +502,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-disabled",
-      "property": "background-color",
+      "property": "color",
       "state": ["disabled"],
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -478,9 +518,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-disabled",
-      "property": "background-color",
+      "property": "color",
       "state": ["disabled"],
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -493,9 +534,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-down",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -508,9 +550,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-down",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -523,9 +566,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-down",
-      "property": "background-color",
+      "property": "color",
       "state": ["down"],
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -538,9 +582,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-hover",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -553,9 +598,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-hover",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -568,9 +614,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-hover",
-      "property": "background-color",
+      "property": "color",
       "state": ["hover"],
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -583,9 +630,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-keyboard-focus",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
-      "colorScheme": "light"
+      "colorScheme": "light",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -598,9 +646,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-keyboard-focus",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
-      "colorScheme": "dark"
+      "colorScheme": "dark",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -613,9 +662,10 @@
       "component": "menu",
       "anatomy": "menu-item",
       "legacyKey": "menu-item-background-color-keyboard-focus",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
-      "colorScheme": "wireframe"
+      "colorScheme": "wireframe",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -675,8 +725,10 @@
   {
     "name": {
       "component": "popover",
-      "property": "border-color",
-      "colorScheme": "light"
+      "property": "color",
+      "colorScheme": "light",
+      "object": "border",
+      "legacyKey": "popover-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
@@ -687,8 +739,10 @@
   {
     "name": {
       "component": "popover",
-      "property": "border-color",
-      "colorScheme": "dark"
+      "property": "color",
+      "colorScheme": "dark",
+      "object": "border",
+      "legacyKey": "popover-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "d1edde4a-c912-42fb-b8d4-e10e6b994d2f",
@@ -699,8 +753,10 @@
   {
     "name": {
       "component": "popover",
-      "property": "border-color",
-      "colorScheme": "wireframe"
+      "property": "color",
+      "colorScheme": "wireframe",
+      "object": "border",
+      "legacyKey": "popover-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -711,8 +767,10 @@
   {
     "name": {
       "component": "popover",
-      "property": "border-opacity",
-      "colorScheme": "light"
+      "property": "opacity",
+      "colorScheme": "light",
+      "object": "border",
+      "legacyKey": "popover-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0",
@@ -723,8 +781,10 @@
   {
     "name": {
       "component": "popover",
-      "property": "border-opacity",
-      "colorScheme": "dark"
+      "property": "opacity",
+      "colorScheme": "dark",
+      "object": "border",
+      "legacyKey": "popover-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "1.0",
@@ -735,8 +795,10 @@
   {
     "name": {
       "component": "popover",
-      "property": "border-opacity",
-      "colorScheme": "wireframe"
+      "property": "opacity",
+      "colorScheme": "wireframe",
+      "object": "border",
+      "legacyKey": "popover-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0",
@@ -747,9 +809,10 @@
   {
     "name": {
       "component": "select-box",
-      "property": "border-color",
+      "property": "color",
       "state": ["selected"],
-      "legacyKey": "select-box-selected-border-color"
+      "legacyKey": "select-box-selected-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -758,8 +821,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
-      "state": ["down"]
+      "property": "color",
+      "state": ["down"],
+      "object": "background",
+      "legacyKey": "stack-item-background-color-down"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -768,8 +833,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
-      "state": ["hover"]
+      "property": "color",
+      "state": ["hover"],
+      "object": "background",
+      "legacyKey": "stack-item-background-color-hover"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -778,9 +845,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
+      "property": "color",
       "state": ["keyboard-focus"],
-      "legacyKey": "stack-item-background-color-key-focus"
+      "legacyKey": "stack-item-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -789,9 +857,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "default"],
-      "legacyKey": "stack-item-selected-background-color-default"
+      "legacyKey": "stack-item-selected-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "16d156d1-4af9-4878-9984-643a2c08aff8",
@@ -800,9 +869,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "down"],
-      "legacyKey": "stack-item-selected-background-color-down"
+      "legacyKey": "stack-item-selected-background-color-down",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dac01571-b26a-4aef-ace7-d0e34e917570",
@@ -811,10 +881,11 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected"],
       "emphasis": "emphasized",
-      "legacyKey": "stack-item-selected-background-color-emphasized"
+      "legacyKey": "stack-item-selected-background-color-emphasized",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "e05251ac-d64a-4157-9b20-224f0392269e",
@@ -823,9 +894,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "hover"],
-      "legacyKey": "stack-item-selected-background-color-hover"
+      "legacyKey": "stack-item-selected-background-color-hover",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -834,9 +906,10 @@
   {
     "name": {
       "component": "stack-item",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected", "keyboard-focus"],
-      "legacyKey": "stack-item-selected-background-color-key-focus"
+      "legacyKey": "stack-item-selected-background-color-key-focus",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "8a182a6b-149b-41a6-b608-fc247bcc298f",
@@ -868,7 +941,9 @@
   {
     "name": {
       "component": "swatch",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "swatch-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
@@ -877,7 +952,9 @@
   {
     "name": {
       "component": "swatch",
-      "property": "border-opacity"
+      "property": "opacity",
+      "object": "border",
+      "legacyKey": "swatch-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
@@ -887,9 +964,10 @@
     "name": {
       "component": "swatch",
       "anatomy": "icon",
-      "property": "border-color",
+      "property": "color",
       "state": ["disabled"],
-      "legacyKey": "swatch-disabled-icon-border-color"
+      "legacyKey": "swatch-disabled-icon-border-color",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
@@ -899,9 +977,10 @@
     "name": {
       "component": "swatch",
       "anatomy": "icon",
-      "property": "border-opacity",
+      "property": "opacity",
       "state": ["disabled"],
-      "legacyKey": "swatch-disabled-icon-border-opacity"
+      "legacyKey": "swatch-disabled-icon-border-opacity",
+      "object": "border"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.42",
@@ -910,7 +989,9 @@
   {
     "name": {
       "component": "swatch-group",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "swatch-group-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "dbe6ded6-404a-4011-9a64-d2375eca73d3",
@@ -956,9 +1037,10 @@
     "name": {
       "component": "table",
       "anatomy": "row",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected"],
-      "legacyKey": "table-selected-row-background-color"
+      "legacyKey": "table-selected-row-background-color",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b40c677-e046-4a49-b421-8a4451844512",
@@ -968,10 +1050,11 @@
     "name": {
       "component": "table",
       "anatomy": "row",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected"],
       "emphasis": "non-emphasized",
-      "legacyKey": "table-selected-row-background-color-non-emphasized"
+      "legacyKey": "table-selected-row-background-color-non-emphasized",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc",
@@ -1034,7 +1117,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "border-color"
+      "property": "color",
+      "object": "border",
+      "legacyKey": "thumbnail-border-color"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f417fb5b-c7cc-41c2-a870-f6cd9a280c22",
@@ -1043,7 +1128,9 @@
   {
     "name": {
       "component": "thumbnail",
-      "property": "border-opacity"
+      "property": "opacity",
+      "object": "border",
+      "legacyKey": "thumbnail-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.1",
@@ -1076,10 +1163,11 @@
     "name": {
       "component": "tree-view",
       "anatomy": "row",
-      "property": "background-color",
+      "property": "color",
       "state": ["selected"],
       "emphasis": "emphasized",
-      "legacyKey": "tree-view-selected-row-background-color-emphasized"
+      "legacyKey": "tree-view-selected-row-background-color-emphasized",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "6b40c677-e046-4a49-b421-8a4451844512",

--- a/packages/design-data/tokens/icons.tokens.json
+++ b/packages/design-data/tokens/icons.tokens.json
@@ -1303,9 +1303,10 @@
   {
     "name": {
       "icon": "icon",
-      "property": "background-color",
+      "property": "color",
       "variant": "inverse",
-      "legacyKey": "icon-color-inverse-background"
+      "legacyKey": "icon-color-inverse-background",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "5233b8b1-4bdd-4253-9973-10a02cd8d1ee",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -4495,7 +4495,9 @@
   {
     "name": {
       "component": "card",
-      "property": "selection-background-size",
+      "anatomy": "selection",
+      "object": "background",
+      "property": "size",
       "legacyKey": "card-selection-background-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5270,7 +5272,9 @@
   {
     "name": {
       "component": "coach-indicator",
-      "property": "collapsed-ring-rounding-increment",
+      "qualifier": "collapsed",
+      "anatomy": "ring",
+      "property": "rounding-increment",
       "legacyKey": "coach-indicator-collapsed-ring-rounding-increment"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5305,7 +5309,9 @@
   {
     "name": {
       "component": "coach-indicator",
-      "property": "expanded-ring-rounding-increment",
+      "qualifier": "expanded",
+      "anatomy": "ring",
+      "property": "rounding-increment",
       "legacyKey": "coach-indicator-expanded-ring-rounding-increment"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5740,7 +5746,9 @@
   {
     "name": {
       "component": "collection-card",
-      "property": "minimum-height-hero-extra-large",
+      "variant": "hero",
+      "property": "minimum-height",
+      "size": "xl",
       "legacyKey": "collection-card-minimum-height-hero-extra-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5750,7 +5758,9 @@
   {
     "name": {
       "component": "collection-card",
-      "property": "minimum-height-hero-extra-small",
+      "variant": "hero",
+      "property": "minimum-height",
+      "size": "xs",
       "legacyKey": "collection-card-minimum-height-hero-extra-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5760,7 +5770,9 @@
   {
     "name": {
       "component": "collection-card",
-      "property": "minimum-height-hero-large",
+      "variant": "hero",
+      "property": "minimum-height",
+      "size": "l",
       "legacyKey": "collection-card-minimum-height-hero-large"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5770,7 +5782,9 @@
   {
     "name": {
       "component": "collection-card",
-      "property": "minimum-height-hero-medium",
+      "variant": "hero",
+      "property": "minimum-height",
+      "size": "m",
       "legacyKey": "collection-card-minimum-height-hero-medium"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -5780,7 +5794,9 @@
   {
     "name": {
       "component": "collection-card",
-      "property": "minimum-height-hero-small",
+      "variant": "hero",
+      "property": "minimum-height",
+      "size": "s",
       "legacyKey": "collection-card-minimum-height-hero-small"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -7132,7 +7148,9 @@
   {
     "name": {
       "component": "drop-zone",
-      "property": "cjk-title-font-size",
+      "script": "cjk",
+      "anatomy": "title",
+      "property": "font-size",
       "legacyKey": "drop-zone-cjk-title-font-size"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
@@ -9223,7 +9241,8 @@
   {
     "name": {
       "component": "menu",
-      "property": "item-section-divider-height",
+      "anatomy": "section-divider",
+      "property": "height",
       "legacyKey": "menu-item-section-divider-height"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -10853,7 +10872,9 @@
   {
     "name": {
       "component": "radio-button",
-      "property": "selection-indicator",
+      "anatomy": "indicator",
+      "state": ["selected"],
+      "property": "width",
       "legacyKey": "radio-button-selection-indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",
@@ -17043,7 +17064,9 @@
   {
     "name": {
       "component": "table",
-      "property": "border-divider-width",
+      "object": "border",
+      "anatomy": "divider",
+      "property": "width",
       "legacyKey": "table-border-divider-width"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",

--- a/packages/design-data/tokens/layout-component.tokens.json
+++ b/packages/design-data/tokens/layout-component.tokens.json
@@ -14798,7 +14798,9 @@
   {
     "name": {
       "component": "swatch-group",
-      "property": "border-opacity"
+      "property": "opacity",
+      "object": "border",
+      "legacyKey": "swatch-group-border-opacity"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/opacity.json",
     "value": "0.2",

--- a/packages/design-data/tokens/layout.tokens.json
+++ b/packages/design-data/tokens/layout.tokens.json
@@ -6034,7 +6034,9 @@
   },
   {
     "name": {
-      "property": "side-focus-indicator",
+      "orientation": "vertical",
+      "anatomy": "focus-indicator",
+      "property": "thickness",
       "legacyKey": "side-focus-indicator"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/dimension.json",

--- a/packages/design-data/tokens/semantic-color-palette.tokens.json
+++ b/packages/design-data/tokens/semantic-color-palette.tokens.json
@@ -163,10 +163,11 @@
     "name": {
       "colorRole": "accent",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "accent-subtle-background-color-default"
+      "legacyKey": "accent-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
@@ -178,10 +179,11 @@
     "name": {
       "colorRole": "accent",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "accent-subtle-background-color-default"
+      "legacyKey": "accent-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "ea67f054-1f42-427e-a768-beb8d21de2a3",
@@ -193,10 +195,11 @@
     "name": {
       "colorRole": "accent",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "accent-subtle-background-color-default"
+      "legacyKey": "accent-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
@@ -423,10 +426,11 @@
     "name": {
       "colorRole": "informative",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "informative-subtle-background-color-default"
+      "legacyKey": "informative-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
@@ -438,10 +442,11 @@
     "name": {
       "colorRole": "informative",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "informative-subtle-background-color-default"
+      "legacyKey": "informative-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a",
@@ -453,10 +458,11 @@
     "name": {
       "colorRole": "informative",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "informative-subtle-background-color-default"
+      "legacyKey": "informative-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
@@ -680,10 +686,11 @@
     "name": {
       "colorRole": "negative",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "negative-subtle-background-color-default"
+      "legacyKey": "negative-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "14919f0c-a40f-48d1-adfd-55826de8e600",
@@ -695,10 +702,11 @@
     "name": {
       "colorRole": "negative",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "negative-subtle-background-color-default"
+      "legacyKey": "negative-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
@@ -710,10 +718,11 @@
     "name": {
       "colorRole": "negative",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "negative-subtle-background-color-default"
+      "legacyKey": "negative-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "14919f0c-a40f-48d1-adfd-55826de8e600",
@@ -885,10 +894,11 @@
     "name": {
       "colorRole": "notice",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "notice-subtle-background-color-default"
+      "legacyKey": "notice-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
@@ -900,10 +910,11 @@
     "name": {
       "colorRole": "notice",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "notice-subtle-background-color-default"
+      "legacyKey": "notice-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd",
@@ -915,10 +926,11 @@
     "name": {
       "colorRole": "notice",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "notice-subtle-background-color-default"
+      "legacyKey": "notice-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
@@ -1090,10 +1102,11 @@
     "name": {
       "colorRole": "positive",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "light",
-      "legacyKey": "positive-subtle-background-color-default"
+      "legacyKey": "positive-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "00a2adcc-7b8a-4e94-97d2-51a647016265",
@@ -1105,10 +1118,11 @@
     "name": {
       "colorRole": "positive",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "dark",
-      "legacyKey": "positive-subtle-background-color-default"
+      "legacyKey": "positive-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "2c75e63f-e628-487d-a143-e03de065d5ee",
@@ -1120,10 +1134,11 @@
     "name": {
       "colorRole": "positive",
       "variant": "subtle",
-      "property": "background-color",
+      "property": "color",
       "state": ["default"],
       "colorScheme": "wireframe",
-      "legacyKey": "positive-subtle-background-color-default"
+      "legacyKey": "positive-subtle-background-color-default",
+      "object": "background"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",
     "$ref": "00a2adcc-7b8a-4e94-97d2-51a647016265",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -1077,7 +1077,7 @@
   },
   {
     "name": {
-      "property": "default-font-family",
+      "property": "font-family",
       "legacyKey": "default-font-family"
     },
     "$schema": "https://opensource.adobe.com/spectrum-design-data/schemas/token-types/alias.json",

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -226,6 +226,13 @@ const VARIANTS_JSON: &str = r##"{
       "usedIn": ["tokens"]
     },
     {
+      "id": "hero",
+      "label": "Hero",
+      "description": "Large featured-card layout variant with maximized visual prominence",
+      "category": "emphasis",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "static",
       "label": "Static",
       "description": "Context variant indicating the token does not change with theme",
@@ -314,6 +321,20 @@ const VARIANTS_JSON: &str = r##"{
       "id": "elevated",
       "label": "Elevated",
       "description": "Elevated surface or shadow context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "base",
+      "label": "Base",
+      "description": "Base (lowest) surface context",
+      "category": "context",
+      "usedIn": ["tokens"]
+    },
+    {
+      "id": "layer",
+      "label": "Layer",
+      "description": "Stacked surface layer context",
       "category": "context",
       "usedIn": ["tokens"]
     },
@@ -1991,6 +2012,11 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "corner-radius",
       "label": "Corner Radius",
       "description": "Corner rounding radius"
+    },
+    {
+      "id": "rounding-increment",
+      "label": "Rounding Increment",
+      "description": "Step size added to a ring or ring-like anatomy's corner rounding per nesting level"
     },
     {
       "id": "outline-width",

--- a/tools/token-mapping-analyzer/scripts/decompose-surface-color-284-8.mjs
+++ b/tools/token-mapping-analyzer/scripts/decompose-surface-color-284-8.mjs
@@ -70,24 +70,12 @@ for (const filename of files) {
       continue;
     }
 
-    const patched = {
+    token.name = {
       ...token.name,
       object: map.object,
       property: map.property,
       legacyKey,
     };
-
-    // Safety check: the patched name object must still resolve to the same
-    // legacy key via the pin (serialize() prefers an explicit legacyKey, so
-    // this mainly guards against a typo in MAPPING).
-    const resolved = patched.legacyKey;
-    if (resolved !== legacyKey) {
-      skipped++;
-      console.warn(`  SKIP (mismatch): ${filename} ${legacyKey}`);
-      continue;
-    }
-
-    token.name = patched;
     applied++;
   }
 

--- a/tools/token-mapping-analyzer/scripts/decompose-surface-color-284-8.mjs
+++ b/tools/token-mapping-analyzer/scripts/decompose-surface-color-284-8.mjs
@@ -1,0 +1,109 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+/**
+ * One-off decomposition for spectrum-design-data-284.8: splits the four
+ * registered legacy-alias atomic properties (background-color, border-color,
+ * visual-color, border-opacity) into object + property. decompose() doesn't
+ * attempt this split itself (it matches the whole registered property term
+ * first), so apply.js's generic --field object pass can't reach these; this
+ * script performs the same whole-object-merge + roundtrip-safety pattern by
+ * hand for exactly this known-safe mapping.
+ *
+ * Usage: node scripts/decompose-surface-color-284-8.mjs [--write]
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { loadRegistries } from "../src/registry-index.js";
+import { serialize } from "../src/decomposer.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../..");
+const CASCADE_DIR = resolve(REPO_ROOT, "packages/design-data/tokens");
+const write = process.argv.includes("--write");
+
+const MAPPING = {
+  "background-color": { object: "background", property: "color" },
+  "border-color": { object: "border", property: "color" },
+  "visual-color": { object: "visual", property: "color" },
+  "border-opacity": { object: "border", property: "opacity" },
+};
+
+const registry = loadRegistries();
+const files = readdirSync(CASCADE_DIR)
+  .filter((f) => f.endsWith(".tokens.json"))
+  .sort();
+
+let totalApplied = 0;
+let totalSkipped = 0;
+
+for (const filename of files) {
+  const filePath = resolve(CASCADE_DIR, filename);
+  const tokens = JSON.parse(readFileSync(filePath, "utf-8"));
+  let applied = 0;
+  let skipped = 0;
+
+  for (const token of tokens) {
+    if (!token.name || typeof token.name !== "object") continue;
+    if (token.deprecated) continue;
+    const map = MAPPING[token.name.property];
+    if (!map) continue;
+    if (token.name.object !== undefined) continue; // already migrated
+
+    // Legacy key must be pinned explicitly regardless of whether it already
+    // was, exactly as for every other decomposition in this epic-284 sweep.
+    const legacyKey =
+      token.name.legacyKey ??
+      serialize(token.name, registry.tokenNameMap, registry.serializationOrder);
+    if (!legacyKey) {
+      skipped++;
+      console.warn(`  SKIP (no legacyKey derivable): ${filename} ${JSON.stringify(token.name)}`);
+      continue;
+    }
+
+    const patched = {
+      ...token.name,
+      object: map.object,
+      property: map.property,
+      legacyKey,
+    };
+
+    // Safety check: the patched name object must still resolve to the same
+    // legacy key via the pin (serialize() prefers an explicit legacyKey, so
+    // this mainly guards against a typo in MAPPING).
+    const resolved = patched.legacyKey;
+    if (resolved !== legacyKey) {
+      skipped++;
+      console.warn(`  SKIP (mismatch): ${filename} ${legacyKey}`);
+      continue;
+    }
+
+    token.name = patched;
+    applied++;
+  }
+
+  totalApplied += applied;
+  totalSkipped += skipped;
+  if (applied > 0) {
+    console.log(`  ${filename}: ${applied} applied`);
+    if (write) {
+      writeFileSync(filePath, JSON.stringify(tokens, null, 2) + "\n");
+    }
+  }
+}
+
+console.log(`\n=== surface-color decomposition (284.8)${write ? " (WROTE)" : " (dry run)"} ===`);
+console.log(`  Applied: ${totalApplied}`);
+console.log(`  Skipped: ${totalSkipped}`);
+if (!write && totalApplied > 0) {
+  console.log("\nRun with --write to persist.");
+}

--- a/tools/token-mapping-analyzer/test/apply.test.js
+++ b/tools/token-mapping-analyzer/test/apply.test.js
@@ -49,6 +49,7 @@ const OTHER_DECOMPOSABLE_FIELDS = [
   "contrast",
   "easing",
   "motionRole",
+  "icon",
 ];
 
 /** Recursively collect every token object decomposed for `size` alone. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Three-part follow-up to #1313 (284.3), sweeping up the remaining property-fusion
residue that the earlier audit's `token` (legacyKey-shaped) filter missed.

### 284.6 — background/opacity residue

- **packages/design-data/tokens/color-aliases.tokens.json**: split
  `background-opacity-key-focus` into `object`/`property`, matching the
  sibling `background-*-opacity` state tokens.
- **packages/design-data/tokens/color-component.tokens.json**: split
  `card-background-loading-color`, `table-selected-row-background-opacity`
  (+ hover/non-emphasized variants), `tree-view-row-background-hover`, and
  `tree-view-selected-row-background-{default,hover}` into `object`/`property`,
  keeping existing `legacyKey` pins.

`stack-item-selected-background-color-highlight` was left unsplit — it fails
legacy-verify with `component: "stack-item"` set (the reference legacy JSON
has no `component` field for this token), and `anatomy: "item"` isn't
`standaloneScope`-flagged, so it would trip a new SPEC-025 error. That's a
registry decision, not a data-only change — out of scope here.

### 284.7 — final misc single-off residue

- **registry/variants.json**: register `base`/`layer` (context) and `hero`
  (card emphasis) variant ids.
- **registry/property-terms.json**: register `rounding-increment`.
- **color-aliases.tokens.json**: `background-{base,layer-1,layer-2}-color`
  split into `variant`/`object`/`property`.
- **typography.tokens.json**: `default-font-family` simplified to atomic
  `property:"font-family"`.
- **layout-component.tokens.json**: split `card-selection-background-size`,
  coach-indicator ring rounding-increments, `menu-item-section-divider-
  height`, `radio-button-selection-indicator` (adds `state:["selected"]`),
  `table-border-divider-width`, `collection-card-minimum-height-hero-*` (5),
  `drop-zone-cjk-title-font-size`.
- **layout.tokens.json**: `side-focus-indicator` (vertical-tabs selection
  indicator) split into `orientation:"vertical"`/`anatomy:"focus-
  indicator"`/`property:"thickness"`, reusing existing vocabulary.
- `opacity-checkerboard-square-{dark,light}` intentionally left atomic — a
  design-asset checkerboard swatch, not a styling surface.

### 284.8 — surface-color legacy alias residue

The remaining `surface-colorRole` fusion bucket (179 unique tokens): registered
legacy-alias atomic property terms (`background-color`, `border-color`,
`visual-color`, `border-opacity`) that still structurally fused an `object`
concept into `property`. Team decision (Slack poll): split all four; leave
`content-color`/`fill-color` atomic (established precedent).

- **color-aliases.tokens.json**, **color-component.tokens.json**,
  **icons.tokens.json**, **layout-component.tokens.json**,
  **semantic-color-palette.tokens.json**: split `background-color` →
  `object:"background"` + `property:"color"`, `border-color` →
  `object:"border"` + `property:"color"`, `visual-color` →
  `object:"visual"` + `property:"color"`, `border-opacity` →
  `object:"border"` + `property:"opacity"`, across 353 token entries, with an
  explicit `legacyKey` pin on every changed token.
- Deprecated tokens with these properties were left untouched (out of scope).

## Related Issue

Closes spectrum-design-data-284.6, spectrum-design-data-284.7, and
spectrum-design-data-284.8 (part of epic spectrum-design-data-284,
"Decompose fused token-name property values into structured fields").

## Motivation and Context

284.3 (#1313) decomposed the bulk of surface/colorRole/anatomy fusion, but a
re-audit by the actual current `property` field (rather than the legacyKey-
shaped display string) turned up three more waves of residue: 8 background/
opacity tokens (284.6), a final grab-bag of one-off fusions across components
(284.7), and the last open `surface-colorRole` bucket of registered
legacy-alias properties (284.8). This PR closes all three.

## How Has This Been Tested?

- `cargo run -p design-data-cli -- migrate legacy-verify --reference packages/tokens/src packages/design-data/tokens` — byte-identical legacy output.
- `cargo run -p design-data-cli -- migrate roundtrip-verify packages/tokens/src` — OK.
- `moon run design-data:validate` — 0 SPEC-025 errors.
- `moon run sdk:codegen`, `moon run sdk:codegen-check`, `moon run sdk:test`, `moon run sdk:lint` — all pass.
- `moon run :test` (JS/AVA across the monorepo) — all pass.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` — both changesets valid.
- Re-ran `tools/token-mapping-analyzer` — residue now limited to intentionally-atomic tokens (`opacity-checkerboard-*`, `content-color`), deprecated tokens (skipped by design), and pre-existing unrelated outliers (`stack-item-background-color`, `border-dash-gap/length`, etc.).

## Screenshots (if appropriate):

N/A — data-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

