### PR TITLE
fix(design-data): decompose typography component-scale fusion (284.9)

### DIFF
--- a/.changeset/decompose-typography-component-scale.md
+++ b/.changeset/decompose-typography-component-scale.md
@@ -1,0 +1,15 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose the last fused `name.property` residue: the 15 `component-{size}-{weight}`
+typography tokens (closes spectrum-design-data-284.9). Legacy output is unchanged
+(`legacyKey` pinned throughout).
+
+- **packages/design-data/tokens/typography.tokens.json**: split `component-l-bold` etc.
+  into `variant:"component"` + `property:"typography"` + `size` + existing `weight`.
+- **packages/design-data/registry/variants.json**: registered `component` under a new
+  `typography-role` category (compact in-component scale, alongside body/detail/heading/title).
+- **packages/design-data/registry/property-terms.json**: registered `typography`
+  (composite type-style property, the only non-atomic typography term left in the corpus).
+- **sdk/core/src/registry_data.rs**: regenerated from the registry JSON above.

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -194,6 +194,11 @@
       "description": "Horizontal spacing between characters"
     },
     {
+      "id": "typography",
+      "label": "Typography",
+      "description": "Composite type style bundling font family, size, weight, letter-spacing, and line-height in one value"
+    },
+    {
       "id": "text-align",
       "label": "Text Align",
       "description": "Horizontal alignment of text content"

--- a/packages/design-data/registry/property-terms.json
+++ b/packages/design-data/registry/property-terms.json
@@ -54,6 +54,16 @@
       "description": "CSS outline color"
     },
     {
+      "id": "square-dark",
+      "label": "Square (Dark)",
+      "description": "Color of the darker of the two alternating tiles in an opacity checkerboard pattern. \"Dark\" identifies the tile's fixed relative lightness (paired with square-light), not the surrounding colorScheme theme — this token still varies per colorScheme."
+    },
+    {
+      "id": "square-light",
+      "label": "Square (Light)",
+      "description": "Color of the lighter of the two alternating tiles in an opacity checkerboard pattern. \"Light\" identifies the tile's fixed relative lightness (paired with square-dark), not the surrounding colorScheme theme — this token still varies per colorScheme."
+    },
+    {
       "id": "opacity",
       "label": "Opacity",
       "description": "Element transparency level"

--- a/packages/design-data/registry/variants.json
+++ b/packages/design-data/registry/variants.json
@@ -229,6 +229,13 @@
       "usedIn": ["tokens"]
     },
     {
+      "id": "component",
+      "label": "Component",
+      "description": "Compact in-component typography scale, alongside the page-level body/detail/heading/title roles",
+      "category": "typography-role",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "static",
       "label": "Static",
       "description": "Context variant indicating the token does not change with theme",

--- a/packages/design-data/tokens/typography.tokens.json
+++ b/packages/design-data/tokens/typography.tokens.json
@@ -837,7 +837,9 @@
   },
   {
     "name": {
-      "property": "component-l-bold",
+      "variant": "component",
+      "property": "typography",
+      "size": "l",
       "weight": "bold",
       "legacyKey": "component-l-bold"
     },
@@ -853,7 +855,9 @@
   },
   {
     "name": {
-      "property": "component-l-medium",
+      "variant": "component",
+      "property": "typography",
+      "size": "l",
       "weight": "medium",
       "legacyKey": "component-l-medium"
     },
@@ -869,7 +873,9 @@
   },
   {
     "name": {
-      "property": "component-l-regular",
+      "variant": "component",
+      "property": "typography",
+      "size": "l",
       "weight": "regular",
       "legacyKey": "component-l-regular"
     },
@@ -885,7 +891,9 @@
   },
   {
     "name": {
-      "property": "component-m-bold",
+      "variant": "component",
+      "property": "typography",
+      "size": "m",
       "weight": "bold",
       "legacyKey": "component-m-bold"
     },
@@ -901,7 +909,9 @@
   },
   {
     "name": {
-      "property": "component-m-medium",
+      "variant": "component",
+      "property": "typography",
+      "size": "m",
       "weight": "medium",
       "legacyKey": "component-m-medium"
     },
@@ -917,7 +927,9 @@
   },
   {
     "name": {
-      "property": "component-m-regular",
+      "variant": "component",
+      "property": "typography",
+      "size": "m",
       "weight": "regular",
       "legacyKey": "component-m-regular"
     },
@@ -933,7 +945,9 @@
   },
   {
     "name": {
-      "property": "component-s-bold",
+      "variant": "component",
+      "property": "typography",
+      "size": "s",
       "weight": "bold",
       "legacyKey": "component-s-bold"
     },
@@ -949,7 +963,9 @@
   },
   {
     "name": {
-      "property": "component-s-medium",
+      "variant": "component",
+      "property": "typography",
+      "size": "s",
       "weight": "medium",
       "legacyKey": "component-s-medium"
     },
@@ -965,7 +981,9 @@
   },
   {
     "name": {
-      "property": "component-s-regular",
+      "variant": "component",
+      "property": "typography",
+      "size": "s",
       "weight": "regular",
       "legacyKey": "component-s-regular"
     },
@@ -981,7 +999,9 @@
   },
   {
     "name": {
-      "property": "component-xl-bold",
+      "variant": "component",
+      "property": "typography",
+      "size": "xl",
       "weight": "bold",
       "legacyKey": "component-xl-bold"
     },
@@ -997,7 +1017,9 @@
   },
   {
     "name": {
-      "property": "component-xl-medium",
+      "variant": "component",
+      "property": "typography",
+      "size": "xl",
       "weight": "medium",
       "legacyKey": "component-xl-medium"
     },
@@ -1013,7 +1035,9 @@
   },
   {
     "name": {
-      "property": "component-xl-regular",
+      "variant": "component",
+      "property": "typography",
+      "size": "xl",
       "weight": "regular",
       "legacyKey": "component-xl-regular"
     },
@@ -1029,7 +1053,9 @@
   },
   {
     "name": {
-      "property": "component-xs-bold",
+      "variant": "component",
+      "property": "typography",
+      "size": "xs",
       "weight": "bold",
       "legacyKey": "component-xs-bold"
     },
@@ -1045,7 +1071,9 @@
   },
   {
     "name": {
-      "property": "component-xs-medium",
+      "variant": "component",
+      "property": "typography",
+      "size": "xs",
       "weight": "medium",
       "legacyKey": "component-xs-medium"
     },
@@ -1061,7 +1089,9 @@
   },
   {
     "name": {
-      "property": "component-xs-regular",
+      "variant": "component",
+      "property": "typography",
+      "size": "xs",
       "weight": "regular",
       "legacyKey": "component-xs-regular"
     },

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -1931,6 +1931,16 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "description": "CSS outline color"
     },
     {
+      "id": "square-dark",
+      "label": "Square (Dark)",
+      "description": "Color of the darker of the two alternating tiles in an opacity checkerboard pattern. \"Dark\" identifies the tile's fixed relative lightness (paired with square-light), not the surrounding colorScheme theme — this token still varies per colorScheme."
+    },
+    {
+      "id": "square-light",
+      "label": "Square (Light)",
+      "description": "Color of the lighter of the two alternating tiles in an opacity checkerboard pattern. \"Light\" identifies the tile's fixed relative lightness (paired with square-dark), not the surrounding colorScheme theme — this token still varies per colorScheme."
+    },
+    {
       "id": "opacity",
       "label": "Opacity",
       "description": "Element transparency level"

--- a/sdk/core/src/registry_data.rs
+++ b/sdk/core/src/registry_data.rs
@@ -233,6 +233,13 @@ const VARIANTS_JSON: &str = r##"{
       "usedIn": ["tokens"]
     },
     {
+      "id": "component",
+      "label": "Component",
+      "description": "Compact in-component typography scale, alongside the page-level body/detail/heading/title roles",
+      "category": "typography-role",
+      "usedIn": ["tokens"]
+    },
+    {
       "id": "static",
       "label": "Static",
       "description": "Context variant indicating the token does not change with theme",
@@ -2062,6 +2069,11 @@ const PROPERTY_TERMS_JSON: &str = r##"{
       "id": "letter-spacing",
       "label": "Letter Spacing",
       "description": "Horizontal spacing between characters"
+    },
+    {
+      "id": "typography",
+      "label": "Typography",
+      "description": "Composite type style bundling font family, size, weight, letter-spacing, and line-height in one value"
     },
     {
       "id": "text-align",

--- a/tools/token-mapping-analyzer/src/decomposer.js
+++ b/tools/token-mapping-analyzer/src/decomposer.js
@@ -72,6 +72,17 @@ export const COMPOUND_PROPERTIES = [
   "width-multiplier",
   "minimum-width-multiplier",
   "maximum-width-multiplier",
+  // Registered atomic property terms whose segments happen to collide with
+  // an unrelated object/anatomy registry id -- kept atomic per bead 284.3/284.9
+  // judgment calls, not decomposition gaps. "content" is also a registered
+  // object id (header/footer-content anatomy); "square" is a registered
+  // anatomy id (opacity-checkerboard design asset).
+  "content-color",
+  "square-dark",
+  "square-light",
+  // "row" is a registered anatomy id, but "row-height" (table section header)
+  // is its own atomic sizing concept, not anatomy:"row" + property:"height".
+  "row-height",
 ];
 
 /**


### PR DESCRIPTION
## Description

Finishes epic spectrum-design-data-284 (fused `name.property` decomposition): the last
genuine residue was the 15 `component-{size}-{weight}` typography tokens, which fused a
typography-role variant, the composite type-style property, and a t-shirt size into one
string. This PR also fixes two false positives in the `tools/token-mapping-analyzer`
residue detector and documents the `opacity-checkerboard-square-{dark,light}` property
terms that were flagged by it.

- **packages/design-data/tokens/typography.tokens.json**: split `component-l-bold` etc.
  into `variant:"component"` + `property:"typography"` + `size` + existing `weight`.
  `legacyKey` is pinned throughout, so legacy output is unchanged.
- **packages/design-data/registry/variants.json**: registered `component` under a new
  `typography-role` category (compact in-component scale, alongside body/detail/heading/title).
- **packages/design-data/registry/property-terms.json**: registered `typography`
  (composite type-style property) and `square-dark`/`square-light` (opacity-checkerboard
  tile color, kept atomic — "dark"/"light" identify the tile's fixed relative lightness,
  not the surrounding colorScheme theme, so decomposing further would collide with
  `colorScheme` semantics).
- **sdk/core/src/registry_data.rs**: regenerated from the registry JSON above.
- **tools/token-mapping-analyzer/src/decomposer.js**: stop flagging `content-color`,
  `square-dark`, `square-light`, and `row-height` as unresolved fusion — they're
  registered atomic property terms whose segments happen to collide with an unrelated
  object/anatomy registry id, not real decomposition gaps.

## Related Issue

Closes spectrum-design-data-284.9.

## Motivation and Context

Last item in the 284 fusion-residue sweep — after this, every `name.property` in the
corpus is atomic, with fused segments moved to structured fields.

## How Has This Been Tested?

- `cargo run -p design-data-cli -- migrate legacy-verify` — legacy output OK, byte-identical.
- `cargo run -p design-data-cli -- migrate roundtrip-verify` — roundtrip OK.
- `moon run design-data:validate sdk:test sdk:lint` — all green.
- `moon run :test` (JS/AVA) — all green except a pre-existing `sdk-wasm:test` parity
  failure (`Dataset.embedded() query result .raw is a plain object, not a Map`),
  confirmed to fail identically on `main` in an isolated worktree — unrelated to this change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
