### PR TITLE
fix(design-data): decompose stack-item background-highlight fusion (284)

### DIFF
--- a/.changeset/decompose-stack-item-background-highlight.md
+++ b/.changeset/decompose-stack-item-background-highlight.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": patch
+---
+
+Decompose the last remaining fused `name.property`: the stack-item selected/highlight
+background-color token (closes spectrum-design-data-284). Legacy output is unchanged
+(`legacyKey` pinned).
+
+- **packages/design-data/tokens/color-aliases.tokens.json**: split
+  `stack-item-selected-background-color-highlight`'s fused `stack-item-background-color`
+  property into `object:"background"` + `property:"color"`. The `stack-item` prefix isn't
+  reintroduced as a `component` field — the legacy reference data for this cross-component
+  alias never tagged it with one, so `legacyKey` is the only place it's preserved.

--- a/packages/design-data/tokens/color-aliases.tokens.json
+++ b/packages/design-data/tokens/color-aliases.tokens.json
@@ -5276,8 +5276,9 @@
   },
   {
     "name": {
+      "object": "background",
+      "property": "color",
       "state": ["selected"],
-      "property": "stack-item-background-color",
       "qualifier": "highlight",
       "legacyKey": "stack-item-selected-background-color-highlight"
     },


### PR DESCRIPTION
## Description

Closes out epic spectrum-design-data-284 (fused `name.property` decomposition). This was
the last remaining fused property in the whole corpus, found via a re-run of the
`tools/token-mapping-analyzer` residue analyzer after #1315 merged.

- **packages/design-data/tokens/color-aliases.tokens.json**: split the
  `stack-item-selected-background-color-highlight` token's fused `stack-item-background-color`
  property into `object:"background"` + `property:"color"`. No `component` field was added —
  the legacy reference data (`packages/tokens/src`) for this cross-component alias never
  tagged it with one (unlike sibling `stack-item-background-color-*` tokens in
  `color-component.tokens.json`, which do carry `component:"stack-item"` because their
  legacy reference does too). Adding `component` here caused a real `legacy-verify`
  mismatch, so `stack-item` stays only in the pinned `legacyKey`.

## Related Issue

Closes spectrum-design-data-284.

## Motivation and Context

`node tools/token-mapping-analyzer/src/index.js` now reports `Fused properties (active): 0`
— every `name.property` in the corpus is atomic.

## How Has This Been Tested?

- `cargo run -p design-data-cli -- migrate legacy-verify` — legacy output OK, byte-identical.
- `cargo run -p design-data-cli -- migrate roundtrip-verify` — roundtrip OK.
- `moon run design-data:validate sdk:test sdk:lint` — all green.
- `moon run :test` (JS/AVA) — all green except the pre-existing `sdk-wasm:test` parity
  failure (`Dataset.embedded() query result .raw is a plain object, not a Map`), already
  confirmed unrelated (fails identically on `main`).
- Re-ran the token-mapping-analyzer residue report to confirm zero fused properties remain.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
