### PR TITLE
feat(design-data): teach Figma export generator to honor name-mapping overrides (11k.5)

### DIFF
--- a/.changeset/figma-mapping-overrides.md
+++ b/.changeset/figma-mapping-overrides.md
@@ -1,0 +1,13 @@
+---
+"@adobe/spectrum-design-data": minor
+---
+
+The Figma export generator now honors a name-mapping override artifact
+(closes spectrum-design-data-11k.5).
+
+- **sdk/core/src/figma/mapping.rs**: `build_export_payload` takes an optional
+  `overrides: Option<&HashMap<String, String>>` (legacyKey to Figma name);
+  absent or empty overrides keep today's `{prefix}/{legacyKey}` naming.
+- **sdk/cli/src/main.rs**: `figma export` gains a `--mapping <PATH>` flag
+  that loads overrides from a `figma audit` artifact (or a bare
+  `{legacyKey: name}` JSON object).

--- a/.changeset/figma-mapping-overrides.md
+++ b/.changeset/figma-mapping-overrides.md
@@ -7,7 +7,8 @@ The Figma export generator now honors a name-mapping override artifact
 
 - **sdk/core/src/figma/mapping.rs**: `build_export_payload` takes an optional
   `overrides: Option<&HashMap<String, String>>` (legacyKey to Figma name);
-  absent or empty overrides keep today's `{prefix}/{legacyKey}` naming.
+  absent or empty overrides keep today's `{prefix}/{legacyKey}` naming;
+  remapping an existing name creates a new variable rather than renaming.
 - **sdk/cli/src/main.rs**: `figma export` gains a `--mapping <PATH>` flag
   that loads overrides from a `figma audit` artifact (or a bare
   `{legacyKey: name}` JSON object).

--- a/sdk/cli/src/main.rs
+++ b/sdk/cli/src/main.rs
@@ -18,7 +18,7 @@ mod data;
 mod format;
 mod lifecycle;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use design_data_core::cache;
@@ -452,6 +452,10 @@ enum FigmaSub {
         /// Generate payload without calling the API
         #[arg(long)]
         dry_run: bool,
+        /// Path to a name-mapping override artifact (from `figma audit`); overrides
+        /// take precedence over the default `{prefix}/{legacyKey}` naming
+        #[arg(long, value_name = "PATH")]
+        mapping: Option<PathBuf>,
     },
     /// Audit generated Figma Variable names against a captured snapshot (offline, no API call)
     Audit {
@@ -1110,14 +1114,43 @@ fn run_query(
     }
 }
 
+/// Load a legacyKey → Figma-name override map from a `figma audit` artifact
+/// (which nests it under an `overrides` field) or a bare `{legacyKey: name}`
+/// JSON object. Empty-string values (the artifact's "needs a decision"
+/// placeholder) are dropped.
+fn load_overrides(path: &Path) -> miette::Result<HashMap<String, String>> {
+    let text = std::fs::read_to_string(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("reading mapping file {}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("parsing mapping file {}", path.display()))?;
+    let map = value.get("overrides").unwrap_or(&value);
+    let entries = map
+        .as_object()
+        .ok_or_else(|| miette::miette!("mapping file {} is not a JSON object", path.display()))?;
+    Ok(entries
+        .iter()
+        .filter_map(|(k, v)| {
+            v.as_str()
+                .filter(|s| !s.is_empty())
+                .map(|s| (k.clone(), s.to_string()))
+        })
+        .collect())
+}
+
 fn run_figma_export(
     path: &Path,
     file_key: &str,
     token: &str,
     dry_run: bool,
+    mapping: Option<&Path>,
 ) -> miette::Result<ExitCode> {
     let rt = tokio::runtime::Runtime::new().into_diagnostic()?;
     let client = figma::api::FigmaClient::new(token.to_string());
+
+    // 0. Load name-mapping overrides, if given.
+    let overrides = mapping.map(load_overrides).transpose()?;
 
     // 1. GET existing variables to obtain collection/mode IDs.
     eprintln!("Fetching existing variables from Figma...");
@@ -1127,8 +1160,9 @@ fn run_figma_export(
 
     // 2. Build the export payload.
     eprintln!("Building export payload from {}...", path.display());
-    let (body, summary) = figma::mapping::build_export_payload(path, &response.meta)
-        .map_err(|e| miette::miette!("{e}"))?;
+    let (body, summary) =
+        figma::mapping::build_export_payload(path, &response.meta, overrides.as_ref())
+            .map_err(|e| miette::miette!("{e}"))?;
 
     // 3. Output or post.
     if dry_run {
@@ -1808,7 +1842,8 @@ fn main() -> ExitCode {
                 file_key,
                 token,
                 dry_run,
-            } => run_figma_export(&path, &file_key, &token, dry_run),
+                mapping,
+            } => run_figma_export(&path, &file_key, &token, dry_run, mapping.as_deref()),
             FigmaSub::Audit {
                 snapshot,
                 token_dir,

--- a/sdk/core/src/figma/audit.rs
+++ b/sdk/core/src/figma/audit.rs
@@ -65,7 +65,7 @@ pub struct AuditReport {
 /// [`crate::legacy::convert_dir`] produces from cascade `.tokens.json` files,
 /// not the cascade format itself.
 pub fn audit_names(existing: &VariablesMeta, token_dir: &Path) -> Result<AuditReport, FigmaError> {
-    let (body, summary) = build_export_payload(token_dir, existing)?;
+    let (body, summary) = build_export_payload(token_dir, existing, None)?;
 
     // Real variable names per collection, from the snapshot (non-remote only,
     // matching summarize_variables' existing convention). The real file has

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -113,6 +113,11 @@ pub struct ExportSummary {
 ///
 /// `existing` is the result of `GET /v1/files/:file_key/variables/local` —
 /// used to look up collection and mode IDs for the target collections.
+///
+/// `overrides` maps a legacy token key to an explicit Figma Variable name
+/// (from a `figma audit` artifact); keys absent from the map fall back to the
+/// default `{prefix}/{legacyKey}` naming. `None` or an empty map preserves
+/// today's naming for every token.
 pub fn build_export_payload(
     token_dir: &Path,
     existing: &VariablesMeta,
@@ -431,6 +436,10 @@ fn make_variable_action(
         .and_then(|m| m.get(token_name))
         .cloned()
         .unwrap_or_else(|| format!("{prefix}/{token_name}"));
+    // Match against the final (possibly overridden) name. An override that
+    // points at a name not already in the file produces a CREATE, not a
+    // rename of the old variable — Figma's variables payload has no rename
+    // action, so remapping an existing token surfaces as a new variable.
     let (action, id, var_id) =
         if let Some(&existing_id) = existing_var_index.get(figma_name.as_str()) {
             let real_id = existing_id.to_string();

--- a/sdk/core/src/figma/mapping.rs
+++ b/sdk/core/src/figma/mapping.rs
@@ -116,6 +116,7 @@ pub struct ExportSummary {
 pub fn build_export_payload(
     token_dir: &Path,
     existing: &VariablesMeta,
+    overrides: Option<&HashMap<String, String>>,
 ) -> Result<(PostVariablesBody, ExportSummary), FigmaError> {
     // 1. Look up collection and mode IDs from the existing file.
     let color_col =
@@ -174,6 +175,7 @@ pub fn build_export_payload(
                 &color_mode_ids,
                 &value_index,
                 &existing_var_index,
+                overrides,
                 &mut variables,
                 &mut mode_values,
                 &mut summary,
@@ -187,6 +189,7 @@ pub fn build_export_payload(
                 &scale_mode_ids,
                 &value_index,
                 &existing_var_index,
+                overrides,
                 &mut variables,
                 &mut mode_values,
                 &mut summary,
@@ -202,6 +205,7 @@ pub fn build_export_payload(
                 color_default_mode,
                 &value_index,
                 &existing_var_index,
+                overrides,
                 &mut variables,
                 &mut mode_values,
                 &mut summary,
@@ -218,6 +222,7 @@ pub fn build_export_payload(
                 &value_index,
                 &all_tokens,
                 &existing_var_index,
+                overrides,
                 &mut variables,
                 &mut mode_values,
                 &mut summary,
@@ -240,6 +245,7 @@ pub fn build_export_payload(
                 scale_default_mode,
                 &value_index,
                 &existing_var_index,
+                overrides,
                 &mut variables,
                 &mut mode_values,
                 &mut summary,
@@ -411,6 +417,7 @@ fn value_to_figma(value_str: &str, figma_type: &str) -> Option<Value> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn make_variable_action(
     token_name: &str,
     prefix: &str,
@@ -418,8 +425,12 @@ fn make_variable_action(
     figma_type: &str,
     description: Option<&str>,
     existing_var_index: &HashMap<&str, &str>,
+    overrides: Option<&HashMap<String, String>>,
 ) -> (VariableAction, String) {
-    let figma_name = format!("{prefix}/{token_name}");
+    let figma_name = overrides
+        .and_then(|m| m.get(token_name))
+        .cloned()
+        .unwrap_or_else(|| format!("{prefix}/{token_name}"));
     let (action, id, var_id) =
         if let Some(&existing_id) = existing_var_index.get(figma_name.as_str()) {
             let real_id = existing_id.to_string();
@@ -453,6 +464,7 @@ fn process_color_set_token(
     mode_ids: &HashMap<String, String>,
     value_index: &HashMap<String, String>,
     existing_var_index: &HashMap<&str, &str>,
+    overrides: Option<&HashMap<String, String>>,
     variables: &mut Vec<VariableAction>,
     mode_values: &mut Vec<ModeValueAction>,
     summary: &mut ExportSummary,
@@ -483,6 +495,7 @@ fn process_color_set_token(
         figma_type,
         desc,
         existing_var_index,
+        overrides,
     );
     variables.push(va);
     summary.variables_created += 1;
@@ -526,6 +539,7 @@ fn process_scale_set_token(
     mode_ids: &HashMap<String, String>,
     value_index: &HashMap<String, String>,
     existing_var_index: &HashMap<&str, &str>,
+    overrides: Option<&HashMap<String, String>>,
     variables: &mut Vec<VariableAction>,
     mode_values: &mut Vec<ModeValueAction>,
     summary: &mut ExportSummary,
@@ -579,6 +593,7 @@ fn process_scale_set_token(
         figma_type,
         desc,
         existing_var_index,
+        overrides,
     );
     variables.push(va);
     summary.variables_created += 1;
@@ -623,6 +638,7 @@ fn process_flat_token(
     default_mode_id: &str,
     value_index: &HashMap<String, String>,
     existing_var_index: &HashMap<&str, &str>,
+    overrides: Option<&HashMap<String, String>>,
     variables: &mut Vec<VariableAction>,
     mode_values: &mut Vec<ModeValueAction>,
     summary: &mut ExportSummary,
@@ -666,6 +682,7 @@ fn process_flat_token(
         figma_type,
         desc,
         existing_var_index,
+        overrides,
     );
     variables.push(va);
     summary.variables_created += 1;
@@ -690,6 +707,7 @@ fn process_alias_token(
     value_index: &HashMap<String, String>,
     all_tokens: &[(String, Value)],
     existing_var_index: &HashMap<&str, &str>,
+    overrides: Option<&HashMap<String, String>>,
     variables: &mut Vec<VariableAction>,
     mode_values: &mut Vec<ModeValueAction>,
     summary: &mut ExportSummary,
@@ -774,6 +792,7 @@ fn process_alias_token(
         figma_type,
         desc,
         existing_var_index,
+        overrides,
     );
     variables.push(va);
     summary.variables_created += 1;
@@ -865,7 +884,7 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
         assert_eq!(summary.variables_created, 1);
         assert_eq!(summary.mode_values_set, 3);
         assert_eq!(body.variables.len(), 1);
@@ -894,13 +913,51 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
         assert_eq!(summary.variables_created, 1);
         assert_eq!(body.variables[0].name, "platformScale/spacing-100");
         assert_eq!(body.variables[0].resolved_type, "FLOAT");
         // Value should be 8.0
         let val = &body.variable_mode_values[0].value;
         assert_eq!(val.as_f64(), Some(8.0));
+    }
+
+    #[test]
+    fn override_remaps_name_absent_override_stays_1to1() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("layout.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            "{}",
+            json!({
+                "spacing-100": {
+                    "$schema": "https://example.com/dimension.json",
+                    "value": "8px",
+                    "uuid": "d1"
+                },
+                "spacing-200": {
+                    "$schema": "https://example.com/dimension.json",
+                    "value": "16px",
+                    "uuid": "d2"
+                }
+            })
+        )
+        .unwrap();
+
+        let meta = mock_meta();
+        let overrides: HashMap<String, String> = [(
+            "spacing-100".to_string(),
+            "Layout/spacing-100-real".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let (body, _summary) = build_export_payload(dir.path(), &meta, Some(&overrides)).unwrap();
+
+        let by_name = |n: &str| body.variables.iter().find(|v| v.name == n);
+        assert!(by_name("Layout/spacing-100-real").is_some());
+        assert!(by_name("platformScale/spacing-200").is_some());
     }
 
     #[test]
@@ -928,7 +985,7 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (_body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        let (_body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
         // base-color (flat color) + alias-color (alias→color)
         assert_eq!(summary.variables_created, 2);
         assert!(summary.skipped_alias_unresolved.is_empty());
@@ -974,7 +1031,7 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
 
         assert!(
             summary.skipped_alias_unresolved.is_empty(),
@@ -1035,7 +1092,7 @@ mod tests {
         .unwrap();
 
         let meta = mock_meta();
-        let (body, summary) = build_export_payload(dir.path(), &meta).unwrap();
+        let (body, summary) = build_export_payload(dir.path(), &meta, None).unwrap();
         assert_eq!(summary.variables_created, 0);
         assert_eq!(summary.skipped_composite.len(), 2);
         assert!(body.variables.is_empty());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Stacked on #1321 (11k.4). Extends `build_export_payload` (and the internal
`process_*`/`make_variable_action` helpers) with an optional `overrides:
Option<&HashMap<String, String>>` parameter — a legacyKey → Figma-name map.
When a token's legacyKey has an override, the generator emits that name
instead of the default `{prefix}/{legacyKey}`; absent or empty overrides
keep today's 1:1 behavior unchanged for every existing caller.

`design-data figma export` gains a `--mapping <PATH>` flag that loads the
override map from a `figma audit` artifact (reads its nested `overrides`
field) or a bare `{legacyKey: name}` JSON object, dropping any empty-string
placeholder entries (the audit's "needs a decision" markers).

## Related Issue

spectrum-design-data-11k.5 (bd), depends on spectrum-design-data-11k.4 (#1321)

## Motivation and Context

11k.4's audit produces an override scaffold for every naming divergence
between the generator and the real S2–Web file. This closes the loop: once
someone fills in real names for the scaffold's `generated_only` entries,
`figma export --mapping <artifact>` will actually emit them, moving the
generator from "1:1 by convention" toward "authoritative for the real file."

## How Has This Been Tested?

- New unit test in `mapping.rs`: one token with an override remaps to the
  override name; a second token with no override still gets the default
  `{prefix}/{legacyKey}` name.
- All existing `mapping.rs` tests remain green, unchanged.
- `moon run sdk:build && moon run sdk:test && moon run sdk:lint` (clippy
  `-D warnings`) all pass.
- `node tools/changeset-linter/src/cli.js check --fail-on-warnings` passes.

## Screenshots (if appropriate):

N/A — CLI/library change only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
